### PR TITLE
Migrate from tower-lsp to tower-lsp-server 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,32 +124,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "autocfg"
@@ -199,12 +177,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -526,11 +498,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1427,7 +1400,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1469,16 +1442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lsp-types"
-version = "0.94.1"
+name = "ls-types"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "c029d4b509074b7d59dac432d87d4c24badaaf6c6c9c8b7ac030ae8022dc118d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
+ "fluent-uri",
+ "percent-encoding",
  "serde",
  "serde_json",
- "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -1724,26 +1697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,7 +1826,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1969,7 +1922,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2077,7 +2030,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2154,7 +2107,7 @@ dependencies = [
  "rsigma-eval",
  "rsigma-parser",
  "tokio",
- "tower-lsp",
+ "tower-lsp-server",
 ]
 
 [[package]]
@@ -2179,7 +2132,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2316,7 +2269,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2433,17 +2386,6 @@ name = "serde_json_path_macros_internal"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2716,20 +2658,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -2749,14 +2677,14 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2768,37 +2696,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+checksum = "2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",
  "httparse",
- "lsp-types",
+ "ls-types",
  "memchr",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
- "tower-lsp-macros",
+ "tower",
  "tracing",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2970,7 +2884,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3152,7 +3065,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3543,7 +3456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.3.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.3.0" }
-tower-lsp = "0.20"
+tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"
 env_logger = "0.11"

--- a/crates/rsigma-lsp/src/code_action.rs
+++ b/crates/rsigma-lsp/src/code_action.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rsigma_parser::lint::{
     self, FixDisposition, FixPatch, LintConfig, LintWarning, lint_yaml_str_with_config,
 };
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::ls_types::*;
 
 use crate::position::{LineIndex, resolve_path};
 
