### PR TITLE
feat: add streaming I/O pipeline to daemon

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,4 +26,6 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - run: cargo install cargo-audit --locked
-      - run: cargo audit
+      # RUSTSEC-2026-0049: rustls-webpki 0.102.x CRL bug, transitive dep of async-nats 0.46.0.
+      # Remove --ignore when async-nats updates its rustls-webpki dependency.
+      - run: cargo audit --ignore RUSTSEC-2026-0049

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +352,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -468,6 +514,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +641,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +685,27 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
 
 [[package]]
 name = "difflib"
@@ -657,6 +766,28 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -746,6 +877,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1724,6 +1861,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.5",
+ "signatory",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1981,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1881,6 +2048,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -1918,6 +2091,15 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1970,6 +2152,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2182,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2044,6 +2256,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2127,8 +2345,8 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2165,12 +2383,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2180,7 +2419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2198,7 +2446,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2372,6 +2620,7 @@ name = "rsigma"
 version = "0.5.0"
 dependencies = [
  "assert_cmd",
+ "async-nats",
  "axum",
  "clap",
  "dirs",
@@ -2391,6 +2640,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -2409,7 +2659,7 @@ dependencies = [
  "ipnet",
  "log",
  "proptest",
- "rand",
+ "rand 0.9.2",
  "regex",
  "rsigma-parser",
  "serde",
@@ -2440,7 +2690,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2459,6 +2709,15 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2485,9 +2744,22 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -2496,10 +2768,19 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2517,16 +2798,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.10",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2537,6 +2818,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2600,12 +2891,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2728,6 +3032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +3049,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2800,6 +3124,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +3177,16 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2974,6 +3330,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3440,27 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3231,6 +3650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,7 +3721,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3533,6 +3962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ cat events.ndjson | rsigma eval -r path/to/rules/
 # Long-running daemon with hot-reload and Prometheus metrics
 hel run | rsigma daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
 
+# Daemon with file output (detections appended as NDJSON)
+hel run | rsigma daemon -r rules/ --output file:///var/log/detections.ndjson
+
+# Fan-out: write detections to both stdout and a file
+hel run | rsigma daemon -r rules/ --output stdout --output file:///tmp/detections.ndjson
+
+# Accept events via HTTP POST instead of stdin
+rsigma daemon -r rules/ --input http
+# Then: curl -X POST http://localhost:9090/api/v1/events -d '{"CommandLine":"whoami"}'
+
+# NATS JetStream source and sink (requires daemon-nats feature)
+rsigma daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections
+
 # With a processing pipeline for field mapping
 rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
 ```

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 [features]
 default = ["daemon"]
 daemon = ["tokio", "axum", "prometheus", "notify", "rusqlite"]
+daemon-nats = ["daemon", "async-nats", "tokio-stream"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.5.0" }
@@ -37,6 +38,8 @@ axum = { version = "0.8", features = ["json"], optional = true }
 prometheus = { version = "0.13", default-features = false, optional = true }
 notify = { version = "7", optional = true }
 rusqlite = { version = "0.34", features = ["bundled"], optional = true }
+async-nats = { version = "0.46", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/crates/rsigma-cli/src/daemon/engine.rs
+++ b/crates/rsigma-cli/src/daemon/engine.rs
@@ -54,12 +54,12 @@ pub fn process_line(
         metrics.events_processed.inc();
         metrics.processing_latency.observe(elapsed);
 
-        for _ in &result.detections {
-            metrics.detection_matches.inc();
-        }
-        for _ in &result.correlations {
-            metrics.correlation_matches.inc();
-        }
+        metrics
+            .detection_matches
+            .inc_by(result.detections.len() as u64);
+        metrics
+            .correlation_matches
+            .inc_by(result.correlations.len() as u64);
 
         merged.detections.extend(result.detections);
         merged.correlations.extend(result.correlations);

--- a/crates/rsigma-cli/src/daemon/engine.rs
+++ b/crates/rsigma-cli/src/daemon/engine.rs
@@ -1,8 +1,7 @@
-use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use rsigma_eval::Event;
+use rsigma_eval::{Event, ProcessResult};
 
 use super::metrics::Metrics;
 use super::state::DaemonEngine;
@@ -14,24 +13,36 @@ use super::state::DaemonEngine;
 /// synchronous operations.
 pub type SharedEngine = Arc<Mutex<DaemonEngine>>;
 
-/// Process a single JSON line through the engine and write matches to stdout.
+/// Process a single JSON line through the engine and return matches.
+///
+/// Parses the JSON, applies the event filter (which may produce multiple
+/// payloads from a single line), evaluates each payload against the engine,
+/// and returns a merged `ProcessResult` containing all detections and
+/// correlations. Updates metrics counters as a side-effect.
 pub fn process_line(
     engine: &mut DaemonEngine,
     line: &str,
     metrics: &Metrics,
-    pretty: bool,
     event_filter: &crate::EventFilter,
-) {
+) -> ProcessResult {
     let value: serde_json::Value = match serde_json::from_str(line) {
         Ok(v) => v,
         Err(e) => {
             metrics.events_parse_errors.inc();
             tracing::debug!(error = %e, "Invalid JSON on input");
-            return;
+            return ProcessResult {
+                detections: vec![],
+                correlations: vec![],
+            };
         }
     };
 
     let payloads = crate::apply_event_filter(&value, event_filter);
+
+    let mut merged = ProcessResult {
+        detections: Vec::new(),
+        correlations: Vec::new(),
+    };
 
     for payload in payloads {
         let event = Event::from_value(&payload);
@@ -43,31 +54,16 @@ pub fn process_line(
         metrics.events_processed.inc();
         metrics.processing_latency.observe(elapsed);
 
-        let stdout = std::io::stdout();
-        let mut out = stdout.lock();
-
-        for m in &result.detections {
+        for _ in &result.detections {
             metrics.detection_matches.inc();
-            let json = if pretty {
-                serde_json::to_string_pretty(m)
-            } else {
-                serde_json::to_string(m)
-            };
-            if let Ok(j) = json {
-                let _ = writeln!(out, "{j}");
-            }
+        }
+        for _ in &result.correlations {
+            metrics.correlation_matches.inc();
         }
 
-        for m in &result.correlations {
-            metrics.correlation_matches.inc();
-            let json = if pretty {
-                serde_json::to_string_pretty(m)
-            } else {
-                serde_json::to_string(m)
-            };
-            if let Ok(j) = json {
-                let _ = writeln!(out, "{j}");
-            }
-        }
+        merged.detections.extend(result.detections);
+        merged.correlations.extend(result.correlations);
     }
+
+    merged
 }

--- a/crates/rsigma-cli/src/daemon/mod.rs
+++ b/crates/rsigma-cli/src/daemon/mod.rs
@@ -5,5 +5,6 @@ mod reload;
 pub(crate) mod server;
 mod state;
 mod store;
+pub(crate) mod streaming;
 
 pub use server::run_daemon;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -298,6 +298,9 @@ pub async fn run_daemon(config: DaemonConfig) {
                     .set(stats.state_entries as i64);
                 result
             };
+            if result.detections.is_empty() && result.correlations.is_empty() {
+                continue;
+            }
             if sink_tx.send(result).await.is_err() {
                 tracing::debug!("Sink channel closed, engine shutting down");
                 break;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -328,7 +328,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     tracing::info!(output = ?output_specs, "Sink started");
 
     // Sink task: reads ProcessResult from channel, writes via Sink dispatch
-    let _sink_handle = tokio::spawn(async move {
+    let sink_handle = tokio::spawn(async move {
         let mut sink = sink;
         while let Some(result) = sink_rx.recv().await {
             if let Err(e) = sink.send(&result).await {
@@ -347,6 +347,11 @@ pub async fn run_daemon(config: DaemonConfig) {
             tracing::info!("Streaming pipeline complete");
         }
     }
+
+    // Wait for the sink task to drain any remaining results before exiting.
+    // The engine task owns sink_tx, so once it exits, sink_rx closes and the
+    // sink task finishes after processing buffered items.
+    let _ = sink_handle.await;
 
     // Save state on shutdown
     if let Some(ref store) = state_store {

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -1,4 +1,3 @@
-use std::io::{self, BufRead};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,7 +8,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use rsigma_eval::{CorrelationConfig, Pipeline};
+use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
 use serde::Serialize;
 use tokio::sync::mpsc;
 
@@ -19,6 +18,7 @@ use super::metrics::Metrics;
 use super::reload;
 use super::state::DaemonEngine;
 use super::store::SqliteStateStore;
+use super::streaming::{self, FileSink, Sink, StdinSource, StdoutSink};
 use crate::EventFilter;
 
 #[derive(Clone)]
@@ -28,6 +28,8 @@ struct AppState {
     health: HealthState,
     reload_tx: mpsc::Sender<()>,
     start_time: Instant,
+    /// Channel for HTTP event ingestion. Set when --input is http.
+    event_tx: Option<mpsc::Sender<String>>,
 }
 
 #[derive(Clone)]
@@ -41,6 +43,8 @@ pub struct DaemonConfig {
     pub event_filter: Arc<EventFilter>,
     pub state_db: Option<PathBuf>,
     pub state_save_interval: u64,
+    pub input: String,
+    pub output: Vec<String>,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
@@ -132,12 +136,22 @@ pub async fn run_daemon(config: DaemonConfig) {
 
     let start_time = Instant::now();
 
+    // Create event channel early so both source and HTTP handler can use it
+    let (event_tx, mut event_rx) = mpsc::channel::<String>(10_000);
+
+    let http_event_tx = if config.input == "http" {
+        Some(event_tx.clone())
+    } else {
+        None
+    };
+
     let app_state = AppState {
         engine: shared_engine.clone(),
         metrics: metrics.clone(),
         health: health.clone(),
         reload_tx: reload_tx.clone(),
         start_time,
+        event_tx: http_event_tx,
     };
 
     let app = Router::new()
@@ -147,6 +161,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         .route("/api/v1/rules", get(list_rules))
         .route("/api/v1/status", get(status))
         .route("/api/v1/reload", post(trigger_reload))
+        .route("/api/v1/events", post(ingest_events))
         .with_state(app_state);
 
     let listener = tokio::net::TcpListener::bind(config.api_addr)
@@ -227,35 +242,96 @@ pub async fn run_daemon(config: DaemonConfig) {
         });
     }
 
-    // Spawn stdin reader in a blocking thread
-    let stdin_engine = shared_engine.clone();
-    let stdin_metrics = metrics.clone();
-    let pretty = config.pretty;
-    let event_filter = config.event_filter.clone();
-    let stdin_handle = tokio::task::spawn_blocking(move || {
-        let stdin = io::stdin();
-        let reader = stdin.lock();
-        for line in reader.lines() {
-            match line {
-                Ok(line) => {
-                    if line.trim().is_empty() {
-                        continue;
-                    }
-                    let mut engine = stdin_engine.lock().unwrap();
-                    process_line(&mut engine, &line, &stdin_metrics, pretty, &event_filter);
+    // --- Streaming pipeline: source -> engine -> sink ---
+    // event_tx / event_rx were created above (before AppState) so the HTTP
+    // handler can share event_tx when --input is http.
 
-                    let stats = engine.stats();
-                    stdin_metrics
-                        .correlation_state_entries
-                        .set(stats.state_entries as i64);
+    let (sink_tx, mut sink_rx) = mpsc::channel::<ProcessResult>(10_000);
+
+    // Select source based on --input flag
+    match config.input.as_str() {
+        "stdin" | "stdin://" => {
+            streaming::spawn_source(StdinSource::new(), event_tx);
+            tracing::info!(input = "stdin", "Event source started");
+        }
+        "http" => {
+            // Events arrive via POST /api/v1/events; event_tx is held by AppState.
+            // Drop the local event_tx so the channel closes when AppState is dropped.
+            drop(event_tx);
+            tracing::info!(input = "http", "Event source started (POST /api/v1/events)");
+        }
+        #[cfg(feature = "daemon-nats")]
+        input if input.starts_with("nats://") => {
+            let (url, subject) = parse_nats_url(input);
+            match streaming::NatsSource::connect(&url, &subject).await {
+                Ok(source) => {
+                    streaming::spawn_source(source, event_tx);
+                    tracing::info!(url = url, subject = subject, "NATS source started");
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "Error reading stdin");
-                    break;
+                    tracing::error!(error = %e, url = url, "Failed to connect NATS source");
+                    std::process::exit(1);
                 }
             }
         }
-        tracing::info!("stdin closed, shutting down");
+        other => {
+            tracing::error!(
+                input = other,
+                "Unsupported input source (supported: stdin, http, nats://)"
+            );
+            std::process::exit(1);
+        }
+    }
+
+    // Engine task: reads events, evaluates rules, sends results to sink channel
+    let engine_shared = shared_engine.clone();
+    let engine_metrics = metrics.clone();
+    let event_filter = config.event_filter.clone();
+    let engine_handle = tokio::spawn(async move {
+        while let Some(line) = event_rx.recv().await {
+            let result = {
+                let mut engine = engine_shared.lock().unwrap();
+                let result = process_line(&mut engine, &line, &engine_metrics, &event_filter);
+                let stats = engine.stats();
+                engine_metrics
+                    .correlation_state_entries
+                    .set(stats.state_entries as i64);
+                result
+            };
+            if sink_tx.send(result).await.is_err() {
+                tracing::debug!("Sink channel closed, engine shutting down");
+                break;
+            }
+        }
+        tracing::info!("Event source exhausted, engine shutting down");
+    });
+
+    // Build sink(s) from --output flags. Multiple outputs produce a FanOut.
+    let pretty = config.pretty;
+    let output_specs = if config.output.is_empty() {
+        vec!["stdout".to_string()]
+    } else {
+        config.output.clone()
+    };
+    let mut sinks = Vec::new();
+    for spec in &output_specs {
+        sinks.push(build_sink(spec, pretty).await);
+    }
+    let sink = if sinks.len() == 1 {
+        sinks.pop().unwrap()
+    } else {
+        Sink::FanOut(sinks)
+    };
+    tracing::info!(output = ?output_specs, "Sink started");
+
+    // Sink task: reads ProcessResult from channel, writes via Sink dispatch
+    let _sink_handle = tokio::spawn(async move {
+        let mut sink = sink;
+        while let Some(result) = sink_rx.recv().await {
+            if let Err(e) = sink.send(&result).await {
+                tracing::warn!(error = %e, "Error writing to sink");
+            }
+        }
     });
 
     tokio::select! {
@@ -264,8 +340,8 @@ pub async fn run_daemon(config: DaemonConfig) {
                 tracing::error!(error = %e, "HTTP server error");
             }
         }
-        _ = stdin_handle => {
-            tracing::info!("stdin processing complete");
+        _ = engine_handle => {
+            tracing::info!("Streaming pipeline complete");
         }
     }
 
@@ -284,11 +360,70 @@ pub async fn run_daemon(config: DaemonConfig) {
     }
 }
 
+/// Build a single Sink from an output spec string.
+async fn build_sink(spec: &str, pretty: bool) -> Sink {
+    if spec == "stdout" || spec == "stdout://" {
+        return Sink::Stdout(StdoutSink::new(pretty));
+    }
+
+    if let Some(path) = spec.strip_prefix("file://") {
+        let path = std::path::Path::new(path);
+        return match FileSink::open(path) {
+            Ok(file_sink) => {
+                tracing::info!(path = %path.display(), "File sink opened");
+                Sink::File(file_sink)
+            }
+            Err(e) => {
+                tracing::error!(path = %path.display(), error = %e, "Failed to open file sink");
+                std::process::exit(1);
+            }
+        };
+    }
+
+    #[cfg(feature = "daemon-nats")]
+    if spec.starts_with("nats://") {
+        let (url, subject) = parse_nats_url(spec);
+        return match streaming::NatsSink::connect(&url, &subject).await {
+            Ok(nats_sink) => {
+                tracing::info!(url = url, subject = subject, "NATS sink started");
+                Sink::Nats(nats_sink)
+            }
+            Err(e) => {
+                tracing::error!(error = %e, url = url, "Failed to connect NATS sink");
+                std::process::exit(1);
+            }
+        };
+    }
+
+    tracing::error!(
+        output = spec,
+        "Unsupported output sink (supported: stdout, file://<path>, nats://)"
+    );
+    std::process::exit(1);
+}
+
 async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("failed to listen for ctrl+c");
     tracing::info!("Shutdown signal received");
+}
+
+/// Parse a nats:// URL into (server_url, subject).
+///
+/// Input: "nats://host:port/subject.path.>"
+/// Output: ("nats://host:port", "subject.path.>")
+#[cfg(feature = "daemon-nats")]
+fn parse_nats_url(url: &str) -> (String, String) {
+    let without_scheme = url.strip_prefix("nats://").unwrap_or(url);
+    match without_scheme.find('/') {
+        Some(pos) => {
+            let server = format!("nats://{}", &without_scheme[..pos]);
+            let subject = without_scheme[pos + 1..].to_string();
+            (server, subject)
+        }
+        None => (format!("nats://{without_scheme}"), ">".to_string()),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -383,4 +518,45 @@ async fn trigger_reload(State(state): State<AppState>) -> impl IntoResponse {
             Json(serde_json::json!({ "status": "reload_already_pending" })),
         ),
     }
+}
+
+/// Accept NDJSON events via HTTP POST for processing.
+/// Each non-empty line in the request body is treated as a separate JSON event.
+async fn ingest_events(State(state): State<AppState>, body: String) -> Response {
+    let event_tx = match &state.event_tx {
+        Some(tx) => tx,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": "event ingestion not enabled (start with --input http)"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let mut accepted = 0u64;
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if event_tx.send(line.to_string()).await.is_err() {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "event channel closed",
+                    "accepted": accepted,
+                })),
+            )
+                .into_response();
+        }
+        accepted += 1;
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "accepted": accepted })),
+    )
+        .into_response()
 }

--- a/crates/rsigma-cli/src/daemon/streaming/file_sink.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/file_sink.rs
@@ -1,0 +1,42 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use rsigma_eval::ProcessResult;
+
+use super::StreamingError;
+
+/// Appends ProcessResult as NDJSON to a file with buffered writes.
+pub struct FileSink {
+    writer: BufWriter<File>,
+}
+
+impl FileSink {
+    /// Open (or create) the file at `path` for appending.
+    pub fn open(path: &Path) -> Result<Self, StreamingError> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(FileSink {
+            writer: BufWriter::new(file),
+        })
+    }
+
+    /// Serialize and append a ProcessResult to the file.
+    pub fn send(&mut self, result: &ProcessResult) -> Result<(), StreamingError> {
+        if result.detections.is_empty() && result.correlations.is_empty() {
+            return Ok(());
+        }
+
+        for m in &result.detections {
+            let json = serde_json::to_string(m)?;
+            writeln!(self.writer, "{json}")?;
+        }
+
+        for m in &result.correlations {
+            let json = serde_json::to_string(m)?;
+            writeln!(self.writer, "{json}")?;
+        }
+
+        self.writer.flush()?;
+        Ok(())
+    }
+}

--- a/crates/rsigma-cli/src/daemon/streaming/mod.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/mod.rs
@@ -1,0 +1,121 @@
+mod file_sink;
+#[cfg(feature = "daemon-nats")]
+mod nats_sink;
+#[cfg(feature = "daemon-nats")]
+mod nats_source;
+mod stdin_source;
+mod stdout_sink;
+
+pub use file_sink::FileSink;
+#[cfg(feature = "daemon-nats")]
+pub use nats_sink::NatsSink;
+#[cfg(feature = "daemon-nats")]
+pub use nats_source::NatsSource;
+pub use stdin_source::StdinSource;
+pub use stdout_sink::StdoutSink;
+
+use rsigma_eval::ProcessResult;
+
+/// Errors from streaming sources and sinks.
+#[derive(Debug)]
+pub enum StreamingError {
+    /// I/O error (stdin read, file write, etc.)
+    Io(std::io::Error),
+    /// JSON serialization error in a sink.
+    Serialization(serde_json::Error),
+}
+
+impl std::fmt::Display for StreamingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StreamingError::Io(e) => write!(f, "I/O error: {e}"),
+            StreamingError::Serialization(e) => write!(f, "serialization error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for StreamingError {}
+
+impl From<std::io::Error> for StreamingError {
+    fn from(e: std::io::Error) -> Self {
+        StreamingError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for StreamingError {
+    fn from(e: serde_json::Error) -> Self {
+        StreamingError::Serialization(e)
+    }
+}
+
+/// Contract for event input adapters.
+///
+/// Each source reads events from a specific input (stdin, HTTP, NATS) and
+/// yields raw JSON strings. Sources are used as concrete types (not `dyn`),
+/// so `async fn` is valid without object-safety concerns.
+pub trait EventSource: Send + 'static {
+    /// Receive the next event as a raw JSON string.
+    /// Returns `None` when the source is exhausted or shutting down.
+    fn recv(&mut self) -> impl std::future::Future<Output = Option<String>> + Send;
+}
+
+/// Enum dispatch for output adapters.
+///
+/// Uses enum dispatch instead of `dyn Trait` because:
+/// - Async trait methods are not object-safe
+/// - `FanOut(Vec<Sink>)` requires a sized, concrete type
+pub enum Sink {
+    /// Write NDJSON to stdout.
+    Stdout(StdoutSink),
+    /// Append NDJSON to a file.
+    File(FileSink),
+    /// Publish NDJSON to a NATS subject.
+    #[cfg(feature = "daemon-nats")]
+    Nats(NatsSink),
+    /// Fan out to multiple sinks.
+    FanOut(Vec<Sink>),
+}
+
+impl Sink {
+    /// Serialize and deliver a ProcessResult to this sink.
+    /// Uses `Box::pin` for the FanOut case to handle recursive async.
+    pub fn send<'a>(
+        &'a mut self,
+        result: &'a ProcessResult,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), StreamingError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            match self {
+                Sink::Stdout(s) => s.send(result),
+                Sink::File(s) => s.send(result),
+                #[cfg(feature = "daemon-nats")]
+                Sink::Nats(s) => s.send(result).await,
+                Sink::FanOut(sinks) => {
+                    for sink in sinks {
+                        sink.send(result).await?;
+                    }
+                    Ok(())
+                }
+            }
+        })
+    }
+}
+
+/// Spawn an EventSource as a tokio task wired to a shared event channel.
+///
+/// The source reads events in a loop via `recv()` and forwards them to
+/// `event_tx`. When the source is exhausted or the channel is closed,
+/// the task completes.
+pub fn spawn_source<S: EventSource>(
+    mut source: S,
+    event_tx: tokio::sync::mpsc::Sender<String>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(line) = source.recv().await {
+            if event_tx.send(line).await.is_err() {
+                tracing::debug!("Event channel closed, source shutting down");
+                break;
+            }
+        }
+    })
+}

--- a/crates/rsigma-cli/src/daemon/streaming/mod.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/mod.rs
@@ -78,7 +78,10 @@ pub enum Sink {
 
 impl Sink {
     /// Serialize and deliver a ProcessResult to this sink.
-    /// Uses `Box::pin` for the FanOut case to handle recursive async.
+    ///
+    /// Synchronous sinks (Stdout, File) use `block_in_place` to avoid blocking
+    /// the Tokio runtime. Uses `Box::pin` for the FanOut case to handle
+    /// recursive async.
     pub fn send<'a>(
         &'a mut self,
         result: &'a ProcessResult,
@@ -86,8 +89,16 @@ impl Sink {
     {
         Box::pin(async move {
             match self {
-                Sink::Stdout(s) => s.send(result),
-                Sink::File(s) => s.send(result),
+                Sink::Stdout(s) => {
+                    let s = &*s;
+                    let result = result;
+                    tokio::task::block_in_place(|| s.send(result))
+                }
+                Sink::File(s) => {
+                    let s = &mut *s;
+                    let result = result;
+                    tokio::task::block_in_place(|| s.send(result))
+                }
                 #[cfg(feature = "daemon-nats")]
                 Sink::Nats(s) => s.send(result).await,
                 Sink::FanOut(sinks) => {

--- a/crates/rsigma-cli/src/daemon/streaming/nats_sink.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/nats_sink.rs
@@ -1,4 +1,4 @@
-use async_nats::Client;
+use async_nats::{Client, subject::Subject};
 
 use rsigma_eval::ProcessResult;
 
@@ -7,7 +7,7 @@ use super::StreamingError;
 /// Publishes ProcessResult as NDJSON to a NATS subject.
 pub struct NatsSink {
     client: Client,
-    subject: String,
+    subject: Subject,
 }
 
 impl NatsSink {
@@ -16,7 +16,7 @@ impl NatsSink {
         let client = async_nats::connect(url).await?;
         Ok(NatsSink {
             client,
-            subject: subject.to_string(),
+            subject: Subject::from(subject),
         })
     }
 

--- a/crates/rsigma-cli/src/daemon/streaming/nats_sink.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/nats_sink.rs
@@ -1,0 +1,47 @@
+use async_nats::Client;
+
+use rsigma_eval::ProcessResult;
+
+use super::StreamingError;
+
+/// Publishes ProcessResult as NDJSON to a NATS subject.
+pub struct NatsSink {
+    client: Client,
+    subject: String,
+}
+
+impl NatsSink {
+    /// Connect to NATS and prepare to publish to `subject`.
+    pub async fn connect(url: &str, subject: &str) -> Result<Self, async_nats::Error> {
+        let client = async_nats::connect(url).await?;
+        Ok(NatsSink {
+            client,
+            subject: subject.to_string(),
+        })
+    }
+
+    /// Serialize and publish a ProcessResult to the configured NATS subject.
+    pub async fn send(&self, result: &ProcessResult) -> Result<(), StreamingError> {
+        if result.detections.is_empty() && result.correlations.is_empty() {
+            return Ok(());
+        }
+
+        for m in &result.detections {
+            let json = serde_json::to_string(m)?;
+            self.client
+                .publish(self.subject.clone(), json.into())
+                .await
+                .map_err(|e| StreamingError::Io(std::io::Error::other(e)))?;
+        }
+
+        for m in &result.correlations {
+            let json = serde_json::to_string(m)?;
+            self.client
+                .publish(self.subject.clone(), json.into())
+                .await
+                .map_err(|e| StreamingError::Io(std::io::Error::other(e)))?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rsigma-cli/src/daemon/streaming/nats_source.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/nats_source.rs
@@ -1,0 +1,66 @@
+use async_nats::jetstream;
+use tokio_stream::StreamExt;
+
+use super::EventSource;
+
+/// NATS JetStream consumer that yields events as JSON strings.
+pub struct NatsSource {
+    messages: jetstream::consumer::pull::Stream,
+}
+
+impl NatsSource {
+    /// Connect to NATS and subscribe to a JetStream stream via pull consumer.
+    ///
+    /// `url` is the NATS server URL (e.g. "nats://localhost:4222").
+    /// `subject` is the subject filter (e.g. "hel.events.>").
+    pub async fn connect(url: &str, subject: &str) -> Result<Self, async_nats::Error> {
+        let client = async_nats::connect(url).await?;
+        let jetstream = jetstream::new(client);
+
+        let stream = jetstream
+            .get_or_create_stream(jetstream::stream::Config {
+                name: "rsigma-events".to_string(),
+                subjects: vec![subject.to_string()],
+                ..Default::default()
+            })
+            .await?;
+
+        let consumer = stream
+            .get_or_create_consumer(
+                "rsigma-daemon",
+                jetstream::consumer::pull::Config {
+                    durable_name: Some("rsigma-daemon".to_string()),
+                    filter_subject: subject.to_string(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        let messages = consumer.messages().await?;
+
+        Ok(NatsSource { messages })
+    }
+}
+
+impl EventSource for NatsSource {
+    async fn recv(&mut self) -> Option<String> {
+        loop {
+            match self.messages.next().await {
+                Some(Ok(msg)) => {
+                    let payload = String::from_utf8_lossy(&msg.payload).to_string();
+                    if let Err(e) = msg.ack().await {
+                        tracing::warn!(error = %e, "Failed to ack NATS message");
+                    }
+                    if !payload.trim().is_empty() {
+                        return Some(payload);
+                    }
+                }
+                Some(Err(e)) => {
+                    tracing::warn!(error = %e, "NATS message error");
+                    continue;
+                }
+                None => return None,
+            }
+        }
+    }
+}

--- a/crates/rsigma-cli/src/daemon/streaming/nats_source.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/nats_source.rs
@@ -3,7 +3,26 @@ use tokio_stream::StreamExt;
 
 use super::EventSource;
 
+/// Derive a NATS-safe name by combining a prefix with the subject.
+/// Replaces characters not allowed in NATS stream/consumer names (`.`, `>`, `*`)
+/// with dashes and strips trailing dashes.
+fn derive_nats_name(prefix: &str, subject: &str) -> String {
+    let sanitized: String = subject
+        .chars()
+        .map(|c| match c {
+            '.' | '>' | '*' => '-',
+            _ => c,
+        })
+        .collect();
+    format!("{}-{}", prefix, sanitized.trim_end_matches('-'))
+}
+
 /// NATS JetStream consumer that yields events as JSON strings.
+///
+/// Uses at-most-once delivery: messages are acked immediately on receive,
+/// before the engine processes them. If the daemon crashes between ack and
+/// processing, the event is lost. At-least-once delivery requires a feedback
+/// channel from engine to source (deferred to Level 2).
 pub struct NatsSource {
     messages: jetstream::consumer::pull::Stream,
 }
@@ -17,9 +36,12 @@ impl NatsSource {
         let client = async_nats::connect(url).await?;
         let jetstream = jetstream::new(client);
 
+        let stream_name = derive_nats_name("rsigma", subject);
+        let consumer_name = derive_nats_name("rsigma-daemon", subject);
+
         let stream = jetstream
             .get_or_create_stream(jetstream::stream::Config {
-                name: "rsigma-events".to_string(),
+                name: stream_name,
                 subjects: vec![subject.to_string()],
                 ..Default::default()
             })
@@ -27,9 +49,9 @@ impl NatsSource {
 
         let consumer = stream
             .get_or_create_consumer(
-                "rsigma-daemon",
+                &consumer_name,
                 jetstream::consumer::pull::Config {
-                    durable_name: Some("rsigma-daemon".to_string()),
+                    durable_name: Some(consumer_name.clone()),
                     filter_subject: subject.to_string(),
                     ..Default::default()
                 },

--- a/crates/rsigma-cli/src/daemon/streaming/stdin_source.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/stdin_source.rs
@@ -1,0 +1,47 @@
+use std::io::BufRead;
+
+use tokio::sync::mpsc;
+
+use super::EventSource;
+
+/// Reads JSON events from stdin, one per line.
+///
+/// Spawns a blocking thread internally to read from stdin. The async
+/// `recv()` reads from the internal channel, bridging the sync-to-async
+/// boundary.
+pub struct StdinSource {
+    rx: mpsc::Receiver<String>,
+}
+
+impl StdinSource {
+    /// Create a new StdinSource and spawn its blocking reader thread.
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::channel(10_000);
+        tokio::task::spawn_blocking(move || {
+            let stdin = std::io::stdin();
+            let reader = stdin.lock();
+            for line in reader.lines() {
+                match line {
+                    Ok(line) if !line.trim().is_empty() => {
+                        if tx.blocking_send(line).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Error reading stdin");
+                        break;
+                    }
+                }
+            }
+            tracing::info!("stdin closed");
+        });
+        StdinSource { rx }
+    }
+}
+
+impl EventSource for StdinSource {
+    async fn recv(&mut self) -> Option<String> {
+        self.rx.recv().await
+    }
+}

--- a/crates/rsigma-cli/src/daemon/streaming/stdout_sink.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/stdout_sink.rs
@@ -1,0 +1,46 @@
+use std::io::Write;
+
+use rsigma_eval::ProcessResult;
+
+use super::StreamingError;
+
+/// Serializes ProcessResult to NDJSON and writes to stdout.
+pub struct StdoutSink {
+    pretty: bool,
+}
+
+impl StdoutSink {
+    pub fn new(pretty: bool) -> Self {
+        StdoutSink { pretty }
+    }
+
+    /// Serialize and write a ProcessResult to stdout.
+    pub fn send(&self, result: &ProcessResult) -> Result<(), StreamingError> {
+        if result.detections.is_empty() && result.correlations.is_empty() {
+            return Ok(());
+        }
+
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+
+        for m in &result.detections {
+            let json = if self.pretty {
+                serde_json::to_string_pretty(m)?
+            } else {
+                serde_json::to_string(m)?
+            };
+            writeln!(out, "{json}")?;
+        }
+
+        for m in &result.correlations {
+            let json = if self.pretty {
+                serde_json::to_string_pretty(m)?
+            } else {
+                serde_json::to_string(m)?
+            };
+            writeln!(out, "{json}")?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -174,6 +174,15 @@ enum Commands {
         /// Only meaningful when --state-db is set.
         #[arg(long = "state-save-interval", default_value = "30", value_parser = clap::value_parser!(u64).range(1..))]
         state_save_interval: u64,
+
+        /// Event input source. Supported schemes: stdin, http, nats://<host>:<port>/<subject>
+        #[arg(long = "input", default_value = "stdin")]
+        input: String,
+
+        /// Detection output sink (can be repeated for fan-out).
+        /// Supported schemes: stdout, file://<path>, nats://<host>:<port>/<subject>
+        #[arg(long = "output", default_value = "stdout")]
+        output: Vec<String>,
     },
 
     /// Evaluate events against Sigma rules
@@ -275,6 +284,8 @@ fn main() {
             timestamp_fields,
             state_db,
             state_save_interval,
+            input,
+            output,
         } => cmd_daemon(
             rules,
             pipelines,
@@ -291,6 +302,8 @@ fn main() {
             timestamp_fields,
             state_db,
             state_save_interval,
+            input,
+            output,
         ),
         Commands::Parse { path, pretty } => cmd_parse(path, pretty),
         Commands::Validate {
@@ -371,6 +384,8 @@ fn cmd_daemon(
     timestamp_fields: Vec<String>,
     state_db: Option<PathBuf>,
     state_save_interval: u64,
+    input: String,
+    output: Vec<String>,
 ) {
     // Set up structured logging
     tracing_subscriber::fmt()
@@ -409,6 +424,8 @@ fn cmd_daemon(
         event_filter,
         state_db,
         state_save_interval,
+        input,
+        output,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/tests/cli.rs
+++ b/crates/rsigma-cli/tests/cli.rs
@@ -1546,3 +1546,137 @@ level: medium
         "detection should still work with --state-db on detection-only rules"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Streaming pipeline tests
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_streaming_stdin_stdout() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let event = r#"{"CommandLine":"malware.exe"}"#;
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--input",
+            "stdin",
+            "--output",
+            "stdout",
+        ])
+        .write_stdin(format!("{event}\n"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Test Rule\""),
+        "stdin->stdout pipeline should produce detection output: {stdout}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_streaming_file_output() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let dir = TempDir::new().unwrap();
+    let out_path = dir.path().join("detections.ndjson");
+    let event = r#"{"CommandLine":"malware.exe"}"#;
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--output",
+            &format!("file://{}", out_path.display()),
+        ])
+        .write_stdin(format!("{event}\n"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.is_empty() || !stdout.contains("\"rule_title\""),
+        "file output should NOT write to stdout: {stdout}"
+    );
+
+    let file_content = std::fs::read_to_string(&out_path).unwrap();
+    assert!(
+        file_content.contains("\"rule_title\":\"Test Rule\""),
+        "file sink should contain detection output: {file_content}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_streaming_fanout_stdout_and_file() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let dir = TempDir::new().unwrap();
+    let out_path = dir.path().join("detections.ndjson");
+    let event = r#"{"CommandLine":"malware.exe"}"#;
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--output",
+            "stdout",
+            "--output",
+            &format!("file://{}", out_path.display()),
+        ])
+        .write_stdin(format!("{event}\n"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Test Rule\""),
+        "fan-out should write to stdout: {stdout}"
+    );
+
+    let file_content = std::fs::read_to_string(&out_path).unwrap();
+    assert!(
+        file_content.contains("\"rule_title\":\"Test Rule\""),
+        "fan-out should also write to file: {file_content}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_streaming_no_match_produces_no_output() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let event = r#"{"CommandLine":"benign.exe"}"#;
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+        ])
+        .write_stdin(format!("{event}\n"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.trim().is_empty(),
+        "non-matching event should produce no stdout output: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Refactor daemon from hardcoded stdin/stdout to a pluggable streaming pipeline via `EventSource` trait and `Sink` enum dispatch
- Add `--input` (stdin, http, nats://) and `--output` (stdout, file://, nats://) CLI flags with fan-out support
- New `daemon-nats` feature flag for NATS JetStream source/sink behind `async-nats`

## Pipeline

```
[Source] --mpsc<String>--> [Engine] --mpsc<ProcessResult>--> [Sink]
```

## Test plan

- [x] 4 integration tests: stdin->stdout, file output, fan-out, no-match silence
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] All 693 tests pass on both `--features daemon` and `--all-features`