### PR TITLE
feat: add SQLite state store for correlation state persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1004,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1540,6 +1561,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-index"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +1933,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -2287,6 +2325,7 @@ dependencies = [
  "prometheus",
  "rsigma-eval",
  "rsigma-parser",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_json_path",
@@ -2347,6 +2386,20 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3240,6 +3293,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 
 [features]
 default = ["daemon"]
-daemon = ["tokio", "axum", "prometheus", "notify"]
+daemon = ["tokio", "axum", "prometheus", "notify", "rusqlite"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.4.0" }
@@ -36,6 +36,7 @@ tokio = { version = "1", features = ["full"], optional = true }
 axum = { version = "0.8", features = ["json"], optional = true }
 prometheus = { version = "0.13", default-features = false, optional = true }
 notify = { version = "7", optional = true }
+rusqlite = { version = "0.34", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -115,12 +115,17 @@ Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-r
 | `--correlation-event-mode` | string | `"none"` | `none`, `full`, or `refs` |
 | `--max-correlation-events` | integer | **10** | Max events stored per correlation window |
 | `--timestamp-field` | repeatable | `[]` | Event field(s) for timestamp extraction |
+| `--state-db` | path | none | Path to SQLite database for persisting correlation state across restarts |
+| `--state-save-interval` | integer | **30** | Seconds between periodic state snapshots (only with `--state-db`) |
 
 **Usage:**
 
 ```bash
 # Basic daemon — stream events, detect, output matches
 hel run | rsigma daemon -r rules/ -p ecs.yml
+
+# With SQLite state persistence (correlation state survives restarts)
+hel run | rsigma daemon -r rules/ -p ecs.yml --state-db ./rsigma-state.db
 
 # With all options
 rsigma daemon \
@@ -129,7 +134,8 @@ rsigma daemon \
   --jq '.event' \
   --suppress 5m \
   --action reset \
-  --api-addr 0.0.0.0:9090
+  --api-addr 0.0.0.0:9090 \
+  --state-db /var/lib/rsigma/state.db
 ```
 
 **HTTP endpoints:**
@@ -166,6 +172,8 @@ rsigma daemon \
 | `rsigma_uptime_seconds` | gauge | Daemon uptime in seconds |
 
 **Logging:** structured JSON to stderr, configurable via `RUST_LOG` environment variable (default: `info`).
+
+**State persistence:** when `--state-db` is set, correlation state (window entries, suppression timestamps, event buffers) is persisted to a SQLite database. State is loaded on startup, saved periodically (default every 30s, configurable via `--state-save-interval`), and saved on graceful shutdown. This allows correlation windows to survive daemon restarts — for example, an `event_count` correlation that saw 2 of 3 required events before a restart will resume from 2 after restarting. The database uses WAL journal mode and stores a single JSON snapshot row. Correlation entries are keyed by stable rule identifiers (id/name), so state survives rule reloads even if internal ordering changes.
 
 **Feature flag:** the daemon subcommand requires the `daemon` feature (enabled by default). To build without daemon dependencies: `cargo build --no-default-features`.
 

--- a/crates/rsigma-cli/src/daemon/mod.rs
+++ b/crates/rsigma-cli/src/daemon/mod.rs
@@ -4,5 +4,6 @@ mod metrics;
 mod reload;
 pub(crate) mod server;
 mod state;
+mod store;
 
 pub use server::run_daemon;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -95,13 +95,19 @@ pub async fn run_daemon(config: DaemonConfig) {
     if let Some(ref store) = state_store {
         match store.load().await {
             Ok(Some(snapshot)) => {
-                let entries = snapshot.windows.values().map(|g| g.len()).sum::<usize>();
                 let mut engine = shared_engine.lock().unwrap();
-                engine.import_state(&snapshot);
-                tracing::info!(
-                    state_entries = entries,
-                    "Correlation state restored from database"
-                );
+                if engine.import_state(&snapshot) {
+                    let entries = snapshot.windows.values().map(|g| g.len()).sum::<usize>();
+                    tracing::info!(
+                        state_entries = entries,
+                        "Correlation state restored from database"
+                    );
+                } else {
+                    tracing::warn!(
+                        snapshot_version = snapshot.version,
+                        "Incompatible snapshot version, starting with fresh state"
+                    );
+                }
             }
             Ok(None) => {
                 tracing::info!("No previous correlation state found in database");

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -18,6 +18,7 @@ use super::health::HealthState;
 use super::metrics::Metrics;
 use super::reload;
 use super::state::DaemonEngine;
+use super::store::SqliteStateStore;
 use crate::EventFilter;
 
 #[derive(Clone)]
@@ -38,11 +39,23 @@ pub struct DaemonConfig {
     pub pretty: bool,
     pub api_addr: SocketAddr,
     pub event_filter: Arc<EventFilter>,
+    pub state_db: Option<PathBuf>,
+    pub state_save_interval: u64,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
     let metrics = Metrics::new();
     let health = HealthState::new();
+
+    // Open SQLite state store if configured
+    let state_store = config.state_db.as_ref().map(|path| {
+        let store = SqliteStateStore::open(path).unwrap_or_else(|e| {
+            tracing::error!(error = %e, path = %path.display(), "Failed to open state database");
+            std::process::exit(1);
+        });
+        tracing::info!(path = %path.display(), "State database opened");
+        Arc::new(store)
+    });
 
     let daemon_engine = DaemonEngine::new(
         config.rules_path.clone(),
@@ -74,6 +87,27 @@ pub async fn run_daemon(config: DaemonConfig) {
             Err(e) => {
                 tracing::error!(error = %e, "Failed to load initial rules");
                 std::process::exit(1);
+            }
+        }
+    }
+
+    // Restore correlation state from SQLite (after rules are loaded, lock released)
+    if let Some(ref store) = state_store {
+        match store.load().await {
+            Ok(Some(snapshot)) => {
+                let entries = snapshot.windows.values().map(|g| g.len()).sum::<usize>();
+                let mut engine = shared_engine.lock().unwrap();
+                engine.import_state(&snapshot);
+                tracing::info!(
+                    state_entries = entries,
+                    "Correlation state restored from database"
+                );
+            }
+            Ok(None) => {
+                tracing::info!("No previous correlation state found in database");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to load state from database, starting fresh");
             }
         }
     }
@@ -161,6 +195,32 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
     });
 
+    // Spawn periodic state saver
+    if let Some(ref store) = state_store {
+        let save_engine = shared_engine.clone();
+        let save_store = store.clone();
+        let save_interval_secs = config.state_save_interval;
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(save_interval_secs));
+            interval.tick().await; // skip first immediate tick
+            loop {
+                interval.tick().await;
+                let snapshot = {
+                    let engine = save_engine.lock().unwrap();
+                    engine.export_state()
+                };
+                if let Some(snapshot) = snapshot {
+                    if let Err(e) = save_store.save(&snapshot).await {
+                        tracing::warn!(error = %e, "Failed to save periodic state snapshot");
+                    } else {
+                        tracing::debug!("Periodic state snapshot saved");
+                    }
+                }
+            }
+        });
+    }
+
     // Spawn stdin reader in a blocking thread
     let stdin_engine = shared_engine.clone();
     let stdin_metrics = metrics.clone();
@@ -200,6 +260,20 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
         _ = stdin_handle => {
             tracing::info!("stdin processing complete");
+        }
+    }
+
+    // Save state on shutdown
+    if let Some(ref store) = state_store {
+        let snapshot = {
+            let engine = shared_engine.lock().unwrap();
+            engine.export_state()
+        };
+        if let Some(snapshot) = snapshot {
+            match store.save(&snapshot).await {
+                Ok(()) => tracing::info!("Correlation state saved to database on shutdown"),
+                Err(e) => tracing::error!(error = %e, "Failed to save state on shutdown"),
+            }
         }
     }
 }

