### PR TITLE
Add `--exclude` glob patterns and detect deprecated aggregation syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2659,7 @@ name = "rsigma-parser"
 version = "0.6.0"
 dependencies = [
  "criterion",
+ "globset",
  "insta",
  "log",
  "pest",
@@ -2654,6 +2668,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -100,6 +100,12 @@ enum Commands {
         #[arg(long = "config")]
         lint_config: Option<PathBuf>,
 
+        /// Exclude paths matching glob patterns (can be repeated).
+        /// Patterns are matched against paths relative to the lint root.
+        /// Example: --exclude "config/**" --exclude "**/unsupported/**"
+        #[arg(long)]
+        exclude: Vec<String>,
+
         /// Auto-fix safe lint issues in-place.
         /// Applies format-preserving fixes to files on disk.
         #[arg(long)]
@@ -338,6 +344,7 @@ fn main() {
             color,
             disable,
             lint_config,
+            exclude,
             fix: apply_fix,
         } => cmd_lint(
             path,
@@ -346,6 +353,7 @@ fn main() {
             &color,
             disable,
             lint_config,
+            exclude,
             apply_fix,
         ),
         Commands::Condition { expr } => cmd_condition(expr),
@@ -549,6 +557,7 @@ fn cmd_validate(path: PathBuf, verbose: bool, pipeline_paths: Vec<PathBuf>) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_lint(
     path: PathBuf,
     schema: Option<String>,
@@ -556,12 +565,13 @@ fn cmd_lint(
     color: &str,
     disable: Vec<String>,
     lint_config_path: Option<PathBuf>,
+    exclude: Vec<String>,
     apply_fix: bool,
 ) {
     let p = Painter::new(color);
 
     // 0. Build lint config from file + CLI flags
-    let config = build_lint_config(&path, disable, lint_config_path);
+    let config = build_lint_config(&path, disable, lint_config_path, exclude);
 
     // 1. Run built-in lint checks (with suppression)
     let results: Vec<FileLintResult> = if path.is_dir() {
@@ -1338,6 +1348,7 @@ fn build_lint_config(
     path: &std::path::Path,
     disable: Vec<String>,
     lint_config_path: Option<PathBuf>,
+    exclude: Vec<String>,
 ) -> LintConfig {
     // Load config file
     let mut config = if let Some(explicit) = lint_config_path {
@@ -1369,10 +1380,11 @@ fn build_lint_config(
         LintConfig::default()
     };
 
-    // Merge --disable CLI flags
-    if !disable.is_empty() {
+    // Merge --disable and --exclude CLI flags
+    if !disable.is_empty() || !exclude.is_empty() {
         let cli_config = LintConfig {
             disabled_rules: disable.into_iter().collect(),
+            exclude_patterns: exclude,
             ..Default::default()
         };
         config.merge(&cli_config);

--- a/crates/rsigma-parser/Cargo.toml
+++ b/crates/rsigma-parser/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+globset = "0.4"
 log = "0.4"
 pest = "2"
 pest_derive = "2"
@@ -22,6 +23,7 @@ thiserror = "2"
 criterion = "0.5"
 insta = "1.46"
 rand = "0.9"
+tempfile = "3"
 
 [[bench]]
 name = "parse"

--- a/crates/rsigma-parser/README.md
+++ b/crates/rsigma-parser/README.md
@@ -218,9 +218,9 @@ filter:
 
 The string must be at least 2 characters (e.g. `1h`). The last character is the unit; the prefix must be a positive integer.
 
-## Linter (65 rules)
+## Linter (66 rules)
 
-65 built-in lint rules derived from the Sigma v2.1.0 specification. Four severity levels: **Error** (spec violation), **Warning** (best-practice issue), **Info** (soft suggestion), **Hint** (stylistic). Info/Hint findings don't cause lint failure.
+66 built-in lint rules derived from the Sigma v2.1.0 specification. Four severity levels: **Error** (spec violation), **Warning** (best-practice issue), **Info** (soft suggestion), **Hint** (stylistic). Info/Hint findings don't cause lint failure.
 
 The linter operates on raw YAML values to catch issues the parser silently ignores.
 
@@ -254,7 +254,7 @@ The linter operates on raw YAML values to catch issues the parser silently ignor
 | `taxonomy_too_long` | Warning | | `taxonomy` exceeds 256 characters |
 | `non_lowercase_key` | Warning | Yes | Top-level key is not lowercase |
 
-### Detection Rules (17)
+### Detection Rules (18)
 
 | Rule | Severity | Fix | Trigger |
 |------|----------|-----|---------|
@@ -275,6 +275,7 @@ The linter operates on raw YAML values to catch issues the parser silently ignor
 | `scope_too_short` | Warning | | `scope` entry under 2 characters |
 | `logsource_value_not_lowercase` | Warning | Yes | Logsource `category`/`product`/`service` not lowercase |
 | `condition_references_unknown` | Error | | Condition references non-existent detection identifier |
+| `deprecated_aggregation_syntax` | Warning | | Condition uses deprecated Sigma v1.x pipe-aggregation syntax (`\| count/min/max/avg/sum/near`); use a correlation rule instead |
 
 ### Correlation Rules (13)
 
@@ -324,7 +325,8 @@ The linter operates on raw YAML values to catch issues the parser silently ignor
 Three-tier system to disable or override lint rules:
 
 - **CLI**: `--disable rule1,rule2` suppresses specific rules globally
-- **Config file**: `.rsigma-lint.yml` (or `.rsigma-lint.yaml`) with `disabled_rules` and `severity_overrides`, auto-discovered by walking ancestor directories from the target path upward
+- **CLI**: `--exclude "pattern"` excludes paths matching glob patterns (relative to lint root, repeatable)
+- **Config file**: `.rsigma-lint.yml` (or `.rsigma-lint.yaml`) with `disabled_rules`, `severity_overrides`, and `exclude`, auto-discovered by walking ancestor directories from the target path upward
 - **Inline comments**: `# rsigma-disable`, `# rsigma-disable rule1, rule2`, `# rsigma-disable-next-line`, `# rsigma-disable-next-line rule1, rule2`
 
 ```yaml
@@ -334,9 +336,12 @@ disabled_rules:
   - missing_author
 severity_overrides:
   title_too_long: info
+exclude:
+  - "config/**"
+  - "**/unsupported/**"
 ```
 
-**Suppression order:** Warnings are first filtered by `disabled_rules`, then by inline suppressions, then `severity_overrides` are applied to remaining warnings.
+**Suppression order:** Excluded paths are skipped during directory traversal. Remaining warnings are filtered by `disabled_rules`, then by inline suppressions, then `severity_overrides` are applied.
 
 Inline `#` inside quoted YAML strings is not treated as a comment.
 

--- a/crates/rsigma-parser/src/lint.rs
+++ b/crates/rsigma-parser/src/lint.rs
@@ -100,6 +100,7 @@ pub enum LintRule {
     ScopeTooShort,
     LogsourceValueNotLowercase,
     ConditionReferencesUnknown,
+    DeprecatedAggregationSyntax,
 
     // ── Correlation rules ────────────────────────────────────────────────
     MissingCorrelation,
@@ -176,6 +177,7 @@ impl fmt::Display for LintRule {
             LintRule::ScopeTooShort => "scope_too_short",
             LintRule::LogsourceValueNotLowercase => "logsource_value_not_lowercase",
             LintRule::ConditionReferencesUnknown => "condition_references_unknown",
+            LintRule::DeprecatedAggregationSyntax => "deprecated_aggregation_syntax",
             LintRule::MissingCorrelation => "missing_correlation",
             LintRule::MissingCorrelationType => "missing_correlation_type",
             LintRule::InvalidCorrelationType => "invalid_correlation_type",
@@ -908,16 +910,24 @@ fn lint_detection_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>)
                     "/detection/condition",
                 ));
             } else if let Some(cond_str) = get_str(det, "condition") {
-                // Check that condition references existing identifiers
-                for ident in extract_condition_identifiers(cond_str) {
-                    if !det_keys.contains(ident.as_str()) {
-                        warnings.push(err(
-                            LintRule::ConditionReferencesUnknown,
-                            format!(
-                                "condition references '{ident}' but no such detection identifier exists"
-                            ),
-                            "/detection/condition",
-                        ));
+                if has_deprecated_aggregation(cond_str) {
+                    warnings.push(warning(
+                        LintRule::DeprecatedAggregationSyntax,
+                        "condition uses deprecated Sigma v1.x aggregation syntax \
+                         (| count/min/max/avg/sum/near); use a correlation rule instead",
+                        "/detection/condition",
+                    ));
+                } else {
+                    for ident in extract_condition_identifiers(cond_str) {
+                        if !det_keys.contains(ident.as_str()) {
+                            warnings.push(err(
+                                LintRule::ConditionReferencesUnknown,
+                                format!(
+                                    "condition references '{ident}' but no such detection identifier exists"
+                                ),
+                                "/detection/condition",
+                            ));
+                        }
                     }
                 }
             }
@@ -1158,6 +1168,26 @@ fn extract_condition_identifiers(condition: &str) -> Vec<String> {
         .filter(|s| !s.contains('*'))
         .map(|s| s.to_string())
         .collect()
+}
+
+/// Detect deprecated Sigma v1.x pipe-aggregation syntax in a condition string.
+///
+/// Patterns like `selection | count(User) by SourceIP > 5` use a pipe followed
+/// by an aggregation keyword. These were replaced by correlation rules in v2.x.
+fn has_deprecated_aggregation(condition: &str) -> bool {
+    let pipe_pos = match condition.find('|') {
+        Some(p) => p,
+        None => return false,
+    };
+    let after_pipe = condition[pipe_pos + 1..].trim_start();
+    let agg_keyword = after_pipe
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .next()
+        .unwrap_or("");
+    matches!(
+        agg_keyword,
+        "count" | "min" | "max" | "avg" | "sum" | "near"
+    )
 }
 
 /// Checks detection logic: null in value lists, single-value |all, empty value lists.
@@ -2038,6 +2068,9 @@ pub struct LintConfig {
     pub disabled_rules: HashSet<String>,
     /// Override the default severity of a rule (e.g. `title_too_long -> Info`).
     pub severity_overrides: HashMap<String, Severity>,
+    /// Glob patterns for paths to exclude from directory linting.
+    /// Matched against relative paths from the lint root (e.g. `"config/**"`).
+    pub exclude_patterns: Vec<String>,
 }
 
 /// Raw YAML shape for `.rsigma-lint.yml`.
@@ -2047,6 +2080,8 @@ struct RawLintConfig {
     disabled_rules: Vec<String>,
     #[serde(default)]
     severity_overrides: HashMap<String, String>,
+    #[serde(default)]
+    exclude: Vec<String>,
 }
 
 impl LintConfig {
@@ -2075,6 +2110,7 @@ impl LintConfig {
         Ok(LintConfig {
             disabled_rules,
             severity_overrides,
+            exclude_patterns: raw.exclude,
         })
     }
 
@@ -2111,11 +2147,33 @@ impl LintConfig {
         for (rule, sev) in &other.severity_overrides {
             self.severity_overrides.insert(rule.clone(), *sev);
         }
+        self.exclude_patterns
+            .extend(other.exclude_patterns.iter().cloned());
     }
 
     /// Check if a rule is disabled.
     pub fn is_disabled(&self, rule: &LintRule) -> bool {
         self.disabled_rules.contains(&rule.to_string())
+    }
+
+    /// Build a compiled [`globset::GlobSet`] from the exclude patterns.
+    ///
+    /// Returns `None` if there are no patterns. Invalid patterns are silently
+    /// skipped (they will have been validated at config load time in practice).
+    pub fn build_exclude_set(&self) -> Option<globset::GlobSet> {
+        if self.exclude_patterns.is_empty() {
+            return None;
+        }
+        let mut builder = globset::GlobSetBuilder::new();
+        for pat in &self.exclude_patterns {
+            if let Ok(glob) = globset::GlobBuilder::new(pat)
+                .literal_separator(false)
+                .build()
+            {
+                builder.add(glob);
+            }
+        }
+        builder.build().ok()
     }
 }
 
@@ -2298,16 +2356,22 @@ pub fn lint_yaml_file_with_config(
 }
 
 /// Lint a directory with config-based suppression.
+///
+/// Respects `config.exclude_patterns`: glob patterns matched against paths
+/// relative to `dir` (e.g. `"config/**"` skips `<dir>/config/...`).
 pub fn lint_yaml_directory_with_config(
     dir: &Path,
     config: &LintConfig,
 ) -> crate::error::Result<Vec<FileLintResult>> {
     let mut results = Vec::new();
     let mut visited = HashSet::new();
+    let exclude_set = config.build_exclude_set();
 
     fn walk(
         dir: &Path,
+        base: &Path,
         config: &LintConfig,
+        exclude_set: &Option<globset::GlobSet>,
         results: &mut Vec<FileLintResult>,
         visited: &mut HashSet<std::path::PathBuf>,
     ) -> crate::error::Result<()> {
@@ -2324,6 +2388,14 @@ pub fn lint_yaml_directory_with_config(
 
         for entry in entries {
             let path = entry.path();
+
+            if let Some(gs) = exclude_set
+                && let Ok(rel) = path.strip_prefix(base)
+                && gs.is_match(rel)
+            {
+                continue;
+            }
+
             if path.is_dir() {
                 if path
                     .file_name()
@@ -2332,7 +2404,7 @@ pub fn lint_yaml_directory_with_config(
                 {
                     continue;
                 }
-                walk(&path, config, results, visited)?;
+                walk(&path, base, config, exclude_set, results, visited)?;
             } else if matches!(
                 path.extension().and_then(|e| e.to_str()),
                 Some("yml" | "yaml")
@@ -2355,7 +2427,7 @@ pub fn lint_yaml_directory_with_config(
         Ok(())
     }
 
-    walk(dir, config, &mut results, &mut visited)?;
+    walk(dir, dir, config, &exclude_set, &mut results, &mut visited)?;
     Ok(results)
 }
 
@@ -4242,6 +4314,7 @@ detection:
             severity_overrides: [("rule_d".to_string(), Severity::Hint)]
                 .into_iter()
                 .collect(),
+            exclude_patterns: vec!["test/**".to_string()],
         };
 
         base.merge(&other);
@@ -4249,6 +4322,7 @@ detection:
         assert!(base.disabled_rules.contains("rule_c"));
         assert_eq!(base.severity_overrides.get("rule_b"), Some(&Severity::Info));
         assert_eq!(base.severity_overrides.get("rule_d"), Some(&Severity::Hint));
+        assert_eq!(base.exclude_patterns, vec!["test/**".to_string()]);
     }
 
     #[test]
@@ -4628,5 +4702,216 @@ detection:
             find_fix(&w, LintRule::InvalidStatus).is_none(),
             "no fix when edit distance is too large"
         );
+    }
+
+    // ── Deprecated aggregation syntax ───────────────────────────────────
+
+    #[test]
+    fn deprecated_aggregation_count() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 4625
+    condition: selection | count(TargetUserName) by IpAddress > 5
+level: medium
+"#,
+        );
+        assert!(has_rule(&w, LintRule::DeprecatedAggregationSyntax));
+        assert!(has_no_rule(&w, LintRule::ConditionReferencesUnknown));
+        let dag = w
+            .iter()
+            .find(|w| w.rule == LintRule::DeprecatedAggregationSyntax)
+            .unwrap();
+        assert_eq!(dag.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn deprecated_aggregation_near() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection | near(field) by host
+level: medium
+"#,
+        );
+        assert!(has_rule(&w, LintRule::DeprecatedAggregationSyntax));
+        assert!(has_no_rule(&w, LintRule::ConditionReferencesUnknown));
+    }
+
+    #[test]
+    fn no_deprecated_aggregation_for_normal_condition() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        field: value
+    condition: selection
+level: medium
+"#,
+        );
+        assert!(has_no_rule(&w, LintRule::DeprecatedAggregationSyntax));
+    }
+
+    #[test]
+    fn no_deprecated_aggregation_for_pipe_in_field_modifier() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        field|contains: value
+    condition: selection
+level: medium
+"#,
+        );
+        assert!(has_no_rule(&w, LintRule::DeprecatedAggregationSyntax));
+        assert!(has_no_rule(&w, LintRule::ConditionReferencesUnknown));
+    }
+
+    #[test]
+    fn has_deprecated_aggregation_function() {
+        assert!(has_deprecated_aggregation(
+            "selection | count(User) by SourceIP > 5"
+        ));
+        assert!(has_deprecated_aggregation(
+            "selection |  sum(Amount) by Account > 1000"
+        ));
+        assert!(has_deprecated_aggregation(
+            "selection | near(field) by host"
+        ));
+        assert!(has_deprecated_aggregation(
+            "selection | min(score) by host > 0"
+        ));
+        assert!(has_deprecated_aggregation(
+            "selection | max(score) by host > 100"
+        ));
+        assert!(has_deprecated_aggregation(
+            "selection | avg(score) by host > 50"
+        ));
+        assert!(!has_deprecated_aggregation("selection and not filter"));
+        assert!(!has_deprecated_aggregation("1 of selection*"));
+        assert!(!has_deprecated_aggregation("all of them"));
+    }
+
+    // ── Exclude patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn lint_config_exclude_from_yaml() {
+        let yaml = r#"
+disabled_rules:
+  - missing_description
+exclude:
+  - "config/**"
+  - "**/unsupported/**"
+"#;
+        let tmp = std::env::temp_dir().join("rsigma_test_exclude.yml");
+        std::fs::write(&tmp, yaml).unwrap();
+        let config = LintConfig::load(&tmp).unwrap();
+        std::fs::remove_file(&tmp).ok();
+
+        assert!(config.disabled_rules.contains("missing_description"));
+        assert_eq!(config.exclude_patterns.len(), 2);
+        assert_eq!(config.exclude_patterns[0], "config/**");
+        assert_eq!(config.exclude_patterns[1], "**/unsupported/**");
+    }
+
+    #[test]
+    fn lint_config_build_exclude_set_empty() {
+        let config = LintConfig::default();
+        assert!(config.build_exclude_set().is_none());
+    }
+
+    #[test]
+    fn lint_config_build_exclude_set_matches() {
+        let config = LintConfig {
+            exclude_patterns: vec!["config/**".to_string()],
+            ..Default::default()
+        };
+        let gs = config.build_exclude_set().expect("should build");
+        assert!(gs.is_match("config/data_mapping/foo.yaml"));
+        assert!(gs.is_match("config/nested/deep/bar.yml"));
+        assert!(!gs.is_match("rules/windows/test.yml"));
+    }
+
+    #[test]
+    fn lint_directory_with_excludes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rules_dir = tmp.path().join("rules");
+        let config_dir = tmp.path().join("config");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        // Valid rule
+        std::fs::write(
+            rules_dir.join("good.yml"),
+            r#"
+title: Good Rule
+logsource:
+    category: test
+detection:
+    sel:
+        field: value
+    condition: sel
+level: medium
+"#,
+        )
+        .unwrap();
+
+        // Non-rule config file (would produce errors if linted)
+        std::fs::write(
+            config_dir.join("mapping.yaml"),
+            r#"
+Title: Logon
+Channel: Security
+EventID: 4624
+"#,
+        )
+        .unwrap();
+
+        // Without excludes: config file produces errors
+        let no_exclude = LintConfig::default();
+        let results = lint_yaml_directory_with_config(tmp.path(), &no_exclude).unwrap();
+        let config_warnings: Vec<_> = results
+            .iter()
+            .filter(|r| r.path.to_string_lossy().contains("config"))
+            .flat_map(|r| &r.warnings)
+            .collect();
+        assert!(
+            !config_warnings.is_empty(),
+            "config file should produce warnings without excludes"
+        );
+
+        // With excludes: config file is skipped
+        let with_exclude = LintConfig {
+            exclude_patterns: vec!["config/**".to_string()],
+            ..Default::default()
+        };
+        let results = lint_yaml_directory_with_config(tmp.path(), &with_exclude).unwrap();
+        let config_results: Vec<_> = results
+            .iter()
+            .filter(|r| r.path.to_string_lossy().contains("config"))
+            .collect();
+        assert!(config_results.is_empty(), "config file should be excluded");
+
+        // The valid rule should still be linted
+        let rule_results: Vec<_> = results
+            .iter()
+            .filter(|r| r.path.to_string_lossy().contains("good.yml"))
+            .collect();
+        assert_eq!(rule_results.len(), 1);
     }
 }


### PR DESCRIPTION
I tried linting [hayabusa-rules](https://github.com/Yamato-Security/hayabusa-rules) and found a lot of discrepancies. Some are deprecated syntax, and other are legitimate errors. Hence, I added a new lint rule plus an glob-based exclusion CLI flag and config key.

The linter adheres to the [Sigma Rule Specification v2.1.0](https://raw.githubusercontent.com/SigmaHQ/sigma-specification/main/json-schema/sigma-detection-rule-schema.json), and certain lint rules must be disabled for the hayabusa-rules repo, like these: `invalid_tag`, `deprecated_aggregation_syntax` `,wildcard_only_value`, `non_lowercase_key` and `unknown_tag_namespace`.

## Summary

- Add `--exclude <PATTERN>` CLI flag (repeatable) and `exclude:` list in `.rsigma-lint.yml` to skip non-rule YAML files during directory linting
- Add `deprecated_aggregation_syntax` warning that detects legacy Sigma v1.x pipe-aggregation conditions (`| count/min/max/avg/sum/near`) and replaces the noisy per-token `condition_references_unknown` errors with a single clear diagnostic

## Test plan

- [x] 141 lint unit tests pass (9 new)
- [x] 71 CLI integration tests pass
- [x] Verified on hayabusa-rules: errors drop from 139 to 1 (with `--exclude "config/**"`)