### PR TITLE
release: v0.6.0 - streaming detection engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "async-nats",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -15,8 +15,8 @@ daemon = ["tokio", "axum", "prometheus", "notify", "rusqlite"]
 daemon-nats = ["daemon", "async-nats", "tokio-stream"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.5.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.5.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.6.0", features = ["parallel"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 parallel = ["rayon"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.5.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.5.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.5.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.6.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"


### PR DESCRIPTION
## Summary

Bumps workspace to `v0.6.0`. The v0.6.0 release turns the rsigma daemon from a stdin/stdout pipe into a deployable streaming detection engine with parallel evaluation.

## What's New

### Streaming I/O adapters (Level 1 — #15)

The daemon now speaks NATS JetStream, HTTP, and files — not just stdin/stdout.

```bash
# HTTP POST input
rsigma daemon -r rules/ --input http
# Then: curl -X POST http://localhost:9090/api/v1/events -d '{"CommandLine":"whoami"}'

# NATS JetStream end-to-end (requires daemon-nats feature)
rsigma daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections

# File output
rsigma daemon -r rules/ --output file:///var/log/detections.ndjson

# Fan-out to multiple sinks
rsigma daemon -r rules/ --output stdout --output file:///tmp/detections.ndjson
```

- **`EventSource` trait + `Sink` enum** — pluggable adapters with enum dispatch; async-friendly `Sink::FanOut(Vec<Sink>)` for multi-sink output.
- **`--input` / `--output` URL schemes** — `stdin://`, `http://`, `nats://`, `file://`, `stdout://`; multiple `--output` flags clone `ProcessResult` per sink via bounded mpsc channels.
- **`daemon-nats` feature flag** — gates `async-nats`; durable JetStream consumer with ACK, publisher sink.
- **`process_line()` refactored** — now returns typed `ProcessResult`; serialization is a sink concern, engine stays pure.

### Async pipeline hardening (Level 2 — #16)

- **Fully async stdin** via `tokio::io::AsyncBufReadExt` (no more `spawn_blocking`).
- **Configurable back-pressure** — `--buffer-size` (default 10,000) sets bounded mpsc capacity for both source→engine and engine→sink queues.
- **Micro-batched evaluation** — `--batch-size` (default 1); engine collects up to N events per mutex acquisition via `try_recv()`.
- **Graceful drain on shutdown** — `--drain-timeout` (default 5s) lets in-flight events finish before state save; natural EOF drains without timeout.
- **5 new Prometheus metrics:**
  - `rsigma_input_queue_depth`, `rsigma_output_queue_depth` (gauges)
  - `rsigma_back_pressure_events_total` (counter)
  - `rsigma_pipeline_latency_seconds`, `rsigma_batch_size` (histograms)

### Performance: inverted index + parallel batch evaluation (Level 3 — #17)

- **Inverted index** — `RuleIndex` maps `(field, exact_value) → rule indices` at load time. `Engine::evaluate()` queries candidates instead of scanning all rules. Rules without exact-match items are marked unindexable and always evaluated (no false negatives).
- **Feature-gated rayon** — new `parallel` feature on `rsigma-eval` enables `Engine::evaluate_batch()` and `CorrelationEngine::process_batch()`. Parallel detection + sequential correlation via a borrow split.
- **Daemon integration** — `process_batch_lines()` replaces the per-event loop.
- **Benchmark results** (5,000 rules, synthetic events):
  - Detection evaluation: **2.4–2.7× speedup** from indexing alone.
  - Correlation throughput: **~1.7× improvement** (indexed + sequential).
  - Batch evaluation scales with core count.

### New public APIs (`rsigma-eval`)

- `Engine::evaluate_batch(&self, events: &[&Event]) -> Vec<Vec<MatchResult>>`
- `CorrelationEngine::evaluate(&self, event: &Event) -> Vec<MatchResult>`
- `CorrelationEngine::process_with_detections(&mut self, event, detections, timestamp_secs) -> ProcessResult`
- `CorrelationEngine::process_batch(&mut self, events: &[&Event]) -> Vec<ProcessResult>`

### Pipeline parity (#13)

- **Named condition IDs** supported in `rule_cond_expression` (not just numeric indices).
- **Correlation rules** now apply processing pipelines consistently with detection rules.

### Dependencies & security (#21)

- `async-nats` 0.46 → 0.47 (drops pinned vulnerable `rustls-webpki 0.102.8`, `rustls-pemfile 2.2.0`, `rand 0.8.5`)
- `rustls-webpki` → 0.103.12 (RUSTSEC-2026-0049/-0098/-0099)
- `rand` → 0.9.4 (GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097)
- `lodash` override → 4.18.x in VS Code extension (devDependency-only)
- Dropped now-obsolete `--ignore RUSTSEC-2026-0049` from `audit.yml`
- `cargo audit`: 0 vulnerabilities

### Docs

- README updated with streaming examples (NATS / HTTP / file / fan-out / batching).
- `rsigma-eval` README updated with new APIs and benchmark tables.

## Test Plan

- [x] `cargo build --all-features` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean (Rust 1.95)
- [x] `cargo test --all-features --workspace` — 713 tests passing
- [x] `cargo audit` — 0 vulnerabilities
- [ ] CI green

## Post-merge

1. Create a GitHub release tagged `v0.6.0` — the `Release binaries` workflow will attach cross-platform artifacts.
2. Replace the auto-generated release notes with the curated summary above.