--- a/crates/rsigma-cli/src/daemon/state.rs
+++ b/crates/rsigma-cli/src/daemon/state.rs
@@ -44,8 +44,12 @@ impl DaemonEngine {
     }
 
     /// Load (or reload) rules from the configured path.
-    /// Returns Ok(()) on success, or an error string.
+    ///
+    /// On reload, correlation state is exported before replacing the engine
+    /// and re-imported after, so in-flight windows and suppression state
+    /// survive rule changes (entries for removed correlations are dropped).
     pub fn load_rules(&mut self) -> Result<EngineStats, String> {
+        let previous_state = self.export_state();
         let collection = load_collection(&self.rules_path)?;
         let has_correlations = !collection.correlations.is_empty();
 
@@ -59,10 +63,14 @@ impl DaemonEngine {
                 .add_collection(&collection)
                 .map_err(|e| format!("Error compiling rules: {e}"))?;
 
+            if let Some(snapshot) = previous_state {
+                engine.import_state(snapshot);
+            }
+
             let stats = EngineStats {
                 detection_rules: engine.detection_rule_count(),
                 correlation_rules: engine.correlation_rule_count(),
-                state_entries: 0,
+                state_entries: engine.state_count(),
             };
             self.engine = EngineVariant::WithCorrelations(Box::new(engine));
             Ok(stats)
@@ -128,10 +136,13 @@ impl DaemonEngine {
     }
 
     /// Import previously exported correlation state.
-    /// No-op if the engine is detection-only or snapshot is `None`.
-    pub fn import_state(&mut self, snapshot: &CorrelationSnapshot) {
+    /// Returns `true` if the import succeeded, `false` if the snapshot version
+    /// is incompatible. No-op (returns `true`) if the engine is detection-only.
+    pub fn import_state(&mut self, snapshot: &CorrelationSnapshot) -> bool {
         if let EngineVariant::WithCorrelations(engine) = &mut self.engine {
-            engine.import_state(snapshot.clone());
+            engine.import_state(snapshot.clone())
+        } else {
+            true
         }
     }
 }

--- a/crates/rsigma-cli/src/daemon/state.rs
+++ b/crates/rsigma-cli/src/daemon/state.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 
-use rsigma_eval::{CorrelationConfig, CorrelationEngine, Engine, Event, Pipeline, ProcessResult};
+use rsigma_eval::{
+    CorrelationConfig, CorrelationEngine, CorrelationSnapshot, Engine, Event, Pipeline,
+    ProcessResult,
+};
 use rsigma_parser::SigmaCollection;
 
 /// Wraps a CorrelationEngine (or a plain Engine) and provides the interface
@@ -113,6 +116,23 @@ impl DaemonEngine {
 
     pub fn rules_path(&self) -> &Path {
         &self.rules_path
+    }
+
+    /// Export correlation state as a serializable snapshot.
+    /// Returns `None` if the engine is detection-only (no correlation state to persist).
+    pub fn export_state(&self) -> Option<CorrelationSnapshot> {
+        match &self.engine {
+            EngineVariant::DetectionOnly(_) => None,
+            EngineVariant::WithCorrelations(engine) => Some(engine.export_state()),
+        }
+    }
+
+    /// Import previously exported correlation state.
+    /// No-op if the engine is detection-only or snapshot is `None`.
+    pub fn import_state(&mut self, snapshot: &CorrelationSnapshot) {
+        if let EngineVariant::WithCorrelations(engine) = &mut self.engine {
+            engine.import_state(snapshot.clone());
+        }
     }
 }
 

--- a/crates/rsigma-cli/src/daemon/store.rs
+++ b/crates/rsigma-cli/src/daemon/store.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rsigma_eval::CorrelationSnapshot;
+
+/// SQLite-backed state store for persisting correlation state across restarts.
+///
+/// Follows the same pattern as helr's `SqliteStateStore`: a single
+/// `rusqlite::Connection` behind `Arc<Mutex<_>>`, with all DB work running
+/// in `tokio::task::spawn_blocking` to avoid blocking the async runtime.
+pub struct SqliteStateStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+impl SqliteStateStore {
+    /// Open (or create) a SQLite database at `path` and initialize the schema.
+    pub fn open(path: &Path) -> Result<Self, String> {
+        let conn = rusqlite::Connection::open(path)
+            .map_err(|e| format!("open sqlite {:?}: {}", path, e))?;
+
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode = WAL;
+            CREATE TABLE IF NOT EXISTS rsigma_correlation_state (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                snapshot TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+            "#,
+        )
+        .map_err(|e| format!("init sqlite schema: {e}"))?;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Save a correlation snapshot to the database.
+    /// Replaces any existing snapshot (single-row table).
+    pub async fn save(&self, snapshot: &CorrelationSnapshot) -> Result<(), String> {
+        let json =
+            serde_json::to_string(snapshot).map_err(|e| format!("serialize snapshot: {e}"))?;
+        let conn = self.conn.clone();
+        let updated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        tokio::task::spawn_blocking(move || {
+            let c = conn.lock().map_err(|_| "state store lock poisoned")?;
+            c.execute(
+                "INSERT INTO rsigma_correlation_state (id, snapshot, updated_at) VALUES (1, ?1, ?2)
+                 ON CONFLICT (id) DO UPDATE SET snapshot = ?1, updated_at = ?2",
+                rusqlite::params![&json, updated_at],
+            )
+            .map_err(|e| format!("save snapshot: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("spawn_blocking: {e}"))?
+    }
+
+    /// Load the most recent correlation snapshot from the database.
+    /// Returns `None` if no snapshot has been saved yet.
+    pub async fn load(&self) -> Result<Option<CorrelationSnapshot>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let c = conn.lock().map_err(|_| "state store lock poisoned")?;
+            let mut stmt = c
+                .prepare("SELECT snapshot FROM rsigma_correlation_state WHERE id = 1")
+                .map_err(|e| format!("prepare load: {e}"))?;
+            let mut rows = stmt.query([]).map_err(|e| format!("query: {e}"))?;
+            if let Some(row) = rows.next().map_err(|e| format!("next: {e}"))? {
+                let json: String = row.get(0).map_err(|e| format!("get: {e}"))?;
+                let snapshot: CorrelationSnapshot = serde_json::from_str(&json)
+                    .map_err(|e| format!("deserialize snapshot: {e}"))?;
+                Ok(Some(snapshot))
+            } else {
+                Ok(None)
+            }
+        })
+        .await
+        .map_err(|e| format!("spawn_blocking: {e}"))?
+    }
+}

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -172,7 +172,7 @@ enum Commands {
 
         /// Interval in seconds between periodic state snapshots (default: 30).
         /// Only meaningful when --state-db is set.
-        #[arg(long = "state-save-interval", default_value = "30")]
+        #[arg(long = "state-save-interval", default_value = "30", value_parser = clap::value_parser!(u64).range(1..))]
         state_save_interval: u64,
     },
 

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -164,6 +164,16 @@ enum Commands {
         /// Event field name(s) for timestamp extraction in correlations
         #[arg(long = "timestamp-field")]
         timestamp_fields: Vec<String>,
+
+        /// Path to SQLite database for persisting correlation state across restarts.
+        /// When set, state is loaded on startup and saved periodically + on shutdown.
+        #[arg(long = "state-db")]
+        state_db: Option<PathBuf>,
+
+        /// Interval in seconds between periodic state snapshots (default: 30).
+        /// Only meaningful when --state-db is set.
+        #[arg(long = "state-save-interval", default_value = "30")]
+        state_save_interval: u64,
     },
 
     /// Evaluate events against Sigma rules
@@ -263,6 +273,8 @@ fn main() {
             correlation_event_mode,
             max_correlation_events,
             timestamp_fields,
+            state_db,
+            state_save_interval,
         } => cmd_daemon(
             rules,
             pipelines,
@@ -277,6 +289,8 @@ fn main() {
             correlation_event_mode,
             max_correlation_events,
             timestamp_fields,
+            state_db,
+            state_save_interval,
         ),
         Commands::Parse { path, pretty } => cmd_parse(path, pretty),
         Commands::Validate {
@@ -355,6 +369,8 @@ fn cmd_daemon(
     correlation_event_mode: String,
     max_correlation_events: usize,
     timestamp_fields: Vec<String>,
+    state_db: Option<PathBuf>,
+    state_save_interval: u64,
 ) {
     // Set up structured logging
     tracing_subscriber::fmt()
@@ -391,6 +407,8 @@ fn cmd_daemon(
         pretty,
         api_addr: addr,
         event_filter,
+        state_db,
+        state_save_interval,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/tests/cli.rs
+++ b/crates/rsigma-cli/tests/cli.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1306,5 +1306,243 @@ detection:
         fixed.matches("attack.execution").count(),
         1,
         "duplicate tag should be removed"
+    );
+}
+
+// ===========================================================================
+// Daemon state persistence (--state-db)
+// ===========================================================================
+
+const DAEMON_CORRELATION_RULES: &str = r#"
+title: Login
+id: login-rule
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login
+    condition: selection
+---
+title: Many Logins
+id: many-logins
+correlation:
+    type: event_count
+    rules:
+        - login-rule
+    group-by:
+        - User
+    timespan: 300s
+    condition:
+        gte: 3
+level: high
+"#;
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_state_db_created_on_first_run() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    assert!(!db_path.exists());
+
+    rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin("")
+        .assert()
+        .success();
+
+    assert!(db_path.exists(), "state.db should be created on first run");
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_state_persists_across_restarts() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Run 1: send 2 events (below threshold of 3), state should be saved
+    let events_run1 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                        {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    let output1 = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events_run1)
+        .output()
+        .unwrap();
+
+    assert!(output1.status.success());
+    let stdout1 = String::from_utf8_lossy(&output1.stdout);
+    assert!(
+        stdout1.trim().is_empty(),
+        "Run 1: no correlation output expected (only 2 events), got: {stdout1}"
+    );
+
+    // Run 2: send 1 more event — restored 2 + new 1 = 3, should trigger
+    let events_run2 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    let output2 = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events_run2)
+        .output()
+        .unwrap();
+
+    assert!(output2.status.success());
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        stdout2.contains("\"rule_title\":\"Many Logins\""),
+        "Run 2: correlation should fire with restored state, got: {stdout2}"
+    );
+    assert!(
+        stdout2.contains("\"aggregated_value\":3.0"),
+        "Run 2: aggregated value should be 3.0, got: {stdout2}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_state_db_multiple_groups() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Run 1: 2 events for admin, 1 for bob
+    let events_run1 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                        {\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                        {\"EventType\":\"login\",\"User\":\"bob\"}\n";
+    rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events_run1)
+        .assert()
+        .success();
+
+    // Run 2: 1 event for admin (fires), 1 for bob (still 2, no fire)
+    let events_run2 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                        {\"EventType\":\"login\",\"User\":\"bob\"}\n";
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events_run2)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "exactly one correlation should fire (admin), got: {stdout}"
+    );
+    assert!(lines[0].contains("\"aggregated_value\":3.0"));
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_without_state_db_works() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+
+    let events = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Many Logins\""),
+        "daemon should work without --state-db, got: {stdout}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_detection_only_with_state_db() {
+    let rules_yaml = r#"
+title: Test Rule
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains: "whoami"
+    condition: selection
+level: medium
+"#;
+    let rules = temp_file(".yml", rules_yaml);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+        ])
+        .write_stdin("{\"CommandLine\":\"cmd /c whoami\"}\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Test Rule\""),
+        "detection should still work with --state-db on detection-only rules"
     );
 }

