### PR TITLE
Close pipeline parity gaps: named condition IDs and correlation rule pipelines

### DIFF
--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -26,7 +26,7 @@ use crate::correlation::{
 use crate::engine::Engine;
 use crate::error::{EvalError, Result};
 use crate::event::Event;
-use crate::pipeline::{Pipeline, apply_pipelines};
+use crate::pipeline::{Pipeline, apply_pipelines, apply_pipelines_to_correlation};
 use crate::result::MatchResult;
 
 // =============================================================================
@@ -390,11 +390,23 @@ impl CorrelationEngine {
 
     /// Add a single correlation rule.
     pub fn add_correlation(&mut self, corr: &CorrelationRule) -> Result<()> {
-        // Apply engine-level custom attributes from the correlation rule
-        // (e.g. rsigma.timestamp_field).
-        self.apply_custom_attributes(&corr.custom_attributes);
+        let owned;
+        let effective = if self.pipelines.is_empty() {
+            corr
+        } else {
+            owned = {
+                let mut c = corr.clone();
+                apply_pipelines_to_correlation(&self.pipelines, &mut c)?;
+                c
+            };
+            &owned
+        };
 
-        let compiled = compile_correlation(corr)?;
+        // Apply engine-level custom attributes from the (possibly transformed)
+        // correlation rule (e.g. rsigma.timestamp_field).
+        self.apply_custom_attributes(&effective.custom_attributes);
+
+        let compiled = compile_correlation(effective)?;
         let idx = self.correlations.len();
 
         // Index by each referenced rule ID/name

--- a/crates/rsigma-eval/src/pipeline/conditions.rs
+++ b/crates/rsigma-eval/src/pipeline/conditions.rs
@@ -15,6 +15,16 @@ use super::state::PipelineState;
 // Rule Conditions
 // =============================================================================
 
+/// A rule condition paired with an optional named ID for use in
+/// `rule_cond_expression` logical expressions.
+#[derive(Debug, Clone)]
+pub struct NamedRuleCondition {
+    /// Optional ID referenced by `rule_cond_expression` (e.g. `"is_windows"`).
+    /// When absent, the condition is addressed by its positional index (`cond_N`).
+    pub id: Option<String>,
+    pub condition: RuleCondition,
+}
+
 /// A condition evaluated against a `SigmaRule` (or `CorrelationRule`).
 #[derive(Debug, Clone)]
 pub enum RuleCondition {
@@ -97,11 +107,13 @@ impl RuleCondition {
 
 /// Check if all rule conditions match for a rule.
 pub fn all_rule_conditions_match(
-    conditions: &[RuleCondition],
+    conditions: &[NamedRuleCondition],
     rule: &SigmaRule,
     state: &PipelineState,
 ) -> bool {
-    conditions.iter().all(|c| c.matches_rule(rule, state))
+    conditions
+        .iter()
+        .all(|c| c.condition.matches_rule(rule, state))
 }
 
 // =============================================================================

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -50,7 +50,8 @@ use regex::Regex;
 use crate::error::{EvalError, Result};
 
 pub use conditions::{
-    DetectionItemCondition, FieldNameCondition, RuleCondition, eval_condition_expr,
+    DetectionItemCondition, FieldNameCondition, NamedRuleCondition, RuleCondition,
+    eval_condition_expr,
 };
 pub use finalizers::Finalizer;
 pub use state::PipelineState;
@@ -83,7 +84,7 @@ pub struct TransformationItem {
     /// The transformation to apply.
     pub transformation: Transformation,
     /// Rule-level conditions (all must match for the transformation to fire).
-    pub rule_conditions: Vec<RuleCondition>,
+    pub rule_conditions: Vec<NamedRuleCondition>,
     /// Optional logical expression over condition IDs.
     pub rule_cond_expr: Option<String>,
     /// Detection-item-level conditions.
@@ -155,15 +156,11 @@ impl Pipeline {
             return true;
         }
 
-        // If there's a logical expression, evaluate it
         if let Some(ref expr) = item.rule_cond_expr {
-            // Build a map of condition ID -> result
-            // For this, conditions would need IDs, but the simple case is
-            // "all must match" (AND logic). We fall back to AND for now.
             let mut results = HashMap::new();
-            for (i, cond) in item.rule_conditions.iter().enumerate() {
-                let id = format!("cond_{i}");
-                results.insert(id, cond.matches_rule(rule, state));
+            for (i, named) in item.rule_conditions.iter().enumerate() {
+                let id = named.id.clone().unwrap_or_else(|| format!("cond_{i}"));
+                results.insert(id, named.condition.matches_rule(rule, state));
             }
             return eval_condition_expr(expr, &results);
         }
@@ -171,7 +168,7 @@ impl Pipeline {
         // Default: all conditions must match (AND)
         item.rule_conditions
             .iter()
-            .all(|c| c.matches_rule(rule, state))
+            .all(|c| c.condition.matches_rule(rule, state))
     }
 }
 
@@ -583,7 +580,7 @@ fn parse_transformation(obj: &serde_yaml::Mapping) -> Result<Transformation> {
 // Condition YAML parsing
 // =============================================================================
 
-fn parse_rule_conditions(value: &serde_yaml::Value) -> Result<Vec<RuleCondition>> {
+fn parse_rule_conditions(value: &serde_yaml::Value) -> Result<Vec<NamedRuleCondition>> {
     let items = value.as_sequence().ok_or_else(|| {
         EvalError::InvalidModifiers("rule_conditions must be a sequence".to_string())
     })?;
@@ -591,10 +588,15 @@ fn parse_rule_conditions(value: &serde_yaml::Value) -> Result<Vec<RuleCondition>
     items.iter().map(parse_rule_condition).collect()
 }
 
-fn parse_rule_condition(value: &serde_yaml::Value) -> Result<RuleCondition> {
+fn parse_rule_condition(value: &serde_yaml::Value) -> Result<NamedRuleCondition> {
     let obj = value.as_mapping().ok_or_else(|| {
         EvalError::InvalidModifiers("rule condition must be a mapping".to_string())
     })?;
+
+    let cond_id = obj
+        .get(ykey("id"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
 
     let type_str = obj
         .get(ykey("type"))
@@ -603,7 +605,7 @@ fn parse_rule_condition(value: &serde_yaml::Value) -> Result<RuleCondition> {
             EvalError::InvalidModifiers("rule condition must have a 'type' field".to_string())
         })?;
 
-    match type_str {
+    let condition = match type_str {
         "logsource" => {
             let category = obj
                 .get(ykey("category"))
@@ -691,7 +693,12 @@ fn parse_rule_condition(value: &serde_yaml::Value) -> Result<RuleCondition> {
         other => Err(EvalError::InvalidModifiers(format!(
             "unknown rule condition type: {other}"
         ))),
-    }
+    }?;
+
+    Ok(NamedRuleCondition {
+        id: cond_id,
+        condition,
+    })
 }
 
 fn parse_detection_item_conditions(
@@ -1370,5 +1377,299 @@ transformations:
         assert_eq!(item.rule_conditions.len(), 8);
         assert_eq!(item.detection_item_conditions.len(), 4);
         assert_eq!(item.field_name_conditions.len(), 4);
+    }
+
+    #[test]
+    fn test_named_condition_ids_in_rule_cond_expression() {
+        let yaml = r#"
+name: Named Conditions
+transformations:
+  - type: field_name_prefix
+    prefix: "win."
+    rule_conditions:
+      - id: is_windows
+        type: logsource
+        product: windows
+      - id: is_process
+        type: logsource
+        category: process_creation
+    rule_cond_expression: "is_windows or is_process"
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let item = &pipeline.transformations[0];
+        assert_eq!(item.rule_conditions[0].id, Some("is_windows".to_string()));
+        assert_eq!(item.rule_conditions[1].id, Some("is_process".to_string()));
+
+        let mut rule = rsigma_parser::SigmaRule {
+            title: "Test".to_string(),
+            logsource: rsigma_parser::LogSource {
+                product: Some("windows".to_string()),
+                category: Some("process_creation".to_string()),
+                ..Default::default()
+            },
+            detection: rsigma_parser::Detections {
+                named: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "sel".to_string(),
+                        rsigma_parser::Detection::AllOf(vec![rsigma_parser::DetectionItem {
+                            field: rsigma_parser::FieldSpec::new(
+                                Some("CommandLine".to_string()),
+                                vec![],
+                            ),
+                            values: vec![SigmaValue::String(SigmaString::new("test"))],
+                        }]),
+                    );
+                    m
+                },
+                conditions: vec![rsigma_parser::ConditionExpr::Identifier("sel".to_string())],
+                condition_strings: vec!["sel".to_string()],
+                timeframe: None,
+            },
+            id: None,
+            name: None,
+            related: vec![],
+            taxonomy: None,
+            status: None,
+            description: None,
+            license: None,
+            author: None,
+            references: vec![],
+            date: None,
+            modified: None,
+            fields: vec![],
+            falsepositives: vec![],
+            level: None,
+            tags: vec![],
+            scope: vec![],
+            custom_attributes: HashMap::new(),
+        };
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline.apply(&mut rule, &mut state).unwrap();
+
+        let det = &rule.detection.named["sel"];
+        if let rsigma_parser::Detection::AllOf(items) = det {
+            assert_eq!(items[0].field.name, Some("win.CommandLine".to_string()));
+        } else {
+            panic!("Expected AllOf");
+        }
+    }
+
+    #[test]
+    fn test_named_cond_expression_or_logic() {
+        let yaml = r#"
+name: OR Logic
+transformations:
+  - type: field_name_prefix
+    prefix: "mapped."
+    rule_conditions:
+      - id: is_windows
+        type: logsource
+        product: windows
+      - id: is_process
+        type: logsource
+        category: process_creation
+    rule_cond_expression: "is_windows or is_process"
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+
+        let mut rule = rsigma_parser::SigmaRule {
+            title: "Linux Process".to_string(),
+            logsource: rsigma_parser::LogSource {
+                product: Some("linux".to_string()),
+                category: Some("process_creation".to_string()),
+                ..Default::default()
+            },
+            detection: rsigma_parser::Detections {
+                named: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "sel".to_string(),
+                        rsigma_parser::Detection::AllOf(vec![rsigma_parser::DetectionItem {
+                            field: rsigma_parser::FieldSpec::new(Some("Image".to_string()), vec![]),
+                            values: vec![SigmaValue::String(SigmaString::new("/bin/sh"))],
+                        }]),
+                    );
+                    m
+                },
+                conditions: vec![rsigma_parser::ConditionExpr::Identifier("sel".to_string())],
+                condition_strings: vec!["sel".to_string()],
+                timeframe: None,
+            },
+            id: None,
+            name: None,
+            related: vec![],
+            taxonomy: None,
+            status: None,
+            description: None,
+            license: None,
+            author: None,
+            references: vec![],
+            date: None,
+            modified: None,
+            fields: vec![],
+            falsepositives: vec![],
+            level: None,
+            tags: vec![],
+            scope: vec![],
+            custom_attributes: HashMap::new(),
+        };
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline.apply(&mut rule, &mut state).unwrap();
+
+        // is_windows=false, is_process=true => OR => applied
+        let det = &rule.detection.named["sel"];
+        if let rsigma_parser::Detection::AllOf(items) = det {
+            assert_eq!(items[0].field.name, Some("mapped.Image".to_string()));
+        } else {
+            panic!("Expected AllOf");
+        }
+    }
+
+    #[test]
+    fn test_named_cond_expression_and_logic() {
+        let yaml = r#"
+name: AND Logic
+transformations:
+  - type: field_name_prefix
+    prefix: "win."
+    rule_conditions:
+      - id: is_windows
+        type: logsource
+        product: windows
+      - id: is_process
+        type: logsource
+        category: process_creation
+    rule_cond_expression: "is_windows and is_process"
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+
+        // Linux + process_creation => is_windows=false => AND fails => no prefix
+        let mut rule = rsigma_parser::SigmaRule {
+            title: "Linux Rule".to_string(),
+            logsource: rsigma_parser::LogSource {
+                product: Some("linux".to_string()),
+                category: Some("process_creation".to_string()),
+                ..Default::default()
+            },
+            detection: rsigma_parser::Detections {
+                named: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "sel".to_string(),
+                        rsigma_parser::Detection::AllOf(vec![rsigma_parser::DetectionItem {
+                            field: rsigma_parser::FieldSpec::new(Some("Image".to_string()), vec![]),
+                            values: vec![SigmaValue::String(SigmaString::new("/bin/sh"))],
+                        }]),
+                    );
+                    m
+                },
+                conditions: vec![rsigma_parser::ConditionExpr::Identifier("sel".to_string())],
+                condition_strings: vec!["sel".to_string()],
+                timeframe: None,
+            },
+            id: None,
+            name: None,
+            related: vec![],
+            taxonomy: None,
+            status: None,
+            description: None,
+            license: None,
+            author: None,
+            references: vec![],
+            date: None,
+            modified: None,
+            fields: vec![],
+            falsepositives: vec![],
+            level: None,
+            tags: vec![],
+            scope: vec![],
+            custom_attributes: HashMap::new(),
+        };
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline.apply(&mut rule, &mut state).unwrap();
+
+        // is_windows=false => AND => not applied
+        let det = &rule.detection.named["sel"];
+        if let rsigma_parser::Detection::AllOf(items) = det {
+            assert_eq!(items[0].field.name, Some("Image".to_string()));
+        } else {
+            panic!("Expected AllOf");
+        }
+    }
+
+    #[test]
+    fn test_unnamed_conditions_fallback_to_cond_n() {
+        let yaml = r#"
+name: Fallback IDs
+transformations:
+  - type: field_name_prefix
+    prefix: "x."
+    rule_conditions:
+      - type: logsource
+        product: windows
+      - type: logsource
+        category: process_creation
+    rule_cond_expression: "cond_0 or cond_1"
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        assert!(pipeline.transformations[0].rule_conditions[0].id.is_none());
+        assert!(pipeline.transformations[0].rule_conditions[1].id.is_none());
+
+        let mut rule = rsigma_parser::SigmaRule {
+            title: "Test".to_string(),
+            logsource: rsigma_parser::LogSource {
+                product: Some("linux".to_string()),
+                category: Some("process_creation".to_string()),
+                ..Default::default()
+            },
+            detection: rsigma_parser::Detections {
+                named: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "sel".to_string(),
+                        rsigma_parser::Detection::AllOf(vec![rsigma_parser::DetectionItem {
+                            field: rsigma_parser::FieldSpec::new(Some("Field".to_string()), vec![]),
+                            values: vec![SigmaValue::String(SigmaString::new("val"))],
+                        }]),
+                    );
+                    m
+                },
+                conditions: vec![rsigma_parser::ConditionExpr::Identifier("sel".to_string())],
+                condition_strings: vec!["sel".to_string()],
+                timeframe: None,
+            },
+            id: None,
+            name: None,
+            related: vec![],
+            taxonomy: None,
+            status: None,
+            description: None,
+            license: None,
+            author: None,
+            references: vec![],
+            date: None,
+            modified: None,
+            fields: vec![],
+            falsepositives: vec![],
+            level: None,
+            tags: vec![],
+            scope: vec![],
+            custom_attributes: HashMap::new(),
+        };
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline.apply(&mut rule, &mut state).unwrap();
+
+        // cond_0 (windows)=false, cond_1 (process_creation)=true => OR => applied
+        let det = &rule.detection.named["sel"];
+        if let rsigma_parser::Detection::AllOf(items) = det {
+            assert_eq!(items[0].field.name, Some("x.Field".to_string()));
+        } else {
+            panic!("Expected AllOf");
+        }
     }
 }

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -43,7 +43,7 @@ pub mod transformations;
 use std::collections::HashMap;
 use std::path::Path;
 
-use rsigma_parser::{SigmaCollection, SigmaRule, SigmaString, SigmaValue};
+use rsigma_parser::{CorrelationRule, SigmaCollection, SigmaRule, SigmaString, SigmaValue};
 
 use regex::Regex;
 
@@ -169,6 +169,152 @@ impl Pipeline {
         item.rule_conditions
             .iter()
             .all(|c| c.condition.matches_rule(rule, state))
+    }
+
+    /// Apply this pipeline to a correlation rule, mutating it in place.
+    ///
+    /// Only correlation-applicable transformations fire:
+    /// - `FieldNameMapping` / `FieldNamePrefixMapping` — remap `group_by` and
+    ///   `aliases` mapping values
+    /// - `FieldNamePrefix` / `FieldNameSuffix` — modify `group_by` and alias values
+    /// - `SetCustomAttribute` — set key-value on `custom_attributes`
+    /// - `SetState` — update pipeline state
+    /// - `RuleFailure` — error if conditions match
+    ///
+    /// Detection-specific transforms (value replacements, detection item
+    /// manipulation, etc.) are silently skipped.
+    pub fn apply_to_correlation(
+        &self,
+        corr: &mut CorrelationRule,
+        state: &mut PipelineState,
+    ) -> Result<()> {
+        state.reset_rule();
+
+        for item in &self.transformations {
+            if !self.check_correlation_conditions(corr, state, item) {
+                continue;
+            }
+
+            state.reset_detection_item();
+
+            let applied = apply_correlation_transformation(corr, &item.transformation, state)?;
+
+            if applied && let Some(ref id) = item.id {
+                state.mark_applied(id);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_correlation_conditions(
+        &self,
+        corr: &CorrelationRule,
+        state: &PipelineState,
+        item: &TransformationItem,
+    ) -> bool {
+        if item.rule_conditions.is_empty() {
+            return true;
+        }
+
+        if let Some(ref expr) = item.rule_cond_expr {
+            let mut results = HashMap::new();
+            for (i, named) in item.rule_conditions.iter().enumerate() {
+                let id = named.id.clone().unwrap_or_else(|| format!("cond_{i}"));
+                results.insert(id, named.condition.matches_correlation(corr, state));
+            }
+            return eval_condition_expr(expr, &results);
+        }
+
+        item.rule_conditions
+            .iter()
+            .all(|c| c.condition.matches_correlation(corr, state))
+    }
+}
+
+/// Apply a single transformation to a correlation rule.
+///
+/// Returns `true` if the transformation was meaningfully applied.
+fn apply_correlation_transformation(
+    corr: &mut CorrelationRule,
+    transformation: &Transformation,
+    state: &mut PipelineState,
+) -> Result<bool> {
+    match transformation {
+        Transformation::FieldNameMapping { mapping } => {
+            remap_correlation_fields(corr, |name| mapping.get(name).cloned());
+            Ok(true)
+        }
+
+        Transformation::FieldNamePrefixMapping { mapping } => {
+            remap_correlation_fields(corr, |name| {
+                for (prefix, replacement) in mapping {
+                    if let Some(rest) = name.strip_prefix(prefix.as_str()) {
+                        return Some(format!("{replacement}{rest}"));
+                    }
+                }
+                None
+            });
+            Ok(true)
+        }
+
+        Transformation::FieldNamePrefix { prefix } => {
+            remap_correlation_fields(corr, |name| Some(format!("{prefix}{name}")));
+            Ok(true)
+        }
+
+        Transformation::FieldNameSuffix { suffix } => {
+            remap_correlation_fields(corr, |name| Some(format!("{name}{suffix}")));
+            Ok(true)
+        }
+
+        Transformation::SetCustomAttribute { attribute, value } => {
+            corr.custom_attributes
+                .insert(attribute.clone(), value.clone());
+            Ok(true)
+        }
+
+        Transformation::SetState { key, value } => {
+            state.set_state(key.clone(), serde_json::Value::String(value.clone()));
+            Ok(true)
+        }
+
+        Transformation::RuleFailure { message } => Err(EvalError::InvalidModifiers(format!(
+            "Pipeline rule failure: {message} (correlation: {})",
+            corr.title
+        ))),
+
+        // Detection-specific transforms are no-ops for correlations
+        _ => Ok(false),
+    }
+}
+
+/// Apply a field name mapping function to all field references in a correlation rule:
+/// `group_by` entries, `aliases` mapping values, and the `condition` field.
+fn remap_correlation_fields(corr: &mut CorrelationRule, mapper: impl Fn(&str) -> Option<String>) {
+    for field in &mut corr.group_by {
+        if let Some(new_name) = mapper(field) {
+            *field = new_name;
+        }
+    }
+
+    for alias in &mut corr.aliases {
+        let remapped: HashMap<String, String> = alias
+            .mapping
+            .iter()
+            .map(|(rule_ref, field_name)| {
+                let new_name = mapper(field_name).unwrap_or_else(|| field_name.clone());
+                (rule_ref.clone(), new_name)
+            })
+            .collect();
+        alias.mapping = remapped;
+    }
+
+    if let rsigma_parser::CorrelationCondition::Threshold { ref mut field, .. } = corr.condition
+        && let Some(f) = field.as_ref()
+        && let Some(new_name) = mapper(f)
+    {
+        *field = Some(new_name);
     }
 }
 
@@ -985,6 +1131,18 @@ pub fn apply_pipelines(pipelines: &[Pipeline], rule: &mut SigmaRule) -> Result<(
     Ok(())
 }
 
+/// Apply multiple pipelines to a correlation rule in priority order.
+pub fn apply_pipelines_to_correlation(
+    pipelines: &[Pipeline],
+    corr: &mut CorrelationRule,
+) -> Result<()> {
+    for pipeline in pipelines {
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline.apply_to_correlation(corr, &mut state)?;
+    }
+    Ok(())
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1400,6 +1558,7 @@ transformations:
         assert_eq!(item.rule_conditions[0].id, Some("is_windows".to_string()));
         assert_eq!(item.rule_conditions[1].id, Some("is_process".to_string()));
 
+        // Windows + process_creation => both match, OR is true => prefix applied
         let mut rule = rsigma_parser::SigmaRule {
             title: "Test".to_string(),
             logsource: rsigma_parser::LogSource {
@@ -1458,6 +1617,7 @@ transformations:
 
     #[test]
     fn test_named_cond_expression_or_logic() {
+        // Only is_process matches (linux, not windows), but OR means it still applies
         let yaml = r#"
 name: OR Logic
 transformations:
@@ -1530,6 +1690,7 @@ transformations:
 
     #[test]
     fn test_named_cond_expression_and_logic() {
+        // AND: both must match
         let yaml = r#"
 name: AND Logic
 transformations:
@@ -1671,5 +1832,203 @@ transformations:
         } else {
             panic!("Expected AllOf");
         }
+    }
+
+    // =========================================================================
+    // Correlation pipeline tests
+    // =========================================================================
+
+    fn make_test_correlation() -> CorrelationRule {
+        CorrelationRule {
+            title: "Test Correlation".to_string(),
+            id: Some("corr-1".to_string()),
+            name: Some("test_corr".to_string()),
+            status: None,
+            description: None,
+            author: None,
+            date: None,
+            modified: None,
+            references: vec![],
+            tags: vec![],
+            level: None,
+            correlation_type: rsigma_parser::CorrelationType::EventCount,
+            rules: vec!["rule_a".to_string()],
+            group_by: vec!["SourceIP".to_string(), "DestinationIP".to_string()],
+            timespan: rsigma_parser::Timespan::parse("5m").unwrap(),
+            condition: rsigma_parser::CorrelationCondition::Threshold {
+                predicates: vec![(rsigma_parser::ConditionOperator::Gte, 10)],
+                field: None,
+            },
+            aliases: vec![rsigma_parser::FieldAlias {
+                alias: "src_ip".to_string(),
+                mapping: {
+                    let mut m = HashMap::new();
+                    m.insert("rule_a".to_string(), "SourceIP".to_string());
+                    m
+                },
+            }],
+            generate: true,
+            custom_attributes: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_correlation_pipeline_field_name_mapping() {
+        let yaml = r#"
+name: ECS Field Mapping
+transformations:
+  - type: field_name_mapping
+    mapping:
+      SourceIP: source.ip
+      DestinationIP: destination.ip
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .unwrap();
+
+        assert_eq!(corr.group_by, vec!["source.ip", "destination.ip"]);
+        assert_eq!(corr.aliases[0].mapping["rule_a"], "source.ip");
+    }
+
+    #[test]
+    fn test_correlation_pipeline_field_prefix() {
+        let yaml = r#"
+name: Prefix
+transformations:
+  - type: field_name_prefix
+    prefix: "event."
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .unwrap();
+
+        assert_eq!(corr.group_by, vec!["event.SourceIP", "event.DestinationIP"]);
+    }
+
+    #[test]
+    fn test_correlation_pipeline_set_custom_attribute() {
+        let yaml = r#"
+name: Custom Attr
+transformations:
+  - type: set_custom_attribute
+    attribute: rsigma.action
+    value: reset
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .unwrap();
+
+        assert_eq!(corr.custom_attributes["rsigma.action"], "reset");
+    }
+
+    #[test]
+    fn test_correlation_pipeline_skips_detection_rules() {
+        let yaml = r#"
+name: Detection Only
+transformations:
+  - type: field_name_prefix
+    prefix: "x."
+    rule_conditions:
+      - type: is_sigma_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .unwrap();
+
+        // is_sigma_rule => false for correlations => not applied
+        assert_eq!(corr.group_by, vec!["SourceIP", "DestinationIP"]);
+    }
+
+    #[test]
+    fn test_correlation_pipeline_rule_failure() {
+        let yaml = r#"
+name: Block Correlations
+transformations:
+  - type: rule_failure
+    message: "correlations not supported by this backend"
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        let result = pipeline.apply_to_correlation(&mut corr, &mut state);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("correlations not supported"));
+    }
+
+    #[test]
+    fn test_correlation_pipeline_condition_field_mapping() {
+        let yaml = r#"
+name: Condition Field Mapping
+transformations:
+  - type: field_name_mapping
+    mapping:
+      UserName: user.name
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+
+        let mut corr = make_test_correlation();
+        corr.condition = rsigma_parser::CorrelationCondition::Threshold {
+            predicates: vec![(rsigma_parser::ConditionOperator::Gte, 5)],
+            field: Some("UserName".to_string()),
+        };
+
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .unwrap();
+
+        if let rsigma_parser::CorrelationCondition::Threshold { field, .. } = &corr.condition {
+            assert_eq!(field.as_deref(), Some("user.name"));
+        } else {
+            panic!("Expected Threshold");
+        }
+    }
+
+    #[test]
+    fn test_apply_pipelines_to_correlation_fn() {
+        let yaml = r#"
+name: ECS Mapping
+priority: 10
+transformations:
+  - type: field_name_mapping
+    mapping:
+      SourceIP: source.ip
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+
+        apply_pipelines_to_correlation(&[pipeline], &mut corr).unwrap();
+
+        assert_eq!(corr.group_by[0], "source.ip");
     }
 }


### PR DESCRIPTION
Closes two pipeline parity gaps identified against pySigma:

- **Named condition IDs in `rule_cond_expression`**: Pipeline rule conditions now support an optional `id` field, allowing `rule_cond_expression` to reference conditions by name (e.g. `"is_windows or is_process"`) instead of only positional `cond_N` identifiers. Unnamed conditions fall back to `cond_N` for backwards compatibility.

- **Pipeline application to correlation rules**: Correlation rules now pass through the pipeline system before compilation, enabling field name mappings, prefixes/suffixes, custom attributes, state mutations, and rule failures to transform `group_by` fields, alias mappings, and condition fields on correlation rules — matching pySigma behavior.