### PR TITLE
Unify `custom_rule_attributes` into `custom_attributes`

### DIFF
--- a/crates/rsigma-eval/src/compiler.rs
+++ b/crates/rsigma-eval/src/compiler.rs
@@ -44,10 +44,11 @@ pub struct CompiledRule {
     /// Whether to include the full event JSON in the match result.
     /// Controlled by the `rsigma.include_event` custom attribute.
     pub include_event: bool,
-    /// Custom rule attributes from the original Sigma rule YAML.
-    /// Non-standard top-level fields are propagated to match results.
-    /// Wrapped in `Arc` so that per-match cloning is a pointer bump.
-    pub custom_rule_attributes: Arc<HashMap<String, serde_json::Value>>,
+    /// Custom attributes from the original Sigma rule (merged view of
+    /// arbitrary top-level keys, the explicit `custom_attributes:` block,
+    /// and pipeline `SetCustomAttribute` additions). Propagated to match
+    /// results. Wrapped in `Arc` so per-match cloning is a pointer bump.
+    pub custom_attributes: Arc<HashMap<String, serde_json::Value>>,
 }
 
 /// A compiled detection definition.
@@ -207,9 +208,10 @@ pub fn compile_rule(rule: &SigmaRule) -> Result<CompiledRule> {
     let include_event = rule
         .custom_attributes
         .get("rsigma.include_event")
-        .is_some_and(|v| v == "true");
+        .and_then(|v| v.as_str())
+        == Some("true");
 
-    let custom_rule_attributes = Arc::new(yaml_to_json_map(&rule.custom_rule_attributes));
+    let custom_attributes = Arc::new(yaml_to_json_map(&rule.custom_attributes));
 
     Ok(CompiledRule {
         title: rule.title.clone(),
@@ -220,7 +222,7 @@ pub fn compile_rule(rule: &SigmaRule) -> Result<CompiledRule> {
         detections,
         conditions: rule.detection.conditions.clone(),
         include_event,
-        custom_rule_attributes,
+        custom_attributes,
     })
 }
 
@@ -273,7 +275,7 @@ pub fn evaluate_rule(rule: &CompiledRule, event: &Event) -> Option<MatchResult> 
                 matched_selections,
                 matched_fields,
                 event: event_data,
-                custom_rule_attributes: rule.custom_rule_attributes.clone(),
+                custom_attributes: rule.custom_attributes.clone(),
             });
         }
     }
@@ -1534,7 +1536,10 @@ mod tests {
         assert!(!eval_condition(&cond, &detections, &event2, &mut matched2));
     }
 