@@ -13,7 +13,7 @@ use crate::position::{LineIndex, resolve_path};
 /// the requested range, and converts each into a `CodeAction` with a
 /// `WorkspaceEdit` containing `TextEdit`s.
 pub fn code_actions(
-    uri: &Url,
+    uri: &Uri,
     text: &str,
     request_range: &Range,
     config: &LintConfig,
@@ -189,8 +189,8 @@ mod tests {
         Range::new(Position::new(0, 0), Position::new(u32::MAX, 0))
     }
 
-    fn test_uri() -> Url {
-        Url::parse("file:///test.yml").unwrap()
+    fn test_uri() -> Uri {
+        "file:///test.yml".parse().unwrap()
     }
 
     fn actions_summary(actions: &[&CodeAction]) -> String {

--- a/crates/rsigma-lsp/src/completion.rs
+++ b/crates/rsigma-lsp/src/completion.rs
@@ -8,7 +8,7 @@
 //! - MITRE ATT&CK tags
 //! - Selection names in condition expressions
 
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::ls_types::*;
 
 use crate::data;
 

--- a/crates/rsigma-lsp/src/diagnostics.rs
+++ b/crates/rsigma-lsp/src/diagnostics.rs
@@ -4,7 +4,7 @@
 use rsigma_parser::lint::{
     LintConfig, LintWarning, Severity as LintSeverity, lint_yaml_str_with_config,
 };
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::ls_types::*;
 
 use crate::position::{LineIndex, resolve_path};
 

--- a/crates/rsigma-lsp/src/main.rs
+++ b/crates/rsigma-lsp/src/main.rs
@@ -11,7 +11,7 @@ mod diagnostics;
 mod position;
 mod server;
 
-use tower_lsp::{LspService, Server};
+use tower_lsp_server::{LspService, Server};
 
 #[tokio::main]
 async fn main() {

--- a/crates/rsigma-lsp/src/position.rs
+++ b/crates/rsigma-lsp/src/position.rs
@@ -5,7 +5,7 @@
 //! indentation-aware matching. When a path cannot be resolved, we fall back to
 //! line 0.
 
-use tower_lsp::lsp_types::{Position, Range};
+use tower_lsp_server::ls_types::{Position, Range};
 
 /// A pre-computed line index for fast offset -> line/col lookups.
 pub struct LineIndex {

--- a/crates/rsigma-lsp/src/server.rs
+++ b/crates/rsigma-lsp/src/server.rs
@@ -89,8 +89,7 @@ impl SigmaLanguageServer {
 
         // Abort any existing pending task, then spawn the new one while holding
         // the lock so no concurrent call can slip in between.
-        let mut guard: tokio::sync::MutexGuard<'_, _> =
-            self.pending_diagnostics.lock().await;
+        let mut guard: tokio::sync::MutexGuard<'_, _> = self.pending_diagnostics.lock().await;
         if let Some(handle) = guard.remove(&uri) {
             handle.abort();
         }
@@ -218,8 +217,7 @@ impl LanguageServer for SigmaLanguageServer {
 
         // Cancel any pending diagnostics for this file.
         {
-            let mut pending: tokio::sync::MutexGuard<'_, _> =
-                self.pending_diagnostics.lock().await;
+            let mut pending: tokio::sync::MutexGuard<'_, _> = self.pending_diagnostics.lock().await;
             if let Some(handle) = pending.remove(&uri) {
                 handle.abort();
             }

--- a/crates/rsigma-lsp/src/server.rs
+++ b/crates/rsigma-lsp/src/server.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{Mutex, RwLock};
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::*;
+use tower_lsp_server::{Client, LanguageServer};
 
 use rsigma_parser::lint::LintConfig;
 
@@ -29,9 +29,9 @@ struct DocumentState {
 /// The Sigma Language Server.
 pub struct SigmaLanguageServer {
     client: Client,
-    documents: Arc<RwLock<HashMap<Url, DocumentState>>>,
+    documents: Arc<RwLock<HashMap<Uri, DocumentState>>>,
     /// Abort handles for pending debounced diagnostic tasks.
-    pending_diagnostics: Arc<Mutex<HashMap<Url, tokio::task::AbortHandle>>>,
+    pending_diagnostics: Arc<Mutex<HashMap<Uri, tokio::task::AbortHandle>>>,
 }
 
 impl SigmaLanguageServer {
@@ -44,8 +44,8 @@ impl SigmaLanguageServer {
     }
 
     /// Load lint config for a document by walking ancestors from the file URI.
-    fn load_lint_config(uri: &Url) -> LintConfig {
-        if let Ok(path) = uri.to_file_path()
+    fn load_lint_config(uri: &Uri) -> LintConfig {
+        if let Some(path) = uri.to_file_path()
             && let Some(config_path) = LintConfig::find_in_ancestors(&path)
             && let Ok(config) = LintConfig::load(&config_path)
         {
@@ -55,7 +55,7 @@ impl SigmaLanguageServer {
     }
 
     /// Run diagnostics immediately on a blocking thread and publish results.
-    async fn publish_diagnostics_now(&self, uri: &Url, text: &str, version: i32) {
+    async fn publish_diagnostics_now(&self, uri: &Uri, text: &str, version: i32) {
         let text = text.to_string();
         let config = Self::load_lint_config(uri);
         let diags = match tokio::task::spawn_blocking(move || {
@@ -81,7 +81,7 @@ impl SigmaLanguageServer {
     }
 
     /// Schedule diagnostics with debounce. Cancels any pending run for this URI.
-    async fn schedule_diagnostics(&self, uri: Url, text: String, version: i32) {
+    async fn schedule_diagnostics(&self, uri: Uri, text: String, version: i32) {
         let client = self.client.clone();
         let pending = self.pending_diagnostics.clone();
         let uri_for_task = uri.clone();
@@ -89,7 +89,8 @@ impl SigmaLanguageServer {
 
         // Abort any existing pending task, then spawn the new one while holding
         // the lock so no concurrent call can slip in between.
-        let mut guard = self.pending_diagnostics.lock().await;
+        let mut guard: tokio::sync::MutexGuard<'_, _> =
+            self.pending_diagnostics.lock().await;
         if let Some(handle) = guard.remove(&uri) {
             handle.abort();
         }
@@ -116,20 +117,19 @@ impl SigmaLanguageServer {
                 .publish_diagnostics(uri_for_task.clone(), diags, Some(version))
                 .await;
 
-            pending.lock().await.remove(&uri_for_task);
+            let _: Option<_> = pending.lock().await.remove(&uri_for_task);
         });
 
         guard.insert(uri, task.abort_handle());
     }
 
     /// Check if a URI looks like a Sigma YAML file.
-    fn is_sigma_file(uri: &Url) -> bool {
-        let path = uri.path();
+    fn is_sigma_file(uri: &Uri) -> bool {
+        let path = uri.path().as_str();
         path.ends_with(".yml") || path.ends_with(".yaml")
     }
 }
 
-#[tower_lsp::async_trait]
 impl LanguageServer for SigmaLanguageServer {
     async fn initialize(&self, _params: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
@@ -178,10 +178,8 @@ impl LanguageServer for SigmaLanguageServer {
             self.publish_diagnostics_now(&uri, &text, version).await;
         }
 
-        self.documents
-            .write()
-            .await
-            .insert(uri, DocumentState { text, version });
+        let mut docs: tokio::sync::RwLockWriteGuard<'_, _> = self.documents.write().await;
+        docs.insert(uri, DocumentState { text, version });
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
@@ -197,10 +195,8 @@ impl LanguageServer for SigmaLanguageServer {
                     .await;
             }
 
-            self.documents
-                .write()
-                .await
-                .insert(uri, DocumentState { text, version });
+            let mut docs: tokio::sync::RwLockWriteGuard<'_, _> = self.documents.write().await;
+            docs.insert(uri, DocumentState { text, version });
         }
     }
 
@@ -209,7 +205,7 @@ impl LanguageServer for SigmaLanguageServer {
 
         // Re-lint on save (belt and suspenders — didChange already does it).
         if Self::is_sigma_file(&uri) {
-            let docs = self.documents.read().await;
+            let docs: tokio::sync::RwLockReadGuard<'_, _> = self.documents.read().await;
             if let Some(doc) = docs.get(&uri) {
                 self.publish_diagnostics_now(&uri, &doc.text, doc.version)
                     .await;
@@ -222,13 +218,16 @@ impl LanguageServer for SigmaLanguageServer {
 
         // Cancel any pending diagnostics for this file.
         {
-            let mut pending = self.pending_diagnostics.lock().await;
+            let mut pending: tokio::sync::MutexGuard<'_, _> =
+                self.pending_diagnostics.lock().await;
             if let Some(handle) = pending.remove(&uri) {
                 handle.abort();
             }
         }
 
-        self.documents.write().await.remove(&uri);
+        let mut docs: tokio::sync::RwLockWriteGuard<'_, _> = self.documents.write().await;
+        docs.remove(&uri);
+        drop(docs);
 
         // Clear diagnostics for the closed file.
         self.client.publish_diagnostics(uri, vec![], None).await;
@@ -239,7 +238,7 @@ impl LanguageServer for SigmaLanguageServer {
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
 
-        let docs = self.documents.read().await;
+        let docs: tokio::sync::RwLockReadGuard<'_, _> = self.documents.read().await;
         let Some(doc) = docs.get(uri) else {
             return Ok(None);
         };
@@ -285,7 +284,7 @@ impl LanguageServer for SigmaLanguageServer {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
 
-        let docs = self.documents.read().await;
+        let docs: tokio::sync::RwLockReadGuard<'_, _> = self.documents.read().await;
         let Some(doc) = docs.get(uri) else {
             return Ok(None);
         };
@@ -313,7 +312,7 @@ impl LanguageServer for SigmaLanguageServer {
         let uri = &params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let docs = self.documents.read().await;
+        let docs: tokio::sync::RwLockReadGuard<'_, _> = self.documents.read().await;
         let Some(doc) = docs.get(uri) else {
             return Ok(None);
         };
@@ -339,7 +338,7 @@ impl LanguageServer for SigmaLanguageServer {
     ) -> Result<Option<DocumentSymbolResponse>> {
         let uri = &params.text_document.uri;
 
-        let docs = self.documents.read().await;
+        let docs: tokio::sync::RwLockReadGuard<'_, _> = self.documents.read().await;
         let Some(doc) = docs.get(uri) else {
             return Ok(None);
         };


### PR DESCRIPTION
Migrate from the unmaintained `tower-lsp` (last release 2+ years ago) to `tower-lsp-server` 0.23, the actively maintained community fork.

**API changes:**
- `lsp_types` → `ls_types`
- `Url` → `Uri`
- Removed `#[tower_lsp::async_trait]` (native async traits)
- `to_file_path()` returns `Option` instead of `Result`
- Added explicit guard type annotations required by native async trait inference

All 15 LSP tests pass.