--- a/crates/rsigma-eval/src/correlation.rs
+++ b/crates/rsigma-eval/src/correlation.rs
@@ -213,10 +213,61 @@ const COMPRESSION_LEVEL: Compression = Compression::fast();
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct EventBuffer {
     /// (timestamp, deflate-compressed event JSON) pairs, ordered by timestamp.
+    #[serde(with = "event_buffer_serde")]
     entries: VecDeque<(i64, Vec<u8>)>,
     /// Maximum number of events to retain. When exceeded, the oldest event is
     /// evicted regardless of the time window.
     max_events: usize,
+}
+
+/// Custom serde for EventBuffer entries: encodes compressed bytes as base64
+/// instead of JSON number arrays, cutting snapshot size ~3x.
+mod event_buffer_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::VecDeque;
+
+    #[derive(Serialize, Deserialize)]
+    struct Entry {
+        ts: i64,
+        #[serde(with = "base64_bytes")]
+        data: Vec<u8>,
+    }
+
+    mod base64_bytes {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::STANDARD;
+        use serde::{Deserializer, Serializer};
+
+        pub fn serialize<S: Serializer>(bytes: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+            s.serialize_str(&STANDARD.encode(bytes))
+        }
+
+        pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+            let s: String = serde::Deserialize::deserialize(d)?;
+            STANDARD.decode(s).map_err(serde::de::Error::custom)
+        }
+    }
+
+    pub fn serialize<S: Serializer>(
+        entries: &VecDeque<(i64, Vec<u8>)>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        let v: Vec<Entry> = entries
+            .iter()
+            .map(|(ts, data)| Entry {
+                ts: *ts,
+                data: data.clone(),
+            })
+            .collect();
+        v.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<VecDeque<(i64, Vec<u8>)>, D::Error> {
+        let v: Vec<Entry> = Vec::deserialize(d)?;
+        Ok(v.into_iter().map(|e| (e.ts, e.data)).collect())
+    }
 }
 
 impl EventBuffer {

--- a/crates/rsigma-eval/src/correlation.rs
+++ b/crates/rsigma-eval/src/correlation.rs
@@ -132,7 +132,7 @@ impl CompiledCondition {
 ///
 /// Each element corresponds to a `GroupByField` value extracted from an event.
 /// `None` means the field was absent from the event.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, serde::Deserialize)]
 pub struct GroupKey(pub Vec<Option<String>>);
 
 impl GroupKey {
@@ -210,7 +210,7 @@ const COMPRESSION_LEVEL: Compression = Compression::fast();
 ///
 /// The buffer enforces a hard cap (`max_events`) so memory is bounded at:
 ///   `max_events × (avg_compressed_size + 24)` bytes per group key.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct EventBuffer {
     /// (timestamp, deflate-compressed event JSON) pairs, ordered by timestamp.
     entries: VecDeque<(i64, Vec<u8>)>,
@@ -301,7 +301,7 @@ fn decompress_event(compressed: &[u8]) -> Option<serde_json::Value> {
 /// Each ref costs ~40 bytes (vs. 100–1000+ bytes for compressed events),
 /// making this mode suitable for high-volume correlations where only
 /// traceability is needed.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct EventRef {
     /// Event timestamp (epoch seconds).
     pub timestamp: i64,
@@ -314,7 +314,7 @@ pub struct EventRef {
 ///
 /// Stores only timestamps and optional event IDs — no event payload,
 /// no compression. This is the minimal-memory alternative to `EventBuffer`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct EventRefBuffer {
     /// Event references, ordered by timestamp.
     entries: VecDeque<EventRef>,
@@ -393,7 +393,7 @@ fn extract_event_id(event: &serde_json::Value) -> Option<String> {
 /// Per-group mutable state within a time window.
 ///
 /// Each variant matches the type of aggregation being performed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub enum WindowState {
     /// For `event_count`: timestamps of matching events.
     EventCount { timestamps: VecDeque<i64> },

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -1156,6 +1156,7 @@ impl CorrelationEngine {
         }
 
         CorrelationSnapshot {
+            version: SNAPSHOT_VERSION,
             windows,
             last_alert,
             event_buffers,
@@ -1166,7 +1167,13 @@ impl CorrelationEngine {
     /// Import previously exported state, mapping stable identifiers back to
     /// current correlation indices. Entries whose identifiers no longer match
     /// any loaded correlation are silently dropped.
-    pub fn import_state(&mut self, snapshot: CorrelationSnapshot) {
+    ///
+    /// Returns `false` (and imports nothing) if the snapshot version is
+    /// incompatible with the current schema.
+    pub fn import_state(&mut self, snapshot: CorrelationSnapshot) -> bool {
+        if snapshot.version != SNAPSHOT_VERSION {
+            return false;
+        }
         let id_to_idx = self.build_id_to_index_map();
 
         for (corr_id, groups) in snapshot.windows {
@@ -1200,6 +1207,8 @@ impl CorrelationEngine {
                 }
             }
         }
+
+        true
     }
 
     /// Stable identifier for a correlation rule: prefers id, then name, then title.
@@ -1221,6 +1230,9 @@ impl CorrelationEngine {
     }
 }
 
+/// Current snapshot schema version. Bump when the serialized format changes.
+const SNAPSHOT_VERSION: u32 = 1;
+
 /// Serializable snapshot of all mutable correlation state.
 ///
 /// Uses stable string identifiers (correlation id/name/title) as keys so the
@@ -1229,6 +1241,9 @@ impl CorrelationEngine {
 /// `GroupKey` cannot be used as a JSON object key.
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct CorrelationSnapshot {
+    /// Schema version — used to detect incompatible snapshots on load.
+    #[serde(default = "default_snapshot_version")]
+    pub version: u32,
     /// Per-correlation, per-group window state.
     pub windows: HashMap<String, Vec<(GroupKey, WindowState)>>,
     /// Per-correlation, per-group last alert timestamp (for suppression).
@@ -1237,6 +1252,10 @@ pub struct CorrelationSnapshot {
     pub event_buffers: HashMap<String, Vec<(GroupKey, EventBuffer)>>,
     /// Per-correlation, per-group event reference buffers.
     pub event_ref_buffers: HashMap<String, Vec<(GroupKey, EventRefBuffer)>>,
+}
+
+fn default_snapshot_version() -> u32 {
+    1
 }
 
 impl Default for CorrelationEngine {

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -1111,6 +1111,132 @@ impl CorrelationEngine {
     pub fn engine(&self) -> &Engine {
         &self.engine
     }
+
+    /// Export all mutable correlation state as a serializable snapshot.
+    ///
+    /// The snapshot uses stable correlation identifiers (id > name > title)
+    /// instead of internal indices, so it survives rule reloads as long as
+    /// the correlation rules keep the same identifiers.
+    pub fn export_state(&self) -> CorrelationSnapshot {
+        let mut windows: HashMap<String, Vec<(GroupKey, WindowState)>> = HashMap::new();
+        for ((idx, gk), ws) in &self.state {
+            let corr_id = self.correlation_stable_id(*idx);
+            windows
+                .entry(corr_id)
+                .or_default()
+                .push((gk.clone(), ws.clone()));
+        }
+
+        let mut last_alert: HashMap<String, Vec<(GroupKey, i64)>> = HashMap::new();
+        for ((idx, gk), ts) in &self.last_alert {
+            let corr_id = self.correlation_stable_id(*idx);
+            last_alert
+                .entry(corr_id)
+                .or_default()
+                .push((gk.clone(), *ts));
+        }
+
+        let mut event_buffers: HashMap<String, Vec<(GroupKey, EventBuffer)>> = HashMap::new();
+        for ((idx, gk), buf) in &self.event_buffers {
+            let corr_id = self.correlation_stable_id(*idx);
+            event_buffers
+                .entry(corr_id)
+                .or_default()
+                .push((gk.clone(), buf.clone()));
+        }
+
+        let mut event_ref_buffers: HashMap<String, Vec<(GroupKey, EventRefBuffer)>> =
+            HashMap::new();
+        for ((idx, gk), buf) in &self.event_ref_buffers {
+            let corr_id = self.correlation_stable_id(*idx);
+            event_ref_buffers
+                .entry(corr_id)
+                .or_default()
+                .push((gk.clone(), buf.clone()));
+        }
+
+        CorrelationSnapshot {
+            windows,
+            last_alert,
+            event_buffers,
+            event_ref_buffers,
+        }
+    }
+
+    /// Import previously exported state, mapping stable identifiers back to
+    /// current correlation indices. Entries whose identifiers no longer match
+    /// any loaded correlation are silently dropped.
+    pub fn import_state(&mut self, snapshot: CorrelationSnapshot) {
+        let id_to_idx = self.build_id_to_index_map();
+
+        for (corr_id, groups) in snapshot.windows {
+            if let Some(&idx) = id_to_idx.get(&corr_id) {
+                for (gk, ws) in groups {
+                    self.state.insert((idx, gk), ws);
+                }
+            }
+        }
+
+        for (corr_id, groups) in snapshot.last_alert {
+            if let Some(&idx) = id_to_idx.get(&corr_id) {
+                for (gk, ts) in groups {
+                    self.last_alert.insert((idx, gk), ts);
+                }
+            }
+        }
+
+        for (corr_id, groups) in snapshot.event_buffers {
+            if let Some(&idx) = id_to_idx.get(&corr_id) {
+                for (gk, buf) in groups {
+                    self.event_buffers.insert((idx, gk), buf);
+                }
+            }
+        }
+
+        for (corr_id, groups) in snapshot.event_ref_buffers {
+            if let Some(&idx) = id_to_idx.get(&corr_id) {
+                for (gk, buf) in groups {
+                    self.event_ref_buffers.insert((idx, gk), buf);
+                }
+            }
+        }
+    }
+
+    /// Stable identifier for a correlation rule: prefers id, then name, then title.
+    fn correlation_stable_id(&self, idx: usize) -> String {
+        let corr = &self.correlations[idx];
+        corr.id
+            .clone()
+            .or_else(|| corr.name.clone())
+            .unwrap_or_else(|| corr.title.clone())
+    }
+
+    /// Build a reverse map from stable id → current correlation index.
+    fn build_id_to_index_map(&self) -> HashMap<String, usize> {
+        self.correlations
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| (self.correlation_stable_id(idx), idx))
+            .collect()
+    }
+}
+
+/// Serializable snapshot of all mutable correlation state.
+///
+/// Uses stable string identifiers (correlation id/name/title) as keys so the
+/// snapshot can be restored after a rule reload, even if internal indices change.
+/// Inner maps use `Vec<(GroupKey, T)>` instead of `HashMap<GroupKey, T>` because
+/// `GroupKey` cannot be used as a JSON object key.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CorrelationSnapshot {
+    /// Per-correlation, per-group window state.
+    pub windows: HashMap<String, Vec<(GroupKey, WindowState)>>,
+    /// Per-correlation, per-group last alert timestamp (for suppression).
+    pub last_alert: HashMap<String, Vec<(GroupKey, i64)>>,
+    /// Per-correlation, per-group compressed event buffers.
+    pub event_buffers: HashMap<String, Vec<(GroupKey, EventBuffer)>>,
+    /// Per-correlation, per-group event reference buffers.
+    pub event_ref_buffers: HashMap<String, Vec<(GroupKey, EventRefBuffer)>>,
 }
 
 impl Default for CorrelationEngine {

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -107,7 +107,7 @@ pub use correlation::{
 };
 pub use correlation_engine::{
     CorrelationAction, CorrelationConfig, CorrelationEngine, CorrelationEventMode,
-    CorrelationResult, ProcessResult, TimestampFallback,
+    CorrelationResult, CorrelationSnapshot, ProcessResult, TimestampFallback,
 };
 pub use engine::Engine;
 pub use error::{EvalError, Result};

--- a/crates/rsigma-eval/tests/state_snapshot.rs
+++ b/crates/rsigma-eval/tests/state_snapshot.rs
@@ -383,12 +383,13 @@ detection:
     // Engine with only detection rules, no correlations
     let mut engine = corr_engine(yaml);
     let snapshot = CorrelationSnapshot {
+        version: 1,
         windows: Default::default(),
         last_alert: Default::default(),
         event_buffers: Default::default(),
         event_ref_buffers: Default::default(),
     };
-    engine.import_state(snapshot);
+    assert!(engine.import_state(snapshot));
     assert_eq!(engine.state_count(), 0);
 }
 
@@ -410,4 +411,21 @@ fn expired_state_not_restored_after_window() {
         r.correlations.is_empty(),
         "old restored events should be evicted by the time window"
     );
+}
+
+#[test]
+fn import_rejects_incompatible_version() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+
+    let mut snapshot = engine.export_state();
+    snapshot.version = 999;
+
+    let mut engine2 = corr_engine(EVENT_COUNT_YAML);
+    assert!(
+        !engine2.import_state(snapshot),
+        "import should reject incompatible version"
+    );
+    assert_eq!(engine2.state_count(), 0, "no state should be imported");
 }

--- a/crates/rsigma-eval/tests/state_snapshot.rs
+++ b/crates/rsigma-eval/tests/state_snapshot.rs
@@ -1,0 +1,413 @@
+mod helpers;
+
+use helpers::{corr_engine, corr_engine_with_config, process};
+use rsigma_eval::{CorrelationConfig, CorrelationEventMode, CorrelationSnapshot};
+use serde_json::json;
+
+const EVENT_COUNT_YAML: &str = r#"
+title: Login
+id: login-rule
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login
+    condition: selection
+---
+title: Many Logins
+id: many-logins
+correlation:
+    type: event_count
+    rules:
+        - login-rule
+    group-by:
+        - User
+    timespan: 300s
+    condition:
+        gte: 3
+level: high
+"#;
+
+const VALUE_COUNT_YAML: &str = r#"
+title: Login
+id: login-rule
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login
+    condition: selection
+---
+title: Many Sources
+id: many-sources
+correlation:
+    type: value_count
+    rules:
+        - login-rule
+    group-by:
+        - User
+    timespan: 300s
+    condition:
+        field: SourceIP
+        gte: 3
+level: high
+"#;
+
+const TEMPORAL_YAML: &str = r#"
+title: Recon
+id: recon-rule
+logsource:
+    category: network
+detection:
+    selection:
+        EventType: recon
+    condition: selection
+---
+title: Exploit
+id: exploit-rule
+logsource:
+    category: network
+detection:
+    selection:
+        EventType: exploit
+    condition: selection
+---
+title: Recon Then Exploit
+id: recon-exploit
+correlation:
+    type: temporal
+    rules:
+        - recon-rule
+        - exploit-rule
+    group-by:
+        - Host
+    timespan: 120s
+    condition:
+        gte: 2
+level: critical
+"#;
+
+fn login_event(user: &str) -> serde_json::Value {
+    json!({"EventType": "login", "User": user})
+}
+
+fn login_event_with_ip(user: &str, ip: &str) -> serde_json::Value {
+    json!({"EventType": "login", "User": user, "SourceIP": ip})
+}
+
+// =============================================================================
+// Snapshot round-trip serialization
+// =============================================================================
+
+#[test]
+fn snapshot_empty_engine_exports_empty() {
+    let engine = corr_engine(EVENT_COUNT_YAML);
+    let snapshot = engine.export_state();
+    assert!(snapshot.windows.is_empty());
+    assert!(snapshot.last_alert.is_empty());
+    assert!(snapshot.event_buffers.is_empty());
+    assert!(snapshot.event_ref_buffers.is_empty());
+}
+
+#[test]
+fn snapshot_json_round_trip() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+
+    let snapshot = engine.export_state();
+    let json = serde_json::to_string(&snapshot).unwrap();
+    let restored: CorrelationSnapshot = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(snapshot.windows.len(), restored.windows.len());
+    for (corr_id, entries) in &snapshot.windows {
+        let restored_entries = restored.windows.get(corr_id).unwrap();
+        assert_eq!(entries.len(), restored_entries.len());
+    }
+}
+
+#[test]
+fn snapshot_uses_stable_ids_not_indices() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    process(&mut engine, login_event("admin"), 1000);
+
+    let snapshot = engine.export_state();
+    assert!(
+        snapshot.windows.contains_key("many-logins"),
+        "snapshot should use correlation id as key, got: {:?}",
+        snapshot.windows.keys().collect::<Vec<_>>()
+    );
+}
+
+// =============================================================================
+// Export → import preserves state
+// =============================================================================
+
+#[test]
+fn export_import_preserves_event_count_state() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    // Feed 2 events (below threshold of 3)
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+    assert_eq!(engine.state_count(), 1);
+
+    let snapshot = engine.export_state();
+
+    // Create a fresh engine and import the snapshot
+    let mut engine2 = corr_engine(EVENT_COUNT_YAML);
+    assert_eq!(engine2.state_count(), 0);
+    engine2.import_state(snapshot);
+    assert_eq!(engine2.state_count(), 1);
+
+    // One more event should trigger the correlation (2 restored + 1 new = 3)
+    let result = process(&mut engine2, login_event("admin"), 1002);
+    assert_eq!(
+        result.correlations.len(),
+        1,
+        "correlation should fire with restored state + new event"
+    );
+    assert_eq!(result.correlations[0].aggregated_value, 3.0);
+}
+
+#[test]
+fn export_import_preserves_value_count_state() {
+    let mut engine = corr_engine(VALUE_COUNT_YAML);
+    process(&mut engine, login_event_with_ip("admin", "10.0.0.1"), 1000);
+    process(&mut engine, login_event_with_ip("admin", "10.0.0.2"), 1001);
+
+    let snapshot = engine.export_state();
+    let mut engine2 = corr_engine(VALUE_COUNT_YAML);
+    engine2.import_state(snapshot);
+
+    // Third distinct SourceIP should trigger value_count >= 3
+    let result = process(&mut engine2, login_event_with_ip("admin", "10.0.0.3"), 1002);
+    assert_eq!(result.correlations.len(), 1);
+    assert_eq!(result.correlations[0].aggregated_value, 3.0);
+}
+
+#[test]
+fn export_import_preserves_temporal_state() {
+    let mut engine = corr_engine(TEMPORAL_YAML);
+    process(
+        &mut engine,
+        json!({"EventType": "recon", "Host": "srv1"}),
+        1000,
+    );
+
+    let snapshot = engine.export_state();
+    let mut engine2 = corr_engine(TEMPORAL_YAML);
+    engine2.import_state(snapshot);
+
+    // Exploit after recon should trigger temporal correlation
+    let result = process(
+        &mut engine2,
+        json!({"EventType": "exploit", "Host": "srv1"}),
+        1010,
+    );
+    assert_eq!(
+        result.correlations.len(),
+        1,
+        "temporal correlation should fire with restored recon + new exploit"
+    );
+}
+
+#[test]
+fn export_import_preserves_multiple_groups() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+    process(&mut engine, login_event("bob"), 1000);
+    assert_eq!(engine.state_count(), 2);
+
+    let snapshot = engine.export_state();
+    let mut engine2 = corr_engine(EVENT_COUNT_YAML);
+    engine2.import_state(snapshot);
+    assert_eq!(engine2.state_count(), 2);
+
+    // admin: 2 restored + 1 = 3 → fires
+    let r = process(&mut engine2, login_event("admin"), 1002);
+    assert_eq!(r.correlations.len(), 1);
+
+    // bob: 1 restored + 1 = 2 → doesn't fire
+    let r = process(&mut engine2, login_event("bob"), 1002);
+    assert!(r.correlations.is_empty());
+}
+
+// =============================================================================
+// Suppression state persistence
+// =============================================================================
+
+#[test]
+fn export_import_preserves_suppression_state() {
+    let config = CorrelationConfig {
+        suppress: Some(60),
+        ..CorrelationConfig::default()
+    };
+    let mut engine = corr_engine_with_config(EVENT_COUNT_YAML, config.clone());
+
+    // Trigger correlation
+    for i in 0..3 {
+        process(&mut engine, login_event("admin"), 1000 + i);
+    }
+    // Should be suppressed now
+    let r = process(&mut engine, login_event("admin"), 1004);
+    assert!(r.correlations.is_empty(), "should be suppressed");
+
+    let snapshot = engine.export_state();
+    assert!(
+        !snapshot.last_alert.is_empty(),
+        "last_alert should be populated"
+    );
+
+    let mut engine2 = corr_engine_with_config(EVENT_COUNT_YAML, config);
+    engine2.import_state(snapshot);
+
+    // Should still be suppressed in the restored engine (within 60s window)
+    for i in 0..3 {
+        process(&mut engine2, login_event("admin"), 1010 + i);
+    }
+    let r = process(&mut engine2, login_event("admin"), 1013);
+    assert!(
+        r.correlations.is_empty(),
+        "suppression should survive restore"
+    );
+}
+
+// =============================================================================
+// Event buffer persistence
+// =============================================================================
+
+#[test]
+fn export_import_preserves_event_buffers_full_mode() {
+    let config = CorrelationConfig {
+        correlation_event_mode: CorrelationEventMode::Full,
+        max_correlation_events: 10,
+        ..CorrelationConfig::default()
+    };
+    let mut engine = corr_engine_with_config(EVENT_COUNT_YAML, config.clone());
+
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+
+    let snapshot = engine.export_state();
+    assert!(
+        !snapshot.event_buffers.is_empty(),
+        "event_buffers should be populated in Full mode"
+    );
+
+    // Serialize and deserialize the snapshot (simulates SQLite round-trip)
+    let json = serde_json::to_string(&snapshot).unwrap();
+    let restored: CorrelationSnapshot = serde_json::from_str(&json).unwrap();
+
+    let mut engine2 = corr_engine_with_config(EVENT_COUNT_YAML, config);
+    engine2.import_state(restored);
+
+    // Third event triggers correlation with events from buffer
+    let r = process(&mut engine2, login_event("admin"), 1002);
+    assert_eq!(r.correlations.len(), 1);
+    assert!(
+        r.correlations[0].events.is_some(),
+        "events should be included from restored buffer"
+    );
+}
+
+#[test]
+fn export_import_preserves_event_ref_buffers() {
+    let config = CorrelationConfig {
+        correlation_event_mode: CorrelationEventMode::Refs,
+        max_correlation_events: 10,
+        ..CorrelationConfig::default()
+    };
+    let mut engine = corr_engine_with_config(EVENT_COUNT_YAML, config.clone());
+
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+
+    let snapshot = engine.export_state();
+    assert!(
+        !snapshot.event_ref_buffers.is_empty(),
+        "event_ref_buffers should be populated in Refs mode"
+    );
+
+    let json = serde_json::to_string(&snapshot).unwrap();
+    let restored: CorrelationSnapshot = serde_json::from_str(&json).unwrap();
+
+    let mut engine2 = corr_engine_with_config(EVENT_COUNT_YAML, config);
+    engine2.import_state(restored);
+
+    let r = process(&mut engine2, login_event("admin"), 1002);
+    assert_eq!(r.correlations.len(), 1);
+    assert!(
+        r.correlations[0].event_refs.is_some(),
+        "event_refs should be included from restored buffer"
+    );
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn import_drops_unknown_correlation_ids() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    process(&mut engine, login_event("admin"), 1000);
+
+    let mut snapshot = engine.export_state();
+    // Rename the correlation id to something that doesn't exist
+    let entries = snapshot.windows.remove("many-logins").unwrap();
+    snapshot
+        .windows
+        .insert("nonexistent-rule".to_string(), entries);
+
+    let mut engine2 = corr_engine(EVENT_COUNT_YAML);
+    engine2.import_state(snapshot);
+    assert_eq!(
+        engine2.state_count(),
+        0,
+        "unknown correlation ids should be dropped"
+    );
+}
+
+#[test]
+fn import_into_empty_engine_is_noop() {
+    let yaml = r#"
+title: Login
+id: login-rule
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login
+    condition: selection
+"#;
+    // Engine with only detection rules, no correlations
+    let mut engine = corr_engine(yaml);
+    let snapshot = CorrelationSnapshot {
+        windows: Default::default(),
+        last_alert: Default::default(),
+        event_buffers: Default::default(),
+        event_ref_buffers: Default::default(),
+    };
+    engine.import_state(snapshot);
+    assert_eq!(engine.state_count(), 0);
+}
+
+#[test]
+fn expired_state_not_restored_after_window() {
+    let mut engine = corr_engine(EVENT_COUNT_YAML);
+    process(&mut engine, login_event("admin"), 1000);
+    process(&mut engine, login_event("admin"), 1001);
+
+    let snapshot = engine.export_state();
+
+    let mut engine2 = corr_engine(EVENT_COUNT_YAML);
+    engine2.import_state(snapshot);
+
+    // Process event far in the future (past the 300s window)
+    // The restored timestamps (1000, 1001) should be evicted
+    let r = process(&mut engine2, login_event("admin"), 2000);
+    assert!(
+        r.correlations.is_empty(),
+        "old restored events should be evicted by the time window"
+    );
+}


### PR DESCRIPTION
## Summary

Correlation state (window entries, suppression timestamps, event buffers) can now survive daemon restarts via an opt-in SQLite-backed state store.

- **`rsigma-eval`**: Add `Serialize`/`Deserialize` to `GroupKey`, `WindowState`, `EventBuffer`, `EventRefBuffer`. Add `CorrelationSnapshot` type with schema versioning and `export_state()`/`import_state()` on `CorrelationEngine`, using stable correlation identifiers (id/name/title) instead of internal `usize` indices so state survives rule reloads. Compressed event bytes are base64-encoded in snapshots for ~3x size reduction
- **`rsigma-cli` (daemon)**: Add `SqliteStateStore` following helr's pattern (`rusqlite` bundled, `Arc<Mutex<Connection>>`, `spawn_blocking`). New `--state-db` flag opts into persistence, `--state-save-interval` controls snapshot frequency (default 30s, validated >= 1). State is loaded on startup, saved periodically, and saved on graceful shutdown. WAL journal mode for concurrent reads. Correlation state is preserved across hot-reloads (export before swap, re-import after)
- **19 new tests** covering snapshot round-trip, state persistence across restarts, suppression state, event buffer serialization, version compatibility, edge cases, and CLI integration

### Usage

```bash
# Without persistence (default, same as before)
rsigma daemon -r rules/ -p ecs.yml

# With SQLite state persistence
rsigma daemon -r rules/ -p ecs.yml --state-db ./rsigma-state.db

# With custom save interval (every 10 seconds)
rsigma daemon -r rules/ -p ecs.yml --state-db ./rsigma-state.db --state-save-interval 10
```

### How it works

1. On startup: open (or create) SQLite DB, load rules, restore snapshot if one exists (version-checked)
2. Periodically (default 30s, configurable via `--state-save-interval`): export correlation state and save to DB
3. On hot-reload: export state before replacing engine, re-import after — entries for removed correlations are dropped
4. On shutdown (SIGINT/stdin EOF): final snapshot save
5. On next startup: snapshot is imported, mapping correlation IDs back to current indices

### New files

| File | Purpose |
|------|---------|
| `daemon/store.rs` | `SqliteStateStore` — open, save, load with single-row snapshot table |
| `tests/state_snapshot.rs` | 14 rsigma-eval snapshot tests |
| `tests/cli.rs` (additions) | 5 CLI integration tests for `--state-db` |

### Key design decisions

- **Snapshot versioning**: `CorrelationSnapshot` includes a `version` field (currently 1) validated on import. Incompatible snapshots from future schema changes are cleanly rejected with a warning instead of opaque deserialization errors. Uses `serde(default)` for backward compatibility
- **Base64 encoding**: `EventBuffer` entries contain deflate-compressed payloads. Custom serde module encodes these as base64 strings instead of JSON number arrays, cutting snapshot storage ~3x
- **State across reloads**: `DaemonEngine::load_rules` exports correlation state before swapping the engine and re-imports after, so in-flight windows, suppression timers, and event buffers survive rule changes
- **Interval validation**: `--state-save-interval` uses `clap::value_parser!(u64).range(1..)` to reject 0 at the CLI level, preventing a tight-loop timer

### Test coverage (19 new tests)

**rsigma-eval** (14 tests):
- Snapshot serialization round-trip (empty, populated, JSON)
- Stable ID keys (not indices)
- Export/import for event_count, value_count, temporal correlations
- Multi-group state independence
- Suppression state persistence
- Event buffer persistence (Full and Refs modes)
- Unknown correlation IDs silently dropped
- Expired state correctly evicted after time window
- Incompatible snapshot version rejected

**rsigma-cli** (5 tests):
- `--state-db` creates SQLite file on first run
- State persists across daemon restarts (2 events run 1 + 1 event run 2 = threshold fires)
- Per-group state persists independently
- Daemon works without `--state-db`
- Detection-only rules with `--state-db` don't crash

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — all tests pass
- [x] `cargo audit` clean
- [x] Integration test: 2 events → save → restart → 1 event → correlation fires
- [x] Detection-only engine with `--state-db` works correctly
- [x] Incompatible snapshot version gracefully rejected