-    fn make_test_sigma_rule(title: &str, custom_attributes: HashMap<String, String>) -> SigmaRule {
+    fn make_test_sigma_rule(
+        title: &str,
+        custom_attributes: HashMap<String, serde_yaml::Value>,
+    ) -> SigmaRule {
         use rsigma_parser::{Detections, LogSource};
         SigmaRule {
             title: title.to_string(),
@@ -1579,14 +1584,16 @@ mod tests {
             fields: vec![],
             falsepositives: vec![],
             custom_attributes,
-            custom_rule_attributes: HashMap::new(),
         }
     }
 
     #[test]
     fn test_include_event_custom_attribute() {
         let mut attrs = HashMap::new();
-        attrs.insert("rsigma.include_event".to_string(), "true".to_string());
+        attrs.insert(
+            "rsigma.include_event".to_string(),
+            serde_yaml::Value::String("true".to_string()),
+        );
         let rule = make_test_sigma_rule("Include Event Test", attrs);
 
         let compiled = compile_rule(&rule).unwrap();
@@ -1613,7 +1620,7 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_rule_attributes_propagate_to_match_result() {
+    fn test_custom_attributes_propagate_to_match_result() {
         let yaml = r#"
 title: Rule With Custom Attrs
 logsource:
@@ -1631,45 +1638,81 @@ severity_score: 42
 
         let compiled = compile_rule(rule).unwrap();
 
-        // Custom rule attributes should be on the compiled rule
         assert_eq!(
-            compiled.custom_rule_attributes.get("my_custom_field"),
+            compiled.custom_attributes.get("my_custom_field"),
             Some(&serde_json::Value::String("some_value".to_string()))
         );
         assert_eq!(
-            compiled.custom_rule_attributes.get("severity_score"),
+            compiled.custom_attributes.get("severity_score"),
             Some(&serde_json::json!(42))
         );
 
-        // Standard fields should NOT be in custom_rule_attributes
-        assert!(!compiled.custom_rule_attributes.contains_key("title"));
-        assert!(!compiled.custom_rule_attributes.contains_key("level"));
+        assert!(!compiled.custom_attributes.contains_key("title"));
+        assert!(!compiled.custom_attributes.contains_key("level"));
 
-        // Match the rule and verify attributes propagate to MatchResult
         let ev = json!({"action": "login"});
         let event = Event::from_value(&ev);
         let result = evaluate_rule(&compiled, &event).unwrap();
 
         assert_eq!(
-            result.custom_rule_attributes.get("my_custom_field"),
+            result.custom_attributes.get("my_custom_field"),
             Some(&serde_json::Value::String("some_value".to_string()))
         );
         assert_eq!(
-            result.custom_rule_attributes.get("severity_score"),
+            result.custom_attributes.get("severity_score"),
             Some(&serde_json::json!(42))
         );
     }
 
     #[test]
-    fn test_empty_custom_rule_attributes() {
+    fn test_empty_custom_attributes() {
         let rule = make_test_sigma_rule("No Custom Attrs", HashMap::new());
         let compiled = compile_rule(&rule).unwrap();
-        assert!(compiled.custom_rule_attributes.is_empty());
+        assert!(compiled.custom_attributes.is_empty());
 
         let ev = json!({"action": "login"});
         let event = Event::from_value(&ev);
         let result = evaluate_rule(&compiled, &event).unwrap();
-        assert!(result.custom_rule_attributes.is_empty());
+        assert!(result.custom_attributes.is_empty());
+    }
+
+    #[test]
+    fn test_pipeline_set_custom_attribute_overrides_rule_yaml() {
+        // The YAML sets `rsigma.include_event: false`; the pipeline then writes
+        // "true" via `SetCustomAttribute` — last-write-wins.
+        let yaml = r#"
+title: Override Test
+logsource:
+    category: test
+detection:
+    selection:
+        action: login
+    condition: selection
+level: low
+custom_attributes:
+    rsigma.include_event: "false"
+"#;
+        let pipeline_yaml = r#"
+name: override
+transformations:
+  - type: set_custom_attribute
+    attribute: rsigma.include_event
+    value: "true"
+"#;
+        let collection = rsigma_parser::parse_sigma_yaml(yaml).unwrap();
+        let mut rule = collection.rules[0].clone();
+        let pipeline = crate::pipeline::parse_pipeline(pipeline_yaml).unwrap();
+        crate::pipeline::apply_pipelines(&[pipeline], &mut rule).unwrap();
+
+        assert_eq!(
+            rule.custom_attributes
+                .get("rsigma.include_event")
+                .and_then(|v| v.as_str()),
+            Some("true")
+        );
+
+        let compiled = compile_rule(&rule).unwrap();
+        assert!(compiled.include_event);
     }
 }
 

--- a/crates/rsigma-eval/src/correlation.rs
+++ b/crates/rsigma-eval/src/correlation.rs
@@ -59,9 +59,9 @@ pub struct CompiledCorrelation {
     /// Maximum events to store per window group for event inclusion.
     /// `None` means use the engine default (`CorrelationConfig.max_correlation_events`).
     pub max_events: Option<usize>,
-    /// Custom rule attributes from the original Sigma correlation rule YAML.
+    /// Custom attributes from the original Sigma correlation rule (merged).
     /// Wrapped in `Arc` so that per-match cloning is a pointer bump.
-    pub custom_rule_attributes: Arc<HashMap<String, serde_json::Value>>,
+    pub custom_attributes: Arc<HashMap<String, serde_json::Value>>,
 }
 
 /// A group-by field, potentially aliased per referenced rule.
@@ -834,30 +834,35 @@ pub fn compile_correlation(rule: &CorrelationRule) -> Result<CompiledCorrelation
     let suppress_secs = rule
         .custom_attributes
         .get("rsigma.suppress")
-        .and_then(|v| rsigma_parser::Timespan::parse(v).ok())
+        .and_then(|v| v.as_str())
+        .and_then(|s| rsigma_parser::Timespan::parse(s).ok())
         .map(|ts| ts.seconds);
 
-    let action = rule.custom_attributes.get("rsigma.action").and_then(|v| {
-        v.parse::<crate::correlation_engine::CorrelationAction>()
-            .ok()
-    });
+    let action = rule
+        .custom_attributes
+        .get("rsigma.action")
+        .and_then(|v| v.as_str())
+        .and_then(|s| {
+            s.parse::<crate::correlation_engine::CorrelationAction>()
+                .ok()
+        });
 
     let event_mode = rule
         .custom_attributes
         .get("rsigma.correlation_event_mode")
-        .and_then(|v| {
-            v.parse::<crate::correlation_engine::CorrelationEventMode>()
+        .and_then(|v| v.as_str())
+        .and_then(|s| {
+            s.parse::<crate::correlation_engine::CorrelationEventMode>()
                 .ok()
         });
 
     let max_events = rule
         .custom_attributes
         .get("rsigma.max_correlation_events")
-        .and_then(|v| v.parse::<usize>().ok());
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<usize>().ok());
 
-    let custom_rule_attributes = Arc::new(crate::compiler::yaml_to_json_map(
-        &rule.custom_rule_attributes,
-    ));
+    let custom_attributes = Arc::new(crate::compiler::yaml_to_json_map(&rule.custom_attributes));
 
     Ok(CompiledCorrelation {
         id: rule.id.clone(),
@@ -876,7 +881,7 @@ pub fn compile_correlation(rule: &CorrelationRule) -> Result<CompiledCorrelation
         action,
         event_mode,
         max_events,
-        custom_rule_attributes,
+        custom_attributes,
     })
 }
 
@@ -1684,17 +1689,24 @@ level: high
     fn test_compile_correlation_with_custom_attributes() {
         use rsigma_parser::*;
 
-        let mut custom_attributes = std::collections::HashMap::new();
+        let mut custom_attributes: HashMap<String, serde_yaml::Value> =
+            std::collections::HashMap::new();
         custom_attributes.insert(
             "rsigma.correlation_event_mode".to_string(),
-            "refs".to_string(),
+            serde_yaml::Value::String("refs".to_string()),
         );
         custom_attributes.insert(
             "rsigma.max_correlation_events".to_string(),
-            "25".to_string(),
+            serde_yaml::Value::String("25".to_string()),
         );
-        custom_attributes.insert("rsigma.suppress".to_string(), "5m".to_string());
-        custom_attributes.insert("rsigma.action".to_string(), "reset".to_string());
+        custom_attributes.insert(
+            "rsigma.suppress".to_string(),
+            serde_yaml::Value::String("5m".to_string()),
+        );
+        custom_attributes.insert(
+            "rsigma.action".to_string(),
+            serde_yaml::Value::String("reset".to_string()),
+        );
 
         let rule = CorrelationRule {
             title: "Test Corr".to_string(),
@@ -1721,7 +1733,6 @@ level: high
             aliases: vec![],
             generate: false,
             custom_attributes,
-            custom_rule_attributes: HashMap::new(),
         };
 
         let compiled = compile_correlation(&rule).unwrap();

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -246,8 +246,11 @@ pub struct CorrelationResult {
     /// Custom rule attributes from the original Sigma correlation rule YAML.
     /// Contains any non-standard top-level fields from the rule definition.
     /// Wrapped in `Arc` so that per-match cloning is a pointer bump.
+    /// Custom attributes from the original Sigma correlation rule (merged
+    /// view of arbitrary top-level keys, the `custom_attributes:` block, and
+    /// any pipeline-applied overrides).
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_rule_attributes: Arc<HashMap<String, serde_json::Value>>,
+    pub custom_attributes: Arc<HashMap<String, serde_json::Value>>,
 }
 
 // =============================================================================
@@ -369,16 +372,19 @@ impl CorrelationEngine {
     ///   Only applied when the CLI did not already set `--suppress`.
     /// - `rsigma.action` — sets the default post-fire action (`alert`/`reset`).
     ///   Only applied when the CLI did not already set `--action`.
-    fn apply_custom_attributes(&mut self, attrs: &std::collections::HashMap<String, String>) {
+    fn apply_custom_attributes(
+        &mut self,
+        attrs: &std::collections::HashMap<String, serde_yaml::Value>,
+    ) {
         // rsigma.timestamp_field — prepend to priority list, skip duplicates
-        if let Some(field) = attrs.get("rsigma.timestamp_field")
-            && !self.config.timestamp_fields.contains(field)
+        if let Some(field) = attrs.get("rsigma.timestamp_field").and_then(|v| v.as_str())
+            && !self.config.timestamp_fields.iter().any(|f| f == field)
         {
-            self.config.timestamp_fields.insert(0, field.clone());
+            self.config.timestamp_fields.insert(0, field.to_string());
         }
 
         // rsigma.suppress — only when CLI didn't already set one
-        if let Some(val) = attrs.get("rsigma.suppress")
+        if let Some(val) = attrs.get("rsigma.suppress").and_then(|v| v.as_str())
             && self.config.suppress.is_none()
             && let Ok(ts) = rsigma_parser::Timespan::parse(val)
         {
@@ -386,7 +392,7 @@ impl CorrelationEngine {
         }
 
         // rsigma.action — only when CLI left it at the default (Alert)
-        if let Some(val) = attrs.get("rsigma.action")
+        if let Some(val) = attrs.get("rsigma.action").and_then(|v| v.as_str())
             && self.config.action_on_match == CorrelationAction::Alert
             && let Ok(a) = val.parse::<CorrelationAction>()
         {
@@ -960,7 +966,7 @@ impl CorrelationEngine {
                     timespan_secs: timespan,
                     events,
                     event_refs,
-                    custom_rule_attributes: corr.custom_rule_attributes.clone(),
+                    custom_attributes: corr.custom_attributes.clone(),
                 };
                 out.push(result);
 
@@ -1064,7 +1070,7 @@ impl CorrelationEngine {
                         // over correlation results, not raw events)
                         events: None,
                         event_refs: None,
-                        custom_rule_attributes: corr.custom_rule_attributes.clone(),
+                        custom_attributes: corr.custom_attributes.clone(),
                     });
                 }
             }
@@ -3247,11 +3253,19 @@ level: high
     // Custom attribute → engine config tests
     // =========================================================================
 
+    fn yaml_str_attrs<const N: usize>(
+        pairs: [(&str, &str); N],
+    ) -> std::collections::HashMap<String, serde_yaml::Value> {
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), serde_yaml::Value::String(v.to_string())))
+            .collect()
+    }
+
     #[test]
     fn test_custom_attr_timestamp_field() {
         let mut engine = CorrelationEngine::new(CorrelationConfig::default());
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("rsigma.timestamp_field".to_string(), "time".to_string());
+        let attrs = yaml_str_attrs([("rsigma.timestamp_field", "time")]);
         engine.apply_custom_attributes(&attrs);
 
         assert_eq!(
@@ -3270,8 +3284,7 @@ level: high
     #[test]
     fn test_custom_attr_timestamp_field_no_duplicates() {
         let mut engine = CorrelationEngine::new(CorrelationConfig::default());
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("rsigma.timestamp_field".to_string(), "time".to_string());
+        let attrs = yaml_str_attrs([("rsigma.timestamp_field", "time")]);
         // Apply twice — should not duplicate
         engine.apply_custom_attributes(&attrs);
         engine.apply_custom_attributes(&attrs);
@@ -3290,8 +3303,7 @@ level: high
         let mut engine = CorrelationEngine::new(CorrelationConfig::default());
         assert!(engine.config.suppress.is_none());
 
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("rsigma.suppress".to_string(), "5m".to_string());
+        let attrs = yaml_str_attrs([("rsigma.suppress", "5m")]);
         engine.apply_custom_attributes(&attrs);
 
         assert_eq!(engine.config.suppress, Some(300));
@@ -3305,8 +3317,7 @@ level: high
         };
         let mut engine = CorrelationEngine::new(config);
 
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("rsigma.suppress".to_string(), "5m".to_string());
+        let attrs = yaml_str_attrs([("rsigma.suppress", "5m")]);
         engine.apply_custom_attributes(&attrs);
 
         assert_eq!(
@@ -3321,8 +3332,7 @@ level: high
         let mut engine = CorrelationEngine::new(CorrelationConfig::default());
         assert_eq!(engine.config.action_on_match, CorrelationAction::Alert);
 
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("rsigma.action".to_string(), "reset".to_string());
+        let attrs = yaml_str_attrs([("rsigma.action", "reset")]);
         engine.apply_custom_attributes(&attrs);
 
         assert_eq!(engine.config.action_on_match, CorrelationAction::Reset);
@@ -3336,8 +3346,7 @@ level: high
         };
         let mut engine = CorrelationEngine::new(config);
 
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("rsigma.action".to_string(), "alert".to_string());
+        let attrs = yaml_str_attrs([("rsigma.action", "alert")]);
         engine.apply_custom_attributes(&attrs);
 
         assert_eq!(
@@ -4295,7 +4304,7 @@ level: high
     }
 
     #[test]
-    fn test_correlation_result_custom_rule_attributes() {
+    fn test_correlation_result_custom_attributes() {
         let yaml = r#"
 title: Login
 id: login-cra
@@ -4338,26 +4347,25 @@ level: high
                 let corr = &result.correlations[0];
                 assert_eq!(corr.rule_title, "Many Logins");
                 assert_eq!(
-                    corr.custom_rule_attributes.get("my_custom_field"),
+                    corr.custom_attributes.get("my_custom_field"),
                     Some(&serde_json::Value::String("hello".to_string()))
                 );
                 assert_eq!(
-                    corr.custom_rule_attributes.get("priority"),
+                    corr.custom_attributes.get("priority"),
                     Some(&serde_json::json!(9))
                 );
-                let nested = corr.custom_rule_attributes.get("nested").unwrap();
+                let nested = corr.custom_attributes.get("nested").unwrap();
                 assert_eq!(nested.get("key"), Some(&serde_json::json!("value")));
 
-                // Standard fields must not leak into custom_rule_attributes
-                assert!(!corr.custom_rule_attributes.contains_key("title"));
-                assert!(!corr.custom_rule_attributes.contains_key("correlation"));
-                assert!(!corr.custom_rule_attributes.contains_key("level"));
+                assert!(!corr.custom_attributes.contains_key("title"));
+                assert!(!corr.custom_attributes.contains_key("correlation"));
+                assert!(!corr.custom_attributes.contains_key("level"));
             }
         }
     }
 
     #[test]
-    fn test_detection_result_custom_rule_attributes() {
+    fn test_detection_result_custom_attributes() {
         let yaml = r#"
 title: Login Detection
 logsource:
@@ -4381,13 +4389,13 @@ score: 42
         assert_eq!(result.detections.len(), 1);
         let det = &result.detections[0];
         assert_eq!(
-            det.custom_rule_attributes.get("my_detection_tag"),
+            det.custom_attributes.get("my_detection_tag"),
             Some(&serde_json::Value::String("important".to_string()))
         );
         assert_eq!(
-            det.custom_rule_attributes.get("score"),
+            det.custom_attributes.get("score"),
             Some(&serde_json::json!(42))
         );
-        assert!(!det.custom_rule_attributes.contains_key("title"));
+        assert!(!det.custom_attributes.contains_key("title"));
     }
 }

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -243,9 +243,6 @@ pub struct CorrelationResult {
     /// Contains up to `max_correlation_events` timestamp + optional ID pairs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_refs: Option<Vec<EventRef>>,
-    /// Custom rule attributes from the original Sigma correlation rule YAML.
-    /// Contains any non-standard top-level fields from the rule definition.
-    /// Wrapped in `Arc` so that per-match cloning is a pointer bump.
     /// Custom attributes from the original Sigma correlation rule (merged
     /// view of arbitrary top-level keys, the `custom_attributes:` block, and
     /// any pipeline-applied overrides).

--- a/crates/rsigma-eval/src/pipeline/conditions.rs
+++ b/crates/rsigma-eval/src/pipeline/conditions.rs
@@ -469,7 +469,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
         let state = PipelineState::default();
 
@@ -517,7 +516,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         assert!(RuleCondition::IsSigmaRule.matches_rule(&rule, &state));
@@ -553,7 +551,6 @@ mod tests {
             tags: vec!["attack.execution".to_string(), "attack.t1059".to_string()],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         assert!(
@@ -636,7 +633,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         assert!(!cond.matches_rule(&rule, &state));

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -270,7 +270,7 @@ fn apply_correlation_transformation(
 
         Transformation::SetCustomAttribute { attribute, value } => {
             corr.custom_attributes
-                .insert(attribute.clone(), value.clone());
+                .insert(attribute.clone(), serde_yaml::Value::String(value.clone()));
             Ok(true)
         }
 
@@ -1288,7 +1288,6 @@ transformations:
             tags: vec![],
             scope: vec![],
             custom_attributes: std::collections::HashMap::new(),
-            custom_rule_attributes: std::collections::HashMap::new(),
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -1362,7 +1361,6 @@ transformations:
             tags: vec![],
             scope: vec![],
             custom_attributes: std::collections::HashMap::new(),
-            custom_rule_attributes: std::collections::HashMap::new(),
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -1604,7 +1602,6 @@ transformations:
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -1677,7 +1674,6 @@ transformations:
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -1752,7 +1748,6 @@ transformations:
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -1825,7 +1820,6 @@ transformations:
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -1877,7 +1871,6 @@ transformations:
             }],
             generate: true,
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         }
     }
 
@@ -1945,7 +1938,10 @@ transformations:
             .apply_to_correlation(&mut corr, &mut state)
             .unwrap();
 
-        assert_eq!(corr.custom_attributes["rsigma.action"], "reset");
+        assert_eq!(
+            corr.custom_attributes["rsigma.action"],
+            serde_yaml::Value::String("reset".to_string())
+        );
     }
 
     #[test]

--- a/crates/rsigma-eval/src/pipeline/transformations.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations.rs
@@ -133,9 +133,9 @@ pub enum Transformation {
 
     /// Set a custom attribute on the rule.
     ///
-    /// Stores the key-value pair in `SigmaRule.custom_attributes`.
-    /// Backends / engines can read these to modify per-rule behavior
-    /// (e.g. `rsigma.suppress`, `rsigma.action`).
+    /// Stores the key-value pair in `SigmaRule.custom_attributes` as a
+    /// `serde_yaml::Value::String`. Backends / engines can read these to
+    /// modify per-rule behavior (e.g. `rsigma.suppress`, `rsigma.action`).
     /// Mirrors pySigma's `SetCustomAttributeTransformation`.
     SetCustomAttribute { attribute: String, value: String },
 
@@ -404,7 +404,7 @@ impl Transformation {
 
             Transformation::SetCustomAttribute { attribute, value } => {
                 rule.custom_attributes
-                    .insert(attribute.clone(), value.clone());
+                    .insert(attribute.clone(), serde_yaml::Value::String(value.clone()));
                 Ok(true)
             }
 
@@ -1490,7 +1490,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         }
     }
 
@@ -1742,7 +1741,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::default();
@@ -2069,8 +2067,10 @@ mod tests {
         let result = t.apply(&mut rule, &mut state, &[], &[], false).unwrap();
         assert!(result);
         assert_eq!(
-            rule.custom_attributes.get("custom.key"),
-            Some(&"custom_value".to_string())
+            rule.custom_attributes
+                .get("custom.key")
+                .and_then(|v| v.as_str()),
+            Some("custom_value")
         );
     }
 
@@ -2255,7 +2255,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::default();
@@ -2312,7 +2311,6 @@ mod tests {
             tags: vec![],
             scope: vec![],
             custom_attributes: HashMap::new(),
-            custom_rule_attributes: HashMap::new(),
         };
 
         let mut state = PipelineState::default();
@@ -2815,8 +2813,10 @@ transformations:
 
         // step4: custom attribute was set
         assert_eq!(
-            rule.custom_attributes.get("rsigma.processed"),
-            Some(&"true".to_string())
+            rule.custom_attributes
+                .get("rsigma.processed")
+                .and_then(|v| v.as_str()),
+            Some("true")
         );
 
         // All steps should be tracked

--- a/crates/rsigma-eval/src/result.rs
+++ b/crates/rsigma-eval/src/result.rs
@@ -28,11 +28,14 @@ pub struct MatchResult {
     /// `rsigma.include_event` custom attribute is set to `"true"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<serde_json::Value>,
-    /// Custom rule attributes parsed from the original Sigma rule YAML.
-    /// Contains any non-standard top-level fields from the rule definition.
+    /// Custom attributes carried from the original Sigma rule.
+    ///
+    /// Contains the merged view of (a) arbitrary non-standard top-level keys,
+    /// (b) the explicit `custom_attributes:` block, and (c) anything added by
+    /// pipeline `SetCustomAttribute` transformations.
     /// Wrapped in `Arc` so that per-match cloning is a pointer bump.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_rule_attributes: Arc<HashMap<String, serde_json::Value>>,
+    pub custom_attributes: Arc<HashMap<String, serde_json::Value>>,
 }
 
 /// A specific field match within a detection.

--- a/crates/rsigma-parser/README.md
+++ b/crates/rsigma-parser/README.md
@@ -183,7 +183,7 @@ When the `re` modifier is present, string values are parsed with `SigmaValue::fr
 - **Extended (string):** `"rule_a and rule_b"` for temporal types — parsed as a boolean expression over rule references.
 - **Default (temporal, no condition):** `Threshold { predicates: [(Gte, 1)], field: None }`.
 - **Timeframe/timespan:** The parser accepts both `timeframe` and `timespan` keys.
-- **Custom attributes:** Correlation rules support a `custom_attributes` mapping (string-to-string) for `rsigma.*` engine extensions.
+- **Custom attributes:** Both detection and correlation rules expose a unified `custom_attributes` map (`HashMap<String, serde_yaml::Value>`). It merges (a) any arbitrary top-level YAML key that is not part of the Sigma schema, (b) entries of the optional top-level `custom_attributes:` mapping (explicit block wins over arbitrary keys of the same name), and (c) values set by pipeline `SetCustomAttribute` transformations (applied last, last-write-wins). Engines read `rsigma.*` extensions (`rsigma.suppress`, `rsigma.action`, `rsigma.correlation_event_mode`, etc.) from this map.
 
 ## Filter Rules
 

--- a/crates/rsigma-parser/src/ast.rs
+++ b/crates/rsigma-parser/src/ast.rs
@@ -433,21 +433,18 @@ pub struct SigmaRule {
     pub tags: Vec<String>,
     pub scope: Vec<String>,
 
-    /// Custom attributes set by pipeline transformations (e.g. `SetCustomAttribute`).
+    /// Custom attributes attached to the rule.
     ///
-    /// Backends / engines can read these to modify behavior per-rule.
-    /// This mirrors pySigma's `SigmaRule.custom_attributes` dict.
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_attributes: HashMap<String, String>,
-
-    /// Custom rule attributes parsed from the Sigma rule YAML.
+    /// Populated from (a) any top-level YAML key that is not part of the
+    /// standard Sigma rule schema, (b) the entries of the dedicated top-level
+    /// `custom_attributes:` mapping (explicit entries win over arbitrary keys
+    /// of the same name), and (c) pipeline transformations such as
+    /// `SetCustomAttribute`, which are applied last and override both.
     ///
-    /// Any top-level key that is not part of the standard Sigma rule schema
-    /// is captured here as a custom rule attribute. This allows rule authors
-    /// to attach arbitrary metadata to rules and have it propagate through
-    /// the evaluation pipeline to match results.
+    /// Mirrors pySigma's `SigmaRule.custom_attributes` dict. Engines and
+    /// backends can read these to modify per-rule behavior.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_rule_attributes: HashMap<String, serde_yaml::Value>,
+    pub custom_attributes: HashMap<String, serde_yaml::Value>,
 }
 
 // =============================================================================
@@ -574,17 +571,16 @@ pub struct CorrelationRule {
     pub condition: CorrelationCondition,
     pub aliases: Vec<FieldAlias>,
     pub generate: bool,
-    /// Custom key-value attributes (e.g. `rsigma.correlation_event_mode`).
-    /// Parsed from the top-level `custom_attributes` mapping in the YAML or set
-    /// programmatically. Mirrors `SigmaRule.custom_attributes`.
-    pub custom_attributes: HashMap<String, String>,
 
-    /// Custom rule attributes parsed from the correlation rule YAML.
+    /// Custom attributes attached to the correlation rule.
     ///
-    /// Any top-level key that is not part of the standard Sigma correlation
-    /// rule schema is captured here. Mirrors `SigmaRule.custom_rule_attributes`.
+    /// Populated the same way as `SigmaRule.custom_attributes`: arbitrary
+    /// top-level YAML keys, the dedicated `custom_attributes:` block, and
+    /// pipeline `SetCustomAttribute` transformations (last-write-wins).
+    /// Engine-level `rsigma.*` extensions (e.g. `rsigma.correlation_event_mode`,
+    /// `rsigma.suppress`, `rsigma.action`) are read from here.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_rule_attributes: HashMap<String, serde_yaml::Value>,
+    pub custom_attributes: HashMap<String, serde_yaml::Value>,
 }
 
 // =============================================================================

--- a/crates/rsigma-parser/src/parser.rs
+++ b/crates/rsigma-parser/src/parser.rs
@@ -236,21 +236,10 @@ fn parse_detection_rule(value: &Value) -> Result<SigmaRule> {
         .transpose()?
         .unwrap_or_default();
 
-    // Custom attributes (rsigma.* extension keys) — mirrors pySigma's
-    // `SigmaRule.custom_attributes`. Parsed from the top-level `custom_attributes`
-    // mapping; pipeline transformations may also populate this field.
-    let custom_attributes: HashMap<String, String> = m
-        .get(val_key("custom_attributes"))
-        .and_then(|v| v.as_mapping())
-        .map(|attrs| {
-            attrs
-                .iter()
-                .filter_map(|(k, v)| Some((k.as_str()?.to_string(), v.as_str()?.to_string())))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Collect custom rule attributes: any top-level key not in the standard schema
+    // Custom attributes: merge arbitrary top-level keys and the entries of the
+    // dedicated `custom_attributes:` mapping. Entries in `custom_attributes:`
+    // win over a top-level key of the same name (last-write-wins).
+    // Mirrors pySigma's `SigmaRule.custom_attributes` dict.
     let standard_rule_keys: &[&str] = &[
         "title",
         "id",
@@ -273,18 +262,7 @@ fn parse_detection_rule(value: &Value) -> Result<SigmaRule> {
         "scope",
         "custom_attributes",
     ];
-
-    let custom_rule_attributes: HashMap<String, Value> = m
-        .iter()
-        .filter_map(|(k, v)| {
-            let key = k.as_str()?;
-            if standard_rule_keys.contains(&key) {
-                None
-            } else {
-                Some((key.to_string(), v.clone()))
-            }
-        })
-        .collect();
+    let custom_attributes = collect_custom_attributes(m, standard_rule_keys);
 
     Ok(SigmaRule {
         title,
@@ -307,8 +285,44 @@ fn parse_detection_rule(value: &Value) -> Result<SigmaRule> {
         tags: get_str_list(m, "tags"),
         scope: get_str_list(m, "scope"),
         custom_attributes,
-        custom_rule_attributes,
     })
+}
+
+/// Build the unified `custom_attributes` map for a rule document.
+///
+/// Merges two sources:
+/// 1. Any top-level YAML key not in `standard_keys` (kept as-is, supports
+///    arbitrary nested values).
+/// 2. The entries of the top-level `custom_attributes:` mapping (if present),
+///    which override (1) for colliding keys.
+///
+/// Pipeline transformations such as `SetCustomAttribute` are applied later
+/// and can further override both sources.
+fn collect_custom_attributes(
+    m: &serde_yaml::Mapping,
+    standard_keys: &[&str],
+) -> HashMap<String, Value> {
+    let mut attrs: HashMap<String, Value> = m
+        .iter()
+        .filter_map(|(k, v)| {
+            let key = k.as_str()?;
+            if standard_keys.contains(&key) {
+                None
+            } else {
+                Some((key.to_string(), v.clone()))
+            }
+        })
+        .collect();
+
+    if let Some(Value::Mapping(explicit)) = m.get(val_key("custom_attributes")) {
+        for (k, v) in explicit {
+            if let Some(key) = k.as_str() {
+                attrs.insert(key.to_string(), v.clone());
+            }
+        }
+    }
+
+    attrs
 }
 
 // =============================================================================
@@ -607,19 +621,6 @@ fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
     // Aliases
     let aliases = parse_correlation_aliases(corr);
 
-    // Custom attributes (rsigma.* extension keys)
-    let custom_attributes: HashMap<String, String> = m
-        .get(val_key("custom_attributes"))
-        .and_then(|v| v.as_mapping())
-        .map(|attrs| {
-            attrs
-                .iter()
-                .filter_map(|(k, v)| Some((k.as_str()?.to_string(), v.as_str()?.to_string())))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Collect custom correlation rule attributes: any top-level key not in the standard schema
     // Top-level keys from the Sigma correlation-rules JSON schema plus keys this
     // parser reads from the document root (including common extensions).
     let standard_correlation_keys: &[&str] = &[
@@ -640,18 +641,7 @@ fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
         "taxonomy",
         "title",
     ];
-
-    let custom_rule_attributes: HashMap<String, Value> = m
-        .iter()
-        .filter_map(|(k, v)| {
-            let key = k.as_str()?;
-            if standard_correlation_keys.contains(&key) {
-                None
-            } else {
-                Some((key.to_string(), v.clone()))
-            }
-        })
-        .collect();
+    let custom_attributes = collect_custom_attributes(m, standard_correlation_keys);
 
     Ok(CorrelationRule {
         title,
@@ -675,7 +665,6 @@ fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
         aliases,
         generate,
         custom_attributes,
-        custom_rule_attributes,
     })
 }
 
@@ -1071,20 +1060,28 @@ level: high
 
         let corr = &collection.correlations[0];
         assert_eq!(
-            corr.custom_attributes.get("rsigma.correlation_event_mode"),
-            Some(&"refs".to_string())
+            corr.custom_attributes
+                .get("rsigma.correlation_event_mode")
+                .and_then(Value::as_str),
+            Some("refs")
         );
         assert_eq!(
-            corr.custom_attributes.get("rsigma.suppress"),
-            Some(&"5m".to_string())
+            corr.custom_attributes
+                .get("rsigma.suppress")
+                .and_then(Value::as_str),
+            Some("5m")
         );
         assert_eq!(
-            corr.custom_attributes.get("rsigma.action"),
-            Some(&"reset".to_string())
+            corr.custom_attributes
+                .get("rsigma.action")
+                .and_then(Value::as_str),
+            Some("reset")
         );
         assert_eq!(
-            corr.custom_attributes.get("rsigma.max_correlation_events"),
-            Some(&"25".to_string())
+            corr.custom_attributes
+                .get("rsigma.max_correlation_events")
+                .and_then(Value::as_str),
+            Some("25")
         );
     }
 
@@ -1952,7 +1949,7 @@ level: medium
     }
 
     #[test]
-    fn test_parse_detection_rule_custom_rule_attributes() {
+    fn test_parse_detection_rule_custom_attributes_arbitrary_keys() {
         let yaml = r#"
 title: Test Rule With Custom Attrs
 logsource:
@@ -1979,39 +1976,36 @@ custom_object:
         let rule = &collection.rules[0];
         assert_eq!(rule.title, "Test Rule With Custom Attrs");
 
-        // Custom rule attributes should be captured
         assert_eq!(
-            rule.custom_rule_attributes.get("my_custom_field"),
+            rule.custom_attributes.get("my_custom_field"),
             Some(&Value::String("some_value".to_string()))
         );
         assert_eq!(
-            rule.custom_rule_attributes
+            rule.custom_attributes
                 .get("severity_score")
                 .and_then(|v| v.as_u64()),
             Some(42)
         );
         assert_eq!(
-            rule.custom_rule_attributes.get("organization"),
+            rule.custom_attributes.get("organization"),
             Some(&Value::String("ACME Corp".to_string()))
         );
 
-        // List values should be preserved
-        let custom_list = rule.custom_rule_attributes.get("custom_list").unwrap();
+        let custom_list = rule.custom_attributes.get("custom_list").unwrap();
         assert!(custom_list.is_sequence());
 
-        // Object values should be preserved
-        let custom_obj = rule.custom_rule_attributes.get("custom_object").unwrap();
+        let custom_obj = rule.custom_attributes.get("custom_object").unwrap();
         assert!(custom_obj.is_mapping());
 
-        // Standard fields should NOT be in custom_rule_attributes
-        assert!(!rule.custom_rule_attributes.contains_key("title"));
-        assert!(!rule.custom_rule_attributes.contains_key("logsource"));
-        assert!(!rule.custom_rule_attributes.contains_key("detection"));
-        assert!(!rule.custom_rule_attributes.contains_key("level"));
+        assert!(!rule.custom_attributes.contains_key("title"));
+        assert!(!rule.custom_attributes.contains_key("logsource"));
+        assert!(!rule.custom_attributes.contains_key("detection"));
+        assert!(!rule.custom_attributes.contains_key("level"));
+        assert!(!rule.custom_attributes.contains_key("custom_attributes"));
     }
 
     #[test]
-    fn test_parse_detection_rule_no_custom_rule_attributes() {
+    fn test_parse_detection_rule_no_custom_attributes() {
         let yaml = r#"
 title: Standard Rule
 logsource:
@@ -2024,12 +2018,11 @@ level: low
 "#;
         let collection = parse_sigma_yaml(yaml).unwrap();
         let rule = &collection.rules[0];
-        assert!(rule.custom_rule_attributes.is_empty());
         assert!(rule.custom_attributes.is_empty());
     }
 
     #[test]
-    fn test_parse_detection_rule_custom_attributes() {
+    fn test_parse_detection_rule_custom_attributes_explicit_block() {
         let yaml = r#"
 title: Rule With Custom Attrs
 custom_attributes:
@@ -2046,23 +2039,49 @@ level: low
         let collection = parse_sigma_yaml(yaml).unwrap();
         let rule = &collection.rules[0];
         assert_eq!(
-            rule.custom_attributes.get("rsigma.suppress"),
-            Some(&"5m".to_string())
+            rule.custom_attributes
+                .get("rsigma.suppress")
+                .and_then(Value::as_str),
+            Some("5m")
         );
         assert_eq!(
-            rule.custom_attributes.get("rsigma.action"),
-            Some(&"reset".to_string())
+            rule.custom_attributes
+                .get("rsigma.action")
+                .and_then(Value::as_str),
+            Some("reset")
         );
-        // Reserved key — must not leak into custom_rule_attributes
-        assert!(
-            !rule
-                .custom_rule_attributes
-                .contains_key("custom_attributes")
+        // The reserved key itself must not be carried into the merged map.
+        assert!(!rule.custom_attributes.contains_key("custom_attributes"));
+    }
+
+    #[test]
+    fn test_parse_detection_rule_custom_attributes_explicit_overrides_toplevel() {
+        // Arbitrary top-level `priority: top` is captured first, then the
+        // explicit `custom_attributes:` block overrides it.
+        let yaml = r#"
+title: Merge Test
+priority: top
+custom_attributes:
+    priority: explicit
+logsource:
+    category: test
+detection:
+    selection:
+        field: value
+    condition: selection
+"#;
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let rule = &collection.rules[0];
+        assert_eq!(
+            rule.custom_attributes
+                .get("priority")
+                .and_then(Value::as_str),
+            Some("explicit")
         );
     }
 
     #[test]
-    fn test_parse_correlation_rule_custom_rule_attributes() {
+    fn test_parse_correlation_rule_custom_attributes_arbitrary_keys() {
         let yaml = r#"
 title: Login
 id: login-rule
@@ -2099,25 +2118,24 @@ level: high
 
         let corr = &collection.correlations[0];
         assert_eq!(
-            corr.custom_rule_attributes
-                .get("my_custom_correlation_field"),
+            corr.custom_attributes.get("my_custom_correlation_field"),
             Some(&Value::String("custom_value".to_string()))
         );
         assert_eq!(
-            corr.custom_rule_attributes.get("priority"),
+            corr.custom_attributes.get("priority"),
             Some(&Value::String("high_priority".to_string()))
         );
 
-        // Standard correlation fields should NOT be in custom_rule_attributes
-        assert!(!corr.custom_rule_attributes.contains_key("title"));
-        assert!(!corr.custom_rule_attributes.contains_key("correlation"));
-        assert!(!corr.custom_rule_attributes.contains_key("level"));
-        assert!(!corr.custom_rule_attributes.contains_key("id"));
-        assert!(!corr.custom_rule_attributes.contains_key("name"));
-        assert!(!corr.custom_rule_attributes.contains_key("tags"));
-        assert!(!corr.custom_rule_attributes.contains_key("taxonomy"));
-        assert!(!corr.custom_rule_attributes.contains_key("falsepositives"));
-        assert!(!corr.custom_rule_attributes.contains_key("generate"));
+        assert!(!corr.custom_attributes.contains_key("title"));
+        assert!(!corr.custom_attributes.contains_key("correlation"));
+        assert!(!corr.custom_attributes.contains_key("level"));
+        assert!(!corr.custom_attributes.contains_key("id"));
+        assert!(!corr.custom_attributes.contains_key("name"));
+        assert!(!corr.custom_attributes.contains_key("tags"));
+        assert!(!corr.custom_attributes.contains_key("taxonomy"));
+        assert!(!corr.custom_attributes.contains_key("falsepositives"));
+        assert!(!corr.custom_attributes.contains_key("generate"));
+        assert!(!corr.custom_attributes.contains_key("custom_attributes"));
     }
 
     #[test]


### PR DESCRIPTION
Merges the two per-rule dictionaries into a single `custom_attributes` field on `SigmaRule` and `CorrelationRule`, typed as `HashMap<String, serde_yaml::Value>` to preserve nested structures and non-string values. Mirrors pySigma's single `custom_attributes` dict.

Sources, applied in order (last-write-wins):

1. Arbitrary top-level YAML keys not in the standard Sigma schema.
2. Entries of the optional top-level `custom_attributes:` mapping.
3. Pipeline `SetCustomAttribute` transformations, applied after parsing.

Follow-on changes:
- `MatchResult` and `CorrelationResult` expose a single `custom_attributes: Arc<HashMap<String, serde_json::Value>>` (renamed from `custom_rule_attributes`).
- `apply_custom_attributes` in the correlation engine and all `rsigma.*` readers now look up `serde_yaml::Value::as_str()`.
- Pipeline `SetCustomAttribute` stores `Value::String(...)`.
- Parser tests cover the explicit-block override of arbitrary keys; compiler tests cover pipeline overriding the rule YAML.

BREAKING: `custom_rule_attributes` is removed from the public AST and runtime types. Code reading `rule.custom_attributes` must now treat values as `serde_yaml::Value` (use `.as_str()` to recover the old string view). Since #26 was merged recently and not released, this is okay.

xref https://github.com/timescale/rsigma/issues/20#issuecomment-4270503284

@fwosar I'd appreciate your review! 🙏 