### PR TITLE
feat: inverted index + parallel batch evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,6 +2660,7 @@ dependencies = [
  "log",
  "proptest",
  "rand 0.9.2",
+ "rayon",
  "regex",
  "rsigma-parser",
  "serde",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -16,7 +16,7 @@ daemon-nats = ["daemon", "async-nats", "tokio-stream"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.5.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.5.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.5.0", features = ["parallel"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-cli/src/daemon/engine.rs
+++ b/crates/rsigma-cli/src/daemon/engine.rs
@@ -13,47 +13,73 @@ use super::state::DaemonEngine;
 /// synchronous operations.
 pub type SharedEngine = Arc<Mutex<DaemonEngine>>;
 
-/// Process a single JSON line through the engine and return matches.
+/// Process a batch of JSON lines using parallel batch evaluation.
 ///
-/// Parses the JSON, applies the event filter (which may produce multiple
-/// payloads from a single line), evaluates each payload against the engine,
-/// and returns a merged `ProcessResult` containing all detections and
-/// correlations. Updates metrics counters as a side-effect.
-pub fn process_line(
+/// Parses each line, applies the event filter, then evaluates all resulting
+/// events together via `DaemonEngine::process_batch()` (which uses parallel
+/// detection + sequential correlation). Returns one `ProcessResult` per
+/// input line, with multi-payload lines merged.
+pub fn process_batch_lines(
     engine: &mut DaemonEngine,
-    line: &str,
+    batch: &[String],
     metrics: &Metrics,
     event_filter: &crate::EventFilter,
-) -> ProcessResult {
-    let value: serde_json::Value = match serde_json::from_str(line) {
-        Ok(v) => v,
-        Err(e) => {
-            metrics.events_parse_errors.inc();
-            tracing::debug!(error = %e, "Invalid JSON on input");
-            return ProcessResult {
+) -> Vec<ProcessResult> {
+    // Phase 1: Parse JSON and apply event filters, tracking line origin.
+    // Payloads are owned here so Events can borrow them during evaluation.
+    let mut parsed: Vec<(usize, Vec<serde_json::Value>)> = Vec::with_capacity(batch.len());
+    for (line_idx, line) in batch.iter().enumerate() {
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(value) => {
+                let payloads = crate::apply_event_filter(&value, event_filter);
+                if !payloads.is_empty() {
+                    parsed.push((line_idx, payloads));
+                }
+            }
+            Err(e) => {
+                metrics.events_parse_errors.inc();
+                tracing::debug!(error = %e, "Invalid JSON on input");
+            }
+        }
+    }
+
+    // Flatten: (line_idx, &Value) for each payload across all lines
+    let mut flat: Vec<(usize, &serde_json::Value)> = Vec::new();
+    for (line_idx, payloads) in &parsed {
+        for payload in payloads {
+            flat.push((*line_idx, payload));
+        }
+    }
+
+    if flat.is_empty() {
+        return (0..batch.len())
+            .map(|_| ProcessResult {
                 detections: vec![],
                 correlations: vec![],
-            };
-        }
-    };
+            })
+            .collect();
+    }
 
-    let payloads = crate::apply_event_filter(&value, event_filter);
+    // Phase 2: Batch evaluation — parallel detection + sequential correlation
+    let events: Vec<Event> = flat.iter().map(|(_, v)| Event::from_value(v)).collect();
+    let event_refs: Vec<&Event> = events.iter().collect();
 
-    let mut merged = ProcessResult {
-        detections: Vec::new(),
-        correlations: Vec::new(),
-    };
+    let start = Instant::now();
+    let batch_results = engine.process_batch(&event_refs);
+    let elapsed = start.elapsed().as_secs_f64();
+    let per_event_latency = elapsed / event_refs.len() as f64;
 
-    for payload in payloads {
-        let event = Event::from_value(&payload);
+    // Phase 3: Merge results per input line and update metrics
+    let mut line_results: Vec<ProcessResult> = (0..batch.len())
+        .map(|_| ProcessResult {
+            detections: vec![],
+            correlations: vec![],
+        })
+        .collect();
 
-        let start = Instant::now();
-        let result = engine.process_event(&event);
-        let elapsed = start.elapsed().as_secs_f64();
-
+    for ((line_idx, _), result) in flat.iter().zip(batch_results) {
         metrics.events_processed.inc();
-        metrics.processing_latency.observe(elapsed);
-
+        metrics.processing_latency.observe(per_event_latency);
         metrics
             .detection_matches
             .inc_by(result.detections.len() as u64);
@@ -61,9 +87,11 @@ pub fn process_line(
             .correlation_matches
             .inc_by(result.correlations.len() as u64);
 
-        merged.detections.extend(result.detections);
-        merged.correlations.extend(result.correlations);
+        line_results[*line_idx].detections.extend(result.detections);
+        line_results[*line_idx]
+            .correlations
+            .extend(result.correlations);
     }
 
-    merged
+    line_results
 }

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -12,7 +12,7 @@ use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
 use serde::Serialize;
 use tokio::sync::mpsc;
 
-use super::engine::{SharedEngine, process_line};
+use super::engine::{SharedEngine, process_batch_lines};
 use super::health::HealthState;
 use super::metrics::Metrics;
 use super::reload;
@@ -324,10 +324,8 @@ pub async fn run_daemon(config: DaemonConfig) {
 
             let results: Vec<ProcessResult> = {
                 let mut engine = engine_shared.lock().unwrap();
-                let results: Vec<_> = batch
-                    .iter()
-                    .map(|line| process_line(&mut engine, line, &engine_metrics, &event_filter))
-                    .collect();
+                let results =
+                    process_batch_lines(&mut engine, &batch, &engine_metrics, &event_filter);
                 let stats = engine.stats();
                 engine_metrics
                     .correlation_state_entries

--- a/crates/rsigma-cli/src/daemon/state.rs
+++ b/crates/rsigma-cli/src/daemon/state.rs
@@ -94,16 +94,23 @@ impl DaemonEngine {
         }
     }
 
-    pub fn process_event(&mut self, event: &Event) -> ProcessResult {
+    /// Process a batch of events using parallel detection + sequential correlation.
+    ///
+    /// Delegates to `Engine::evaluate_batch` or `CorrelationEngine::process_batch`
+    /// depending on whether correlation rules are loaded.
+    pub fn process_batch(&mut self, events: &[&Event]) -> Vec<ProcessResult> {
         match &mut self.engine {
             EngineVariant::DetectionOnly(engine) => {
-                let detections = engine.evaluate(event);
-                ProcessResult {
-                    detections,
-                    correlations: vec![],
-                }
+                let batch_detections = engine.evaluate_batch(events);
+                batch_detections
+                    .into_iter()
+                    .map(|detections| ProcessResult {
+                        detections,
+                        correlations: vec![],
+                    })
+                    .collect()
             }
-            EngineVariant::WithCorrelations(engine) => engine.process_event(event),
+            EngineVariant::WithCorrelations(engine) => engine.process_batch(events),
         }
     }
 

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[features]
+parallel = ["rayon"]
+
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.5.0" }
 serde = { version = "1", features = ["derive"] }
@@ -21,6 +24,7 @@ thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 flate2 = "1"
 log = "0.4"
+rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -466,16 +466,16 @@ Rules are pre-filtered at evaluation time using an inverted index on exact-match
 
 ### Detection Evaluation
 
-| Scenario | Time | Throughput |
-|----------|------|------------|
-| Compile 1,000 rules | 946 µs | -- |
-| Compile 5,000 rules | 4.7 ms | -- |
-| 1 event vs 100 rules | 2.3 µs | -- |
-| 1 event vs 1,000 rules | 30 µs | -- |
-| 1 event vs 5,000 rules | 164 µs | -- |
-| 100K events vs 100 rules | 253 ms | **396K events/sec** |
-| Wildcard-heavy (1,000 rules, 100 events) | 18.3 µs | -- |
-| Regex-heavy (1,000 rules, 100 events) | 5.1 µs | -- |
+| Scenario | Baseline | Indexed | Speedup |
+|----------|----------|---------|---------|
+| Compile 1,000 rules | 740 µs | 946 µs | 0.8x (index build) |
+| Compile 5,000 rules | 3.8 ms | 4.7 ms | 0.8x (index build) |
+| 1 event vs 100 rules | 5.6 µs | 2.3 µs | **2.4x** |
+| 1 event vs 1,000 rules | 81 µs | 30 µs | **2.7x** |
+| 1 event vs 5,000 rules | 415 µs | 164 µs | **2.5x** |
+| 100K events vs 100 rules | 613 ms (163K/s) | 253 ms (396K/s) | **2.4x** |
+| Wildcard-heavy (1,000 rules, 100 events) | 16 µs | 18 µs | ~1x (unindexable) |
+| Regex-heavy (1,000 rules, 100 events) | 3.3 µs | 5.1 µs | ~1x (unindexable) |
 
 ### Batch Evaluation (sequential vs `parallel` feature)
 
@@ -487,14 +487,14 @@ Rules are pre-filtered at evaluation time using an inverted index on exact-match
 
 ### Correlation Engine
 
-| Scenario | Time | Throughput |
-|----------|------|------------|
-| 1K events, 20 event_count correlations | 988 µs | **1.01M events/sec** |
-| 1K events, 10 temporal correlations | 502 µs | **1.99M events/sec** |
-| 100K events, 50 detection + 10 correlation rules | 176 ms | **568K events/sec** |
-| Batch 10K events (sequential) | 18.1 ms | **552K events/sec** |
-| Batch 10K events (process_batch) | 19.2 ms | **521K events/sec** |
-| 50K unique group keys (state pressure) | 38.4 ms | **1.30M events/sec** |
+| Scenario | Baseline | Indexed | Speedup |
+|----------|----------|---------|---------|
+| 1K events, 20 event_count correlations | 1.08 ms (926K/s) | 988 µs (1.01M/s) | 1.1x |
+| 1K events, 10 temporal correlations | 489 µs (2.04M/s) | 502 µs (1.99M/s) | ~1x |
+| 100K events, 50 detection + 10 correlation rules | 293 ms (342K/s) | 176 ms (568K/s) | **1.7x** |
+| Batch 10K events (sequential) | -- | 18.1 ms (552K/s) | -- |
+| Batch 10K events (process_batch) | -- | 19.2 ms (521K/s) | -- |
+| 50K unique group keys (state pressure) | 32.9 ms (1.52M/s) | 38.4 ms (1.30M/s) | ~1x |
 
 ```bash
 cargo bench --bench eval

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -23,6 +23,7 @@ This library is part of [rsigma].
 | `apply_filter(filter: &FilterRule)` | Inject filter as `AND NOT` into referenced rules |
 | `evaluate(event: &Event)` | Evaluate all rules against an event |
 | `evaluate_with_logsource(event, logsource)` | Evaluate with logsource-based pre-filtering |
+| `evaluate_batch(events: &[&Event])` | Evaluate all rules against multiple events (parallel with `parallel` feature) |
 | `rule_count()` | Number of loaded rules |
 | `rules()` | Access the compiled rules slice |
 
@@ -37,6 +38,9 @@ This library is part of [rsigma].
 | `add_correlation(corr: &CorrelationRule)` | Add a single correlation rule |
 | `process_event(event: &Event)` | Evaluate + update correlation state (wall-clock time) |
 | `process_event_at(event, timestamp_secs)` | Evaluate + update state with explicit timestamp |
+| `evaluate(event: &Event)` | Run detection only (no correlation state update) |
+| `process_with_detections(event, detections, ts)` | Feed pre-computed detections into correlation state |
+| `process_batch(events: &[&Event])` | Parallel detection + sequential correlation for a batch of events |
 | `evict_expired(now)` | Manually evict expired state entries |
 | `state_count()` | Number of active correlation state entries |
 | `event_buffer_count()` | Total events stored across all buffers |
@@ -457,29 +461,40 @@ let result = engine.process_event_at(&event, timestamp_secs);
 
 ## Benchmarks
 
-Criterion.rs benchmarks with synthetic rules and events (Apple M-series, single-threaded):
+Criterion.rs benchmarks with synthetic rules and events (Apple M-series, single-threaded unless noted).
+Rules are pre-filtered at evaluation time using an inverted index on exact-match field-value pairs.
 
 ### Detection Evaluation
 
 | Scenario | Time | Throughput |
 |----------|------|------------|
-| Compile 1,000 rules | 669 us | -- |
-| Compile 5,000 rules | 3.4 ms | -- |
-| 1 event vs 100 rules | 4.8 us | -- |
-| 1 event vs 1,000 rules | 65 us | -- |
-| 1 event vs 5,000 rules | 336 us | -- |
-| 100K events vs 100 rules | 458 ms | **218K events/sec** |
-| Wildcard-heavy (1,000 rules, 100 events) | 5.9 ms | -- |
-| Regex-heavy (1,000 rules, 100 events) | 7.3 ms | -- |
+| Compile 1,000 rules | 946 µs | -- |
+| Compile 5,000 rules | 4.7 ms | -- |
+| 1 event vs 100 rules | 2.3 µs | -- |
+| 1 event vs 1,000 rules | 30 µs | -- |
+| 1 event vs 5,000 rules | 164 µs | -- |
+| 100K events vs 100 rules | 253 ms | **396K events/sec** |
+| Wildcard-heavy (1,000 rules, 100 events) | 18.3 µs | -- |
+| Regex-heavy (1,000 rules, 100 events) | 5.1 µs | -- |
+
+### Batch Evaluation (sequential vs `parallel` feature)
+
+| Rules | Events | Sequential | Batch |
+|-------|--------|------------|-------|
+| 100 | 1,000 | 2.5 ms | 2.5 ms |
+| 1,000 | 1,000 | 30.5 ms | 31.0 ms |
+| 5,000 | 1,000 | 162 ms | 164 ms |
 
 ### Correlation Engine
 
 | Scenario | Time | Throughput |
 |----------|------|------------|
-| 1K events, 20 event_count correlations | 727 us | **1.37M events/sec** |
-| 1K events, 10 temporal correlations | 411 us | **2.43M events/sec** |
-| 100K events, 50 detection + 10 correlation rules | 217 ms | **462K events/sec** |
-| 50K unique group keys (state pressure) | 35.8 ms | **1.40M events/sec** |
+| 1K events, 20 event_count correlations | 988 µs | **1.01M events/sec** |
+| 1K events, 10 temporal correlations | 502 µs | **1.99M events/sec** |
+| 100K events, 50 detection + 10 correlation rules | 176 ms | **568K events/sec** |
+| Batch 10K events (sequential) | 18.1 ms | **552K events/sec** |
+| Batch 10K events (process_batch) | 19.2 ms | **521K events/sec** |
+| 50K unique group keys (state pressure) | 38.4 ms | **1.30M events/sec** |
 
 ```bash
 cargo bench --bench eval

--- a/crates/rsigma-eval/benches/correlation.rs
+++ b/crates/rsigma-eval/benches/correlation.rs
@@ -148,6 +148,64 @@ fn bench_correlation_throughput(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: batch correlation (process_batch vs sequential process_event_at)
+// ---------------------------------------------------------------------------
+
+fn bench_correlation_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("correlation_batch");
+    group.sample_size(10);
+
+    let yaml = datagen::gen_rules_with_event_count_correlations(50, 10);
+    let collection = parse_sigma_yaml(&yaml).unwrap();
+
+    let n_events = 10_000;
+    let event_values = datagen::gen_event_values(n_events);
+    let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+
+    group.throughput(criterion::Throughput::Elements(n_events as u64));
+
+    // Sequential: loop calling process_event_at per event
+    group.bench_with_input(
+        BenchmarkId::new("mode", "sequential"),
+        &events,
+        |b, events| {
+            b.iter_with_setup(
+                || {
+                    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+                    engine.add_collection(&collection).unwrap();
+                    engine
+                },
+                |mut engine| {
+                    let base_ts = 1_000_000i64;
+                    for (i, event) in events.iter().enumerate() {
+                        let result = engine.process_event_at(black_box(event), base_ts + i as i64);
+                        black_box(&result);
+                    }
+                },
+            );
+        },
+    );
+
+    // Batch: process_batch (parallel detection + sequential correlation)
+    group.bench_with_input(BenchmarkId::new("mode", "batch"), &events, |b, events| {
+        b.iter_with_setup(
+            || {
+                let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+                engine.add_collection(&collection).unwrap();
+                engine
+            },
+            |mut engine| {
+                let refs: Vec<&Event> = events.iter().collect();
+                let results = engine.process_batch(black_box(&refs));
+                black_box(results);
+            },
+        );
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Benchmark: state pressure (many unique group keys)
 // ---------------------------------------------------------------------------
 
@@ -236,6 +294,7 @@ criterion_group!(
     bench_correlation_event_count,
     bench_correlation_temporal,
     bench_correlation_throughput,
+    bench_correlation_batch,
     bench_correlation_state_pressure,
 );
 criterion_main!(benches);

--- a/crates/rsigma-eval/benches/datagen.rs
+++ b/crates/rsigma-eval/benches/datagen.rs
@@ -155,6 +155,7 @@ pub fn gen_single_rule(rng: &mut StdRng, id: usize) -> String {
 
     let mut detection = String::new();
     detection.push_str("    selection:\n");
+    let mut used_keys = std::collections::HashSet::new();
     for _ in 0..num_items {
         let field = FIELD_NAMES[rng.random_range(0..FIELD_NAMES.len())];
         let val = STRING_VALUES[rng.random_range(0..STRING_VALUES.len())];
@@ -165,17 +166,22 @@ pub fn gen_single_rule(rng: &mut StdRng, id: usize) -> String {
             3 => "|endswith",
             _ => "",
         };
-        detection.push_str(&format!("        {field}{modifier}: '{val}'\n"));
+        let key = format!("{field}{modifier}");
+        if !used_keys.insert(key.clone()) {
+            continue;
+        }
+        detection.push_str(&format!("        {key}: '{val}'\n"));
     }
 
-    if rng.random_bool(0.3) {
+    let has_filter = rng.random_bool(0.3);
+    if has_filter {
         detection.push_str("    filter:\n");
         let field = FIELD_NAMES[rng.random_range(0..FIELD_NAMES.len())];
         let val = STRING_VALUES[rng.random_range(0..STRING_VALUES.len())];
         detection.push_str(&format!("        {field}: '{val}'\n"));
     }
 
-    let condition = if rng.random_bool(0.3) {
+    let condition = if has_filter {
         "selection and not filter".to_string()
     } else {
         "selection".to_string()

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -137,6 +137,55 @@ fn bench_eval_wildcard_heavy(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: batch parallel evaluation vs sequential
+// ---------------------------------------------------------------------------
+
+fn bench_eval_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eval_batch");
+    group.sample_size(20);
+
+    for (n_rules, n_events) in [(100, 1_000), (1000, 1_000), (5000, 1_000)] {
+        let yaml = datagen::gen_n_rules(n_rules);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+
+        let event_values = datagen::gen_event_values(n_events);
+        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+
+        group.throughput(criterion::Throughput::Elements(n_events as u64));
+
+        // Sequential: loop calling evaluate() per event
+        let label = format!("{n_rules}r_seq");
+        group.bench_with_input(
+            BenchmarkId::new("sequential", &label),
+            &events,
+            |b, events| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for event in events {
+                        total += engine.evaluate(black_box(event)).len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+
+        // Batch: evaluate_batch() (parallel when feature enabled)
+        let label = format!("{n_rules}r_batch");
+        group.bench_with_input(BenchmarkId::new("batch", &label), &events, |b, events| {
+            b.iter(|| {
+                let refs: Vec<&Event> = events.iter().collect();
+                let results = engine.evaluate_batch(black_box(&refs));
+                black_box(results);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Benchmark: regex-heavy rules
 // ---------------------------------------------------------------------------
 
@@ -179,6 +228,7 @@ criterion_group!(
     bench_compile_rules,
     bench_eval_single_event,
     bench_eval_throughput,
+    bench_eval_batch,
     bench_eval_wildcard_heavy,
     bench_eval_regex_heavy,
 );

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -19,7 +19,6 @@ fn bench_compile_rules(c: &mut Criterion) {
     for n in [100, 500, 1000, 5000] {
         let yaml = datagen::gen_n_rules(n);
         let collection = parse_sigma_yaml(&yaml).unwrap();
-
         group.bench_with_input(
             BenchmarkId::new("count", n),
             &collection,

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -573,13 +573,14 @@ impl CorrelationEngine {
     /// - `WallClock`: use `Utc::now()` (good for real-time streaming)
     /// - `Skip`: return detections only, skip correlation state updates
     pub fn process_event(&mut self, event: &Event) -> ProcessResult {
+        let all_detections = self.engine.evaluate(event);
+
         let ts = match self.extract_event_timestamp(event) {
             Some(ts) => ts,
             None => match self.config.timestamp_fallback {
                 TimestampFallback::WallClock => Utc::now().timestamp(),
                 TimestampFallback::Skip => {
                     // Still run detection (stateless), but skip correlation
-                    let all_detections = self.engine.evaluate(event);
                     let detections = self.filter_detections(all_detections);
                     return ProcessResult {
                         detections,
@@ -588,7 +589,7 @@ impl CorrelationEngine {
                 }
             },
         };
-        self.process_event_at(event, ts)
+        self.process_with_detections(event, all_detections, ts)
     }
 
     /// Process an event with an explicit Unix epoch timestamp (seconds).
@@ -596,30 +597,51 @@ impl CorrelationEngine {
     /// The timestamp is clamped to `[0, i64::MAX / 2]` to prevent overflow
     /// when adding timespan durations internally.
     pub fn process_event_at(&mut self, event: &Event, timestamp_secs: i64) -> ProcessResult {
+        let all_detections = self.engine.evaluate(event);
+        self.process_with_detections(event, all_detections, timestamp_secs)
+    }
+
+    /// Process an event with pre-computed detection results.
+    ///
+    /// Enables external parallelism: callers can run detection (via
+    /// [`evaluate`](Self::evaluate)) in parallel, then feed results here
+    /// sequentially for stateful correlation.
+    pub fn process_with_detections(
+        &mut self,
+        event: &Event,
+        all_detections: Vec<MatchResult>,
+        timestamp_secs: i64,
+    ) -> ProcessResult {
         let timestamp_secs = timestamp_secs.clamp(0, i64::MAX / 2);
 
-        // Step 1: Memory management — evict before adding new state to enforce limit
+        // Memory management — evict before adding new state to enforce limit
         if self.state.len() >= self.config.max_state_entries {
             self.evict_all(timestamp_secs);
         }
 
-        // Step 2: Run stateless detection
-        let all_detections = self.engine.evaluate(event);
-
-        // Step 3: Feed detection matches into correlations
+        // Feed detection matches into correlations
         let mut correlations = Vec::new();
         self.feed_detections(event, &all_detections, timestamp_secs, &mut correlations);
 
-        // Step 4: Chain — correlation results may trigger higher-level correlations
+        // Chain — correlation results may trigger higher-level correlations
         self.chain_correlations(&correlations, timestamp_secs);
 
-        // Step 5: Filter detections by generate flag
+        // Filter detections by generate flag
         let detections = self.filter_detections(all_detections);
 
         ProcessResult {
             detections,
             correlations,
         }
+    }
+
+    /// Run stateless detection only (no correlation), delegating to the inner engine.
+    ///
+    /// Takes `&self` so it can be called concurrently from multiple threads
+    /// (e.g. via `rayon::par_iter`) while the mutable correlation phase runs
+    /// sequentially afterwards.
+    pub fn evaluate(&self, event: &Event) -> Vec<MatchResult> {
+        self.engine.evaluate(event)
     }
 
     /// Filter detections by the `generate` flag / `emit_detections` config.

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -4164,4 +4164,125 @@ level: high
             Some(CorrelationAction::Reset)
         );
     }
+
+    #[test]
+    fn test_process_with_detections_matches_process_event_at() {
+        let yaml = r#"
+title: Login Failure
+id: login-fail
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login_failure
+    condition: selection
+---
+title: Brute Force
+correlation:
+    type: event_count
+    rules:
+        - login-fail
+    group-by:
+        - User
+    timespan: 60s
+    condition:
+        gte: 3
+level: high
+"#;
+        let collection = parse_sigma_yaml(yaml).unwrap();
+
+        // Run with process_event_at
+        let mut engine1 = CorrelationEngine::new(CorrelationConfig::default());
+        engine1.add_collection(&collection).unwrap();
+
+        let events: Vec<serde_json::Value> = (0..5)
+            .map(|i| json!({"EventType": "login_failure", "User": "admin", "@timestamp": format!("2025-01-01T00:00:0{}Z", i + 1)}))
+            .collect();
+
+        let results1: Vec<ProcessResult> = events
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let e = Event::from_value(v);
+                engine1.process_event_at(&e, 1000 + i as i64)
+            })
+            .collect();
+
+        // Run with evaluate + process_with_detections
+        let mut engine2 = CorrelationEngine::new(CorrelationConfig::default());
+        engine2.add_collection(&collection).unwrap();
+
+        let results2: Vec<ProcessResult> = events
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let e = Event::from_value(v);
+                let detections = engine2.evaluate(&e);
+                engine2.process_with_detections(&e, detections, 1000 + i as i64)
+            })
+            .collect();
+
+        // Same number of results
+        assert_eq!(results1.len(), results2.len());
+        for (r1, r2) in results1.iter().zip(results2.iter()) {
+            assert_eq!(r1.detections.len(), r2.detections.len());
+            assert_eq!(r1.correlations.len(), r2.correlations.len());
+        }
+    }
+
+    #[test]
+    fn test_process_batch_matches_sequential() {
+        let yaml = r#"
+title: Login Failure
+id: login-fail-batch
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login_failure
+    condition: selection
+---
+title: Brute Force Batch
+correlation:
+    type: event_count
+    rules:
+        - login-fail-batch
+    group-by:
+        - User
+    timespan: 60s
+    condition:
+        gte: 3
+level: high
+"#;
+        let collection = parse_sigma_yaml(yaml).unwrap();
+
+        let event_values: Vec<serde_json::Value> = (0..5)
+            .map(|i| json!({"EventType": "login_failure", "User": "admin", "@timestamp": format!("2025-01-01T00:00:0{}Z", i + 1)}))
+            .collect();
+
+        // Sequential
+        let mut engine1 = CorrelationEngine::new(CorrelationConfig::default());
+        engine1.add_collection(&collection).unwrap();
+        let sequential: Vec<ProcessResult> = event_values
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let e = Event::from_value(v);
+                engine1.process_event_at(&e, 1000 + i as i64)
+            })
+            .collect();
+
+        // Batch
+        let mut engine2 = CorrelationEngine::new(CorrelationConfig::default());
+        engine2.add_collection(&collection).unwrap();
+        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let refs: Vec<&Event> = events.iter().collect();
+        let batch = engine2.process_batch(&refs);
+
+        assert_eq!(sequential.len(), batch.len());
+        for (seq, bat) in sequential.iter().zip(batch.iter()) {
+            assert_eq!(seq.detections.len(), bat.detections.len());
+            assert_eq!(seq.correlations.len(), bat.correlations.len());
+        }
+    }
 }

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -644,6 +644,71 @@ impl CorrelationEngine {
         self.engine.evaluate(event)
     }
 
+    /// Process a batch of events: parallel detection, then sequential correlation.
+    ///
+    /// When the `parallel` feature is enabled, the stateless detection phase runs
+    /// concurrently via rayon. Timestamp extraction also runs in the parallel
+    /// phase (it borrows `&self.config` immutably). After `collect()` releases the
+    /// immutable borrows, each event's pre-computed detections are fed into the
+    /// stateful correlation engine sequentially.
+    pub fn process_batch<'a>(&mut self, events: &[&'a Event<'a>]) -> Vec<ProcessResult> {
+        // Borrow split: take immutable refs to fields needed for the parallel phase.
+        // These are released by collect() before the sequential &mut self phase.
+        let engine = &self.engine;
+        let ts_fields = &self.config.timestamp_fields;
+
+        let batch_results: Vec<(Vec<MatchResult>, Option<i64>)> = {
+            #[cfg(feature = "parallel")]
+            {
+                use rayon::prelude::*;
+                events
+                    .par_iter()
+                    .map(|e| {
+                        let detections = engine.evaluate(e);
+                        let ts = extract_event_ts(e, ts_fields);
+                        (detections, ts)
+                    })
+                    .collect()
+            }
+            #[cfg(not(feature = "parallel"))]
+            {
+                events
+                    .iter()
+                    .map(|e| {
+                        let detections = engine.evaluate(e);
+                        let ts = extract_event_ts(e, ts_fields);
+                        (detections, ts)
+                    })
+                    .collect()
+            }
+        };
+
+        // Sequential correlation phase
+        let mut results = Vec::with_capacity(events.len());
+        for ((detections, ts_opt), event) in batch_results.into_iter().zip(events) {
+            match ts_opt {
+                Some(ts) => {
+                    results.push(self.process_with_detections(event, detections, ts));
+                }
+                None => match self.config.timestamp_fallback {
+                    TimestampFallback::WallClock => {
+                        let ts = Utc::now().timestamp();
+                        results.push(self.process_with_detections(event, detections, ts));
+                    }
+                    TimestampFallback::Skip => {
+                        // Still return detection results, but skip correlation
+                        let detections = self.filter_detections(detections);
+                        results.push(ProcessResult {
+                            detections,
+                            correlations: Vec::new(),
+                        });
+                    }
+                },
+            }
+        }
+        results
+    }
+
     /// Filter detections by the `generate` flag / `emit_detections` config.
     ///
     /// If `emit_detections` is false and some rules are correlation-only,
@@ -1301,6 +1366,21 @@ impl Default for CorrelationEngine {
 // =============================================================================
 // Timestamp parsing helpers
 // =============================================================================
+
+/// Extract a timestamp from an event using the given field names.
+///
+/// Standalone version of `CorrelationEngine::extract_event_timestamp` for use
+/// in contexts where borrowing `&self` is not possible (e.g. rayon closures).
+fn extract_event_ts(event: &Event, timestamp_fields: &[String]) -> Option<i64> {
+    for field_name in timestamp_fields {
+        if let Some(val) = event.get_field(field_name)
+            && let Some(ts) = parse_timestamp_value(val)
+        {
+            return Some(ts);
+        }
+    }
+    None
+}
 
 /// Parse a JSON value as a Unix epoch timestamp in seconds.
 fn parse_timestamp_value(val: &serde_json::Value) -> Option<i64> {

--- a/crates/rsigma-eval/src/engine.rs
+++ b/crates/rsigma-eval/src/engine.rs
@@ -1560,4 +1560,59 @@ level: low
         let ev = json!({"winlog.CommandLine": "testing"});
         assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
     }
+
+    #[test]
+    fn test_evaluate_batch_matches_sequential() {
+        let yaml = r#"
+title: Login
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+---
+title: Process Create
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+    condition: selection
+---
+title: Keyword
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+
+        let vals = [
+            json!({"EventType": "login", "User": "admin"}),
+            json!({"EventType": "process_create", "CommandLine": "whoami"}),
+            json!({"EventType": "file_create"}),
+            json!({"CommandLine": "whoami /all"}),
+        ];
+        let events: Vec<Event> = vals.iter().map(Event::from_value).collect();
+
+        // Sequential
+        let sequential: Vec<Vec<_>> = events.iter().map(|e| engine.evaluate(e)).collect();
+
+        // Batch
+        let refs: Vec<&Event> = events.iter().collect();
+        let batch = engine.evaluate_batch(&refs);
+
+        assert_eq!(sequential.len(), batch.len());
+        for (seq, bat) in sequential.iter().zip(batch.iter()) {
+            assert_eq!(seq.len(), bat.len());
+            for (s, b) in seq.iter().zip(bat.iter()) {
+                assert_eq!(s.rule_title, b.rule_title);
+            }
+        }
+    }
 }

--- a/crates/rsigma-eval/src/engine.rs
+++ b/crates/rsigma-eval/src/engine.rs
@@ -11,6 +11,7 @@ use crate::error::Result;
 use crate::event::Event;
 use crate::pipeline::{Pipeline, apply_pipelines};
 use crate::result::MatchResult;
+use crate::rule_index::RuleIndex;
 
 /// The main rule evaluation engine.
 ///
@@ -55,6 +56,9 @@ pub struct Engine {
     /// Monotonic counter used to namespace injected filter detections,
     /// preventing key collisions when multiple filters share detection names.
     filter_counter: usize,
+    /// Inverted index mapping `(field, exact_value)` to candidate rule indices.
+    /// Rebuilt after every rule mutation (add, filter).
+    rule_index: RuleIndex,
 }
 
 impl Engine {
@@ -65,6 +69,7 @@ impl Engine {
             pipelines: Vec::new(),
             include_event: false,
             filter_counter: 0,
+            rule_index: RuleIndex::empty(),
         }
     }
 
@@ -75,6 +80,7 @@ impl Engine {
             pipelines: vec![pipeline],
             include_event: false,
             filter_counter: 0,
+            rule_index: RuleIndex::empty(),
         }
     }
 
@@ -96,6 +102,7 @@ impl Engine {
     /// Add a single parsed Sigma rule.
     ///
     /// If pipelines are set, the rule is cloned and transformed before compilation.
+    /// The inverted index is rebuilt after adding the rule.
     pub fn add_rule(&mut self, rule: &SigmaRule) -> Result<()> {
         let compiled = if self.pipelines.is_empty() {
             compile_rule(rule)?
@@ -105,6 +112,7 @@ impl Engine {
             compile_rule(&transformed)?
         };
         self.rules.push(compiled);
+        self.rebuild_index();
         Ok(())
     }
 
@@ -112,21 +120,30 @@ impl Engine {
     ///
     /// Filter rules modify referenced detection rules by appending exclusion
     /// conditions. Correlation rules are handled by `CorrelationEngine`.
+    /// The inverted index is rebuilt once after all rules and filters are loaded.
     pub fn add_collection(&mut self, collection: &SigmaCollection) -> Result<()> {
         for rule in &collection.rules {
-            self.add_rule(rule)?;
+            let compiled = if self.pipelines.is_empty() {
+                compile_rule(rule)?
+            } else {
+                let mut transformed = rule.clone();
+                apply_pipelines(&self.pipelines, &mut transformed)?;
+                compile_rule(&transformed)?
+            };
+            self.rules.push(compiled);
         }
-        // Apply filter rules after all detection rules are loaded
         for filter in &collection.filters {
-            self.apply_filter(filter)?;
+            self.apply_filter_no_rebuild(filter)?;
         }
+        self.rebuild_index();
         Ok(())
     }
 
     /// Add all detection rules from a collection, applying the given pipelines.
     ///
     /// This is a convenience method that temporarily sets pipelines, adds the
-    /// collection, then clears them.
+    /// collection, then clears them. The inverted index is rebuilt once after
+    /// all rules and filters are loaded.
     pub fn add_collection_with_pipelines(
         &mut self,
         collection: &SigmaCollection,
@@ -140,11 +157,16 @@ impl Engine {
         result
     }
 
-    /// Apply a filter rule to all referenced detection rules.
-    ///
-    /// For each detection in the filter, compile it and inject it into matching
-    /// rules as `AND NOT filter_condition`.
+    /// Apply a filter rule to all referenced detection rules and rebuild the index.
     pub fn apply_filter(&mut self, filter: &FilterRule) -> Result<()> {
+        self.apply_filter_no_rebuild(filter)?;
+        self.rebuild_index();
+        Ok(())
+    }
+
+    /// Apply a filter rule without rebuilding the index.
+    /// Used internally when multiple mutations are batched.
+    fn apply_filter_no_rebuild(&mut self, filter: &FilterRule) -> Result<()> {
         // Compile filter detections
         let mut filter_detections = Vec::new();
         for (name, detection) in &filter.detection.named {
@@ -222,15 +244,22 @@ impl Engine {
         Ok(())
     }
 
-    /// Add a pre-compiled rule directly.
+    /// Add a pre-compiled rule directly and rebuild the index.
     pub fn add_compiled_rule(&mut self, rule: CompiledRule) {
         self.rules.push(rule);
+        self.rebuild_index();
     }
 
-    /// Evaluate an event against all rules, returning matches.
+    /// Rebuild the inverted index from the current rule set.
+    fn rebuild_index(&mut self) {
+        self.rule_index = RuleIndex::build(&self.rules);
+    }
+
+    /// Evaluate an event against candidate rules using the inverted index.
     pub fn evaluate(&self, event: &Event) -> Vec<MatchResult> {
         let mut results = Vec::new();
-        for rule in &self.rules {
+        for idx in self.rule_index.candidates(event) {
+            let rule = &self.rules[idx];
             if let Some(mut m) = evaluate_rule(rule, event) {
                 if self.include_event && m.event.is_none() {
                     m.event = Some(event.as_value().clone());
@@ -241,19 +270,19 @@ impl Engine {
         results
     }
 
-    /// Evaluate an event against rules matching the given logsource.
+    /// Evaluate an event against candidate rules matching the given logsource.
     ///
-    /// Only rules whose logsource is compatible with `event_logsource` are
-    /// evaluated. A rule's logsource is compatible if every field it specifies
-    /// (category, product, service) matches the corresponding field in the
-    /// event logsource.
+    /// Uses the inverted index for candidate pre-filtering, then applies the
+    /// logsource constraint. Only rules whose logsource is compatible with
+    /// `event_logsource` are evaluated.
     pub fn evaluate_with_logsource(
         &self,
         event: &Event,
         event_logsource: &LogSource,
     ) -> Vec<MatchResult> {
         let mut results = Vec::new();
-        for rule in &self.rules {
+        for idx in self.rule_index.candidates(event) {
+            let rule = &self.rules[idx];
             if logsource_matches(&rule.logsource, event_logsource)
                 && let Some(mut m) = evaluate_rule(rule, event)
             {

--- a/crates/rsigma-eval/src/engine.rs
+++ b/crates/rsigma-eval/src/engine.rs
@@ -295,6 +295,23 @@ impl Engine {
         results
     }
 
+    /// Evaluate a batch of events, returning per-event match results.
+    ///
+    /// When the `parallel` feature is enabled, events are evaluated concurrently
+    /// using rayon's work-stealing thread pool. Otherwise, falls back to
+    /// sequential evaluation.
+    pub fn evaluate_batch<'a>(&self, events: &[&'a Event<'a>]) -> Vec<Vec<MatchResult>> {
+        #[cfg(feature = "parallel")]
+        {
+            use rayon::prelude::*;
+            events.par_iter().map(|e| self.evaluate(e)).collect()
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            events.iter().map(|e| self.evaluate(e)).collect()
+        }
+    }
+
     /// Number of rules loaded in the engine.
     pub fn rule_count(&self) -> usize {
         self.rules.len()

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -96,6 +96,7 @@ pub mod event;
 pub mod matcher;
 pub mod pipeline;
 pub mod result;
+pub(crate) mod rule_index;
 
 // Re-export the most commonly used types and functions at crate root
 pub use compiler::{

--- a/crates/rsigma-eval/src/rule_index.rs
+++ b/crates/rsigma-eval/src/rule_index.rs
@@ -1,0 +1,535 @@
+//! Inverted index for rule pre-filtering.
+//!
+//! At rule load time, builds a mapping from `(field_name, exact_value)` to
+//! rule indices. At evaluation time, the event's field values are used to
+//! look up candidate rules, avoiding the O(n_rules) linear scan.
+//!
+//! The index is an **over-approximation**: it may return rules that don't
+//! actually match (false positives filtered by `evaluate_rule`), but never
+//! misses a rule that should match (no false negatives).
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::compiler::{CompiledDetection, CompiledDetectionItem, CompiledRule};
+use crate::event::Event;
+use crate::matcher::CompiledMatcher;
+
+/// Pre-computed inverted index over compiled rules.
+///
+/// Maps `field_name -> { lowercase_value -> [rule_indices] }` for exact-match
+/// detection items. Rules with no indexable exact-match fields are tracked in
+/// `unindexable` and always evaluated.
+pub(crate) struct RuleIndex {
+    /// Maps field_name -> { lowercase_value -> sorted rule indices }.
+    field_index: HashMap<String, HashMap<String, Vec<usize>>>,
+    /// Rule indices that must always be evaluated (no exact-match fields,
+    /// or at least one detection branch has no exact-match coverage).
+    unindexable: Vec<usize>,
+    /// Total number of rules (for candidate dedup bitvec sizing).
+    rule_count: usize,
+}
+
+impl RuleIndex {
+    /// Build an empty index.
+    pub(crate) fn empty() -> Self {
+        RuleIndex {
+            field_index: HashMap::new(),
+            unindexable: Vec::new(),
+            rule_count: 0,
+        }
+    }
+
+    /// Build an index from a slice of compiled rules.
+    ///
+    /// For each rule, walks all detections and extracts `(field, exact_value)`
+    /// pairs from `CompiledMatcher::Exact` variants. A rule is fully indexable
+    /// only if **every** named detection has at least one exact-match item.
+    /// Otherwise, the rule is placed in the unindexable set to avoid false
+    /// negatives from OR conditions that reach an unindexable branch.
+    pub(crate) fn build(rules: &[CompiledRule]) -> Self {
+        let mut field_index: HashMap<String, HashMap<String, Vec<usize>>> = HashMap::new();
+        let mut unindexable: Vec<usize> = Vec::new();
+
+        for (rule_idx, rule) in rules.iter().enumerate() {
+            let mut all_pairs: Vec<(String, String)> = Vec::new();
+            let mut every_detection_has_pairs = true;
+
+            for detection in rule.detections.values() {
+                let pairs = extract_exact_pairs(detection);
+                if pairs.is_empty() {
+                    every_detection_has_pairs = false;
+                }
+                all_pairs.extend(pairs);
+            }
+
+            if all_pairs.is_empty() || !every_detection_has_pairs {
+                unindexable.push(rule_idx);
+            } else {
+                for (field, value) in all_pairs {
+                    field_index
+                        .entry(field)
+                        .or_default()
+                        .entry(value)
+                        .or_default()
+                        .push(rule_idx);
+                }
+            }
+        }
+
+        RuleIndex {
+            field_index,
+            unindexable,
+            rule_count: rules.len(),
+        }
+    }
+
+    /// Return candidate rule indices for the given event.
+    ///
+    /// Looks up each indexed field name in the event, then checks the field's
+    /// value against the index. Returns the union of all matching rule indices
+    /// plus all unindexable rules, deduplicated.
+    pub(crate) fn candidates(&self, event: &Event) -> Vec<usize> {
+        if self.field_index.is_empty() {
+            return (0..self.rule_count).collect();
+        }
+
+        let mut seen = vec![false; self.rule_count];
+        let mut result = Vec::new();
+
+        for (field_name, value_map) in &self.field_index {
+            if let Some(event_value) = event.get_field(field_name)
+                && let Some(search_key) = value_to_lowercase_string(event_value)
+                && let Some(rule_indices) = value_map.get(&search_key)
+            {
+                for &idx in rule_indices {
+                    if !seen[idx] {
+                        seen[idx] = true;
+                        result.push(idx);
+                    }
+                }
+            }
+        }
+
+        for &idx in &self.unindexable {
+            if !seen[idx] {
+                seen[idx] = true;
+                result.push(idx);
+            }
+        }
+
+        result
+    }
+
+    /// Number of rules tracked by the index.
+    #[cfg(test)]
+    pub(crate) fn rule_count(&self) -> usize {
+        self.rule_count
+    }
+
+    /// Number of rules that are always evaluated (not indexable).
+    #[cfg(test)]
+    pub(crate) fn unindexable_count(&self) -> usize {
+        self.unindexable.len()
+    }
+
+    /// Number of unique indexed field names.
+    #[cfg(test)]
+    pub(crate) fn indexed_field_count(&self) -> usize {
+        self.field_index.len()
+    }
+}
+
+/// Extract all `(lowercase_field, lowercase_value)` pairs from a compiled detection.
+fn extract_exact_pairs(detection: &CompiledDetection) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    match detection {
+        CompiledDetection::AllOf(items) => {
+            for item in items {
+                extract_from_item(item, &mut pairs);
+            }
+        }
+        CompiledDetection::AnyOf(subs) => {
+            for sub in subs {
+                pairs.extend(extract_exact_pairs(sub));
+            }
+        }
+        CompiledDetection::Keywords(_) => {}
+    }
+    pairs
+}
+
+/// Extract exact-match values from a single detection item.
+///
+/// Field names are stored in their original case because `Event::get_field()`
+/// performs case-sensitive JSON key lookups.
+fn extract_from_item(item: &CompiledDetectionItem, out: &mut Vec<(String, String)>) {
+    let field = match &item.field {
+        Some(f) => f.as_str(),
+        None => return,
+    };
+    extract_from_matcher(&item.matcher, field, out);
+}
+
+/// Recursively extract exact string values from a compiled matcher.
+fn extract_from_matcher(matcher: &CompiledMatcher, field: &str, out: &mut Vec<(String, String)>) {
+    match matcher {
+        CompiledMatcher::Exact { value, .. } => {
+            out.push((field.to_string(), value.to_lowercase()));
+        }
+        CompiledMatcher::AnyOf(children) => {
+            for child in children {
+                extract_from_matcher(child, field, out);
+            }
+        }
+        CompiledMatcher::AllOf(children) => {
+            for child in children {
+                extract_from_matcher(child, field, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Convert a JSON value to a lowercase string for index lookup.
+///
+/// Returns `None` for null, objects, and arrays (not meaningful for exact match).
+fn value_to_lowercase_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.to_lowercase()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Engine;
+    use rsigma_parser::parse_sigma_yaml;
+    use serde_json::json;
+
+    fn build_index(yaml: &str) -> (Engine, RuleIndex) {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+        let index = RuleIndex::build(engine.rules());
+        (engine, index)
+    }
+
+    #[test]
+    fn test_exact_match_indexed() {
+        let (_, index) = build_index(
+            r#"
+title: Login Event
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+"#,
+        );
+
+        assert_eq!(index.rule_count(), 1);
+        assert_eq!(index.unindexable_count(), 0);
+        assert_eq!(index.indexed_field_count(), 1);
+    }
+
+    #[test]
+    fn test_contains_only_unindexable() {
+        let (_, index) = build_index(
+            r#"
+title: Whoami Detection
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#,
+        );
+
+        assert_eq!(index.rule_count(), 1);
+        assert_eq!(index.unindexable_count(), 1);
+        assert_eq!(index.indexed_field_count(), 0);
+    }
+
+    #[test]
+    fn test_mixed_items_in_allof_detection() {
+        let (_, index) = build_index(
+            r#"
+title: Process Create
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#,
+        );
+
+        // The single AllOf detection has exact + contains items.
+        // The detection HAS exact pairs, so the rule is indexed.
+        assert_eq!(index.unindexable_count(), 0);
+        assert!(index.indexed_field_count() > 0);
+    }
+
+    #[test]
+    fn test_candidates_returns_matching_rule() {
+        let (_, index) = build_index(
+            r#"
+title: Login Event
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+"#,
+        );
+
+        let ev = json!({"EventType": "login", "User": "admin"});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert_eq!(candidates, vec![0]);
+    }
+
+    #[test]
+    fn test_candidates_skips_non_matching() {
+        let (_, index) = build_index(
+            r#"
+title: Login Event
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+"#,
+        );
+
+        let ev = json!({"EventType": "file_create", "User": "admin"});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_unindexable_always_returned() {
+        let (_, index) = build_index(
+            r#"
+title: Wildcard Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#,
+        );
+
+        let ev = json!({"SomeField": "whatever"});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert_eq!(candidates, vec![0]);
+    }
+
+    #[test]
+    fn test_case_insensitive_lookup() {
+        let (_, index) = build_index(
+            r#"
+title: Login Event
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'LOGIN'
+    condition: selection
+"#,
+        );
+
+        let ev = json!({"EventType": "login"});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert_eq!(candidates, vec![0]);
+    }
+
+    #[test]
+    fn test_multiple_rules_selective_candidates() {
+        let yaml = r#"
+title: Login
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+---
+title: File Create
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'file_create'
+    condition: selection
+---
+title: Process Create
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+    condition: selection
+"#;
+        let (_, index) = build_index(yaml);
+
+        assert_eq!(index.rule_count(), 3);
+        assert_eq!(index.unindexable_count(), 0);
+
+        let ev = json!({"EventType": "login"});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert_eq!(candidates, vec![0]);
+
+        let ev2 = json!({"EventType": "process_create"});
+        let event2 = Event::from_value(&ev2);
+        let candidates2 = index.candidates(&event2);
+        assert_eq!(candidates2, vec![2]);
+    }
+
+    #[test]
+    fn test_or_with_mixed_indexable_unindexable_detections() {
+        let (_, index) = build_index(
+            r#"
+title: Mixed OR
+logsource:
+    product: windows
+detection:
+    selection_a:
+        EventType: 'login'
+    selection_b:
+        CommandLine|contains: 'whoami'
+    condition: 1 of selection_*
+"#,
+        );
+
+        // selection_b has no exact pairs, so the rule is unindexable
+        // (conservatively correct for OR conditions).
+        assert_eq!(index.unindexable_count(), 1);
+    }
+
+    #[test]
+    fn test_anyof_exact_values_indexed() {
+        let (_, index) = build_index(
+            r#"
+title: Multi Value
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType:
+            - 'login'
+            - 'logout'
+    condition: selection
+"#,
+        );
+
+        assert_eq!(index.unindexable_count(), 0);
+
+        let ev_login = json!({"EventType": "login"});
+        let ev_logout = json!({"EventType": "logout"});
+        let ev_other = json!({"EventType": "file_create"});
+
+        assert_eq!(index.candidates(&Event::from_value(&ev_login)), vec![0]);
+        assert_eq!(index.candidates(&Event::from_value(&ev_logout)), vec![0]);
+        assert!(index.candidates(&Event::from_value(&ev_other)).is_empty());
+    }
+
+    #[test]
+    fn test_numeric_event_value_lookup() {
+        let (_, index) = build_index(
+            r#"
+title: Port Check
+logsource:
+    product: windows
+detection:
+    selection:
+        DestinationPort: '443'
+    condition: selection
+"#,
+        );
+
+        let ev = json!({"DestinationPort": 443});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert_eq!(candidates, vec![0]);
+    }
+
+    #[test]
+    fn test_empty_index_returns_all() {
+        let index = RuleIndex::empty();
+        assert_eq!(index.rule_count(), 0);
+    }
+
+    #[test]
+    fn test_dedup_candidates() {
+        let yaml = r#"
+title: Multi Field
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+        Protocol: 'TCP'
+    condition: selection
+"#;
+        let (_, index) = build_index(yaml);
+
+        // Event matches BOTH indexed fields for the same rule.
+        // Candidate should appear only once.
+        let ev = json!({"EventType": "login", "Protocol": "TCP"});
+        let event = Event::from_value(&ev);
+        let candidates = index.candidates(&event);
+        assert_eq!(candidates, vec![0]);
+    }
+
+    #[test]
+    fn test_keyword_detection_unindexable() {
+        let (_, index) = build_index(
+            r#"
+title: Keyword Rule
+logsource:
+    product: windows
+detection:
+    keywords:
+        - 'suspicious'
+        - 'malware'
+    condition: keywords
+"#,
+        );
+
+        assert_eq!(index.unindexable_count(), 1);
+    }
+
+    #[test]
+    fn test_regex_only_unindexable() {
+        let (_, index) = build_index(
+            r#"
+title: Regex Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|re: '(?i)whoami.*'
+    condition: selection
+"#,
+        );
+
+        assert_eq!(index.unindexable_count(), 1);
+        assert_eq!(index.indexed_field_count(), 0);
+    }
+}

--- a/crates/rsigma-parser/benches/datagen.rs
+++ b/crates/rsigma-parser/benches/datagen.rs
@@ -103,6 +103,7 @@ pub fn gen_single_rule(rng: &mut StdRng, id: usize) -> String {
 
     let mut detection = String::new();
     detection.push_str("    selection:\n");
+    let mut used_keys = std::collections::HashSet::new();
     for _ in 0..num_items {
         let field = FIELD_NAMES[rng.random_range(0..FIELD_NAMES.len())];
         let val = STRING_VALUES[rng.random_range(0..STRING_VALUES.len())];
@@ -113,18 +114,23 @@ pub fn gen_single_rule(rng: &mut StdRng, id: usize) -> String {
             3 => "|endswith",
             _ => "",
         };
-        detection.push_str(&format!("        {field}{modifier}: '{val}'\n"));
+        let key = format!("{field}{modifier}");
+        if !used_keys.insert(key.clone()) {
+            continue;
+        }
+        detection.push_str(&format!("        {key}: '{val}'\n"));
     }
 
     // Optionally add a filter
-    if rng.random_bool(0.3) {
+    let has_filter = rng.random_bool(0.3);
+    if has_filter {
         detection.push_str("    filter:\n");
         let field = FIELD_NAMES[rng.random_range(0..FIELD_NAMES.len())];
         let val = STRING_VALUES[rng.random_range(0..STRING_VALUES.len())];
         detection.push_str(&format!("        {field}: '{val}'\n"));
     }
 
-    let condition = if rng.random_bool(0.3) {
+    let condition = if has_filter {
         "selection and not filter".to_string()
     } else {
         "selection".to_string()


### PR DESCRIPTION
## Summary

- **Inverted index** for rule pre-filtering: build a `(field, exact_value) → rule_indices` HashMap at load time, reducing per-event evaluation from O(rules) to O(candidates). Rules without exact-match fields are marked unindexable and always evaluated.
- **Batch evaluation APIs**: `Engine::evaluate_batch()` and `CorrelationEngine::process_batch()` with feature-gated `rayon` parallelism (parallel detection + sequential correlation via borrow split).
- **Daemon integration**: replace per-event `process_line` loop with `process_batch_lines` for end-to-end batch processing.
- **Benchmarks**: Criterion benchmarks for indexed vs baseline and batch vs sequential. Fixed pre-existing datagen bugs (filter/condition mismatch, duplicate YAML keys).

Detection evaluation: **2.4–2.7x faster**. Correlation throughput (large workload): **1.7x faster**. Compilation ~20% slower (one-time index build).

## Test plan

- [x] Unit tests for `RuleIndex` (15 tests covering exact, wildcard, regex, mixed, dedup)
- [x] Unit tests verifying `evaluate_batch` matches sequential `evaluate`
- [x] Unit tests verifying `process_with_detections` matches `process_event_at`
- [x] Unit tests verifying `process_batch` matches sequential correlation
- [x] Existing `daemon_streaming_batch_size` CLI test exercises new batch path
- [x] All 714 tests pass, zero clippy warnings