### PR TITLE
feat: async pipeline hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ rsigma daemon -r rules/ --input http
 # NATS JetStream source and sink (requires daemon-nats feature)
 rsigma daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections
 
+# Tune pipeline: micro-batch 64 events per lock, 50K buffer, 10s drain on shutdown
+rsigma daemon -r rules/ --batch-size 64 --buffer-size 50000 --drain-timeout 10
+
 # With a processing pipeline for field mapping
 rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
 ```

--- a/crates/rsigma-cli/src/daemon/metrics.rs
+++ b/crates/rsigma-cli/src/daemon/metrics.rs
@@ -16,6 +16,11 @@ pub struct Metrics {
     pub reloads_failed: IntCounter,
     pub processing_latency: Histogram,
     pub uptime_seconds: Gauge,
+    pub input_queue_depth: IntGauge,
+    pub output_queue_depth: IntGauge,
+    pub back_pressure_events: IntCounter,
+    pub pipeline_latency: Histogram,
+    pub batch_size_histogram: Histogram,
 }
 
 impl Metrics {
@@ -82,6 +87,41 @@ impl Metrics {
             "Daemon uptime in seconds",
         ))
         .unwrap();
+        let input_queue_depth = IntGauge::with_opts(Opts::new(
+            "rsigma_input_queue_depth",
+            "Current events buffered in source→engine channel",
+        ))
+        .unwrap();
+        let output_queue_depth = IntGauge::with_opts(Opts::new(
+            "rsigma_output_queue_depth",
+            "Current results buffered in engine→sink channel",
+        ))
+        .unwrap();
+        let back_pressure_events = IntCounter::with_opts(Opts::new(
+            "rsigma_back_pressure_events_total",
+            "Times a source was blocked on a full event channel",
+        ))
+        .unwrap();
+        let pipeline_latency = Histogram::with_opts(
+            HistogramOpts::new(
+                "rsigma_pipeline_latency_seconds",
+                "End-to-end latency from event dequeue to sink send",
+            )
+            .buckets(vec![
+                0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5,
+            ]),
+        )
+        .unwrap();
+        let batch_size_histogram = Histogram::with_opts(
+            HistogramOpts::new(
+                "rsigma_batch_size",
+                "Number of events processed per engine lock acquisition",
+            )
+            .buckets(vec![
+                1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0,
+            ]),
+        )
+        .unwrap();
 
         registry
             .register(Box::new(events_processed.clone()))
@@ -110,6 +150,21 @@ impl Metrics {
             .register(Box::new(processing_latency.clone()))
             .unwrap();
         registry.register(Box::new(uptime_seconds.clone())).unwrap();
+        registry
+            .register(Box::new(input_queue_depth.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(output_queue_depth.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(back_pressure_events.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(pipeline_latency.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(batch_size_histogram.clone()))
+            .unwrap();
 
         Metrics {
             registry,
@@ -124,6 +179,11 @@ impl Metrics {
             reloads_failed,
             processing_latency,
             uptime_seconds,
+            input_queue_depth,
+            output_queue_depth,
+            back_pressure_events,
+            pipeline_latency,
+            batch_size_histogram,
         }
     }
 

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -45,6 +45,9 @@ pub struct DaemonConfig {
     pub state_save_interval: u64,
     pub input: String,
     pub output: Vec<String>,
+    pub buffer_size: usize,
+    pub batch_size: usize,
+    pub drain_timeout: u64,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
@@ -137,7 +140,8 @@ pub async fn run_daemon(config: DaemonConfig) {
     let start_time = Instant::now();
 
     // Create event channel early so both source and HTTP handler can use it
-    let (event_tx, mut event_rx) = mpsc::channel::<String>(10_000);
+    let buffer_size = config.buffer_size;
+    let (event_tx, mut event_rx) = mpsc::channel::<String>(buffer_size);
 
     let http_event_tx = if config.input == "http" {
         Some(event_tx.clone())
@@ -246,27 +250,31 @@ pub async fn run_daemon(config: DaemonConfig) {
     // event_tx / event_rx were created above (before AppState) so the HTTP
     // handler can share event_tx when --input is http.
 
-    let (sink_tx, mut sink_rx) = mpsc::channel::<ProcessResult>(10_000);
+    let (sink_tx, mut sink_rx) = mpsc::channel::<ProcessResult>(buffer_size);
 
-    // Select source based on --input flag
-    match config.input.as_str() {
+    // Select source based on --input flag. Store the source handle so we can
+    // abort it on shutdown to trigger graceful drain.
+    let source_handle: Option<tokio::task::JoinHandle<()>> = match config.input.as_str() {
         "stdin" | "stdin://" => {
-            streaming::spawn_source(StdinSource::new(), event_tx);
+            let h = streaming::spawn_source(StdinSource::new(), event_tx, Some(metrics.clone()));
             tracing::info!(input = "stdin", "Event source started");
+            Some(h)
         }
         "http" => {
             // Events arrive via POST /api/v1/events; event_tx is held by AppState.
             // Drop the local event_tx so the channel closes when AppState is dropped.
             drop(event_tx);
             tracing::info!(input = "http", "Event source started (POST /api/v1/events)");
+            None
         }
         #[cfg(feature = "daemon-nats")]
         input if input.starts_with("nats://") => {
             let (url, subject) = parse_nats_url(input);
             match streaming::NatsSource::connect(&url, &subject).await {
                 Ok(source) => {
-                    streaming::spawn_source(source, event_tx);
+                    let h = streaming::spawn_source(source, event_tx, Some(metrics.clone()));
                     tracing::info!(url = url, subject = subject, "NATS source started");
+                    Some(h)
                 }
                 Err(e) => {
                     tracing::error!(error = %e, url = url, "Failed to connect NATS source");
@@ -281,28 +289,70 @@ pub async fn run_daemon(config: DaemonConfig) {
             );
             std::process::exit(1);
         }
-    }
+    };
 
-    // Engine task: reads events, evaluates rules, sends results to sink channel
+    // Engine task: reads events, evaluates rules, sends results to sink channel.
+    // Supports micro-batching: collects up to batch_size events per lock acquisition.
     let engine_shared = shared_engine.clone();
     let engine_metrics = metrics.clone();
     let event_filter = config.event_filter.clone();
-    let engine_handle = tokio::spawn(async move {
-        while let Some(line) = event_rx.recv().await {
-            let result = {
+    let batch_size = config.batch_size;
+    let mut engine_handle = tokio::spawn(async move {
+        loop {
+            let pipeline_start = std::time::Instant::now();
+
+            let first = match event_rx.recv().await {
+                Some(line) => line,
+                None => break,
+            };
+            engine_metrics.input_queue_depth.dec();
+
+            let mut batch = Vec::with_capacity(batch_size.min(64));
+            batch.push(first);
+            while batch.len() < batch_size {
+                match event_rx.try_recv() {
+                    Ok(line) => {
+                        engine_metrics.input_queue_depth.dec();
+                        batch.push(line);
+                    }
+                    Err(_) => break,
+                }
+            }
+            engine_metrics
+                .batch_size_histogram
+                .observe(batch.len() as f64);
+
+            let results: Vec<ProcessResult> = {
                 let mut engine = engine_shared.lock().unwrap();
-                let result = process_line(&mut engine, &line, &engine_metrics, &event_filter);
+                let results: Vec<_> = batch
+                    .iter()
+                    .map(|line| process_line(&mut engine, line, &engine_metrics, &event_filter))
+                    .collect();
                 let stats = engine.stats();
                 engine_metrics
                     .correlation_state_entries
                     .set(stats.state_entries as i64);
-                result
+                results
             };
-            if result.detections.is_empty() && result.correlations.is_empty() {
-                continue;
+
+            let mut shutdown = false;
+            for result in results {
+                if result.detections.is_empty() && result.correlations.is_empty() {
+                    continue;
+                }
+                engine_metrics.output_queue_depth.inc();
+                if sink_tx.send(result).await.is_err() {
+                    tracing::debug!("Sink channel closed, engine shutting down");
+                    shutdown = true;
+                    break;
+                }
             }
-            if sink_tx.send(result).await.is_err() {
-                tracing::debug!("Sink channel closed, engine shutting down");
+
+            engine_metrics
+                .pipeline_latency
+                .observe(pipeline_start.elapsed().as_secs_f64());
+
+            if shutdown {
                 break;
             }
         }
@@ -328,30 +378,55 @@ pub async fn run_daemon(config: DaemonConfig) {
     tracing::info!(output = ?output_specs, "Sink started");
 
     // Sink task: reads ProcessResult from channel, writes via Sink dispatch
+    let sink_metrics = metrics.clone();
     let sink_handle = tokio::spawn(async move {
         let mut sink = sink;
         while let Some(result) = sink_rx.recv().await {
+            sink_metrics.output_queue_depth.dec();
             if let Err(e) = sink.send(&result).await {
                 tracing::warn!(error = %e, "Error writing to sink");
             }
         }
     });
 
-    tokio::select! {
+    let drain_duration = std::time::Duration::from_secs(config.drain_timeout);
+
+    let shutdown_triggered = tokio::select! {
         result = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal()) => {
             if let Err(e) = result {
                 tracing::error!(error = %e, "HTTP server error");
             }
+            true
         }
-        _ = engine_handle => {
+        _ = &mut engine_handle => {
             tracing::info!("Streaming pipeline complete");
+            false
         }
-    }
+    };
 
-    // Wait for the sink task to drain any remaining results before exiting.
-    // The engine task owns sink_tx, so once it exits, sink_rx closes and the
-    // sink task finishes after processing buffered items.
-    let _ = sink_handle.await;
+    if shutdown_triggered {
+        tracing::info!("Shutdown signal received, draining pipeline...");
+
+        // Abort the source task to stop feeding new events. Dropping its
+        // event_tx clone closes event_rx once the engine drains buffered events.
+        if let Some(h) = source_handle {
+            h.abort();
+        }
+
+        let drain = async {
+            let _ = engine_handle.await;
+            let _ = sink_handle.await;
+        };
+        if tokio::time::timeout(drain_duration, drain).await.is_err() {
+            tracing::warn!(
+                timeout_secs = config.drain_timeout,
+                "Drain timeout exceeded, some events may be lost"
+            );
+        }
+    } else {
+        // Engine exited naturally (source exhausted). Drain the sink.
+        let _ = sink_handle.await;
+    }
 
     // Save state on shutdown
     if let Some(ref store) = state_store {

--- a/crates/rsigma-cli/src/daemon/streaming/mod.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/mod.rs
@@ -116,14 +116,34 @@ impl Sink {
 ///
 /// The source reads events in a loop via `recv()` and forwards them to
 /// `event_tx`. When the source is exhausted or the channel is closed,
-/// the task completes.
+/// the task completes. Tracks `input_queue_depth` and `back_pressure_events`
+/// metrics when provided.
 pub fn spawn_source<S: EventSource>(
     mut source: S,
     event_tx: tokio::sync::mpsc::Sender<String>,
+    metrics: Option<crate::daemon::metrics::Metrics>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(line) = source.recv().await {
-            if event_tx.send(line).await.is_err() {
+            if let Some(ref m) = metrics {
+                match event_tx.try_send(line) {
+                    Ok(()) => {
+                        m.input_queue_depth.inc();
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(line)) => {
+                        m.back_pressure_events.inc();
+                        m.input_queue_depth.inc();
+                        if event_tx.send(line).await.is_err() {
+                            tracing::debug!("Event channel closed, source shutting down");
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::debug!("Event channel closed, source shutting down");
+                        break;
+                    }
+                }
+            } else if event_tx.send(line).await.is_err() {
                 tracing::debug!("Event channel closed, source shutting down");
                 break;
             }

--- a/crates/rsigma-cli/src/daemon/streaming/stdin_source.rs
+++ b/crates/rsigma-cli/src/daemon/streaming/stdin_source.rs
@@ -1,47 +1,35 @@
-use std::io::BufRead;
-
-use tokio::sync::mpsc;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use super::EventSource;
 
 /// Reads JSON events from stdin, one per line.
 ///
-/// Spawns a blocking thread internally to read from stdin. The async
-/// `recv()` reads from the internal channel, bridging the sync-to-async
-/// boundary.
+/// Uses `tokio::io::stdin()` with `AsyncBufReadExt::lines()` for fully async
+/// reading without a background blocking thread.
 pub struct StdinSource {
-    rx: mpsc::Receiver<String>,
+    lines: tokio::io::Lines<BufReader<tokio::io::Stdin>>,
 }
 
 impl StdinSource {
-    /// Create a new StdinSource and spawn its blocking reader thread.
     pub fn new() -> Self {
-        let (tx, rx) = mpsc::channel(10_000);
-        tokio::task::spawn_blocking(move || {
-            let stdin = std::io::stdin();
-            let reader = stdin.lock();
-            for line in reader.lines() {
-                match line {
-                    Ok(line) if !line.trim().is_empty() => {
-                        if tx.blocking_send(line).is_err() {
-                            break;
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(e) => {
-                        tracing::warn!(error = %e, "Error reading stdin");
-                        break;
-                    }
-                }
-            }
-            tracing::info!("stdin closed");
-        });
-        StdinSource { rx }
+        let stdin = tokio::io::stdin();
+        let lines = BufReader::new(stdin).lines();
+        StdinSource { lines }
     }
 }
 
 impl EventSource for StdinSource {
     async fn recv(&mut self) -> Option<String> {
-        self.rx.recv().await
+        loop {
+            match self.lines.next_line().await {
+                Ok(Some(line)) if !line.trim().is_empty() => return Some(line),
+                Ok(Some(_)) => continue,
+                Ok(None) => return None,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Error reading stdin");
+                    return None;
+                }
+            }
+        }
     }
 }

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -183,6 +183,20 @@ enum Commands {
         /// Supported schemes: stdout, file://<path>, nats://<host>:<port>/<subject>
         #[arg(long = "output", default_value = "stdout")]
         output: Vec<String>,
+
+        /// Bounded channel capacity for source→engine and engine→sink queues.
+        /// Higher values absorb bursts; lower values apply back-pressure sooner.
+        #[arg(long = "buffer-size", default_value = "10000")]
+        buffer_size: usize,
+
+        /// Maximum events to process per engine lock acquisition.
+        /// Reduces mutex overhead under load. 1 = process one at a time (default).
+        #[arg(long = "batch-size", default_value = "1")]
+        batch_size: usize,
+
+        /// Seconds to wait for in-flight events to drain on shutdown (default: 5).
+        #[arg(long = "drain-timeout", default_value = "5")]
+        drain_timeout: u64,
     },
 
     /// Evaluate events against Sigma rules
@@ -286,6 +300,9 @@ fn main() {
             state_save_interval,
             input,
             output,
+            buffer_size,
+            batch_size,
+            drain_timeout,
         } => cmd_daemon(
             rules,
             pipelines,
@@ -304,6 +321,9 @@ fn main() {
             state_save_interval,
             input,
             output,
+            buffer_size,
+            batch_size,
+            drain_timeout,
         ),
         Commands::Parse { path, pretty } => cmd_parse(path, pretty),
         Commands::Validate {
@@ -386,6 +406,9 @@ fn cmd_daemon(
     state_save_interval: u64,
     input: String,
     output: Vec<String>,
+    buffer_size: usize,
+    batch_size: usize,
+    drain_timeout: u64,
 ) {
     // Set up structured logging
     tracing_subscriber::fmt()
@@ -426,6 +449,9 @@ fn cmd_daemon(
         state_save_interval,
         input,
         output,
+        buffer_size,
+        batch_size,
+        drain_timeout,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/tests/cli.rs
+++ b/crates/rsigma-cli/tests/cli.rs
@@ -1680,3 +1680,66 @@ fn daemon_streaming_no_match_produces_no_output() {
         "non-matching event should produce no stdout output: {stdout}"
     );
 }
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_streaming_batch_size() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let events = (0..5)
+        .map(|_| r#"{"CommandLine":"malware.exe"}"#)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--batch-size",
+            "4",
+        ])
+        .write_stdin(events)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let matches: Vec<_> = stdout.lines().collect();
+    assert_eq!(
+        matches.len(),
+        5,
+        "batch-size=4 should still produce 5 detections: got {count}",
+        count = matches.len()
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_streaming_custom_buffer_size() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let event = r#"{"CommandLine":"malware.exe"}"#;
+
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--buffer-size",
+            "16",
+        ])
+        .write_stdin(format!("{event}\n"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Test Rule\""),
+        "small buffer-size should still produce output: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Async stdin**: replace `spawn_blocking` reader with `tokio::io::AsyncBufReadExt`
- **Pipeline tuning flags**: `--buffer-size`, `--batch-size`, `--drain-timeout`
- **Micro-batching**: engine collects up to N events per mutex lock via `try_recv()`
- **5 new Prometheus metrics**: `rsigma_input_queue_depth`, `rsigma_output_queue_depth`, `rsigma_back_pressure_events_total`, `rsigma_pipeline_latency_seconds`, `rsigma_batch_size`
- **Graceful drain**: on SIGTERM, abort source → drain engine → drain sink, with configurable timeout

## Test plan

- [x] All 71 existing tests pass
- [x] `daemon_streaming_batch_size` — 5 events with `--batch-size 4` produces 5 detections
- [x] `daemon_streaming_custom_buffer_size` — `--buffer-size 16` works correctly
- [x] `cargo clippy --all-targets --all-features` clean (0 warnings)