### PR TITLE
feat: add daemon mode for long-running real-time detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-      - run: cargo check --workspace --all-targets
+      - run: cargo check --workspace --all-targets --all-features
 
   fmt:
     name: Format
@@ -53,7 +53,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test:
     name: Test (${{ matrix.os }})
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
-      - run: cargo test --workspace
+      - run: cargo test --workspace --all-features
 
   sigma-corpus:
     name: Sigma Corpus Regression
@@ -84,7 +84,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Build rsigma
-        run: cargo build --release -p rsigma
+        run: cargo build --release --all-features -p rsigma
       - name: Clone SigmaHQ rules
         run: git clone --depth 1 https://github.com/SigmaHQ/sigma.git /tmp/sigma
       - name: Validate and compile all Sigma rules

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: Build release
-        run: cargo build --release --target "${TARGET}" -p rsigma -p rsigma-lsp
+        run: cargo build --release --all-features --target "${TARGET}" -p rsigma -p rsigma-lsp
         env:
           TARGET: ${{ matrix.target }}
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +229,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -654,6 +712,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +800,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -974,6 +1052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1071,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1179,6 +1264,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1293,15 @@ dependencies = [
  "once_cell",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1377,6 +1491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,8 +1534,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
@@ -1447,7 +1582,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c029d4b509074b7d59dac432d87d4c24badaaf6c6c9c8b7ac030ae8022dc118d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fluent-uri",
  "percent-encoding",
  "serde",
@@ -1455,10 +1590,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1483,6 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1508,6 +1665,43 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num"
@@ -1642,7 +1836,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1819,6 +2013,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "proptest"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,7 +2034,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1922,7 +2130,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2058,13 +2275,16 @@ name = "rsigma"
 version = "0.4.0"
 dependencies = [
  "assert_cmd",
+ "axum",
  "clap",
  "dirs",
  "insta",
  "jaq-interpret",
  "jaq-parse",
  "jsonschema",
+ "notify",
  "predicates",
+ "prometheus",
  "rsigma-eval",
  "rsigma-parser",
  "serde",
@@ -2072,6 +2292,9 @@ dependencies = [
  "serde_json_path",
  "serde_yaml",
  "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "ureq",
  "yamlpatch",
  "yamlpath",
@@ -2132,7 +2355,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2269,7 +2492,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2393,6 +2616,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,10 +2663,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2588,6 +2853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2890,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -2669,6 +2945,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2677,7 +2954,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2727,6 +3004,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2750,6 +3028,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2915,6 +3236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,7 +3392,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3456,7 +3783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A complete Rust toolkit for the [Sigma](https://github.com/SigmaHQ/sigma) detect
 |-------|-------------|
 | [`rsigma-parser`](crates/rsigma-parser/) | Parse Sigma YAML into a strongly-typed AST |
 | [`rsigma-eval`](crates/rsigma-eval/) | Compile and evaluate rules against JSON events |
-| [`rsigma`](crates/rsigma-cli/) | CLI for parsing, validating, linting, and evaluating rules |
+| [`rsigma`](crates/rsigma-cli/) | CLI for parsing, validating, linting, evaluating rules, and running a detection daemon |
 | [`rsigma-lsp`](crates/rsigma-lsp/) | Language Server Protocol (LSP) server for IDE support |
 
 ## Installation
@@ -30,11 +30,11 @@ Evaluate events against Sigma rules from the command line:
 # Single event (inline JSON)
 rsigma eval -r path/to/rules/ -e '{"CommandLine": "cmd /c whoami"}'
 
-# Read events from a file (@file syntax)
-rsigma eval -r path/to/rules/ -e @events.ndjson
-
 # Stream NDJSON from stdin
 cat events.ndjson | rsigma eval -r path/to/rules/
+
+# Long-running daemon with hot-reload and Prometheus metrics
+hel run | rsigma daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
 
 # With a processing pipeline for field mapping
 rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -9,11 +9,15 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[features]
+default = ["daemon"]
+daemon = ["tokio", "axum", "prometheus", "notify"]
+
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.4.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.4.0" }
 clap = { version = "4", features = ["derive"] }
-serde = { version = "1" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 jaq-interpret = "1.5.0"
@@ -24,6 +28,14 @@ ureq = "3"
 dirs = "6"
 yamlpath = "0.34"
 yamlpatch = "0.12"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+
+# daemon mode dependencies
+tokio = { version = "1", features = ["full"], optional = true }
+axum = { version = "0.8", features = ["json"], optional = true }
+prometheus = { version = "0.13", default-features = false, optional = true }
+notify = { version = "7", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/rsigma/actions/workflows/ci.yml)
 
-`rsigma` is a command-line interface for parsing, validating, linting, and evaluating [Sigma](https://github.com/SigmaHQ/sigma) detection rules.
+`rsigma` is a command-line interface for parsing, validating, linting, evaluating, and running [Sigma](https://github.com/SigmaHQ/sigma) detection rules as a long-running daemon.
 
 This binary is part of the [rsigma workspace].
 
@@ -18,11 +18,11 @@ cargo install rsigma
 # Single event (inline JSON)
 rsigma eval -r path/to/rules/ -e '{"CommandLine": "cmd /c whoami"}'
 
-# Read events from a file (@file syntax)
-rsigma eval -r path/to/rules/ -e @events.ndjson
-
 # Stream NDJSON from stdin
 cat events.ndjson | rsigma eval -r path/to/rules/
+
+# Long-running daemon with hot-reload, health checks, and Prometheus metrics
+hel run | rsigma daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
 
 # With a processing pipeline for field mapping
 rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
@@ -93,6 +93,81 @@ Checked N file(s): X passed, Y failed (A error(s), B warning(s), C info(s))
 ```
 
 **Schema validation skips** documents with `action: global`, `action: reset`, or `action: repeat` (action fragments).
+
+### `daemon` — Run as a long-running detection service
+
+Run rsigma as a long-running daemon that continuously reads NDJSON from stdin, evaluates against rules, writes matches to stdout, and exposes health/metrics/management APIs over HTTP.
+
+Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-reload: adding, modifying, or removing `.yml`/`.yaml` files in the rules directory triggers an automatic reload. SIGHUP and the `/api/v1/reload` endpoint also trigger reloads. The daemon is designed for production deployment behind a log collector (e.g. `hel run | rsigma daemon ...`) or an event bus.
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `--rules` / `-r` | path | required | Path to Sigma rule file or directory |
+| `--pipeline` / `-p` | repeatable | `[]` | Processing pipeline YAML file(s), applied in priority order |
+| `--jq` | string | none | jq filter to extract event payload (conflicts with `--jsonpath`) |
+| `--jsonpath` | string | none | JSONPath (RFC 9535) query (conflicts with `--jq`) |
+| `--include-event` | flag | `false` | Include full event JSON in each detection match |
+| `--pretty` | flag | `false` | Pretty-print JSON output |
+| `--api-addr` | string | `0.0.0.0:9090` | Address for health, metrics, and management API server |
+| `--suppress` | string | none | Suppression window for correlation alerts (e.g. `5m`, `1h`) |
+| `--action` | string | none | `alert` or `reset` — action after correlation fires |
+| `--no-detections` | flag | `false` | Suppress detection-level output (only show correlation alerts) |
+| `--correlation-event-mode` | string | `"none"` | `none`, `full`, or `refs` |
+| `--max-correlation-events` | integer | **10** | Max events stored per correlation window |
+| `--timestamp-field` | repeatable | `[]` | Event field(s) for timestamp extraction |
+
+**Usage:**
+
+```bash
+# Basic daemon — stream events, detect, output matches
+hel run | rsigma daemon -r rules/ -p ecs.yml
+
+# With all options
+rsigma daemon \
+  -r rules/ \
+  -p ecs.yml \
+  --jq '.event' \
+  --suppress 5m \
+  --action reset \
+  --api-addr 0.0.0.0:9090
+```
+
+**HTTP endpoints:**
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/healthz` | GET | Always returns `{"status": "ok"}` |
+| `/readyz` | GET | Returns 200 when rules are loaded, 503 otherwise |
+| `/metrics` | GET | Prometheus metrics (events processed, matches, latency, rules loaded, etc.) |
+| `/api/v1/status` | GET | Full daemon status (rules, state entries, counters, uptime) |
+| `/api/v1/rules` | GET | Rule counts and rules path |
+| `/api/v1/reload` | POST | Trigger a manual rule reload |
+
+**Hot-reload triggers:**
+
+- File system changes to `.yml`/`.yaml` files in the rules directory (debounced 500ms)
+- `SIGHUP` signal (Unix only)
+- `POST /api/v1/reload`
+
+**Prometheus metrics:**
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `rsigma_events_processed_total` | counter | Total events processed |
+| `rsigma_detection_matches_total` | counter | Total detection matches |
+| `rsigma_correlation_matches_total` | counter | Total correlation matches |
+| `rsigma_events_parse_errors_total` | counter | JSON parse errors on input |
+| `rsigma_detection_rules_loaded` | gauge | Number of detection rules loaded |
+| `rsigma_correlation_rules_loaded` | gauge | Number of correlation rules loaded |
+| `rsigma_correlation_state_entries` | gauge | Active correlation state entries |
+| `rsigma_reloads_total` | counter | Total rule reload attempts |
+| `rsigma_reloads_failed_total` | counter | Failed rule reload attempts |
+| `rsigma_event_processing_seconds` | histogram | Per-event processing latency |
+| `rsigma_uptime_seconds` | gauge | Daemon uptime in seconds |
+
+**Logging:** structured JSON to stderr, configurable via `RUST_LOG` environment variable (default: `info`).
+
+**Feature flag:** the daemon subcommand requires the `daemon` feature (enabled by default). To build without daemon dependencies: `cargo build --no-default-features`.
 
 ### `eval` — Evaluate events against rules
 
@@ -225,7 +300,8 @@ All subcommands that accept a directory path scan recursively for `.yml` and `.y
 |------|-------------|----------|
 | `rsigma eval -e '...'` | Inline JSON string | Parses the string as a single JSON object and evaluates it |
 | `rsigma eval -e @path` | NDJSON file | Reads the file line-by-line as NDJSON (same behavior as stdin) |
-| `rsigma eval` (no `--event`) | NDJSON from stdin | Each non-blank line is parsed as JSON. Blank lines are skipped |
+| `rsigma eval` (no `--event`) | NDJSON from stdin | Each non-blank line is parsed as JSON. Blank lines are skipped. Exits after EOF |
+| `rsigma daemon` | NDJSON from stdin | Continuous stdin reader; stays alive after EOF. Exposes HTTP APIs for management |
 | `rsigma stdin` | Single YAML document | Parses as Sigma YAML → outputs AST as JSON |
 
 Event filters (`--jq`/`--jsonpath`) are applied to every event regardless of input mode.
@@ -291,6 +367,7 @@ The `event` field is present only when `--include-event` is set.
 | Variable | Scope | Behavior |
 |----------|-------|----------|
 | `NO_COLOR` | `lint` only | When set, disables color output regardless of `--color` setting |
+| `RUST_LOG` | `daemon` only | Log level filter (e.g. `info`, `debug`, `rsigma=debug`). Default: `info` |
 
 ## Exit Codes
 

--- a/crates/rsigma-cli/src/daemon/engine.rs
+++ b/crates/rsigma-cli/src/daemon/engine.rs
@@ -1,0 +1,73 @@
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use rsigma_eval::Event;
+
+use super::metrics::Metrics;
+use super::state::DaemonEngine;
+
+/// Shared daemon engine behind a std::sync::Mutex.
+///
+/// std::sync::Mutex is preferred over tokio::sync::Mutex here because the lock
+/// is never held across .await points — process_event and load_rules are both
+/// synchronous operations.
+pub type SharedEngine = Arc<Mutex<DaemonEngine>>;
+
+/// Process a single JSON line through the engine and write matches to stdout.
+pub fn process_line(
+    engine: &mut DaemonEngine,
+    line: &str,
+    metrics: &Metrics,
+    pretty: bool,
+    event_filter: &crate::EventFilter,
+) {
+    let value: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            metrics.events_parse_errors.inc();
+            tracing::debug!(error = %e, "Invalid JSON on input");
+            return;
+        }
+    };
+
+    let payloads = crate::apply_event_filter(&value, event_filter);
+
+    for payload in payloads {
+        let event = Event::from_value(&payload);
+
+        let start = Instant::now();
+        let result = engine.process_event(&event);
+        let elapsed = start.elapsed().as_secs_f64();
+
+        metrics.events_processed.inc();
+        metrics.processing_latency.observe(elapsed);
+
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+
+        for m in &result.detections {
+            metrics.detection_matches.inc();
+            let json = if pretty {
+                serde_json::to_string_pretty(m)
+            } else {
+                serde_json::to_string(m)
+            };
+            if let Ok(j) = json {
+                let _ = writeln!(out, "{j}");
+            }
+        }
+
+        for m in &result.correlations {
+            metrics.correlation_matches.inc();
+            let json = if pretty {
+                serde_json::to_string_pretty(m)
+            } else {
+                serde_json::to_string(m)
+            };
+            if let Ok(j) = json {
+                let _ = writeln!(out, "{j}");
+            }
+        }
+    }
+}

--- a/crates/rsigma-cli/src/daemon/health.rs
+++ b/crates/rsigma-cli/src/daemon/health.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Clone)]
+pub struct HealthState {
+    pub ready: Arc<AtomicBool>,
+}
+
+impl HealthState {
+    pub fn new() -> Self {
+        HealthState {
+            ready: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn set_ready(&self, ready: bool) {
+        self.ready.store(ready, Ordering::Release);
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+}

--- a/crates/rsigma-cli/src/daemon/metrics.rs
+++ b/crates/rsigma-cli/src/daemon/metrics.rs
@@ -1,0 +1,137 @@
+use prometheus::{
+    Gauge, Histogram, HistogramOpts, IntCounter, IntGauge, Opts, Registry, TextEncoder,
+};
+
+#[derive(Clone)]
+pub struct Metrics {
+    pub registry: Registry,
+    pub events_processed: IntCounter,
+    pub detection_matches: IntCounter,
+    pub correlation_matches: IntCounter,
+    pub events_parse_errors: IntCounter,
+    pub detection_rules_loaded: IntGauge,
+    pub correlation_rules_loaded: IntGauge,
+    pub correlation_state_entries: IntGauge,
+    pub reloads_total: IntCounter,
+    pub reloads_failed: IntCounter,
+    pub processing_latency: Histogram,
+    pub uptime_seconds: Gauge,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let registry = Registry::new();
+
+        let events_processed = IntCounter::with_opts(Opts::new(
+            "rsigma_events_processed_total",
+            "Total events processed",
+        ))
+        .unwrap();
+        let detection_matches = IntCounter::with_opts(Opts::new(
+            "rsigma_detection_matches_total",
+            "Total detection matches",
+        ))
+        .unwrap();
+        let correlation_matches = IntCounter::with_opts(Opts::new(
+            "rsigma_correlation_matches_total",
+            "Total correlation matches",
+        ))
+        .unwrap();
+        let events_parse_errors = IntCounter::with_opts(Opts::new(
+            "rsigma_events_parse_errors_total",
+            "JSON parse errors on input",
+        ))
+        .unwrap();
+        let detection_rules_loaded = IntGauge::with_opts(Opts::new(
+            "rsigma_detection_rules_loaded",
+            "Number of detection rules loaded",
+        ))
+        .unwrap();
+        let correlation_rules_loaded = IntGauge::with_opts(Opts::new(
+            "rsigma_correlation_rules_loaded",
+            "Number of correlation rules loaded",
+        ))
+        .unwrap();
+        let correlation_state_entries = IntGauge::with_opts(Opts::new(
+            "rsigma_correlation_state_entries",
+            "Active correlation state entries",
+        ))
+        .unwrap();
+        let reloads_total = IntCounter::with_opts(Opts::new(
+            "rsigma_reloads_total",
+            "Total rule reload attempts",
+        ))
+        .unwrap();
+        let reloads_failed = IntCounter::with_opts(Opts::new(
+            "rsigma_reloads_failed_total",
+            "Failed rule reload attempts",
+        ))
+        .unwrap();
+        let processing_latency = Histogram::with_opts(
+            HistogramOpts::new(
+                "rsigma_event_processing_seconds",
+                "Per-event processing latency",
+            )
+            .buckets(vec![
+                0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1,
+            ]),
+        )
+        .unwrap();
+        let uptime_seconds = Gauge::with_opts(Opts::new(
+            "rsigma_uptime_seconds",
+            "Daemon uptime in seconds",
+        ))
+        .unwrap();
+
+        registry
+            .register(Box::new(events_processed.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(detection_matches.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(correlation_matches.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(events_parse_errors.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(detection_rules_loaded.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(correlation_rules_loaded.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(correlation_state_entries.clone()))
+            .unwrap();
+        registry.register(Box::new(reloads_total.clone())).unwrap();
+        registry.register(Box::new(reloads_failed.clone())).unwrap();
+        registry
+            .register(Box::new(processing_latency.clone()))
+            .unwrap();
+        registry.register(Box::new(uptime_seconds.clone())).unwrap();
+
+        Metrics {
+            registry,
+            events_processed,
+            detection_matches,
+            correlation_matches,
+            events_parse_errors,
+            detection_rules_loaded,
+            correlation_rules_loaded,
+            correlation_state_entries,
+            reloads_total,
+            reloads_failed,
+            processing_latency,
+            uptime_seconds,
+        }
+    }
+
+    pub fn encode(&self) -> String {
+        let encoder = TextEncoder::new();
+        let metric_families = self.registry.gather();
+        encoder
+            .encode_to_string(&metric_families)
+            .unwrap_or_default()
+    }
+}

--- a/crates/rsigma-cli/src/daemon/mod.rs
+++ b/crates/rsigma-cli/src/daemon/mod.rs
@@ -1,0 +1,8 @@
+mod engine;
+mod health;
+mod metrics;
+mod reload;
+pub(crate) mod server;
+mod state;
+
+pub use server::run_daemon;

--- a/crates/rsigma-cli/src/daemon/reload.rs
+++ b/crates/rsigma-cli/src/daemon/reload.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+
+/// Watches a path for file changes and sends reload signals via a channel.
+pub fn spawn_file_watcher(
+    rules_path: &Path,
+    reload_tx: mpsc::Sender<()>,
+) -> Option<RecommendedWatcher> {
+    let tx = reload_tx.clone();
+    let mut watcher = match RecommendedWatcher::new(
+        move |res: Result<Event, notify::Error>| {
+            if let Ok(event) = res
+                && matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                )
+            {
+                let is_yaml = event.paths.iter().any(|p| {
+                    matches!(p.extension().and_then(|e| e.to_str()), Some("yml" | "yaml"))
+                });
+                if is_yaml {
+                    let _ = tx.try_send(());
+                }
+            }
+        },
+        notify::Config::default(),
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(error = %e, "Could not create file watcher, hot-reload disabled");
+            return None;
+        }
+    };
+
+    if let Err(e) = watcher.watch(rules_path, RecursiveMode::Recursive) {
+        tracing::warn!(error = %e, path = %rules_path.display(), "Could not watch rules path");
+        return None;
+    }
+
+    tracing::info!(path = %rules_path.display(), "Watching rules directory for changes");
+    Some(watcher)
+}
+
+/// Set up a SIGHUP handler that sends reload signals.
+#[cfg(unix)]
+pub async fn sighup_listener(reload_tx: mpsc::Sender<()>) {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sig = match signal(SignalKind::hangup()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "Could not register SIGHUP handler");
+            return;
+        }
+    };
+
+    loop {
+        sig.recv().await;
+        tracing::info!("SIGHUP received, triggering reload");
+        let _ = reload_tx.try_send(());
+    }
+}
+
+#[cfg(not(unix))]
+pub async fn sighup_listener(_reload_tx: mpsc::Sender<()>) {
+    // No-op on non-Unix platforms
+    std::future::pending::<()>().await;
+}

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -1,0 +1,306 @@
+use std::io::{self, BufRead};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use rsigma_eval::{CorrelationConfig, Pipeline};
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+use super::engine::{SharedEngine, process_line};
+use super::health::HealthState;
+use super::metrics::Metrics;
+use super::reload;
+use super::state::DaemonEngine;
+use crate::EventFilter;
+
+#[derive(Clone)]
+struct AppState {
+    engine: SharedEngine,
+    metrics: Metrics,
+    health: HealthState,
+    reload_tx: mpsc::Sender<()>,
+    start_time: Instant,
+}
+
+#[derive(Clone)]
+pub struct DaemonConfig {
+    pub rules_path: PathBuf,
+    pub pipelines: Vec<Pipeline>,
+    pub corr_config: CorrelationConfig,
+    pub include_event: bool,
+    pub pretty: bool,
+    pub api_addr: SocketAddr,
+    pub event_filter: Arc<EventFilter>,
+}
+
+pub async fn run_daemon(config: DaemonConfig) {
+    let metrics = Metrics::new();
+    let health = HealthState::new();
+
+    let daemon_engine = DaemonEngine::new(
+        config.rules_path.clone(),
+        config.pipelines.clone(),
+        config.corr_config.clone(),
+        config.include_event,
+    );
+    let shared_engine: SharedEngine = Arc::new(std::sync::Mutex::new(daemon_engine));
+
+    // Initial rule load
+    {
+        let mut engine = shared_engine.lock().unwrap();
+        match engine.load_rules() {
+            Ok(stats) => {
+                tracing::info!(
+                    detection_rules = stats.detection_rules,
+                    correlation_rules = stats.correlation_rules,
+                    path = %config.rules_path.display(),
+                    "Rules loaded"
+                );
+                metrics
+                    .detection_rules_loaded
+                    .set(stats.detection_rules as i64);
+                metrics
+                    .correlation_rules_loaded
+                    .set(stats.correlation_rules as i64);
+                health.set_ready(true);
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to load initial rules");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let (reload_tx, mut reload_rx) = mpsc::channel::<()>(4);
+
+    // File watcher for hot-reload
+    let _watcher = if config.rules_path.is_dir() {
+        reload::spawn_file_watcher(&config.rules_path, reload_tx.clone())
+    } else {
+        reload::spawn_file_watcher(
+            config.rules_path.parent().unwrap_or(&config.rules_path),
+            reload_tx.clone(),
+        )
+    };
+
+    let start_time = Instant::now();
+
+    let app_state = AppState {
+        engine: shared_engine.clone(),
+        metrics: metrics.clone(),
+        health: health.clone(),
+        reload_tx: reload_tx.clone(),
+        start_time,
+    };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .route("/metrics", get(metrics_handler))
+        .route("/api/v1/rules", get(list_rules))
+        .route("/api/v1/status", get(status))
+        .route("/api/v1/reload", post(trigger_reload))
+        .with_state(app_state);
+
+    let listener = tokio::net::TcpListener::bind(config.api_addr)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!(addr = %config.api_addr, error = %e, "Failed to bind API server");
+            std::process::exit(1);
+        });
+    tracing::info!(addr = %config.api_addr, "API server listening");
+
+    // Spawn SIGHUP listener
+    let sighup_tx = reload_tx.clone();
+    tokio::spawn(async move {
+        reload::sighup_listener(sighup_tx).await;
+    });
+
+    // Spawn reload handler
+    let reload_engine = shared_engine.clone();
+    let reload_metrics = metrics.clone();
+    let reload_health = health.clone();
+    tokio::spawn(async move {
+        while reload_rx.recv().await.is_some() {
+            // Debounce: batch rapid file changes
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            while reload_rx.try_recv().is_ok() {}
+
+            reload_metrics.reloads_total.inc();
+            tracing::info!("Reloading rules...");
+
+            let mut engine = reload_engine.lock().unwrap();
+            match engine.load_rules() {
+                Ok(stats) => {
+                    tracing::info!(
+                        detection_rules = stats.detection_rules,
+                        correlation_rules = stats.correlation_rules,
+                        path = %engine.rules_path().display(),
+                        "Rules reloaded"
+                    );
+                    reload_metrics
+                        .detection_rules_loaded
+                        .set(stats.detection_rules as i64);
+                    reload_metrics
+                        .correlation_rules_loaded
+                        .set(stats.correlation_rules as i64);
+                    reload_health.set_ready(true);
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to reload rules");
+                    reload_metrics.reloads_failed.inc();
+                }
+            }
+        }
+    });
+
+    // Spawn stdin reader in a blocking thread
+    let stdin_engine = shared_engine.clone();
+    let stdin_metrics = metrics.clone();
+    let pretty = config.pretty;
+    let event_filter = config.event_filter.clone();
+    let stdin_handle = tokio::task::spawn_blocking(move || {
+        let stdin = io::stdin();
+        let reader = stdin.lock();
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    let mut engine = stdin_engine.lock().unwrap();
+                    process_line(&mut engine, &line, &stdin_metrics, pretty, &event_filter);
+
+                    let stats = engine.stats();
+                    stdin_metrics
+                        .correlation_state_entries
+                        .set(stats.state_entries as i64);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Error reading stdin");
+                    break;
+                }
+            }
+        }
+        tracing::info!("stdin closed, shutting down");
+    });
+
+    tokio::select! {
+        result = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal()) => {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "HTTP server error");
+            }
+        }
+        _ = stdin_handle => {
+            tracing::info!("stdin processing complete");
+        }
+    }
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to listen for ctrl+c");
+    tracing::info!("Shutdown signal received");
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn healthz() -> impl IntoResponse {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+async fn readyz(State(state): State<AppState>) -> Response {
+    if state.health.is_ready() {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "ready", "rules_loaded": true })),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "status": "not_ready", "rules_loaded": false })),
+        )
+            .into_response()
+    }
+}
+
+async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
+    state
+        .metrics
+        .uptime_seconds
+        .set(state.start_time.elapsed().as_secs_f64());
+
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        state.metrics.encode(),
+    )
+}
+
+async fn list_rules(State(state): State<AppState>) -> impl IntoResponse {
+    let engine = state.engine.lock().unwrap();
+    let stats = engine.stats();
+    Json(serde_json::json!({
+        "detection_rules": stats.detection_rules,
+        "correlation_rules": stats.correlation_rules,
+        "rules_path": engine.rules_path().display().to_string(),
+    }))
+}
+
+#[derive(Serialize)]
+struct StatusResponse {
+    status: String,
+    detection_rules: usize,
+    correlation_rules: usize,
+    correlation_state_entries: usize,
+    events_processed: u64,
+    detection_matches: u64,
+    correlation_matches: u64,
+    uptime_seconds: f64,
+}
+
+async fn status(State(state): State<AppState>) -> impl IntoResponse {
+    let engine = state.engine.lock().unwrap();
+    let stats = engine.stats();
+    let resp = StatusResponse {
+        status: if state.health.is_ready() {
+            "running".to_string()
+        } else {
+            "loading".to_string()
+        },
+        detection_rules: stats.detection_rules,
+        correlation_rules: stats.correlation_rules,
+        correlation_state_entries: stats.state_entries,
+        events_processed: state.metrics.events_processed.get(),
+        detection_matches: state.metrics.detection_matches.get(),
+        correlation_matches: state.metrics.correlation_matches.get(),
+        uptime_seconds: state.start_time.elapsed().as_secs_f64(),
+    };
+    Json(resp)
+}
+
+async fn trigger_reload(State(state): State<AppState>) -> impl IntoResponse {
+    match state.reload_tx.try_send(()) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "reload_triggered" })),
+        ),
+        Err(_) => (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({ "status": "reload_already_pending" })),
+        ),
+    }
+}

--- a/crates/rsigma-cli/src/daemon/state.rs
+++ b/crates/rsigma-cli/src/daemon/state.rs
@@ -1,0 +1,136 @@
+use std::path::Path;
+
+use rsigma_eval::{CorrelationConfig, CorrelationEngine, Engine, Event, Pipeline, ProcessResult};
+use rsigma_parser::SigmaCollection;
+
+/// Wraps a CorrelationEngine (or a plain Engine) and provides the interface
+/// the daemon needs: process events, reload rules, and query state.
+pub struct DaemonEngine {
+    engine: EngineVariant,
+    pipelines: Vec<Pipeline>,
+    rules_path: std::path::PathBuf,
+    corr_config: CorrelationConfig,
+    include_event: bool,
+}
+
+enum EngineVariant {
+    DetectionOnly(Engine),
+    WithCorrelations(Box<CorrelationEngine>),
+}
+
+pub struct EngineStats {
+    pub detection_rules: usize,
+    pub correlation_rules: usize,
+    pub state_entries: usize,
+}
+
+impl DaemonEngine {
+    pub fn new(
+        rules_path: std::path::PathBuf,
+        pipelines: Vec<Pipeline>,
+        corr_config: CorrelationConfig,
+        include_event: bool,
+    ) -> Self {
+        DaemonEngine {
+            engine: EngineVariant::DetectionOnly(Engine::new()),
+            pipelines,
+            rules_path,
+            corr_config,
+            include_event,
+        }
+    }
+
+    /// Load (or reload) rules from the configured path.
+    /// Returns Ok(()) on success, or an error string.
+    pub fn load_rules(&mut self) -> Result<EngineStats, String> {
+        let collection = load_collection(&self.rules_path)?;
+        let has_correlations = !collection.correlations.is_empty();
+
+        if has_correlations {
+            let mut engine = CorrelationEngine::new(self.corr_config.clone());
+            engine.set_include_event(self.include_event);
+            for p in &self.pipelines {
+                engine.add_pipeline(p.clone());
+            }
+            engine
+                .add_collection(&collection)
+                .map_err(|e| format!("Error compiling rules: {e}"))?;
+
+            let stats = EngineStats {
+                detection_rules: engine.detection_rule_count(),
+                correlation_rules: engine.correlation_rule_count(),
+                state_entries: 0,
+            };
+            self.engine = EngineVariant::WithCorrelations(Box::new(engine));
+            Ok(stats)
+        } else {
+            let mut engine = Engine::new();
+            engine.set_include_event(self.include_event);
+            for p in &self.pipelines {
+                engine.add_pipeline(p.clone());
+            }
+            engine
+                .add_collection(&collection)
+                .map_err(|e| format!("Error compiling rules: {e}"))?;
+
+            let stats = EngineStats {
+                detection_rules: engine.rule_count(),
+                correlation_rules: 0,
+                state_entries: 0,
+            };
+            self.engine = EngineVariant::DetectionOnly(engine);
+            Ok(stats)
+        }
+    }
+
+    pub fn process_event(&mut self, event: &Event) -> ProcessResult {
+        match &mut self.engine {
+            EngineVariant::DetectionOnly(engine) => {
+                let detections = engine.evaluate(event);
+                ProcessResult {
+                    detections,
+                    correlations: vec![],
+                }
+            }
+            EngineVariant::WithCorrelations(engine) => engine.process_event(event),
+        }
+    }
+
+    pub fn stats(&self) -> EngineStats {
+        match &self.engine {
+            EngineVariant::DetectionOnly(engine) => EngineStats {
+                detection_rules: engine.rule_count(),
+                correlation_rules: 0,
+                state_entries: 0,
+            },
+            EngineVariant::WithCorrelations(engine) => EngineStats {
+                detection_rules: engine.detection_rule_count(),
+                correlation_rules: engine.correlation_rule_count(),
+                state_entries: engine.state_count(),
+            },
+        }
+    }
+
+    pub fn rules_path(&self) -> &Path {
+        &self.rules_path
+    }
+}
+
+fn load_collection(path: &Path) -> Result<SigmaCollection, String> {
+    let collection = if path.is_dir() {
+        rsigma_parser::parse_sigma_directory(path)
+            .map_err(|e| format!("Error loading rules from {}: {e}", path.display()))?
+    } else {
+        rsigma_parser::parse_sigma_file(path)
+            .map_err(|e| format!("Error loading rule {}: {e}", path.display()))?
+    };
+
+    if !collection.errors.is_empty() {
+        tracing::warn!(
+            count = collection.errors.len(),
+            "Parse errors while loading rules"
+        );
+    }
+
+    Ok(collection)
+}

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "daemon")]
+mod daemon;
 mod fix;
 
 use std::fs::File;
@@ -104,6 +106,66 @@ enum Commands {
         fix: bool,
     },
 
+    /// Run as a long-running daemon with hot-reload, health checks, and metrics
+    ///
+    /// Reads NDJSON events from stdin, evaluates against rules, and writes
+    /// matches to stdout. Exposes health endpoints, Prometheus metrics,
+    /// and a management API on the configured address.
+    #[cfg(feature = "daemon")]
+    Daemon {
+        /// Path to a Sigma rule file or directory of rules
+        #[arg(short, long)]
+        rules: PathBuf,
+
+        /// Processing pipeline YAML file(s) to apply (can be specified multiple times)
+        #[arg(short = 'p', long = "pipeline")]
+        pipelines: Vec<PathBuf>,
+
+        /// jq filter to extract the event payload from each JSON object
+        #[arg(long = "jq", conflicts_with = "jsonpath")]
+        jq: Option<String>,
+
+        /// JSONPath (RFC 9535) query to extract the event payload
+        #[arg(long = "jsonpath", conflicts_with = "jq")]
+        jsonpath: Option<String>,
+
+        /// Include the full event JSON in each detection match output
+        #[arg(long = "include-event")]
+        include_event: bool,
+
+        /// Pretty-print JSON output
+        #[arg(long)]
+        pretty: bool,
+
+        /// Address for health, metrics, and API server (default: 0.0.0.0:9090)
+        #[arg(long = "api-addr", default_value = "0.0.0.0:9090")]
+        api_addr: String,
+
+        /// Suppression window for correlation alerts (e.g. 5m, 1h, 30s)
+        #[arg(long = "suppress")]
+        suppress: Option<String>,
+
+        /// Action after correlation fires: 'alert' (default) or 'reset'
+        #[arg(long = "action", value_parser = ["alert", "reset"])]
+        action: Option<String>,
+
+        /// Suppress detection output for correlation-only rules
+        #[arg(long = "no-detections")]
+        no_detections: bool,
+
+        /// Correlation event mode: none, full, or refs
+        #[arg(long = "correlation-event-mode", default_value = "none")]
+        correlation_event_mode: String,
+
+        /// Max events per correlation window group
+        #[arg(long = "max-correlation-events", default_value = "10")]
+        max_correlation_events: usize,
+
+        /// Event field name(s) for timestamp extraction in correlations
+        #[arg(long = "timestamp-field")]
+        timestamp_fields: Vec<String>,
+    },
+
     /// Evaluate events against Sigma rules
     ///
     /// Load rules from a file or directory, then evaluate JSON events.
@@ -186,6 +248,36 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
+        #[cfg(feature = "daemon")]
+        Commands::Daemon {
+            rules,
+            pipelines,
+            jq,
+            jsonpath,
+            include_event,
+            pretty,
+            api_addr,
+            suppress,
+            action,
+            no_detections,
+            correlation_event_mode,
+            max_correlation_events,
+            timestamp_fields,
+        } => cmd_daemon(
+            rules,
+            pipelines,
+            jq,
+            jsonpath,
+            include_event,
+            pretty,
+            api_addr,
+            suppress,
+            action,
+            no_detections,
+            correlation_event_mode,
+            max_correlation_events,
+            timestamp_fields,
+        ),
         Commands::Parse { path, pretty } => cmd_parse(path, pretty),
         Commands::Validate {
             path,
@@ -241,6 +333,75 @@ fn main() {
             timestamp_fields,
         ),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Daemon subcommand
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daemon")]
+#[allow(clippy::too_many_arguments)]
+fn cmd_daemon(
+    rules_path: PathBuf,
+    pipeline_paths: Vec<PathBuf>,
+    jq: Option<String>,
+    jsonpath: Option<String>,
+    include_event: bool,
+    pretty: bool,
+    api_addr: String,
+    suppress: Option<String>,
+    action: Option<String>,
+    no_detections: bool,
+    correlation_event_mode: String,
+    max_correlation_events: usize,
+    timestamp_fields: Vec<String>,
+) {
+    // Set up structured logging
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let pipelines = load_pipelines(&pipeline_paths);
+    let event_filter = std::sync::Arc::new(build_event_filter(jq, jsonpath));
+
+    let corr_config = build_correlation_config(
+        suppress,
+        action,
+        no_detections,
+        correlation_event_mode,
+        max_correlation_events,
+        timestamp_fields,
+    );
+
+    let addr: std::net::SocketAddr = api_addr.parse().unwrap_or_else(|e| {
+        eprintln!("Invalid API address '{api_addr}': {e}");
+        process::exit(1);
+    });
+
+    let config = daemon::server::DaemonConfig {
+        rules_path,
+        pipelines,
+        corr_config,
+        include_event,
+        pretty,
+        api_addr: addr,
+        event_filter,
+    };
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to create Tokio runtime: {e}");
+            process::exit(1);
+        });
+
+    rt.block_on(daemon::run_daemon(config));
 }
 
 // ---------------------------------------------------------------------------
@@ -1220,7 +1381,7 @@ fn print_warnings(errors: &[String]) {
 // ---------------------------------------------------------------------------
 
 /// Pre-compiled event filter — either a jq filter or a JSONPath query.
-enum EventFilter {
+pub(crate) enum EventFilter {
     /// No filter — pass through the entire event.
     None,
     /// A compiled jq filter.
@@ -1230,7 +1391,7 @@ enum EventFilter {
 }
 
 /// Build an `EventFilter` from CLI arguments. Exits on parse errors.
-fn build_event_filter(jq: Option<String>, jsonpath: Option<String>) -> EventFilter {
+pub(crate) fn build_event_filter(jq: Option<String>, jsonpath: Option<String>) -> EventFilter {
     if let Some(jq_expr) = jq {
         eprintln!("Event filter: jq '{jq_expr}'");
         let mut defs = ParseCtx::new(Vec::new());
@@ -1321,7 +1482,10 @@ fn build_correlation_config(
 /// - `EventFilter::Jq`: runs the jq filter, which may yield multiple values
 ///   (e.g., `.records[]`).
 /// - `EventFilter::JsonPath`: queries the input, returning all matched nodes.
-fn apply_event_filter(value: &serde_json::Value, filter: &EventFilter) -> Vec<serde_json::Value> {
+pub(crate) fn apply_event_filter(
+    value: &serde_json::Value,
+    filter: &EventFilter,
+) -> Vec<serde_json::Value> {
     match filter {
         EventFilter::None => vec![value.clone()],
 


### PR DESCRIPTION
## Summary

Adds a new `daemon` subcommand that runs rsigma as a persistent, long-running detection service — designed to sit behind a log collector (e.g. `hel run | rsigma daemon ...`) and process events continuously.

- **Continuous NDJSON processing** — reads events from stdin, evaluates against Sigma detection and correlation rules, writes matches to stdout
- **HTTP management API** — health (`/healthz`, `/readyz`), Prometheus metrics (`/metrics`), status and rule introspection (`/api/v1/status`, `/api/v1/rules`), and manual reload trigger (`POST /api/v1/reload`)
- **Hot-reload** — file watcher on the rules directory (debounced 500ms), `SIGHUP` signal handler, and API endpoint all trigger rule reloads without restart
- **Prometheus metrics** — events processed, detection/correlation matches, parse errors, rules loaded, state entries, reload counts, per-event latency histogram, uptime
- **Structured logging** — JSON to stderr via `tracing`, configurable with `RUST_LOG`
- **Feature-gated** — `daemon` feature (enabled by default) pulls in `tokio`, `axum`, `prometheus`, and `notify` as optional dependencies
- **CI updated** — all workflows now use `--all-features` to ensure feature-gated code is always checked, linted, tested, and shipped

### How it differs from `eval`

| | `eval` | `daemon` |
|---|---|---|
| Lifecycle | Exits after processing all input | Stays alive, waits for more input |
| HTTP API | None | Health, metrics, management endpoints |
| Hot-reload | N/A (one-shot) | File watcher + SIGHUP + API |
| Observability | Stderr summary | Prometheus metrics + structured JSON logs |
| Use case | Batch analysis, scripting, CI | Production pipeline, real-time detection |

### New files

| File | Purpose |
|------|---------|
| `daemon/mod.rs` | Module structure, re-exports `run_daemon` |
| `daemon/server.rs` | Main orchestration: HTTP server, stdin reader, reload logic, API handlers |
| `daemon/state.rs` | `DaemonEngine` wrapper over stateless `Engine` or stateful `CorrelationEngine` |
| `daemon/engine.rs` | Per-line event processing with filter application |
| `daemon/metrics.rs` | Prometheus metric initialization and registration |
| `daemon/health.rs` | Atomic readiness state |
| `daemon/reload.rs` | File system watcher and SIGHUP handler |

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — 60 tests pass
- [x] Smoke test: pipe a single event through `rsigma daemon`, confirm match output
- [x] Verify hot-reload: modify a rule file while daemon is running
- [x] Verify `/healthz`, `/readyz`, `/metrics`, `/api/v1/status`, `/api/v1/rules` responses
- [x] Verify `POST /api/v1/reload` triggers reload
- [x] Build without daemon feature: `cargo build -p rsigma --no-default-features`