### PR TITLE
feat(eval)!: generic Event trait + EventValue enum (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Or use the library directly:
 
 ```rust
 use rsigma_parser::parse_sigma_yaml;
-use rsigma_eval::{Engine, Event};
+use rsigma_eval::Engine;
+use rsigma_eval::event::JsonEvent;
 use serde_json::json;
 
 let yaml = r#"
@@ -79,7 +80,7 @@ let collection = parse_sigma_yaml(yaml).unwrap();
 let mut engine = Engine::new();
 engine.add_collection(&collection).unwrap();
 
-let event = Event::from_value(&json!({"CommandLine": "cmd /c whoami"}));
+let event = JsonEvent::borrow(&json!({"CommandLine": "cmd /c whoami"}));
 let matches = engine.evaluate(&event);
 assert_eq!(matches[0].rule_title, "Detect Whoami");
 ```

--- a/crates/rsigma-cli/src/daemon/engine.rs
+++ b/crates/rsigma-cli/src/daemon/engine.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use rsigma_eval::{Event, ProcessResult};
+use rsigma_eval::{JsonEvent, ProcessResult};
 
 use super::metrics::Metrics;
 use super::state::DaemonEngine;
@@ -61,8 +61,8 @@ pub fn process_batch_lines(
     }
 
     // Phase 2: Batch evaluation — parallel detection + sequential correlation
-    let events: Vec<Event> = flat.iter().map(|(_, v)| Event::from_value(v)).collect();
-    let event_refs: Vec<&Event> = events.iter().collect();
+    let events: Vec<JsonEvent> = flat.iter().map(|(_, v)| JsonEvent::borrow(v)).collect();
+    let event_refs: Vec<&JsonEvent> = events.iter().collect();
 
     let start = Instant::now();
     let batch_results = engine.process_batch(&event_refs);

--- a/crates/rsigma-cli/src/daemon/state.rs
+++ b/crates/rsigma-cli/src/daemon/state.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
+use rsigma_eval::event::Event;
 use rsigma_eval::{
-    CorrelationConfig, CorrelationEngine, CorrelationSnapshot, Engine, Event, Pipeline,
-    ProcessResult,
+    CorrelationConfig, CorrelationEngine, CorrelationSnapshot, Engine, Pipeline, ProcessResult,
 };
 use rsigma_parser::SigmaCollection;
 
@@ -98,7 +98,7 @@ impl DaemonEngine {
     ///
     /// Delegates to `Engine::evaluate_batch` or `CorrelationEngine::process_batch`
     /// depending on whether correlation rules are loaded.
-    pub fn process_batch(&mut self, events: &[&Event]) -> Vec<ProcessResult> {
+    pub fn process_batch<E: Event + Sync>(&mut self, events: &[&E]) -> Vec<ProcessResult> {
         match &mut self.engine {
             EngineVariant::DetectionOnly(engine) => {
                 let batch_detections = engine.evaluate_batch(events);

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -11,8 +11,8 @@ use std::time::SystemTime;
 use clap::{Parser, Subcommand};
 use jaq_interpret::{Ctx, FilterT, ParseCtx, RcIter, Val};
 use rsigma_eval::{
-    CorrelationAction, CorrelationConfig, CorrelationEngine, CorrelationEventMode, Engine, Event,
-    Pipeline, parse_pipeline_file,
+    CorrelationAction, CorrelationConfig, CorrelationEngine, CorrelationEventMode, Engine,
+    JsonEvent, Pipeline, parse_pipeline_file,
 };
 use rsigma_parser::lint::{self, FileLintResult, LintConfig};
 use rsigma_parser::{SigmaCollection, parse_sigma_directory, parse_sigma_file, parse_sigma_yaml};
@@ -1131,7 +1131,7 @@ fn cmd_eval_with_correlations(
             };
 
             for payload in apply_event_filter(&value, event_filter) {
-                let event = Event::from_value(&payload);
+                let event = JsonEvent::borrow(&payload);
                 let result = engine.process_event(&event);
 
                 let total = result.detections.len() + result.correlations.len();
@@ -1204,7 +1204,7 @@ fn eval_ndjson_corr(
         };
 
         for payload in apply_event_filter(&value, event_filter) {
-            let event = Event::from_value(&payload);
+            let event = JsonEvent::borrow(&payload);
             let result = engine.process_event(&event);
 
             for m in &result.detections {
@@ -1262,7 +1262,7 @@ fn cmd_eval_detection_only(
                 eprintln!("No matches.");
             } else {
                 for payload in &payloads {
-                    let event = Event::from_value(payload);
+                    let event = JsonEvent::borrow(payload);
                     let matches = engine.evaluate(&event);
 
                     if matches.is_empty() {
@@ -1326,7 +1326,7 @@ fn eval_ndjson_detect(
         };
 
         for payload in apply_event_filter(&value, event_filter) {
-            let event = Event::from_value(&payload);
+            let event = JsonEvent::borrow(&payload);
             let matches = engine.evaluate(&event);
 
             for m in &matches {

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -399,7 +399,8 @@ transformations:
 
 ```rust
 use rsigma_parser::parse_sigma_yaml;
-use rsigma_eval::{Engine, Event, parse_pipeline};
+use rsigma_eval::{Engine, parse_pipeline};
+use rsigma_eval::event::JsonEvent;
 use serde_json::json;
 
 let yaml = r#"
@@ -431,7 +432,7 @@ let mut engine = Engine::new_with_pipeline(pipeline);
 engine.add_collection(&collection).unwrap();
 
 // Rule now expects ECS field names
-let event = Event::from_value(&json!({"process.command_line": "whoami"}));
+let event = JsonEvent::borrow(&json!({"process.command_line": "whoami"}));
 let matches = engine.evaluate(&event);
 ```
 

--- a/crates/rsigma-eval/benches/correlation.rs
+++ b/crates/rsigma-eval/benches/correlation.rs
@@ -8,7 +8,7 @@ mod datagen;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use rand::Rng;
-use rsigma_eval::{CorrelationConfig, CorrelationEngine, Event};
+use rsigma_eval::{CorrelationConfig, CorrelationEngine, JsonEvent};
 use rsigma_parser::parse_sigma_yaml;
 
 // ---------------------------------------------------------------------------
@@ -26,7 +26,7 @@ fn bench_correlation_event_count(c: &mut Criterion) {
         engine.add_collection(&collection).unwrap();
 
         let event_values = datagen::gen_event_values(1_000);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.throughput(criterion::Throughput::Elements(1_000));
 
@@ -70,7 +70,7 @@ fn bench_correlation_temporal(c: &mut Criterion) {
         let collection = parse_sigma_yaml(&yaml).unwrap();
 
         let event_values = datagen::gen_event_values(1_000);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.throughput(criterion::Throughput::Elements(1_000));
 
@@ -113,7 +113,7 @@ fn bench_correlation_throughput(c: &mut Criterion) {
 
     for n_events in [10_000, 100_000] {
         let event_values = datagen::gen_event_values(n_events);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.throughput(criterion::Throughput::Elements(n_events as u64));
 
@@ -160,7 +160,7 @@ fn bench_correlation_batch(c: &mut Criterion) {
 
     let n_events = 10_000;
     let event_values = datagen::gen_event_values(n_events);
-    let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+    let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
     group.throughput(criterion::Throughput::Elements(n_events as u64));
 
@@ -195,7 +195,7 @@ fn bench_correlation_batch(c: &mut Criterion) {
                 engine
             },
             |mut engine| {
-                let refs: Vec<&Event> = events.iter().collect();
+                let refs: Vec<&JsonEvent> = events.iter().collect();
                 let results = engine.process_batch(black_box(&refs));
                 black_box(results);
             },
@@ -254,7 +254,7 @@ level: high
                 })
             })
             .collect();
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.throughput(criterion::Throughput::Elements(n_unique_keys as u64));
 

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -6,7 +6,7 @@
 mod datagen;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use rsigma_eval::{Engine, Event};
+use rsigma_eval::{Engine, JsonEvent};
 use rsigma_parser::parse_sigma_yaml;
 
 // ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ fn bench_eval_single_event(c: &mut Criterion) {
 
     let events = datagen::gen_event_values(1);
     let event_val = &events[0];
-    let event = Event::from_value(event_val);
+    let event = JsonEvent::borrow(event_val);
 
     for n in [100, 500, 1000, 5000] {
         let yaml = datagen::gen_n_rules(n);
@@ -79,7 +79,7 @@ fn bench_eval_throughput(c: &mut Criterion) {
 
     for n_events in [1_000, 10_000, 100_000] {
         let event_values = datagen::gen_event_values(n_events);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.throughput(criterion::Throughput::Elements(n_events as u64));
 
@@ -115,7 +115,7 @@ fn bench_eval_wildcard_heavy(c: &mut Criterion) {
         engine.add_collection(&collection).unwrap();
 
         let event_values = datagen::gen_event_values(100);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.bench_with_input(
             BenchmarkId::new("rules", n),
@@ -150,7 +150,7 @@ fn bench_eval_batch(c: &mut Criterion) {
         engine.add_collection(&collection).unwrap();
 
         let event_values = datagen::gen_event_values(n_events);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.throughput(criterion::Throughput::Elements(n_events as u64));
 
@@ -174,7 +174,7 @@ fn bench_eval_batch(c: &mut Criterion) {
         let label = format!("{n_rules}r_batch");
         group.bench_with_input(BenchmarkId::new("batch", &label), &events, |b, events| {
             b.iter(|| {
-                let refs: Vec<&Event> = events.iter().collect();
+                let refs: Vec<&JsonEvent> = events.iter().collect();
                 let results = engine.evaluate_batch(black_box(&refs));
                 black_box(results);
             });
@@ -198,7 +198,7 @@ fn bench_eval_regex_heavy(c: &mut Criterion) {
         engine.add_collection(&collection).unwrap();
 
         let event_values = datagen::gen_event_values(100);
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
 
         group.bench_with_input(
             BenchmarkId::new("rules", n),

--- a/crates/rsigma-eval/src/compiler.rs
+++ b/crates/rsigma-eval/src/compiler.rs
@@ -752,6 +752,7 @@ pub fn eval_condition(
     }
 }
 
+/// Evaluate a compiled detection against an event.
 fn eval_detection(detection: &CompiledDetection, event: &impl Event) -> bool {
     match detection {
         CompiledDetection::AllOf(items) => {
@@ -762,6 +763,7 @@ fn eval_detection(detection: &CompiledDetection, event: &impl Event) -> bool {
     }
 }
 
+/// Evaluate a single compiled detection item against an event.
 fn eval_detection_item(item: &CompiledDetectionItem, event: &impl Event) -> bool {
     if let Some(expect_exists) = item.exists {
         if let Some(field) = &item.field {
@@ -783,6 +785,7 @@ fn eval_detection_item(item: &CompiledDetectionItem, event: &impl Event) -> bool
     }
 }
 
+/// Collect field matches from matched selections for the MatchResult.
 fn collect_field_matches(
     selection_names: &[String],
     detections: &HashMap<String, CompiledDetection>,

--- a/crates/rsigma-eval/src/compiler.rs
+++ b/crates/rsigma-eval/src/compiler.rs
@@ -252,17 +252,15 @@ fn validate_condition_refs(
 }
 
 /// Evaluate a compiled rule against an event, returning a `MatchResult` if it matches.
-pub fn evaluate_rule(rule: &CompiledRule, event: &Event) -> Option<MatchResult> {
-    // Evaluate each condition (usually just one)
+pub fn evaluate_rule(rule: &CompiledRule, event: &impl Event) -> Option<MatchResult> {
     for condition in &rule.conditions {
         let mut matched_selections = Vec::new();
         if eval_condition(condition, &rule.detections, event, &mut matched_selections) {
-            // Collect field matches from the matched selections
             let matched_fields =
                 collect_field_matches(&matched_selections, &rule.detections, event);
 
             let event_data = if rule.include_event {
-                Some(event.as_value().clone())
+                Some(event.to_json())
             } else {
                 None
             };
@@ -694,7 +692,7 @@ fn compile_value_default(value: &SigmaValue, case_insensitive: bool) -> Result<C
 pub fn eval_condition(
     expr: &ConditionExpr,
     detections: &HashMap<String, CompiledDetection>,
-    event: &Event,
+    event: &impl Event,
     matched_selections: &mut Vec<String>,
 ) -> bool {
     match expr {
@@ -754,8 +752,7 @@ pub fn eval_condition(
     }
 }
 
-/// Evaluate a compiled detection against an event.
-fn eval_detection(detection: &CompiledDetection, event: &Event) -> bool {
+fn eval_detection(detection: &CompiledDetection, event: &impl Event) -> bool {
     match detection {
         CompiledDetection::AllOf(items) => {
             items.iter().all(|item| eval_detection_item(item, event))
@@ -765,39 +762,31 @@ fn eval_detection(detection: &CompiledDetection, event: &Event) -> bool {
     }
 }
 
-/// Evaluate a single compiled detection item against an event.
-fn eval_detection_item(item: &CompiledDetectionItem, event: &Event) -> bool {
-    // Handle exists modifier
+fn eval_detection_item(item: &CompiledDetectionItem, event: &impl Event) -> bool {
     if let Some(expect_exists) = item.exists {
         if let Some(field) = &item.field {
             let exists = event.get_field(field).is_some_and(|v| !v.is_null());
             return exists == expect_exists;
         }
-        return !expect_exists; // No field name + exists → field doesn't exist
+        return !expect_exists;
     }
 
     match &item.field {
         Some(field_name) => {
-            // Field-based detection
             if let Some(value) = event.get_field(field_name) {
-                item.matcher.matches(value, event)
+                item.matcher.matches(&value, event)
             } else {
-                // Field not present — check if matcher handles null
                 matches!(item.matcher, CompiledMatcher::Null)
             }
         }
-        None => {
-            // Keyword detection (no field) — search all string values
-            item.matcher.matches_keyword(event)
-        }
+        None => item.matcher.matches_keyword(event),
     }
 }
 
-/// Collect field matches from matched selections for the MatchResult.
 fn collect_field_matches(
     selection_names: &[String],
     detections: &HashMap<String, CompiledDetection>,
-    event: &Event,
+    event: &impl Event,
 ) -> Vec<FieldMatch> {
     let mut matches = Vec::new();
     for name in selection_names {
@@ -810,7 +799,7 @@ fn collect_field_matches(
 
 fn collect_detection_fields(
     detection: &CompiledDetection,
-    event: &Event,
+    event: &impl Event,
     out: &mut Vec<FieldMatch>,
 ) {
     match detection {
@@ -818,11 +807,11 @@ fn collect_detection_fields(
             for item in items {
                 if let Some(field_name) = &item.field
                     && let Some(value) = event.get_field(field_name)
-                    && item.matcher.matches(value, event)
+                    && item.matcher.matches(&value, event)
                 {
                     out.push(FieldMatch {
                         field: field_name.clone(),
-                        value: value.clone(),
+                        value: value.to_json(),
                     });
                 }
             }
@@ -834,9 +823,7 @@ fn collect_detection_fields(
                 }
             }
         }
-        CompiledDetection::Keywords(_) => {
-            // Keyword matches don't have specific field names
-        }
+        CompiledDetection::Keywords(_) => {}
     }
 }
 
@@ -1094,6 +1081,7 @@ fn expand_windash(input: &str) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::JsonEvent;
     use rsigma_parser::FieldSpec;
     use serde_json::json;
 
@@ -1119,11 +1107,11 @@ mod tests {
         assert_eq!(compiled.field, Some("CommandLine".into()));
 
         let ev = json!({"CommandLine": "whoami"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"CommandLine": "WHOAMI"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(eval_detection_item(&compiled, &event2)); // case-insensitive
     }
 
@@ -1137,11 +1125,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"CommandLine": "cmd /c whoami /all"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"CommandLine": "ipconfig"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2));
     }
 
@@ -1155,11 +1143,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"Image": "C:\\Windows\\cmd.exe"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"Image": "C:\\Windows\\cmd.bat"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2));
     }
 
@@ -1176,11 +1164,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"CommandLine": "net user admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"CommandLine": "net localgroup"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2)); // missing "user"
     }
 
@@ -1228,7 +1216,7 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"CommandLine": "cmd.exe /c whoami"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
     }
 
@@ -1245,13 +1233,13 @@ mod tests {
         let ev_match = json!({"User": "Admin"});
         assert!(eval_detection_item(
             &compiled,
-            &Event::from_value(&ev_match)
+            &JsonEvent::borrow(&ev_match)
         ));
 
         let ev_no_match = json!({"User": "admin"});
         assert!(!eval_detection_item(
             &compiled,
-            &Event::from_value(&ev_no_match)
+            &JsonEvent::borrow(&ev_no_match)
         ));
     }
 
@@ -1268,13 +1256,13 @@ mod tests {
         let ev_exact = json!({"User": "Admin"});
         assert!(eval_detection_item(
             &compiled,
-            &Event::from_value(&ev_exact)
+            &JsonEvent::borrow(&ev_exact)
         ));
 
         let ev_lower = json!({"User": "admin"});
         assert!(eval_detection_item(
             &compiled,
-            &Event::from_value(&ev_lower)
+            &JsonEvent::borrow(&ev_lower)
         ));
     }
 
@@ -1288,11 +1276,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"SourceIP": "10.1.2.3"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"SourceIP": "192.168.1.1"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2));
     }
 
@@ -1306,11 +1294,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"SomeField": "value"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"OtherField": "value"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2));
     }
 
@@ -1324,11 +1312,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"Image": "C:\\Windows\\System32\\cmd.exe"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"Image": "C:\\Windows\\powershell.exe"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2));
     }
 
@@ -1338,11 +1326,11 @@ mod tests {
         let compiled = compile_detection_item(&item).unwrap();
 
         let ev = json!({"EventID": 4688});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert!(eval_detection_item(&compiled, &event));
 
         let ev2 = json!({"EventID": 1000});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(!eval_detection_item(&compiled, &event2));
     }
 
@@ -1437,12 +1425,12 @@ mod tests {
         ]);
 
         let ev = json!({"CommandLine": "whoami", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let mut matched = Vec::new();
         assert!(eval_condition(&cond, &detections, &event, &mut matched));
 
         let ev2 = json!({"CommandLine": "whoami", "User": "SYSTEM"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         let mut matched2 = Vec::new();
         assert!(!eval_condition(&cond, &detections, &event2, &mut matched2));
     }
@@ -1468,7 +1456,7 @@ mod tests {
             "path": "C:\\Users\\admin\\Downloads",
             "username": "admin"
         });
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let mut matched = Vec::new();
         assert!(eval_condition(&cond, &detections, &event, &mut matched));
 
@@ -1477,7 +1465,7 @@ mod tests {
             "path": "C:\\Users\\admin\\Downloads",
             "username": "guest"
         });
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         let mut matched2 = Vec::new();
         assert!(!eval_condition(&cond, &detections, &event2, &mut matched2));
     }
@@ -1498,13 +1486,13 @@ mod tests {
 
         // Match: timestamp at 03:xx UTC
         let ev = json!({"timestamp": "2024-07-10T03:30:00Z"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let mut matched = Vec::new();
         assert!(eval_condition(&cond, &detections, &event, &mut matched));
 
         // No match: timestamp at 12:xx UTC
         let ev2 = json!({"timestamp": "2024-07-10T12:30:00Z"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         let mut matched2 = Vec::new();
         assert!(!eval_condition(&cond, &detections, &event2, &mut matched2));
     }
@@ -1525,13 +1513,13 @@ mod tests {
 
         // Match: December
         let ev = json!({"created": "2024-12-25T10:00:00Z"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let mut matched = Vec::new();
         assert!(eval_condition(&cond, &detections, &event, &mut matched));
 
         // No match: July
         let ev2 = json!({"created": "2024-07-10T10:00:00Z"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         let mut matched2 = Vec::new();
         assert!(!eval_condition(&cond, &detections, &event2, &mut matched2));
     }
@@ -1600,7 +1588,7 @@ mod tests {
         assert!(compiled.include_event);
 
         let ev = json!({"action": "login", "user": "alice"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let result = evaluate_rule(&compiled, &event).unwrap();
         assert!(result.event.is_some());
         assert_eq!(result.event.unwrap(), ev);
@@ -1614,7 +1602,7 @@ mod tests {
         assert!(!compiled.include_event);
 
         let ev = json!({"action": "login", "user": "alice"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let result = evaluate_rule(&compiled, &event).unwrap();
         assert!(result.event.is_none());
     }
@@ -1651,7 +1639,7 @@ severity_score: 42
         assert!(!compiled.custom_attributes.contains_key("level"));
 
         let ev = json!({"action": "login"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let result = evaluate_rule(&compiled, &event).unwrap();
 
         assert_eq!(
@@ -1671,7 +1659,7 @@ severity_score: 42
         assert!(compiled.custom_attributes.is_empty());
 
         let ev = json!({"action": "login"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let result = evaluate_rule(&compiled, &event).unwrap();
         assert!(result.custom_attributes.is_empty());
     }

--- a/crates/rsigma-eval/src/correlation.rs
+++ b/crates/rsigma-eval/src/correlation.rs
@@ -184,7 +184,7 @@ impl GroupKey {
     }
 }
 
-/// Convert a JSON value to a string for group-key purposes.
+/// Convert an [`EventValue`] to a string for group-key purposes.
 fn value_to_string(v: &EventValue) -> Option<String> {
     match v {
         EventValue::Str(s) => Some(s.to_string()),

--- a/crates/rsigma-eval/src/correlation.rs
+++ b/crates/rsigma-eval/src/correlation.rs
@@ -18,7 +18,7 @@ use rsigma_parser::{
 };
 
 use crate::error::{EvalError, Result};
-use crate::event::Event;
+use crate::event::{Event, EventValue};
 
 // =============================================================================
 // Compiled types
@@ -142,12 +142,14 @@ pub struct GroupKey(pub Vec<Option<String>>);
 impl GroupKey {
     /// Extract a group key from an event given the group-by fields and the
     /// rule reference identifiers (ID, name, etc.) that produced the detection match.
-    pub fn extract(event: &Event, group_by: &[GroupByField], rule_refs: &[&str]) -> Self {
+    pub fn extract(event: &impl Event, group_by: &[GroupByField], rule_refs: &[&str]) -> Self {
         let values = group_by
             .iter()
             .map(|field| {
                 let field_name = field.resolve(rule_refs);
-                event.get_field(field_name).and_then(value_to_string)
+                event
+                    .get_field(field_name)
+                    .and_then(|v| value_to_string(&v))
             })
             .collect();
         GroupKey(values)
@@ -183,11 +185,12 @@ impl GroupKey {
 }
 
 /// Convert a JSON value to a string for group-key purposes.
-fn value_to_string(v: &serde_json::Value) -> Option<String> {
+fn value_to_string(v: &EventValue) -> Option<String> {
     match v {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Number(n) => Some(n.to_string()),
-        serde_json::Value::Bool(b) => Some(b.to_string()),
+        EventValue::Str(s) => Some(s.to_string()),
+        EventValue::Int(n) => Some(n.to_string()),
+        EventValue::Float(f) => Some(f.to_string()),
+        EventValue::Bool(b) => Some(b.to_string()),
         _ => None,
     }
 }
@@ -926,12 +929,13 @@ fn compile_condition(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::JsonEvent;
     use serde_json::json;
 
     #[test]
     fn test_group_key_extract() {
         let v = json!({"User": "admin", "Host": "srv01"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let group_by = vec![
             GroupByField::Direct("User".to_string()),
             GroupByField::Direct("Host".to_string()),
@@ -946,7 +950,7 @@ mod tests {
     #[test]
     fn test_group_key_missing_field() {
         let v = json!({"User": "admin"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let group_by = vec![
             GroupByField::Direct("User".to_string()),
             GroupByField::Direct("Host".to_string()),
@@ -958,7 +962,7 @@ mod tests {
     #[test]
     fn test_group_key_aliased() {
         let v = json!({"source.ip": "10.0.0.1"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let group_by = vec![GroupByField::Aliased {
             alias: "internal_ip".to_string(),
             mapping: HashMap::from([

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -26,7 +26,7 @@ use crate::correlation::{
 };
 use crate::engine::Engine;
 use crate::error::{EvalError, Result};
-use crate::event::Event;
+use crate::event::{Event, EventValue};
 use crate::pipeline::{Pipeline, apply_pipelines, apply_pipelines_to_correlation};
 use crate::result::MatchResult;
 
@@ -581,7 +581,7 @@ impl CorrelationEngine {
     /// When no timestamp field is found, the `timestamp_fallback` policy applies:
     /// - `WallClock`: use `Utc::now()` (good for real-time streaming)
     /// - `Skip`: return detections only, skip correlation state updates
-    pub fn process_event(&mut self, event: &Event) -> ProcessResult {
+    pub fn process_event(&mut self, event: &impl Event) -> ProcessResult {
         let all_detections = self.engine.evaluate(event);
 
         let ts = match self.extract_event_timestamp(event) {
@@ -605,7 +605,7 @@ impl CorrelationEngine {
     ///
     /// The timestamp is clamped to `[0, i64::MAX / 2]` to prevent overflow
     /// when adding timespan durations internally.
-    pub fn process_event_at(&mut self, event: &Event, timestamp_secs: i64) -> ProcessResult {
+    pub fn process_event_at(&mut self, event: &impl Event, timestamp_secs: i64) -> ProcessResult {
         let all_detections = self.engine.evaluate(event);
         self.process_with_detections(event, all_detections, timestamp_secs)
     }
@@ -617,7 +617,7 @@ impl CorrelationEngine {
     /// sequentially for stateful correlation.
     pub fn process_with_detections(
         &mut self,
-        event: &Event,
+        event: &impl Event,
         all_detections: Vec<MatchResult>,
         timestamp_secs: i64,
     ) -> ProcessResult {
@@ -649,7 +649,7 @@ impl CorrelationEngine {
     /// Takes `&self` so it can be called concurrently from multiple threads
     /// (e.g. via `rayon::par_iter`) while the mutable correlation phase runs
     /// sequentially afterwards.
-    pub fn evaluate(&self, event: &Event) -> Vec<MatchResult> {
+    pub fn evaluate(&self, event: &impl Event) -> Vec<MatchResult> {
         self.engine.evaluate(event)
     }
 
@@ -660,7 +660,7 @@ impl CorrelationEngine {
     /// phase (it borrows `&self.config` immutably). After `collect()` releases the
     /// immutable borrows, each event's pre-computed detections are fed into the
     /// stateful correlation engine sequentially.
-    pub fn process_batch<'a>(&mut self, events: &[&'a Event<'a>]) -> Vec<ProcessResult> {
+    pub fn process_batch<E: Event + Sync>(&mut self, events: &[&E]) -> Vec<ProcessResult> {
         // Borrow split: take immutable refs to fields needed for the parallel phase.
         // These are released by collect() before the sequential &mut self phase.
         let engine = &self.engine;
@@ -742,7 +742,7 @@ impl CorrelationEngine {
     /// Feed detection matches into correlation window states.
     fn feed_detections(
         &mut self,
-        event: &Event,
+        event: &impl Event,
         detections: &[MatchResult],
         ts: i64,
         out: &mut Vec<CorrelationResult>,
@@ -814,7 +814,7 @@ impl CorrelationEngine {
     fn update_correlation(
         &mut self,
         corr_idx: usize,
-        event: &Event,
+        event: &impl Event,
         ts: i64,
         rule_id: &Option<String>,
         rule_name: &Option<String>,
@@ -864,7 +864,7 @@ impl CorrelationEngine {
             CorrelationType::ValueCount => {
                 if let Some(ref field_name) = corr.condition.field
                     && let Some(val) = event.get_field(field_name)
-                    && let Some(s) = value_to_string_for_count(val)
+                    && let Some(s) = value_to_string_for_count(&val)
                 {
                     state.push_value_count(ts, s);
                 }
@@ -878,7 +878,7 @@ impl CorrelationEngine {
             | CorrelationType::ValueMedian => {
                 if let Some(ref field_name) = corr.condition.field
                     && let Some(val) = event.get_field(field_name)
-                    && let Some(n) = value_to_f64(val)
+                    && let Some(n) = value_to_f64_ev(&val)
                 {
                     state.push_numeric(ts, n);
                 }
@@ -893,7 +893,8 @@ impl CorrelationEngine {
                     .entry(state_key.clone())
                     .or_insert_with(|| EventBuffer::new(max_events));
                 buf.evict(cutoff);
-                buf.push(ts, event.as_value());
+                let json = event.to_json();
+                buf.push(ts, &json);
             }
             CorrelationEventMode::Refs => {
                 let buf = self
@@ -901,7 +902,8 @@ impl CorrelationEngine {
                     .entry(state_key.clone())
                     .or_insert_with(|| EventRefBuffer::new(max_events));
                 buf.evict(cutoff);
-                buf.push(ts, event.as_value());
+                let json = event.to_json();
+                buf.push(ts, &json);
             }
             CorrelationEventMode::None => {}
         }
@@ -1096,10 +1098,10 @@ impl CorrelationEngine {
     /// - ISO 8601 strings (e.g., "2024-07-10T12:30:00Z")
     ///
     /// Returns `None` if no field yields a valid timestamp.
-    fn extract_event_timestamp(&self, event: &Event) -> Option<i64> {
+    fn extract_event_timestamp(&self, event: &impl Event) -> Option<i64> {
         for field_name in &self.config.timestamp_fields {
             if let Some(val) = event.get_field(field_name)
-                && let Some(ts) = parse_timestamp_value(val)
+                && let Some(ts) = parse_timestamp_value(&val)
             {
                 return Some(ts);
             }
@@ -1382,10 +1384,10 @@ impl Default for CorrelationEngine {
 ///
 /// Standalone version of `CorrelationEngine::extract_event_timestamp` for use
 /// in contexts where borrowing `&self` is not possible (e.g. rayon closures).
-fn extract_event_ts(event: &Event, timestamp_fields: &[String]) -> Option<i64> {
+fn extract_event_ts(event: &impl Event, timestamp_fields: &[String]) -> Option<i64> {
     for field_name in timestamp_fields {
         if let Some(val) = event.get_field(field_name)
-            && let Some(ts) = parse_timestamp_value(val)
+            && let Some(ts) = parse_timestamp_value(&val)
         {
             return Some(ts);
         }
@@ -1393,17 +1395,11 @@ fn extract_event_ts(event: &Event, timestamp_fields: &[String]) -> Option<i64> {
     None
 }
 
-/// Parse a JSON value as a Unix epoch timestamp in seconds.
-fn parse_timestamp_value(val: &serde_json::Value) -> Option<i64> {
+fn parse_timestamp_value(val: &EventValue) -> Option<i64> {
     match val {
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Some(normalize_epoch(i))
-            } else {
-                n.as_f64().map(|f| normalize_epoch(f as i64))
-            }
-        }
-        serde_json::Value::String(s) => parse_timestamp_string(s),
+        EventValue::Int(i) => Some(normalize_epoch(*i)),
+        EventValue::Float(f) => Some(normalize_epoch(*f as i64)),
+        EventValue::Str(s) => parse_timestamp_string(s),
         _ => None,
     }
 }
@@ -1442,23 +1438,19 @@ fn parse_timestamp_string(s: &str) -> Option<i64> {
 }
 
 /// Convert a JSON value to a string for value_count purposes.
-fn value_to_string_for_count(v: &serde_json::Value) -> Option<String> {
+fn value_to_string_for_count(v: &EventValue) -> Option<String> {
     match v {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Number(n) => Some(n.to_string()),
-        serde_json::Value::Bool(b) => Some(b.to_string()),
-        serde_json::Value::Null => Some("null".to_string()),
+        EventValue::Str(s) => Some(s.to_string()),
+        EventValue::Int(n) => Some(n.to_string()),
+        EventValue::Float(f) => Some(f.to_string()),
+        EventValue::Bool(b) => Some(b.to_string()),
+        EventValue::Null => Some("null".to_string()),
         _ => None,
     }
 }
 
-/// Convert a JSON value to f64 for numeric aggregation.
-fn value_to_f64(v: &serde_json::Value) -> Option<f64> {
-    match v {
-        serde_json::Value::Number(n) => n.as_f64(),
-        serde_json::Value::String(s) => s.parse().ok(),
-        _ => None,
-    }
+fn value_to_f64_ev(v: &EventValue) -> Option<f64> {
+    v.as_f64()
 }
 
 // =============================================================================
@@ -1468,6 +1460,7 @@ fn value_to_f64(v: &serde_json::Value) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::JsonEvent;
     use rsigma_parser::parse_sigma_yaml;
     use serde_json::json;
 
@@ -1477,40 +1470,40 @@ mod tests {
 
     #[test]
     fn test_parse_timestamp_epoch_secs() {
-        let val = json!(1720612200);
+        let val = EventValue::Int(1720612200);
         assert_eq!(parse_timestamp_value(&val), Some(1720612200));
     }
 
     #[test]
     fn test_parse_timestamp_epoch_millis() {
-        let val = json!(1720612200000i64);
+        let val = EventValue::Int(1720612200000);
         assert_eq!(parse_timestamp_value(&val), Some(1720612200));
     }
 
     #[test]
     fn test_parse_timestamp_rfc3339() {
-        let val = json!("2024-07-10T12:30:00Z");
+        let val = EventValue::Str(std::borrow::Cow::Borrowed("2024-07-10T12:30:00Z"));
         let ts = parse_timestamp_value(&val).unwrap();
         assert_eq!(ts, 1720614600);
     }
 
     #[test]
     fn test_parse_timestamp_naive() {
-        let val = json!("2024-07-10T12:30:00");
+        let val = EventValue::Str(std::borrow::Cow::Borrowed("2024-07-10T12:30:00"));
         let ts = parse_timestamp_value(&val).unwrap();
         assert_eq!(ts, 1720614600);
     }
 
     #[test]
     fn test_parse_timestamp_with_space() {
-        let val = json!("2024-07-10 12:30:00");
+        let val = EventValue::Str(std::borrow::Cow::Borrowed("2024-07-10 12:30:00"));
         let ts = parse_timestamp_value(&val).unwrap();
         assert_eq!(ts, 1720614600);
     }
 
     #[test]
     fn test_parse_timestamp_fractional() {
-        let val = json!("2024-07-10T12:30:00.123Z");
+        let val = EventValue::Str(std::borrow::Cow::Borrowed("2024-07-10T12:30:00.123Z"));
         let ts = parse_timestamp_value(&val).unwrap();
         assert_eq!(ts, 1720614600);
     }
@@ -1525,7 +1518,7 @@ mod tests {
         let engine = CorrelationEngine::new(config);
 
         let v = json!({"@timestamp": "2024-07-10T12:30:00Z", "data": "test"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let ts = engine.extract_event_timestamp(&event);
         assert_eq!(ts, Some(1720614600));
     }
@@ -1545,7 +1538,7 @@ mod tests {
 
         // First field missing, second field present
         let v = json!({"timestamp": 1720613400, "data": "test"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let ts = engine.extract_event_timestamp(&event);
         assert_eq!(ts, Some(1720613400));
     }
@@ -1559,7 +1552,7 @@ mod tests {
         let engine = CorrelationEngine::new(config);
 
         let v = json!({"data": "no timestamp here"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(engine.extract_event_timestamp(&event), None);
     }
 
@@ -1598,7 +1591,7 @@ level: high
 
         // Events with no timestamp field — should NOT update correlation state
         let v = json!({"action": "click", "User": "alice"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
 
         let r1 = engine.process_event(&event);
         assert!(!r1.detections.is_empty(), "detection should still fire");
@@ -1648,7 +1641,7 @@ level: high
         // Events with no timestamp — WallClock fallback means they get Utc::now()
         // and should be close enough to correlate (generous 60s window)
         let v = json!({"action": "click", "User": "alice"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
 
         let _r1 = engine.process_event(&event);
         let _r2 = engine.process_event(&event);
@@ -1704,7 +1697,7 @@ level: high
         let base_ts = 1000i64;
         for i in 0..3 {
             let v = json!({"CommandLine": "whoami", "User": "admin"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, base_ts + i * 10);
 
             // Each event should match the detection rule
@@ -1756,13 +1749,13 @@ level: high
         let ts = 1000i64;
         for i in 0..2 {
             let v = json!({"EventType": "login", "User": "alice"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let r = engine.process_event_at(&event, ts + i);
             assert!(r.correlations.is_empty());
         }
         for i in 0..3 {
             let v = json!({"EventType": "login", "User": "bob"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let r = engine.process_event_at(&event, ts + i);
             if i == 2 {
                 assert_eq!(r.correlations.len(), 1);
@@ -1805,7 +1798,7 @@ level: medium
 
         // Send 2 events at t=0,1 then 1 event at t=15 (outside window)
         let v = json!({"action": "click", "User": "admin"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         engine.process_event_at(&event, 0);
         engine.process_event_at(&event, 1);
         let r = engine.process_event_at(&event, 15);
@@ -1852,7 +1845,7 @@ level: high
         // 3 different users failing login on same host
         for (i, user) in ["alice", "bob", "charlie"].iter().enumerate() {
             let v = json!({"EventType": "failed_login", "Host": "srv01", "User": user});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let r = engine.process_event_at(&event, ts + i as i64);
             if i == 2 {
                 assert_eq!(r.correlations.len(), 1);
@@ -1909,13 +1902,13 @@ level: high
         let ts = 1000i64;
         // Only recon A fires
         let v1 = json!({"CommandLine": "whoami", "User": "admin"});
-        let ev1 = Event::from_value(&v1);
+        let ev1 = JsonEvent::borrow(&v1);
         let r1 = engine.process_event_at(&ev1, ts);
         assert!(r1.correlations.is_empty());
 
         // Now recon B fires — both rules have fired within window
         let v2 = json!({"CommandLine": "ipconfig /all", "User": "admin"});
-        let ev2 = Event::from_value(&v2);
+        let ev2 = JsonEvent::borrow(&v2);
         let r2 = engine.process_event_at(&ev2, ts + 10);
         assert_eq!(r2.correlations.len(), 1);
         assert_eq!(r2.correlations[0].rule_title, "Recon Combo");
@@ -1969,13 +1962,13 @@ level: critical
         let ts = 1000i64;
         // Failed login first
         let v1 = json!({"EventType": "failed_login", "User": "admin"});
-        let ev1 = Event::from_value(&v1);
+        let ev1 = JsonEvent::borrow(&v1);
         let r1 = engine.process_event_at(&ev1, ts);
         assert!(r1.correlations.is_empty());
 
         // Then successful login — correct order!
         let v2 = json!({"EventType": "success_login", "User": "admin"});
-        let ev2 = Event::from_value(&v2);
+        let ev2 = JsonEvent::borrow(&v2);
         let r2 = engine.process_event_at(&ev2, ts + 10);
         assert_eq!(r2.correlations.len(), 1);
     }
@@ -2022,11 +2015,11 @@ level: high
         let ts = 1000i64;
         // B fires first, then A — wrong order
         let v1 = json!({"type": "b", "User": "admin"});
-        let ev1 = Event::from_value(&v1);
+        let ev1 = JsonEvent::borrow(&v1);
         engine.process_event_at(&ev1, ts);
 
         let v2 = json!({"type": "a", "User": "admin"});
-        let ev2 = Event::from_value(&v2);
+        let ev2 = JsonEvent::borrow(&v2);
         let r2 = engine.process_event_at(&ev2, ts + 10);
         assert!(r2.correlations.is_empty());
     }
@@ -2067,12 +2060,12 @@ level: high
 
         let ts = 1000i64;
         let v1 = json!({"action": "upload", "User": "alice", "bytes_sent": 600});
-        let ev1 = Event::from_value(&v1);
+        let ev1 = JsonEvent::borrow(&v1);
         let r1 = engine.process_event_at(&ev1, ts);
         assert!(r1.correlations.is_empty());
 
         let v2 = json!({"action": "upload", "User": "alice", "bytes_sent": 500});
-        let ev2 = Event::from_value(&v2);
+        let ev2 = JsonEvent::borrow(&v2);
         let r2 = engine.process_event_at(&ev2, ts + 5);
         assert_eq!(r2.correlations.len(), 1);
         assert!((r2.correlations[0].aggregated_value - 1100.0).abs() < f64::EPSILON);
@@ -2112,7 +2105,7 @@ level: medium
         // Avg of 400, 600, 800 = 600 > 500
         for (i, latency) in [400, 600, 800].iter().enumerate() {
             let v = json!({"type": "request", "Service": "api", "latency_ms": latency});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let r = engine.process_event_at(&event, ts + i as i64);
             if i == 2 {
                 assert_eq!(r.correlations.len(), 1);
@@ -2155,12 +2148,12 @@ level: low
         engine.add_collection(&collection).unwrap();
 
         let v = json!({"action": "test", "User": "alice"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         engine.process_event_at(&event, 1000);
         assert_eq!(engine.state_count(), 1);
 
         let v2 = json!({"action": "test", "User": "bob"});
-        let event2 = Event::from_value(&v2);
+        let event2 = JsonEvent::borrow(&v2);
         engine.process_event_at(&event2, 1001);
         assert_eq!(engine.state_count(), 2);
 
@@ -2205,7 +2198,7 @@ level: high
         // generate defaults to false — detection matches are still returned
         // (filtering by generate flag is a backend concern, not eval)
         let v = json!({"action": "test", "User": "alice"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let r = engine.process_event_at(&event, 1000);
         assert_eq!(r.detections.len(), 1);
         assert_eq!(r.correlations.len(), 1);
@@ -2255,7 +2248,7 @@ level: high
                 "eventName": "ListBuckets",
                 "userIdentity.arn": "arn:aws:iam::123456789:user/attacker"
             });
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let r = engine.process_event_at(&event, base_ts + i * 60);
             if i == 4 {
                 assert_eq!(r.correlations.len(), 1);
@@ -2337,7 +2330,7 @@ level: critical
         // Send 3 failed logins → triggers "many_failed_chain"
         for i in 0..3 {
             let v = json!({"EventType": "failed_login", "User": "victim"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let r = engine.process_event_at(&event, ts + i);
             if i == 2 {
                 // The event_count correlation should fire
@@ -2357,7 +2350,7 @@ level: critical
         // to have fired. success-login-chain is a detection rule, not a correlation,
         // so it gets matched via the regular detection path.
         let v = json!({"EventType": "success_login", "User": "victim"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let r = engine.process_event_at(&event, ts + 30);
 
         // The detection should match
@@ -2421,7 +2414,7 @@ level: high
             "http.response.status_code": 500,
             "destination.ip": "10.0.0.5"
         });
-        let ev1 = Event::from_value(&v1);
+        let ev1 = JsonEvent::borrow(&v1);
         let r1 = engine.process_event_at(&ev1, ts);
         assert_eq!(r1.detections.len(), 1);
         assert!(r1.correlations.is_empty());
@@ -2431,7 +2424,7 @@ level: high
             "event.type": "connection",
             "source.ip": "10.0.0.5"
         });
-        let ev2 = Event::from_value(&v2);
+        let ev2 = JsonEvent::borrow(&v2);
         let r2 = engine.process_event_at(&ev2, ts + 5);
         assert_eq!(r2.detections.len(), 1);
         // Both rules fired for the same internal_ip group → temporal should fire
@@ -2484,7 +2477,7 @@ level: medium
         // Push some numeric-ish values for the image field
         for (i, val) in [10.0, 20.0, 30.0, 40.0, 50.0].iter().enumerate() {
             let v = json!({"type": "process_creation", "ComputerName": "srv01", "image": val});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let _ = engine.process_event_at(&event, ts + i as i64);
         }
         // The median (30.0) should be <= 50, so condition fires
@@ -2537,12 +2530,12 @@ level: high
 
         // Login failure by alice
         let ev1 = json!({"EventType": "login_failure", "User": "alice"});
-        let r1 = engine.process_event_at(&Event::from_value(&ev1), ts);
+        let r1 = engine.process_event_at(&JsonEvent::borrow(&ev1), ts);
         assert!(r1.correlations.is_empty(), "only one rule fired so far");
 
         // Password change by alice — both rules have now fired
         let ev2 = json!({"EventType": "password_change", "User": "alice"});
-        let r2 = engine.process_event_at(&Event::from_value(&ev2), ts + 10);
+        let r2 = engine.process_event_at(&JsonEvent::borrow(&ev2), ts + 10);
         assert_eq!(
             r2.correlations.len(),
             1,
@@ -2591,7 +2584,7 @@ level: medium
 
         // Only SSH login by bob — "or" means this suffices
         let ev = json!({"EventType": "ssh_login", "User": "bob"});
-        let r = engine.process_event_at(&Event::from_value(&ev), 1000);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), 1000);
         assert_eq!(r.correlations.len(), 1);
         assert_eq!(r.correlations[0].rule_title, "Any Remote Access");
     }
@@ -2636,12 +2629,12 @@ level: high
 
         // Only whoami (recon-1) — should not fire
         let ev = json!({"CommandLine": "whoami", "Host": "srv01"});
-        let r = engine.process_event_at(&Event::from_value(&ev), 1000);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), 1000);
         assert!(r.correlations.is_empty(), "only one of two AND rules fired");
 
         // Now ipconfig (recon-2) — should fire
         let ev2 = json!({"CommandLine": "ipconfig /all", "Host": "srv01"});
-        let r2 = engine.process_event_at(&Event::from_value(&ev2), 1010);
+        let r2 = engine.process_event_at(&JsonEvent::borrow(&ev2), 1010);
         assert_eq!(r2.correlations.len(), 1);
         assert_eq!(r2.correlations[0].rule_title, "Full Recon");
     }
@@ -2692,7 +2685,7 @@ level: critical
         // Service account failures should be filtered — don't count
         for i in 0..5 {
             let ev = json!({"EventType": "auth_failure", "User": "svc_backup"});
-            let r = engine.process_event_at(&Event::from_value(&ev), ts + i);
+            let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + i);
             assert!(
                 r.correlations.is_empty(),
                 "service account should be filtered, no correlation"
@@ -2702,13 +2695,13 @@ level: critical
         // Normal user failures should count
         for i in 0..2 {
             let ev = json!({"EventType": "auth_failure", "User": "alice"});
-            let r = engine.process_event_at(&Event::from_value(&ev), ts + 10 + i);
+            let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 10 + i);
             assert!(r.correlations.is_empty(), "not yet 3 events");
         }
 
         // Third failure triggers correlation
         let ev = json!({"EventType": "auth_failure", "User": "alice"});
-        let r = engine.process_event_at(&Event::from_value(&ev), ts + 12);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 12);
         assert_eq!(r.correlations.len(), 1);
         assert_eq!(r.correlations[0].rule_title, "Brute Force");
     }
@@ -2760,11 +2753,11 @@ level: high
         let ts = 1000i64;
         // Mix of docx and xlsx accesses by same user
         let ev1 = json!({"FileName": "report.docx", "User": "bob"});
-        engine.process_event_at(&Event::from_value(&ev1), ts);
+        engine.process_event_at(&JsonEvent::borrow(&ev1), ts);
         let ev2 = json!({"FileName": "data.xlsx", "User": "bob"});
-        engine.process_event_at(&Event::from_value(&ev2), ts + 1);
+        engine.process_event_at(&JsonEvent::borrow(&ev2), ts + 1);
         let ev3 = json!({"FileName": "notes.docx", "User": "bob"});
-        let r = engine.process_event_at(&Event::from_value(&ev3), ts + 2);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev3), ts + 2);
 
         assert_eq!(r.correlations.len(), 1);
         assert_eq!(r.correlations[0].rule_title, "Mass File Access");
@@ -2805,17 +2798,17 @@ level: medium
         let ts = 1000i64;
         // Event where User field matches the placeholder
         let ev1 = json!({"FilePath": "C:\\Users\\alice\\Temp", "User": "alice"});
-        let r1 = engine.process_event_at(&Event::from_value(&ev1), ts);
+        let r1 = engine.process_event_at(&JsonEvent::borrow(&ev1), ts);
         assert!(r1.correlations.is_empty());
 
         let ev2 = json!({"FilePath": "C:\\Users\\alice\\Temp", "User": "alice"});
-        let r2 = engine.process_event_at(&Event::from_value(&ev2), ts + 1);
+        let r2 = engine.process_event_at(&JsonEvent::borrow(&ev2), ts + 1);
         assert_eq!(r2.correlations.len(), 1);
         assert_eq!(r2.correlations[0].rule_title, "Excessive Temp Access");
 
         // Different user — should NOT match (path says alice, user is bob)
         let ev3 = json!({"FilePath": "C:\\Users\\alice\\Temp", "User": "bob"});
-        let r3 = engine.process_event_at(&Event::from_value(&ev3), ts + 2);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev3), ts + 2);
         // Detection doesn't fire for this event since expand resolves to C:\Users\bob\Temp
         assert_eq!(r3.detections.len(), 0);
     }
@@ -2858,19 +2851,19 @@ level: high
         // Login at 3AM
         let ev1 =
             json!({"EventType": "login", "User": "alice", "Timestamp": "2024-01-15T03:10:00Z"});
-        let r1 = engine.process_event_at(&Event::from_value(&ev1), ts);
+        let r1 = engine.process_event_at(&JsonEvent::borrow(&ev1), ts);
         assert_eq!(r1.detections.len(), 1);
         assert!(r1.correlations.is_empty());
 
         let ev2 =
             json!({"EventType": "login", "User": "alice", "Timestamp": "2024-01-15T03:45:00Z"});
-        let r2 = engine.process_event_at(&Event::from_value(&ev2), ts + 1);
+        let r2 = engine.process_event_at(&JsonEvent::borrow(&ev2), ts + 1);
         assert_eq!(r2.correlations.len(), 1);
         assert_eq!(r2.correlations[0].rule_title, "Frequent Night Logins");
 
         // Login at noon — should NOT count
         let ev3 = json!({"EventType": "login", "User": "bob", "Timestamp": "2024-01-15T12:00:00Z"});
-        let r3 = engine.process_event_at(&Event::from_value(&ev3), ts + 2);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev3), ts + 2);
         assert!(
             r3.detections.is_empty(),
             "noon login should not match night rule"
@@ -2918,25 +2911,25 @@ level: high
         // Send 2 events — gt:2 is false
         for i in 0..2 {
             let ev = json!({"EventType": "login", "User": "alice"});
-            let r = engine.process_event_at(&Event::from_value(&ev), ts + i);
+            let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + i);
             assert!(r.correlations.is_empty(), "2 events should not fire (gt:2)");
         }
 
         // 3rd event — gt:2 is true, lte:5 is true → fires
         let ev3 = json!({"EventType": "login", "User": "alice"});
-        let r3 = engine.process_event_at(&Event::from_value(&ev3), ts + 3);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev3), ts + 3);
         assert_eq!(r3.correlations.len(), 1, "3 events: gt:2 AND lte:5");
 
         // Send events 4, 5 — still in range
         for i in 4..=5 {
             let ev = json!({"EventType": "login", "User": "alice"});
-            let r = engine.process_event_at(&Event::from_value(&ev), ts + i);
+            let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + i);
             assert_eq!(r.correlations.len(), 1, "{i} events still in range");
         }
 
         // 6th event — lte:5 is false → no fire
         let ev6 = json!({"EventType": "login", "User": "alice"});
-        let r6 = engine.process_event_at(&Event::from_value(&ev6), ts + 6);
+        let r6 = engine.process_event_at(&JsonEvent::borrow(&ev6), ts + 6);
         assert!(
             r6.correlations.is_empty(),
             "6 events exceeds lte:5, should not fire"
@@ -2986,27 +2979,27 @@ level: high
         let ts = 1000;
 
         // Fire 3 events to hit threshold
-        engine.process_event_at(&Event::from_value(&ev), ts);
-        engine.process_event_at(&Event::from_value(&ev), ts + 1);
-        let r3 = engine.process_event_at(&Event::from_value(&ev), ts + 2);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 1);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 2);
         assert_eq!(r3.correlations.len(), 1, "should fire on 3rd event");
 
         // 4th event within suppress window → suppressed
-        let r4 = engine.process_event_at(&Event::from_value(&ev), ts + 3);
+        let r4 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 3);
         assert!(
             r4.correlations.is_empty(),
             "should be suppressed within 10s window"
         );
 
         // 5th event still within suppress window → suppressed
-        let r5 = engine.process_event_at(&Event::from_value(&ev), ts + 9);
+        let r5 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 9);
         assert!(
             r5.correlations.is_empty(),
             "should be suppressed at ts+9 (< ts+2+10)"
         );
 
         // Event after suppress window expires → fires again
-        let r6 = engine.process_event_at(&Event::from_value(&ev), ts + 13);
+        let r6 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 13);
         assert_eq!(
             r6.correlations.len(),
             1,
@@ -3028,20 +3021,20 @@ level: high
 
         // Alice hits threshold
         let ev_a = json!({"EventType": "login", "User": "alice"});
-        engine.process_event_at(&Event::from_value(&ev_a), ts);
-        engine.process_event_at(&Event::from_value(&ev_a), ts + 1);
-        let r = engine.process_event_at(&Event::from_value(&ev_a), ts + 2);
+        engine.process_event_at(&JsonEvent::borrow(&ev_a), ts);
+        engine.process_event_at(&JsonEvent::borrow(&ev_a), ts + 1);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev_a), ts + 2);
         assert_eq!(r.correlations.len(), 1, "alice should fire");
 
         // Bob hits threshold — different group key, not suppressed
         let ev_b = json!({"EventType": "login", "User": "bob"});
-        engine.process_event_at(&Event::from_value(&ev_b), ts + 3);
-        engine.process_event_at(&Event::from_value(&ev_b), ts + 4);
-        let r = engine.process_event_at(&Event::from_value(&ev_b), ts + 5);
+        engine.process_event_at(&JsonEvent::borrow(&ev_b), ts + 3);
+        engine.process_event_at(&JsonEvent::borrow(&ev_b), ts + 4);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev_b), ts + 5);
         assert_eq!(r.correlations.len(), 1, "bob should fire independently");
 
         // Alice is still suppressed
-        let r = engine.process_event_at(&Event::from_value(&ev_a), ts + 6);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev_a), ts + 6);
         assert!(r.correlations.is_empty(), "alice still suppressed");
     }
 
@@ -3063,20 +3056,20 @@ level: high
         let ts = 1000;
 
         // Hit threshold: 3 events
-        engine.process_event_at(&Event::from_value(&ev), ts);
-        engine.process_event_at(&Event::from_value(&ev), ts + 1);
-        let r3 = engine.process_event_at(&Event::from_value(&ev), ts + 2);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 1);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 2);
         assert_eq!(r3.correlations.len(), 1, "should fire on 3rd event");
 
         // State was reset, so 4th and 5th events should NOT fire
-        let r4 = engine.process_event_at(&Event::from_value(&ev), ts + 3);
+        let r4 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 3);
         assert!(r4.correlations.is_empty(), "reset: need 3 more events");
 
-        let r5 = engine.process_event_at(&Event::from_value(&ev), ts + 4);
+        let r5 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 4);
         assert!(r5.correlations.is_empty(), "reset: still only 2");
 
         // 6th event (3rd after reset) should fire again
-        let r6 = engine.process_event_at(&Event::from_value(&ev), ts + 5);
+        let r6 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 5);
         assert_eq!(
             r6.correlations.len(),
             1,
@@ -3095,7 +3088,7 @@ level: high
         engine.add_collection(&collection).unwrap();
 
         let ev = json!({"EventType": "login", "User": "alice"});
-        let r = engine.process_event_at(&Event::from_value(&ev), 1000);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), 1000);
         assert_eq!(r.detections.len(), 1, "by default detections are emitted");
     }
 
@@ -3110,7 +3103,7 @@ level: high
         engine.add_collection(&collection).unwrap();
 
         let ev = json!({"EventType": "login", "User": "alice"});
-        let r = engine.process_event_at(&Event::from_value(&ev), 1000);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), 1000);
         assert!(
             r.detections.is_empty(),
             "detection matches should be suppressed when emit_detections=false"
@@ -3152,7 +3145,7 @@ level: high
         engine.add_collection(&collection).unwrap();
 
         let ev = json!({"EventType": "login", "User": "alice"});
-        let r = engine.process_event_at(&Event::from_value(&ev), 1000);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), 1000);
         // generate: true means this rule is NOT correlation-only
         assert_eq!(
             r.detections.len(),
@@ -3180,16 +3173,16 @@ level: high
         let ts = 1000;
 
         // Hit threshold: fires and resets
-        engine.process_event_at(&Event::from_value(&ev), ts);
-        engine.process_event_at(&Event::from_value(&ev), ts + 1);
-        let r3 = engine.process_event_at(&Event::from_value(&ev), ts + 2);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 1);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 2);
         assert_eq!(r3.correlations.len(), 1, "fires on 3rd event");
 
         // Push 3 more events quickly (state was reset, so new count → 3)
         // but suppress window hasn't expired (ts+2 + 5 = ts+7)
-        engine.process_event_at(&Event::from_value(&ev), ts + 3);
-        engine.process_event_at(&Event::from_value(&ev), ts + 4);
-        let r = engine.process_event_at(&Event::from_value(&ev), ts + 5);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 3);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 4);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 5);
         assert!(
             r.correlations.is_empty(),
             "threshold met again but still suppressed"
@@ -3198,7 +3191,7 @@ level: high
         // After suppress expires (at ts+8, which is ts+2+6 > suppress=5),
         // the accumulated events from step 2 (ts+3,4,5) still satisfy gte:3,
         // so the first event after expiry fires immediately and resets.
-        let r = engine.process_event_at(&Event::from_value(&ev), ts + 8);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 8);
         assert_eq!(
             r.correlations.len(),
             1,
@@ -3207,9 +3200,9 @@ level: high
 
         // State was reset again at ts+8, suppress window now ts+8..ts+13.
         // Need 3 new events to fire, and suppress must expire.
-        engine.process_event_at(&Event::from_value(&ev), ts + 9);
-        engine.process_event_at(&Event::from_value(&ev), ts + 10);
-        let r = engine.process_event_at(&Event::from_value(&ev), ts + 11);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 9);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 10);
+        let r = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 11);
         assert!(
             r.correlations.is_empty(),
             "threshold met but suppress window hasn't expired (ts+11 - ts+8 = 3 < 5)"
@@ -3229,20 +3222,20 @@ level: high
         let ev = json!({"EventType": "login", "User": "alice"});
         let ts = 1000;
 
-        engine.process_event_at(&Event::from_value(&ev), ts);
-        engine.process_event_at(&Event::from_value(&ev), ts + 1);
-        let r3 = engine.process_event_at(&Event::from_value(&ev), ts + 2);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts);
+        engine.process_event_at(&JsonEvent::borrow(&ev), ts + 1);
+        let r3 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 2);
         assert_eq!(r3.correlations.len(), 1);
 
         // Without suppression, 4th event should also fire
-        let r4 = engine.process_event_at(&Event::from_value(&ev), ts + 3);
+        let r4 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 3);
         assert_eq!(
             r4.correlations.len(),
             1,
             "no suppression: fires on every event after threshold"
         );
 
-        let r5 = engine.process_event_at(&Event::from_value(&ev), ts + 4);
+        let r5 = engine.process_event_at(&JsonEvent::borrow(&ev), ts + 4);
         assert_eq!(r5.correlations.len(), 1, "still fires");
     }
 
@@ -3369,7 +3362,7 @@ level: high
             "User": "alice",
             "event_time": "2026-02-11T12:00:00Z"
         });
-        let result = engine.process_event(&Event::from_value(&ev));
+        let result = engine.process_event(&JsonEvent::borrow(&ev));
 
         // The detection should match, and timestamp should be ~1739275200 (2026-02-11)
         assert!(!result.detections.is_empty() || result.correlations.is_empty());
@@ -3377,7 +3370,7 @@ level: high
         // If it used Utc::now, the test would still pass but the timestamp would be
         // wildly different. We verify by checking the extracted value directly.
         let ts = engine
-            .extract_event_timestamp(&Event::from_value(&ev))
+            .extract_event_timestamp(&JsonEvent::borrow(&ev))
             .expect("should extract timestamp");
         assert!(
             ts > 1_700_000_000 && ts < 1_800_000_000,
@@ -3624,7 +3617,7 @@ level: high
 
         for i in 0..3 {
             let v = json!({"EventType": "login", "User": "admin", "@timestamp": 1000 + i});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if i == 2 {
                 assert_eq!(result.correlations.len(), 1);
@@ -3673,7 +3666,7 @@ level: high
 
         let mut corr_result = None;
         for (i, ev) in events_sent.iter().enumerate() {
-            let event = Event::from_value(ev);
+            let event = JsonEvent::borrow(ev);
             let result = engine.process_event_at(&event, 1000 + i as i64);
             if !result.correlations.is_empty() {
                 corr_result = Some(result);
@@ -3735,7 +3728,7 @@ level: high
         let mut corr_result = None;
         for i in 0..5 {
             let v = json!({"EventType": "login", "User": "admin", "idx": i});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if !result.correlations.is_empty() {
                 corr_result = Some(result);
@@ -3791,7 +3784,7 @@ level: high
         // First round: 2 events -> fires
         for i in 0..2 {
             let v = json!({"EventType": "login", "User": "admin", "round": 1, "idx": i});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if i == 1 {
                 assert_eq!(result.correlations.len(), 1);
@@ -3803,7 +3796,7 @@ level: high
         // After reset, event buffer should be cleared.
         // Second round: need 2 more events to fire again
         let v = json!({"EventType": "login", "User": "admin", "round": 2, "idx": 0});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let result = engine.process_event_at(&event, 1010);
         assert!(
             result.correlations.is_empty(),
@@ -3811,7 +3804,7 @@ level: high
         );
 
         let v = json!({"EventType": "login", "User": "admin", "round": 2, "idx": 1});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let result = engine.process_event_at(&event, 1011);
         assert_eq!(result.correlations.len(), 1);
         let events = result.correlations[0].events.as_ref().unwrap();
@@ -3854,7 +3847,7 @@ level: high
 
         for i in 0..2 {
             let v = json!({"EventType": "login", "User": "admin"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if i == 1 {
                 assert_eq!(result.correlations.len(), 1);
@@ -3900,14 +3893,14 @@ level: high
         // Push 2 events at ts=1000,1001 — within the 10s window
         for i in 0..2 {
             let v = json!({"EventType": "login", "User": "admin", "idx": i});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             engine.process_event_at(&event, 1000 + i);
         }
 
         // Push 1 more event at ts=1015 — the first 2 events are now outside the
         // 10s window (cutoff = 1015 - 10 = 1005)
         let v = json!({"EventType": "login", "User": "admin", "idx": 2});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let result = engine.process_event_at(&event, 1015);
         // Should NOT fire: only 1 event in window (the one at ts=1015)
         assert!(
@@ -3918,7 +3911,7 @@ level: high
         // Push 2 more to reach threshold
         for i in 3..5 {
             let v = json!({"EventType": "login", "User": "admin", "idx": i});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1016 + i - 3);
             if i == 4 {
                 assert_eq!(result.correlations.len(), 1);
@@ -3970,7 +3963,7 @@ level: high
         // Push some events
         for i in 0..5 {
             let v = json!({"EventType": "login", "User": "admin"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             engine.process_event_at(&event, 1000 + i);
         }
 
@@ -4014,7 +4007,7 @@ level: high
         let mut corr_result = None;
         for i in 0..3 {
             let v = json!({"EventType": "login", "User": "admin", "id": format!("evt-{i}"), "@timestamp": 1000 + i});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if !result.correlations.is_empty() {
                 corr_result = Some(result.correlations[0].clone());
@@ -4072,7 +4065,7 @@ level: high
         let mut corr_result = None;
         for i in 0..2 {
             let v = json!({"EventType": "login", "User": "admin"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if !result.correlations.is_empty() {
                 corr_result = Some(result.correlations[0].clone());
@@ -4123,7 +4116,7 @@ level: high
         let mut corr_result = None;
         for i in 0..3 {
             let v = json!({"EventType": "login", "User": "admin", "id": format!("e{i}")});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, 1000 + i);
             if !result.correlations.is_empty() {
                 corr_result = Some(result.correlations[0].clone());
@@ -4217,7 +4210,7 @@ level: high
             .iter()
             .enumerate()
             .map(|(i, v)| {
-                let e = Event::from_value(v);
+                let e = JsonEvent::borrow(v);
                 engine1.process_event_at(&e, 1000 + i as i64)
             })
             .collect();
@@ -4230,7 +4223,7 @@ level: high
             .iter()
             .enumerate()
             .map(|(i, v)| {
-                let e = Event::from_value(v);
+                let e = JsonEvent::borrow(v);
                 let detections = engine2.evaluate(&e);
                 engine2.process_with_detections(&e, detections, 1000 + i as i64)
             })
@@ -4281,7 +4274,7 @@ level: high
             .iter()
             .enumerate()
             .map(|(i, v)| {
-                let e = Event::from_value(v);
+                let e = JsonEvent::borrow(v);
                 engine1.process_event_at(&e, 1000 + i as i64)
             })
             .collect();
@@ -4289,8 +4282,8 @@ level: high
         // Batch
         let mut engine2 = CorrelationEngine::new(CorrelationConfig::default());
         engine2.add_collection(&collection).unwrap();
-        let events: Vec<Event> = event_values.iter().map(Event::from_value).collect();
-        let refs: Vec<&Event> = events.iter().collect();
+        let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
+        let refs: Vec<&JsonEvent> = events.iter().collect();
         let batch = engine2.process_batch(&refs);
 
         assert_eq!(sequential.len(), batch.len());
@@ -4336,7 +4329,7 @@ level: high
         let base_ts = 1000i64;
         for i in 0..2 {
             let v = json!({"EventType": "login", "User": "alice"});
-            let event = Event::from_value(&v);
+            let event = JsonEvent::borrow(&v);
             let result = engine.process_event_at(&event, base_ts + i * 10);
 
             if i == 1 {
@@ -4380,7 +4373,7 @@ score: 42
         engine.add_collection(&collection).unwrap();
 
         let v = json!({"EventType": "login"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let result = engine.process_event(&event);
 
         assert_eq!(result.detections.len(), 1);

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -1395,6 +1395,7 @@ fn extract_event_ts(event: &impl Event, timestamp_fields: &[String]) -> Option<i
     None
 }
 
+/// Parse an [`EventValue`] as a Unix epoch timestamp in seconds.
 fn parse_timestamp_value(val: &EventValue) -> Option<i64> {
     match val {
         EventValue::Int(i) => Some(normalize_epoch(*i)),
@@ -1437,7 +1438,7 @@ fn parse_timestamp_string(s: &str) -> Option<i64> {
     None
 }
 
-/// Convert a JSON value to a string for value_count purposes.
+/// Convert an [`EventValue`] to a string for value_count purposes.
 fn value_to_string_for_count(v: &EventValue) -> Option<String> {
     match v {
         EventValue::Str(s) => Some(s.to_string()),
@@ -1449,6 +1450,7 @@ fn value_to_string_for_count(v: &EventValue) -> Option<String> {
     }
 }
 
+/// Convert an [`EventValue`] to f64 for numeric aggregation.
 fn value_to_f64_ev(v: &EventValue) -> Option<f64> {
     v.as_f64()
 }

--- a/crates/rsigma-eval/src/engine.rs
+++ b/crates/rsigma-eval/src/engine.rs
@@ -23,6 +23,7 @@ use crate::rule_index::RuleIndex;
 /// ```rust
 /// use rsigma_parser::parse_sigma_yaml;
 /// use rsigma_eval::{Engine, Event};
+/// use rsigma_eval::event::JsonEvent;
 /// use serde_json::json;
 ///
 /// let yaml = r#"
@@ -42,7 +43,7 @@ use crate::rule_index::RuleIndex;
 /// engine.add_collection(&collection).unwrap();
 ///
 /// let event_val = json!({"CommandLine": "cmd /c whoami"});
-/// let event = Event::from_value(&event_val);
+/// let event = JsonEvent::borrow(&event_val);
 /// let matches = engine.evaluate(&event);
 /// assert_eq!(matches.len(), 1);
 /// assert_eq!(matches[0].rule_title, "Detect Whoami");
@@ -256,13 +257,13 @@ impl Engine {
     }
 
     /// Evaluate an event against candidate rules using the inverted index.
-    pub fn evaluate(&self, event: &Event) -> Vec<MatchResult> {
+    pub fn evaluate<E: Event>(&self, event: &E) -> Vec<MatchResult> {
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
             let rule = &self.rules[idx];
             if let Some(mut m) = evaluate_rule(rule, event) {
                 if self.include_event && m.event.is_none() {
-                    m.event = Some(event.as_value().clone());
+                    m.event = Some(event.to_json());
                 }
                 results.push(m);
             }
@@ -275,9 +276,9 @@ impl Engine {
     /// Uses the inverted index for candidate pre-filtering, then applies the
     /// logsource constraint. Only rules whose logsource is compatible with
     /// `event_logsource` are evaluated.
-    pub fn evaluate_with_logsource(
+    pub fn evaluate_with_logsource<E: Event>(
         &self,
-        event: &Event,
+        event: &E,
         event_logsource: &LogSource,
     ) -> Vec<MatchResult> {
         let mut results = Vec::new();
@@ -287,7 +288,7 @@ impl Engine {
                 && let Some(mut m) = evaluate_rule(rule, event)
             {
                 if self.include_event && m.event.is_none() {
-                    m.event = Some(event.as_value().clone());
+                    m.event = Some(event.to_json());
                 }
                 results.push(m);
             }
@@ -300,7 +301,7 @@ impl Engine {
     /// When the `parallel` feature is enabled, events are evaluated concurrently
     /// using rayon's work-stealing thread pool. Otherwise, falls back to
     /// sequential evaluation.
-    pub fn evaluate_batch<'a>(&self, events: &[&'a Event<'a>]) -> Vec<Vec<MatchResult>> {
+    pub fn evaluate_batch<E: Event + Sync>(&self, events: &[&E]) -> Vec<Vec<MatchResult>> {
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
@@ -378,6 +379,7 @@ fn logsource_matches(rule_ls: &LogSource, event_ls: &LogSource) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::JsonEvent;
     use rsigma_parser::parse_sigma_yaml;
     use serde_json::json;
 
@@ -405,7 +407,7 @@ level: medium
         );
 
         let ev = json!({"CommandLine": "cmd /c whoami /all"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let matches = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].rule_title, "Detect Whoami");
@@ -428,7 +430,7 @@ level: medium
         );
 
         let ev = json!({"CommandLine": "ipconfig /all"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let matches = engine.evaluate(&event);
         assert!(matches.is_empty());
     }
@@ -452,12 +454,12 @@ level: high
 
         // Match: whoami by non-SYSTEM user
         let ev = json!({"CommandLine": "whoami", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
 
         // No match: whoami by SYSTEM
         let ev2 = json!({"CommandLine": "whoami", "User": "SYSTEM"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(engine.evaluate(&event2).is_empty());
     }
 
@@ -480,11 +482,11 @@ level: medium
         );
 
         let ev = json!({"CommandLine": "ipconfig /all"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
 
         let ev2 = json!({"CommandLine": "dir"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(engine.evaluate(&event2).is_empty());
     }
 
@@ -505,7 +507,7 @@ level: medium
         );
 
         let ev = json!({"CommandLine": "whoami"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
 
         // Matching logsource
         let ls_match = LogSource {
@@ -546,7 +548,7 @@ level: medium
         );
 
         let ev = json!({"CommandLine": "powershell.exe -enc"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
     }
 
@@ -582,12 +584,12 @@ filter:
 
         // Match: whoami by non-SYSTEM user
         let ev = json!({"CommandLine": "whoami", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
 
         // No match: whoami by SYSTEM (filtered out)
         let ev2 = json!({"CommandLine": "whoami", "User": "SYSTEM"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(engine.evaluate(&event2).is_empty());
     }
 
@@ -616,11 +618,11 @@ filter:
         engine.add_collection(&collection).unwrap();
 
         let ev = json!({"EventType": "alert", "Environment": "prod"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
 
         let ev2 = json!({"EventType": "alert", "Environment": "test"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(engine.evaluate(&event2).is_empty());
     }
 
@@ -652,7 +654,7 @@ level: low
 
         // Only Rule A matches
         let ev = json!({"CommandLine": "whoami"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let matches = engine.evaluate(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].rule_title, "Rule A");
@@ -689,12 +691,12 @@ filter:
 
         // Match: mimikatz not launched by admin toolkit
         let ev = json!({"CommandLine": "mimikatz.exe", "ParentImage": "C:\\cmd.exe"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
 
         // No match: mimikatz launched by admin toolkit (filtered)
         let ev2 = json!({"CommandLine": "mimikatz.exe", "ParentImage": "C:\\admin_toolkit.exe"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert!(engine.evaluate(&event2).is_empty());
     }
 
@@ -728,18 +730,18 @@ filter:
 
         // Match: port 443 to external IP
         let ev = json!({"DestinationPort": 443, "DestinationIp": "8.8.8.8", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         assert_eq!(engine.evaluate(&event).len(), 1);
 
         // Match: port 443 to internal IP but different user (filter needs both)
         let ev2 = json!({"DestinationPort": 443, "DestinationIp": "10.0.0.1", "User": "admin"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         assert_eq!(engine.evaluate(&event2).len(), 1);
 
         // No match: port 443 to internal IP by svc_account (both filter conditions met)
         let ev3 =
             json!({"DestinationPort": 443, "DestinationIp": "10.0.0.1", "User": "svc_account"});
-        let event3 = Event::from_value(&ev3);
+        let event3 = JsonEvent::borrow(&ev3);
         assert!(engine.evaluate(&event3).is_empty());
     }
 
@@ -778,15 +780,15 @@ filter:
 
         // In prod: both rules should fire
         let ev1 = json!({"EventID": 1, "Environment": "prod"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev1)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev1)).len(), 1);
         let ev2 = json!({"EventID": 2, "Environment": "prod"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev2)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev2)).len(), 1);
 
         // In test: both filtered out
         let ev3 = json!({"EventID": 1, "Environment": "test"});
-        assert!(engine.evaluate(&Event::from_value(&ev3)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev3)).is_empty());
         let ev4 = json!({"EventID": 2, "Environment": "test"});
-        assert!(engine.evaluate(&Event::from_value(&ev4)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev4)).is_empty());
     }
 
     // =========================================================================
@@ -812,14 +814,14 @@ level: high
             "TargetFilename": "C:\\Users\\admin\\AppData\\sensitive.dat",
             "username": "admin"
         });
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // No match: different user
         let ev2 = json!({
             "TargetFilename": "C:\\Users\\admin\\AppData\\sensitive.dat",
             "username": "guest"
         });
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     #[test]
@@ -841,14 +843,14 @@ level: medium
             "vendor": "Acme",
             "product": "Widget"
         });
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         let ev2 = json!({
             "RegistryKey": "HKLM\\SOFTWARE\\Acme\\Widget",
             "vendor": "Other",
             "product": "Widget"
         });
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     // =========================================================================
@@ -873,11 +875,11 @@ level: high
 
         // Match: login at 03:xx UTC
         let ev = json!({"EventType": "login", "Timestamp": "2024-07-10T03:45:00Z"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // No match: login at 14:xx UTC
         let ev2 = json!({"EventType": "login", "Timestamp": "2024-07-10T14:45:00Z"});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     #[test]
@@ -897,10 +899,10 @@ level: medium
         let engine = make_engine_with_rule(yaml);
 
         let ev = json!({"EventType": "access", "CreatedAt": "2024-12-25T10:00:00Z"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         let ev2 = json!({"EventType": "access", "CreatedAt": "2024-12-26T10:00:00Z"});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     #[test]
@@ -920,10 +922,10 @@ level: low
         let engine = make_engine_with_rule(yaml);
 
         let ev = json!({"EventType": "auth", "EventTime": "2020-06-15T10:00:00Z"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         let ev2 = json!({"EventType": "auth", "EventTime": "2024-06-15T10:00:00Z"});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     // =========================================================================
@@ -960,19 +962,19 @@ detection:
 
         // First rule matches whoami
         let ev1 = json!({"CommandLine": "whoami /all"});
-        let matches1 = engine.evaluate(&Event::from_value(&ev1));
+        let matches1 = engine.evaluate(&JsonEvent::borrow(&ev1));
         assert_eq!(matches1.len(), 1);
         assert_eq!(matches1[0].rule_title, "Detect Whoami");
 
         // Second rule matches ipconfig (inherited logsource/level)
         let ev2 = json!({"CommandLine": "ipconfig /all"});
-        let matches2 = engine.evaluate(&Event::from_value(&ev2));
+        let matches2 = engine.evaluate(&JsonEvent::borrow(&ev2));
         assert_eq!(matches2.len(), 1);
         assert_eq!(matches2[0].rule_title, "Detect Ipconfig");
 
         // Neither matches dir
         let ev3 = json!({"CommandLine": "dir"});
-        assert!(engine.evaluate(&Event::from_value(&ev3)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev3)).is_empty());
     }
 
     #[test]
@@ -1006,12 +1008,12 @@ detection:
         engine.add_collection(&collection).unwrap();
 
         let ev1 = json!({"CommandLine": "net user admin"});
-        let m1 = engine.evaluate(&Event::from_value(&ev1));
+        let m1 = engine.evaluate(&JsonEvent::borrow(&ev1));
         assert_eq!(m1.len(), 1);
         assert_eq!(m1[0].rule_title, "Detect Net User");
 
         let ev2 = json!({"CommandLine": "net group admins"});
-        let m2 = engine.evaluate(&Event::from_value(&ev2));
+        let m2 = engine.evaluate(&JsonEvent::borrow(&ev2));
         assert_eq!(m2.len(), 1);
         assert_eq!(m2[0].rule_title, "Detect Net Group");
     }
@@ -1038,11 +1040,11 @@ level: medium
 
         // Match: TCP on port 80 (neq 443 is true)
         let ev = json!({"Protocol": "TCP", "DestinationPort": "80"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // No match: TCP on port 443 (neq 443 is false)
         let ev2 = json!({"Protocol": "TCP", "DestinationPort": "443"});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     #[test]
@@ -1060,10 +1062,10 @@ level: medium
         let engine = make_engine_with_rule(yaml);
 
         let ev = json!({"DestinationPort": 80});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         let ev2 = json!({"DestinationPort": 443});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     // =========================================================================
@@ -1090,7 +1092,7 @@ level: medium
         // With `all of them` excluding `_helper`, only `selection` needs to match
         let ev = json!({"CommandLine": "whoami", "User": "admin"});
         assert_eq!(
-            engine.evaluate(&Event::from_value(&ev)).len(),
+            engine.evaluate(&JsonEvent::borrow(&ev)).len(),
             1,
             "all of them should exclude _helper, so only selection is required"
         );
@@ -1116,12 +1118,12 @@ level: medium
 
         // `1 of them` excludes `_private`, so only sel_cmd and sel_ps are considered
         let ev = json!({"CommandLine": "cmd.exe", "User": "guest"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // _private alone should not count
         let ev2 = json!({"CommandLine": "notepad", "User": "admin"});
         assert!(
-            engine.evaluate(&Event::from_value(&ev2)).is_empty(),
+            engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty(),
             "_private should be excluded from 'them'"
         );
     }
@@ -1149,7 +1151,7 @@ level: medium
         // T=0x54,0x00 e=0x65,0x00 s=0x73,0x00 t=0x74,0x00
         // base64 of [0x54,0x00,0x65,0x00,0x73,0x00,0x74,0x00] = "VABlAHMAdAA="
         let ev = json!({"Payload": "VABlAHMAdAA="});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
     }
 
     #[test]
@@ -1169,7 +1171,7 @@ level: medium
         // "AB" in UTF-16BE: A=0x00,0x41 B=0x00,0x42
         // base64 of [0x00,0x41,0x00,0x42] = "AEEAQg=="
         let ev = json!({"Payload": "AEEAQg=="});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
     }
 
     #[test]
@@ -1189,7 +1191,7 @@ level: medium
         // "A" in UTF-16 with BOM: FF FE (BOM) + 41 00 (A in UTF-16LE)
         // base64 of [0xFF,0xFE,0x41,0x00] = "//5BAA=="
         let ev = json!({"Payload": "//5BAA=="});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
     }
 
     // =========================================================================
@@ -1234,11 +1236,11 @@ level: medium
         // Actually, after pipeline transforms the rule's field names,
         // the rule now looks for "process.command_line" in the event.
         let ev = json!({"process.command_line": "cmd /c whoami"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // Old field name should no longer match
         let ev2 = json!({"CommandLine": "cmd /c whoami"});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     #[test]
@@ -1274,11 +1276,11 @@ level: low
 
         // Must have both the original match AND source=windows
         let ev = json!({"CommandLine": "cmd.exe", "source": "windows"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // Missing source field: should not match (pipeline added condition)
         let ev2 = json!({"CommandLine": "cmd.exe"});
-        assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+        assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
     }
 
     #[test]
@@ -1315,7 +1317,7 @@ level: low
 
         // Rule still evaluates based on detection logic
         let ev = json!({"action": "test"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // But with logsource routing, the original windows logsource no longer matches
         let ls = LogSource {
@@ -1325,7 +1327,7 @@ level: low
         };
         assert!(
             engine
-                .evaluate_with_logsource(&Event::from_value(&ev), &ls)
+                .evaluate_with_logsource(&JsonEvent::borrow(&ev), &ls)
                 .is_empty(),
             "logsource was changed; windows/process_creation should not match"
         );
@@ -1337,7 +1339,7 @@ level: low
         };
         assert_eq!(
             engine
-                .evaluate_with_logsource(&Event::from_value(&ev), &ls2)
+                .evaluate_with_logsource(&JsonEvent::borrow(&ev), &ls2)
                 .len(),
             1,
             "elastic/endpoint should match the transformed logsource"
@@ -1374,7 +1376,7 @@ level: low
 
         // After replace: rule looks for "C:/Windows" instead of "C:\Windows"
         let ev = json!({"FilePath": "C:/Windows/System32/cmd.exe"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
     }
 
     #[test]
@@ -1420,13 +1422,13 @@ level: low
 
         // Windows rule: field was prefixed to win.CommandLine
         let ev_win = json!({"win.CommandLine": "whoami"});
-        let m = engine.evaluate(&Event::from_value(&ev_win));
+        let m = engine.evaluate(&JsonEvent::borrow(&ev_win));
         assert_eq!(m.len(), 1);
         assert_eq!(m[0].rule_title, "Windows Rule");
 
         // Linux rule: field was NOT prefixed (still CommandLine)
         let ev_linux = json!({"CommandLine": "whoami"});
-        let m2 = engine.evaluate(&Event::from_value(&ev_linux));
+        let m2 = engine.evaluate(&JsonEvent::borrow(&ev_linux));
         assert_eq!(m2.len(), 1);
         assert_eq!(m2[0].rule_title, "Linux Rule");
     }
@@ -1473,7 +1475,7 @@ level: low
         // After p1: CommandLine -> process.args
         // After p2: process.args -> process.args.keyword
         let ev = json!({"process.args.keyword": "testing"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
     }
 
     #[test]
@@ -1509,13 +1511,13 @@ level: medium
 
         // EventID detection item was dropped, so only CommandLine matters
         let ev = json!({"CommandLine": "whoami"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
 
         // Without pipeline, EventID=1 would also be required
         let mut engine2 = Engine::new();
         engine2.add_collection(&collection).unwrap();
         // Without EventID, should not match
-        assert!(engine2.evaluate(&Event::from_value(&ev)).is_empty());
+        assert!(engine2.evaluate(&JsonEvent::borrow(&ev)).is_empty());
     }
 
     #[test]
@@ -1558,7 +1560,7 @@ level: low
 
         // State was set → prefix was applied
         let ev = json!({"winlog.CommandLine": "testing"});
-        assert_eq!(engine.evaluate(&Event::from_value(&ev)).len(), 1);
+        assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev)).len(), 1);
     }
 
     #[test]
@@ -1598,13 +1600,13 @@ detection:
             json!({"EventType": "file_create"}),
             json!({"CommandLine": "whoami /all"}),
         ];
-        let events: Vec<Event> = vals.iter().map(Event::from_value).collect();
+        let events: Vec<JsonEvent> = vals.iter().map(JsonEvent::borrow).collect();
 
         // Sequential
         let sequential: Vec<Vec<_>> = events.iter().map(|e| engine.evaluate(e)).collect();
 
         // Batch
-        let refs: Vec<&Event> = events.iter().collect();
+        let refs: Vec<&JsonEvent> = events.iter().collect();
         let batch = engine.evaluate_batch(&refs);
 
         assert_eq!(sequential.len(), batch.len());

--- a/crates/rsigma-eval/src/event.rs
+++ b/crates/rsigma-eval/src/event.rs
@@ -1,77 +1,265 @@
-//! Event wrapper with dot-notation field access.
+//! Event abstraction for Sigma rule evaluation.
 //!
-//! Provides a thin wrapper around `serde_json::Value` that supports nested
-//! field access via dot notation (e.g., `actor.id`) with flat-key precedence.
+//! Provides the [`Event`] trait for generic event access, the [`EventValue`]
+//! enum representing field values, and concrete implementations:
+//! - [`JsonEvent`] — zero-copy wrapper around `serde_json::Value`
+//! - [`KvEvent`] — flat key-value pairs (e.g., from logfmt / syslog)
+//! - [`PlainEvent`] — raw log line (keyword matching only)
+//! - [`MapEvent`] — generic `HashMap<K, V>` adapter
+
+use std::borrow::Cow;
+use std::collections::HashMap;
 
 use serde_json::Value;
 
-/// A reference to a JSON event for field access during evaluation.
+/// Maximum nesting depth for recursive JSON traversal.
+const MAX_NESTING_DEPTH: usize = 64;
+
+// =============================================================================
+// EventValue
+// =============================================================================
+
+/// A value retrieved from an event field.
 ///
-/// Flat keys are checked first: `"actor.id"` as a single key takes precedence
-/// over `{"actor": {"id": ...}}` nested traversal.
-#[derive(Debug)]
-pub struct Event<'a> {
-    inner: &'a Value,
+/// Supports zero-copy borrows from JSON-backed events (`Cow::Borrowed`)
+/// and owned values from non-JSON sources (`Cow::Owned`).
+/// Null is distinct from field-absent (`get_field` returns `None`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum EventValue<'a> {
+    Str(Cow<'a, str>),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Null,
+    Array(Vec<EventValue<'a>>),
+    Map(Vec<(Cow<'a, str>, EventValue<'a>)>),
 }
 
-impl<'a> Event<'a> {
-    /// Wrap a JSON value as an event.
-    pub fn from_value(value: &'a Value) -> Self {
-        Event { inner: value }
+impl<'a> EventValue<'a> {
+    /// Coerce to string. Str as-is, Int/Float decimal, Bool "true"/"false".
+    #[inline]
+    pub fn as_str(&self) -> Option<Cow<'_, str>> {
+        match self {
+            EventValue::Str(s) => Some(Cow::Borrowed(s)),
+            EventValue::Int(n) => Some(Cow::Owned(n.to_string())),
+            EventValue::Float(f) => Some(Cow::Owned(f.to_string())),
+            EventValue::Bool(b) => Some(Cow::Borrowed(if *b { "true" } else { "false" })),
+            _ => None,
+        }
     }
 
-    /// Get a field value by name, supporting dot-notation for nested access.
+    /// Coerce to f64. Int lossless, Float as-is, Str parsed.
+    #[inline]
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            EventValue::Float(f) => Some(*f),
+            EventValue::Int(n) => Some(*n as f64),
+            EventValue::Str(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+
+    /// Coerce to i64. Int as-is, Float truncated if exact, Str parsed.
+    #[inline]
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            EventValue::Int(n) => Some(*n),
+            EventValue::Float(f) => {
+                let truncated = *f as i64;
+                if (truncated as f64 - f).abs() < f64::EPSILON {
+                    Some(truncated)
+                } else {
+                    None
+                }
+            }
+            EventValue::Str(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+
+    /// Coerce to bool. Bool as-is, Str: true/false/1/0/yes/no.
+    #[inline]
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            EventValue::Bool(b) => Some(*b),
+            EventValue::Str(s) => match s.to_lowercase().as_str() {
+                "true" | "1" | "yes" => Some(true),
+                "false" | "0" | "no" => Some(false),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        matches!(self, EventValue::Null)
+    }
+
+    /// Convert to `serde_json::Value`.
+    pub fn to_json(&self) -> Value {
+        match self {
+            EventValue::Str(s) => Value::String(s.to_string()),
+            EventValue::Int(n) => Value::Number((*n).into()),
+            EventValue::Float(f) => {
+                serde_json::Number::from_f64(*f).map_or(Value::Null, Value::Number)
+            }
+            EventValue::Bool(b) => Value::Bool(*b),
+            EventValue::Null => Value::Null,
+            EventValue::Array(arr) => Value::Array(arr.iter().map(|v| v.to_json()).collect()),
+            EventValue::Map(entries) => {
+                let map = entries
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_json()))
+                    .collect();
+                Value::Object(map)
+            }
+        }
+    }
+}
+
+impl<'a> From<&'a Value> for EventValue<'a> {
+    fn from(v: &'a Value) -> Self {
+        match v {
+            Value::String(s) => EventValue::Str(Cow::Borrowed(s.as_str())),
+            Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    EventValue::Int(i)
+                } else {
+                    EventValue::Float(n.as_f64().unwrap_or(f64::NAN))
+                }
+            }
+            Value::Bool(b) => EventValue::Bool(*b),
+            Value::Null => EventValue::Null,
+            Value::Array(arr) => EventValue::Array(arr.iter().map(EventValue::from).collect()),
+            Value::Object(map) => EventValue::Map(
+                map.iter()
+                    .map(|(k, v)| (Cow::Borrowed(k.as_str()), EventValue::from(v)))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+// =============================================================================
+// Event trait
+// =============================================================================
+
+/// Generic interface for accessing event data during Sigma rule evaluation.
+///
+/// Implementations provide field lookup (with dot-notation), keyword search
+/// over all string values, and serialization to JSON for correlation storage.
+pub trait Event {
+    /// Look up a field by name. Supports dot-notation for nested access.
     ///
-    /// Checks for a flat key first (exact match), then falls back to
-    /// dot-separated traversal. When a path segment yields an array,
-    /// each element is tried and the first match is returned (OR semantics).
-    pub fn get_field(&self, path: &str) -> Option<&'a Value> {
-        // Flat key check first
-        if let Some(obj) = self.inner.as_object()
+    /// Returns `None` if the field is absent.
+    /// Returns `Some(EventValue::Null)` if the field exists but is null.
+    fn get_field(&self, path: &str) -> Option<EventValue<'_>>;
+
+    /// Check if any string value anywhere in the event satisfies a predicate.
+    /// Used by keyword detection.
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool;
+
+    /// Collect all string values in the event.
+    fn all_string_values(&self) -> Vec<Cow<'_, str>>;
+
+    /// Materialize the event as a `serde_json::Value`.
+    fn to_json(&self) -> Value;
+}
+
+impl<T: Event + ?Sized> Event for &T {
+    fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
+        (**self).get_field(path)
+    }
+
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
+        (**self).any_string_value(pred)
+    }
+
+    fn all_string_values(&self) -> Vec<Cow<'_, str>> {
+        (**self).all_string_values()
+    }
+
+    fn to_json(&self) -> Value {
+        (**self).to_json()
+    }
+}
+
+// =============================================================================
+// JsonEvent
+// =============================================================================
+
+/// Zero-copy event backed by `serde_json::Value`.
+///
+/// Supports both borrowed (`&Value`) and owned (`Value`) backing via `Cow`.
+/// This is the primary implementation for JSON/NDJSON input.
+#[derive(Debug)]
+pub struct JsonEvent<'a> {
+    inner: Cow<'a, Value>,
+}
+
+impl<'a> JsonEvent<'a> {
+    pub fn borrow(v: &'a Value) -> Self {
+        Self {
+            inner: Cow::Borrowed(v),
+        }
+    }
+
+    pub fn owned(v: Value) -> Self {
+        Self {
+            inner: Cow::Owned(v),
+        }
+    }
+}
+
+impl<'a> From<&'a Value> for JsonEvent<'a> {
+    fn from(v: &'a Value) -> Self {
+        Self::borrow(v)
+    }
+}
+
+impl From<Value> for JsonEvent<'static> {
+    fn from(v: Value) -> Self {
+        Self::owned(v)
+    }
+}
+
+impl<'a> Event for JsonEvent<'a> {
+    fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
+        let value: &Value = &self.inner;
+
+        if let Some(obj) = value.as_object()
             && let Some(v) = obj.get(path)
         {
-            return Some(v);
+            return Some(EventValue::from(v));
         }
 
-        // Dot-notation traversal
         if path.contains('.') {
             let parts: Vec<&str> = path.split('.').collect();
-            return traverse(self.inner, &parts);
+            return traverse_json(value, &parts).map(EventValue::from);
         }
 
         None
     }
 
-    /// Iterate over all string values in the event (for keyword detection).
-    ///
-    /// Recursively walks the entire event object and yields every string
-    /// value found, including inside nested objects and arrays. Traversal
-    /// is capped at 64 levels of nesting to prevent stack overflow.
-    pub fn all_string_values(&self) -> Vec<&'a str> {
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
+        any_string_value_json(&self.inner, pred, MAX_NESTING_DEPTH)
+    }
+
+    fn all_string_values(&self) -> Vec<Cow<'_, str>> {
         let mut values = Vec::new();
-        collect_string_values(self.inner, &mut values, MAX_NESTING_DEPTH);
+        collect_string_values_json(&self.inner, &mut values, MAX_NESTING_DEPTH);
         values
     }
 
-    /// Check if any string value in the event satisfies a predicate.
-    ///
-    /// Short-circuits on the first match, avoiding the allocation of
-    /// collecting all string values into a `Vec`.
-    pub fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
-        any_string_value_rec(self.inner, pred, MAX_NESTING_DEPTH)
-    }
-
-    /// Access the underlying JSON value.
-    pub fn as_value(&self) -> &'a Value {
-        self.inner
+    fn to_json(&self) -> Value {
+        self.inner.as_ref().clone()
     }
 }
 
-/// Recursively traverse a JSON value following dot-notation path segments.
-///
-/// When a segment resolves to an array, each element is tried and the first
-/// match for the remaining path is returned.
-fn traverse<'a>(current: &'a Value, parts: &[&str]) -> Option<&'a Value> {
+// -- JsonEvent helpers --------------------------------------------------------
+
+fn traverse_json<'a>(current: &'a Value, parts: &[&str]) -> Option<&'a Value> {
     if parts.is_empty() {
         return Some(current);
     }
@@ -81,12 +269,11 @@ fn traverse<'a>(current: &'a Value, parts: &[&str]) -> Option<&'a Value> {
     match current {
         Value::Object(map) => {
             let next = map.get(head)?;
-            traverse(next, rest)
+            traverse_json(next, rest)
         }
         Value::Array(arr) => {
-            // Try each element — return first that resolves the remaining path
             for item in arr {
-                if let Some(v) = traverse(item, parts) {
+                if let Some(v) = traverse_json(item, parts) {
                     return Some(v);
                 }
             }
@@ -96,10 +283,7 @@ fn traverse<'a>(current: &'a Value, parts: &[&str]) -> Option<&'a Value> {
     }
 }
 
-/// Maximum nesting depth for recursive JSON traversal.
-const MAX_NESTING_DEPTH: usize = 64;
-
-fn any_string_value_rec(v: &Value, pred: &dyn Fn(&str) -> bool, depth: usize) -> bool {
+fn any_string_value_json(v: &Value, pred: &dyn Fn(&str) -> bool, depth: usize) -> bool {
     if depth == 0 {
         return false;
     }
@@ -107,157 +291,445 @@ fn any_string_value_rec(v: &Value, pred: &dyn Fn(&str) -> bool, depth: usize) ->
         Value::String(s) => pred(s.as_str()),
         Value::Object(map) => map
             .values()
-            .any(|val| any_string_value_rec(val, pred, depth - 1)),
+            .any(|val| any_string_value_json(val, pred, depth - 1)),
         Value::Array(arr) => arr
             .iter()
-            .any(|val| any_string_value_rec(val, pred, depth - 1)),
+            .any(|val| any_string_value_json(val, pred, depth - 1)),
         _ => false,
     }
 }
 
-fn collect_string_values<'a>(v: &'a Value, out: &mut Vec<&'a str>, depth: usize) {
+fn collect_string_values_json<'a>(v: &'a Value, out: &mut Vec<Cow<'a, str>>, depth: usize) {
     if depth == 0 {
         return;
     }
     match v {
-        Value::String(s) => out.push(s.as_str()),
+        Value::String(s) => out.push(Cow::Borrowed(s.as_str())),
         Value::Object(map) => {
             for val in map.values() {
-                collect_string_values(val, out, depth - 1);
+                collect_string_values_json(val, out, depth - 1);
             }
         }
         Value::Array(arr) => {
             for val in arr {
-                collect_string_values(val, out, depth - 1);
+                collect_string_values_json(val, out, depth - 1);
             }
         }
         _ => {}
     }
 }
 
+// =============================================================================
+// KvEvent
+// =============================================================================
+
+/// Flat key-value event (e.g., from logfmt, syslog structured data).
+///
+/// No nested access (no dot-notation traversal), no arrays.
+/// All values are strings.
+#[derive(Debug, Clone)]
+pub struct KvEvent {
+    fields: Vec<(String, String)>,
+}
+
+impl KvEvent {
+    pub fn new(fields: Vec<(String, String)>) -> Self {
+        Self { fields }
+    }
+
+    pub fn fields(&self) -> &[(String, String)] {
+        &self.fields
+    }
+}
+
+impl Event for KvEvent {
+    fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
+        self.fields
+            .iter()
+            .find(|(k, _)| k == path)
+            .map(|(_, v)| EventValue::Str(Cow::Borrowed(v.as_str())))
+    }
+
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
+        self.fields.iter().any(|(_, v)| pred(v.as_str()))
+    }
+
+    fn all_string_values(&self) -> Vec<Cow<'_, str>> {
+        self.fields
+            .iter()
+            .map(|(_, v)| Cow::Borrowed(v.as_str()))
+            .collect()
+    }
+
+    fn to_json(&self) -> Value {
+        let map: serde_json::Map<String, Value> = self
+            .fields
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect();
+        Value::Object(map)
+    }
+}
+
+// =============================================================================
+// PlainEvent
+// =============================================================================
+
+/// Raw log line event (keyword matching only).
+///
+/// `get_field` always returns `None`. Useful for keyword-only Sigma rules.
+#[derive(Debug, Clone)]
+pub struct PlainEvent {
+    raw: String,
+}
+
+impl PlainEvent {
+    pub fn new(raw: String) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+}
+
+impl Event for PlainEvent {
+    fn get_field(&self, _path: &str) -> Option<EventValue<'_>> {
+        None
+    }
+
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
+        pred(&self.raw)
+    }
+
+    fn all_string_values(&self) -> Vec<Cow<'_, str>> {
+        vec![Cow::Borrowed(&self.raw)]
+    }
+
+    fn to_json(&self) -> Value {
+        serde_json::json!({ "_raw": self.raw })
+    }
+}
+
+// =============================================================================
+// MapEvent
+// =============================================================================
+
+/// Generic flat-map event for user-defined key-value stores.
+///
+/// Flat key lookup only (no dot-notation, no nesting).
+#[derive(Debug, Clone)]
+pub struct MapEvent<K = String, V = String>
+where
+    K: AsRef<str> + std::fmt::Debug + Clone,
+    V: AsRef<str> + std::fmt::Debug + Clone,
+{
+    inner: HashMap<K, V>,
+}
+
+impl<K, V> MapEvent<K, V>
+where
+    K: AsRef<str> + std::fmt::Debug + Clone,
+    V: AsRef<str> + std::fmt::Debug + Clone,
+{
+    pub fn new(inner: HashMap<K, V>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<K, V> Event for MapEvent<K, V>
+where
+    K: AsRef<str> + std::fmt::Debug + Clone,
+    V: AsRef<str> + std::fmt::Debug + Clone,
+{
+    fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
+        self.inner
+            .iter()
+            .find(|(k, _)| k.as_ref() == path)
+            .map(|(_, v)| EventValue::Str(Cow::Borrowed(v.as_ref())))
+    }
+
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
+        self.inner.values().any(|v| pred(v.as_ref()))
+    }
+
+    fn all_string_values(&self) -> Vec<Cow<'_, str>> {
+        self.inner
+            .values()
+            .map(|v| Cow::Borrowed(v.as_ref()))
+            .collect()
+    }
+
+    fn to_json(&self) -> Value {
+        let map: serde_json::Map<String, Value> = self
+            .inner
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.as_ref().to_string(),
+                    Value::String(v.as_ref().to_string()),
+                )
+            })
+            .collect();
+        Value::Object(map)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
+    // -- JsonEvent tests ------------------------------------------------------
+
     #[test]
-    fn test_flat_field() {
+    fn json_flat_field() {
         let v = json!({"CommandLine": "whoami", "User": "admin"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("CommandLine"),
-            Some(&Value::String("whoami".into()))
+            Some(EventValue::Str(Cow::Borrowed("whoami")))
         );
     }
 
     #[test]
-    fn test_nested_field() {
+    fn json_nested_field() {
         let v = json!({"actor": {"id": "user123", "type": "User"}});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("actor.id"),
-            Some(&Value::String("user123".into()))
+            Some(EventValue::Str(Cow::Borrowed("user123")))
         );
     }
 
     #[test]
-    fn test_flat_key_precedence() {
-        // Flat key "actor.id" takes precedence over nested {"actor":{"id":...}}
+    fn json_flat_key_precedence() {
         let v = json!({"actor.id": "flat_value", "actor": {"id": "nested_value"}});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("actor.id"),
-            Some(&Value::String("flat_value".into()))
+            Some(EventValue::Str(Cow::Borrowed("flat_value")))
         );
     }
 
     #[test]
-    fn test_missing_field() {
+    fn json_missing_field() {
         let v = json!({"foo": "bar"});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(event.get_field("missing"), None);
     }
 
     #[test]
-    fn test_array_traversal() {
-        // a.b is an array of objects; a.b.c should find the first match
+    fn json_null_field() {
+        let v = json!({"foo": null});
+        let event = JsonEvent::borrow(&v);
+        assert_eq!(event.get_field("foo"), Some(EventValue::Null));
+    }
+
+    #[test]
+    fn json_array_traversal() {
         let v = json!({"a": {"b": [{"c": "found"}, {"c": "other"}]}});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("a.b.c"),
-            Some(&Value::String("found".into()))
+            Some(EventValue::Str(Cow::Borrowed("found")))
         );
     }
 
     #[test]
-    fn test_array_traversal_no_match() {
-        // Array elements don't have the requested key
+    fn json_array_traversal_no_match() {
         let v = json!({"a": {"b": [{"x": 1}, {"y": 2}]}});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(event.get_field("a.b.c"), None);
     }
 
     #[test]
-    fn test_array_traversal_deep() {
-        // Two levels of arrays: events[].actors[].name
+    fn json_array_traversal_deep() {
         let v = json!({
             "events": [
                 {"actors": [{"name": "alice"}, {"name": "bob"}]},
                 {"actors": [{"name": "charlie"}]}
             ]
         });
-        let event = Event::from_value(&v);
-        // Should return first match through the nested arrays
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("events.actors.name"),
-            Some(&Value::String("alice".into()))
+            Some(EventValue::Str(Cow::Borrowed("alice")))
         );
     }
 
     #[test]
-    fn test_array_at_root_level() {
-        // Top-level field is an array of objects
+    fn json_array_at_root_level() {
         let v = json!({"process": [{"command_line": "whoami"}, {"command_line": "id"}]});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("process.command_line"),
-            Some(&Value::String("whoami".into()))
+            Some(EventValue::Str(Cow::Borrowed("whoami")))
         );
     }
 
     #[test]
-    fn test_array_returns_array_value() {
-        // Path resolves to an array (not traversing into it)
+    fn json_array_returns_array_value() {
         let v = json!({"a": {"tags": ["t1", "t2"]}});
-        let event = Event::from_value(&v);
-        assert_eq!(event.get_field("a.tags"), Some(&json!(["t1", "t2"])));
+        let event = JsonEvent::borrow(&v);
+        let result = event.get_field("a.tags");
+        assert!(matches!(result, Some(EventValue::Array(_))));
     }
 
     #[test]
-    fn test_flat_key_still_wins_over_array_traversal() {
-        // Flat key "a.b.c" takes precedence over nested array traversal
+    fn json_flat_key_wins_over_array_traversal() {
         let v = json!({"a.b.c": "flat", "a": {"b": [{"c": "nested"}]}});
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         assert_eq!(
             event.get_field("a.b.c"),
-            Some(&Value::String("flat".into()))
+            Some(EventValue::Str(Cow::Borrowed("flat")))
         );
     }
 
     #[test]
-    fn test_all_string_values() {
+    fn json_all_string_values() {
         let v = json!({
             "a": "hello",
             "b": 42,
             "c": {"d": "world", "e": true},
             "f": ["one", "two"]
         });
-        let event = Event::from_value(&v);
+        let event = JsonEvent::borrow(&v);
         let values = event.all_string_values();
-        assert!(values.contains(&"hello"));
-        assert!(values.contains(&"world"));
-        assert!(values.contains(&"one"));
-        assert!(values.contains(&"two"));
+        let strs: Vec<&str> = values.iter().map(|c| c.as_ref()).collect();
+        assert!(strs.contains(&"hello"));
+        assert!(strs.contains(&"world"));
+        assert!(strs.contains(&"one"));
+        assert!(strs.contains(&"two"));
         assert_eq!(values.len(), 4);
+    }
+
+    #[test]
+    fn json_to_json_roundtrip() {
+        let v = json!({"a": 1, "b": "hello", "c": [1, 2]});
+        let event = JsonEvent::borrow(&v);
+        assert_eq!(event.to_json(), v);
+    }
+
+    #[test]
+    fn json_owned_works() {
+        let v = json!({"key": "value"});
+        let event = JsonEvent::owned(v.clone());
+        assert_eq!(
+            event.get_field("key"),
+            Some(EventValue::Str(Cow::Borrowed("value")))
+        );
+        assert_eq!(event.to_json(), v);
+    }
+
+    // -- EventValue coercion tests --------------------------------------------
+
+    #[test]
+    fn event_value_as_str() {
+        assert_eq!(EventValue::Str(Cow::Borrowed("hi")).as_str().unwrap(), "hi");
+        assert_eq!(EventValue::Int(42).as_str().unwrap(), "42");
+        assert_eq!(EventValue::Float(2.71).as_str().unwrap(), "2.71");
+        assert_eq!(EventValue::Bool(true).as_str().unwrap(), "true");
+        assert!(EventValue::Null.as_str().is_none());
+    }
+
+    #[test]
+    fn event_value_as_f64() {
+        assert_eq!(EventValue::Float(2.71).as_f64(), Some(2.71));
+        assert_eq!(EventValue::Int(42).as_f64(), Some(42.0));
+        assert_eq!(EventValue::Str(Cow::Borrowed("1.5")).as_f64(), Some(1.5));
+        assert!(EventValue::Bool(true).as_f64().is_none());
+    }
+
+    #[test]
+    fn event_value_as_i64() {
+        assert_eq!(EventValue::Int(42).as_i64(), Some(42));
+        assert_eq!(EventValue::Float(42.0).as_i64(), Some(42));
+        assert_eq!(EventValue::Float(42.5).as_i64(), None);
+        assert_eq!(EventValue::Str(Cow::Borrowed("100")).as_i64(), Some(100));
+    }
+
+    #[test]
+    fn event_value_to_json() {
+        assert_eq!(EventValue::Str(Cow::Borrowed("hi")).to_json(), json!("hi"));
+        assert_eq!(EventValue::Int(42).to_json(), json!(42));
+        assert_eq!(EventValue::Bool(true).to_json(), json!(true));
+        assert_eq!(EventValue::Null.to_json(), Value::Null);
+    }
+
+    // -- KvEvent tests --------------------------------------------------------
+
+    #[test]
+    fn kv_get_field() {
+        let event = KvEvent::new(vec![
+            ("host".into(), "web01".into()),
+            ("status".into(), "200".into()),
+        ]);
+        assert_eq!(
+            event.get_field("host"),
+            Some(EventValue::Str(Cow::Borrowed("web01")))
+        );
+        assert_eq!(event.get_field("missing"), None);
+    }
+
+    #[test]
+    fn kv_all_string_values() {
+        let event = KvEvent::new(vec![("a".into(), "one".into()), ("b".into(), "two".into())]);
+        let vals = event.all_string_values();
+        assert_eq!(vals.len(), 2);
+    }
+
+    #[test]
+    fn kv_to_json() {
+        let event = KvEvent::new(vec![("key".into(), "val".into())]);
+        let j = event.to_json();
+        assert_eq!(j, json!({"key": "val"}));
+    }
+
+    // -- PlainEvent tests -----------------------------------------------------
+
+    #[test]
+    fn plain_get_field_always_none() {
+        let event = PlainEvent::new("raw log line".into());
+        assert_eq!(event.get_field("anything"), None);
+    }
+
+    #[test]
+    fn plain_keyword_search() {
+        let event = PlainEvent::new("error: disk full".into());
+        assert!(event.any_string_value(&|s| s.contains("disk")));
+        assert!(!event.any_string_value(&|s| s.contains("memory")));
+    }
+
+    #[test]
+    fn plain_to_json() {
+        let event = PlainEvent::new("hello".into());
+        assert_eq!(event.to_json(), json!({"_raw": "hello"}));
+    }
+
+    // -- MapEvent tests -------------------------------------------------------
+
+    #[test]
+    fn map_event_get_field() {
+        let mut m = HashMap::new();
+        m.insert("user".to_string(), "admin".to_string());
+        let event = MapEvent::new(m);
+        assert_eq!(
+            event.get_field("user"),
+            Some(EventValue::Str(Cow::Borrowed("admin")))
+        );
+        assert_eq!(event.get_field("missing"), None);
+    }
+
+    #[test]
+    fn map_event_to_json() {
+        let mut m = HashMap::new();
+        m.insert("k".to_string(), "v".to_string());
+        let event = MapEvent::new(m);
+        assert_eq!(event.to_json(), json!({"k": "v"}));
     }
 }

--- a/crates/rsigma-eval/src/event.rs
+++ b/crates/rsigma-eval/src/event.rs
@@ -193,18 +193,23 @@ impl<T: Event + ?Sized> Event for &T {
 ///
 /// Supports both borrowed (`&Value`) and owned (`Value`) backing via `Cow`.
 /// This is the primary implementation for JSON/NDJSON input.
+///
+/// Flat keys are checked first: `"actor.id"` as a single key takes precedence
+/// over `{"actor": {"id": ...}}` nested traversal.
 #[derive(Debug)]
 pub struct JsonEvent<'a> {
     inner: Cow<'a, Value>,
 }
 
 impl<'a> JsonEvent<'a> {
+    /// Wrap a borrowed JSON value as an event.
     pub fn borrow(v: &'a Value) -> Self {
         Self {
             inner: Cow::Borrowed(v),
         }
     }
 
+    /// Wrap an owned JSON value as an event.
     pub fn owned(v: Value) -> Self {
         Self {
             inner: Cow::Owned(v),
@@ -225,6 +230,11 @@ impl From<Value> for JsonEvent<'static> {
 }
 
 impl<'a> Event for JsonEvent<'a> {
+    /// Get a field value by name, supporting dot-notation for nested access.
+    ///
+    /// Checks for a flat key first (exact match), then falls back to
+    /// dot-separated traversal. When a path segment yields an array,
+    /// each element is tried and the first match is returned (OR semantics).
     fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
         let value: &Value = &self.inner;
 
@@ -242,10 +252,19 @@ impl<'a> Event for JsonEvent<'a> {
         None
     }
 
+    /// Check if any string value in the event satisfies a predicate.
+    ///
+    /// Short-circuits on the first match, avoiding the allocation of
+    /// collecting all string values into a `Vec`.
     fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
         any_string_value_json(&self.inner, pred, MAX_NESTING_DEPTH)
     }
 
+    /// Iterate over all string values in the event (for keyword detection).
+    ///
+    /// Recursively walks the entire event object and yields every string
+    /// value found, including inside nested objects and arrays. Traversal
+    /// is capped at 64 levels of nesting to prevent stack overflow.
     fn all_string_values(&self) -> Vec<Cow<'_, str>> {
         let mut values = Vec::new();
         collect_string_values_json(&self.inner, &mut values, MAX_NESTING_DEPTH);
@@ -259,6 +278,10 @@ impl<'a> Event for JsonEvent<'a> {
 
 // -- JsonEvent helpers --------------------------------------------------------
 
+/// Recursively traverse a JSON value following dot-notation path segments.
+///
+/// When a segment resolves to an array, each element is tried and the first
+/// match for the remaining path is returned.
 fn traverse_json<'a>(current: &'a Value, parts: &[&str]) -> Option<&'a Value> {
     if parts.is_empty() {
         return Some(current);

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -18,7 +18,8 @@
 //!
 //! ```rust
 //! use rsigma_parser::parse_sigma_yaml;
-//! use rsigma_eval::{Engine, Event};
+//! use rsigma_eval::Engine;
+//! use rsigma_eval::event::JsonEvent;
 //! use serde_json::json;
 //!
 //! let yaml = r#"
@@ -38,7 +39,7 @@
 //! engine.add_collection(&collection).unwrap();
 //!
 //! let event_val = json!({"CommandLine": "cmd /c whoami"});
-//! let event = Event::from_value(&event_val);
+//! let event = JsonEvent::borrow(&event_val);
 //! let matches = engine.evaluate(&event);
 //! assert_eq!(matches.len(), 1);
 //! ```
@@ -47,7 +48,8 @@
 //!
 //! ```rust
 //! use rsigma_parser::parse_sigma_yaml;
-//! use rsigma_eval::{CorrelationEngine, CorrelationConfig, Event};
+//! use rsigma_eval::{CorrelationEngine, CorrelationConfig};
+//! use rsigma_eval::event::JsonEvent;
 //! use serde_json::json;
 //!
 //! let yaml = r#"
@@ -79,7 +81,7 @@
 //!
 //! for i in 0..3 {
 //!     let v = json!({"EventType": "login", "User": "admin"});
-//!     let event = Event::from_value(&v);
+//!     let event = JsonEvent::borrow(&v);
 //!     let result = engine.process_event_at(&event, 1000 + i);
 //!     if i == 2 {
 //!         assert_eq!(result.correlations.len(), 1);
@@ -96,7 +98,7 @@ pub mod event;
 pub mod matcher;
 pub mod pipeline;
 pub mod result;
-pub(crate) mod rule_index;
+pub mod rule_index;
 
 // Re-export the most commonly used types and functions at crate root
 pub use compiler::{
@@ -112,7 +114,7 @@ pub use correlation_engine::{
 };
 pub use engine::Engine;
 pub use error::{EvalError, Result};
-pub use event::Event;
+pub use event::{Event, JsonEvent};
 pub use matcher::CompiledMatcher;
 pub use pipeline::{
     Pipeline, apply_pipelines, merge_pipelines, parse_pipeline, parse_pipeline_file,

--- a/crates/rsigma-eval/src/matcher.rs
+++ b/crates/rsigma-eval/src/matcher.rs
@@ -1,17 +1,16 @@
 //! Compiled matchers for zero-allocation hot-path evaluation.
 //!
 //! Each `CompiledMatcher` variant is pre-compiled at rule load time.
-//! At evaluation time, `matches()` performs the comparison against a JSON
-//! value from the event with no dynamic dispatch or allocation.
+//! At evaluation time, `matches()` performs the comparison against an
+//! [`EventValue`] from the event with no dynamic dispatch or allocation.
 
 use std::net::IpAddr;
 
 use chrono::{Datelike, Timelike};
 use ipnet::IpNet;
 use regex::Regex;
-use serde_json::Value;
 
-use crate::event::Event;
+use crate::event::{Event, EventValue};
 
 /// A pre-compiled matcher for a single value comparison.
 ///
@@ -21,97 +20,67 @@ use crate::event::Event;
 #[derive(Debug, Clone)]
 pub enum CompiledMatcher {
     // -- String matchers --
-    /// Exact string equality.
     Exact {
         value: String,
         case_insensitive: bool,
     },
-
-    /// Substring containment.
     Contains {
         value: String,
         case_insensitive: bool,
     },
-
-    /// String starts with prefix.
     StartsWith {
         value: String,
         case_insensitive: bool,
     },
-
-    /// String ends with suffix.
     EndsWith {
         value: String,
         case_insensitive: bool,
     },
-
-    /// Compiled regex pattern (flags baked in at compile time).
     Regex(Regex),
 
     // -- Network --
-    /// CIDR network match for IP addresses.
     Cidr(IpNet),
 
     // -- Numeric --
-    /// Numeric equality.
     NumericEq(f64),
-    /// Numeric greater-than.
     NumericGt(f64),
-    /// Numeric greater-than-or-equal.
     NumericGte(f64),
-    /// Numeric less-than.
     NumericLt(f64),
-    /// Numeric less-than-or-equal.
     NumericLte(f64),
 
     // -- Special --
-    /// Field existence check. `true` = field must exist, `false` = must not exist.
     Exists(bool),
-
-    /// Compare against another field's value.
     FieldRef {
         field: String,
         case_insensitive: bool,
     },
-
-    /// Match null / missing values.
     Null,
-
-    /// Boolean equality.
     BoolEq(bool),
 
     // -- Expand --
-    /// Placeholder expansion: `%fieldname%` is resolved from the event at match time.
     Expand {
         template: Vec<ExpandPart>,
         case_insensitive: bool,
     },
 
     // -- Timestamp --
-    /// Extract a time component from a timestamp field value and match it.
     TimestampPart {
         part: TimePart,
         inner: Box<CompiledMatcher>,
     },
 
     // -- Negation --
-    /// Negated matcher: matches if the inner matcher does NOT match.
     Not(Box<CompiledMatcher>),
 
     // -- Composite --
-    /// Match if ANY child matches (OR).
     AnyOf(Vec<CompiledMatcher>),
-
-    /// Match if ALL children match (AND).
     AllOf(Vec<CompiledMatcher>),
 }
 
 /// A part of an expand template.
 #[derive(Debug, Clone)]
 pub enum ExpandPart {
-    /// Literal text.
     Literal(String),
-    /// A placeholder field name (between `%` delimiters).
     Placeholder(String),
 }
 
@@ -127,11 +96,9 @@ pub enum TimePart {
 }
 
 impl CompiledMatcher {
-    /// Check if this matcher matches a JSON value from an event.
-    ///
-    /// The `event` parameter is needed for `FieldRef` to access other fields.
-    /// The `field_name` is the name of the field being matched (for `FieldRef` comparison).
-    pub fn matches(&self, value: &Value, event: &Event) -> bool {
+    /// Check if this matcher matches an [`EventValue`] from an event.
+    #[inline]
+    pub fn matches(&self, value: &EventValue, event: &impl Event) -> bool {
         match self {
             // -- String matchers --
             CompiledMatcher::Exact {
@@ -195,12 +162,9 @@ impl CompiledMatcher {
             CompiledMatcher::NumericLte(n) => match_numeric_value(value, |v| v <= *n),
 
             // -- Special --
-            CompiledMatcher::Exists(_expect) => {
-                // Exists is handled at the detection item level, not here.
-                // This variant should not be reached during normal value matching.
-                // If it is, treat `value` presence as existence.
+            CompiledMatcher::Exists(expect) => {
                 let exists = !value.is_null();
-                exists == *_expect
+                exists == *expect
             }
 
             CompiledMatcher::FieldRef {
@@ -209,12 +173,12 @@ impl CompiledMatcher {
             } => {
                 if let Some(ref_value) = event.get_field(ref_field) {
                     if *case_insensitive {
-                        match (value_to_str(value), value_to_str(ref_value)) {
+                        match (value.as_str(), ref_value.as_str()) {
                             (Some(a), Some(b)) => a.to_lowercase() == b.to_lowercase(),
-                            _ => value == ref_value,
+                            _ => value == &ref_value,
                         }
                     } else {
-                        value == ref_value
+                        value == &ref_value
                     }
                 } else {
                     false
@@ -224,9 +188,8 @@ impl CompiledMatcher {
             CompiledMatcher::Null => value.is_null(),
 
             CompiledMatcher::BoolEq(expected) => match value {
-                Value::Bool(b) => b == expected,
-                // Also accept string representations
-                Value::String(s) => match s.to_lowercase().as_str() {
+                EventValue::Bool(b) => b == expected,
+                EventValue::Str(s) => match s.to_lowercase().as_str() {
                     "true" | "1" | "yes" => *expected,
                     "false" | "0" | "no" => !*expected,
                     _ => false,
@@ -239,7 +202,6 @@ impl CompiledMatcher {
                 template,
                 case_insensitive,
             } => {
-                // Resolve all placeholders from the event
                 let expanded = expand_template(template, event);
                 match_str_value(value, |s| {
                     if *case_insensitive {
@@ -252,11 +214,9 @@ impl CompiledMatcher {
 
             // -- Timestamp --
             CompiledMatcher::TimestampPart { part, inner } => {
-                // Extract the time component from the value and match it
-                let component = extract_timestamp_part(value, *part);
-                match component {
+                match extract_timestamp_part(value, *part) {
                     Some(n) => {
-                        let num_val = Value::Number(serde_json::Number::from(n));
+                        let num_val = EventValue::Int(n);
                         inner.matches(&num_val, event)
                     }
                     None => false,
@@ -268,25 +228,18 @@ impl CompiledMatcher {
 
             // -- Composite --
             CompiledMatcher::AnyOf(matchers) => matchers.iter().any(|m| m.matches(value, event)),
-
             CompiledMatcher::AllOf(matchers) => matchers.iter().all(|m| m.matches(value, event)),
         }
     }
 
     /// Check if this matcher matches any string value in the event.
     /// Used for keyword detection (field-less matching).
-    ///
-    /// Avoids allocating a `Vec` of all strings and a `String` per value by
-    /// using `matches_str` with a short-circuiting traversal.
-    pub fn matches_keyword(&self, event: &Event) -> bool {
+    #[inline]
+    pub fn matches_keyword(&self, event: &impl Event) -> bool {
         event.any_string_value(&|s| self.matches_str(s))
     }
 
     /// Check if this matcher matches a plain `&str` value.
-    ///
-    /// Handles the string-matching subset of `CompiledMatcher`. Matchers that
-    /// require a full `Value` (numeric comparisons, field refs, etc.) return
-    /// `false` — those are never used in keyword detection.
     fn matches_str(&self, s: &str) -> bool {
         match self {
             CompiledMatcher::Exact {
@@ -333,7 +286,6 @@ impl CompiledMatcher {
             CompiledMatcher::Not(inner) => !inner.matches_str(s),
             CompiledMatcher::AnyOf(matchers) => matchers.iter().any(|m| m.matches_str(s)),
             CompiledMatcher::AllOf(matchers) => matchers.iter().all(|m| m.matches_str(s)),
-            // Non-string matchers are irrelevant for keyword search
             _ => false,
         }
     }
@@ -343,55 +295,36 @@ impl CompiledMatcher {
 // Helper functions
 // ---------------------------------------------------------------------------
 
-/// Try to extract a string representation from a JSON value and apply a predicate.
-///
-/// Handles `String` directly and coerces numbers/bools to string for comparison.
-fn match_str_value(value: &Value, pred: impl Fn(&str) -> bool) -> bool {
+fn match_str_value(value: &EventValue, pred: impl Fn(&str) -> bool) -> bool {
     match_str_value_ref(value, &pred)
 }
 
-fn match_str_value_ref(value: &Value, pred: &dyn Fn(&str) -> bool) -> bool {
+fn match_str_value_ref(value: &EventValue, pred: &dyn Fn(&str) -> bool) -> bool {
     match value {
-        Value::String(s) => pred(s),
-        // Coerce numeric and bool types to strings for string matching
-        Value::Number(n) => pred(&n.to_string()),
-        Value::Bool(b) => pred(if *b { "true" } else { "false" }),
-        // For arrays, match if any element matches
-        Value::Array(arr) => arr.iter().any(|v| match_str_value_ref(v, pred)),
+        EventValue::Str(s) => pred(s),
+        EventValue::Int(n) => pred(&n.to_string()),
+        EventValue::Float(f) => pred(&f.to_string()),
+        EventValue::Bool(b) => pred(if *b { "true" } else { "false" }),
+        EventValue::Array(arr) => arr.iter().any(|v| match_str_value_ref(v, pred)),
         _ => false,
     }
 }
 
-/// Try to extract a numeric value and apply a predicate.
-///
-/// Handles JSON numbers directly and tries to parse strings as numbers.
-fn match_numeric_value(value: &Value, pred: impl Fn(f64) -> bool) -> bool {
+fn match_numeric_value(value: &EventValue, pred: impl Fn(f64) -> bool) -> bool {
     match_numeric_value_ref(value, &pred)
 }
 
-fn match_numeric_value_ref(value: &Value, pred: &dyn Fn(f64) -> bool) -> bool {
+fn match_numeric_value_ref(value: &EventValue, pred: &dyn Fn(f64) -> bool) -> bool {
     match value {
-        Value::Number(n) => n.as_f64().is_some_and(pred),
-        Value::String(s) => s.parse::<f64>().is_ok_and(pred),
-        Value::Array(arr) => arr.iter().any(|v| match_numeric_value_ref(v, pred)),
+        EventValue::Int(n) => pred(*n as f64),
+        EventValue::Float(f) => pred(*f),
+        EventValue::Str(s) => s.parse::<f64>().is_ok_and(pred),
+        EventValue::Array(arr) => arr.iter().any(|v| match_numeric_value_ref(v, pred)),
         _ => false,
-    }
-}
-
-/// Extract a string representation from a JSON value (for FieldRef comparison).
-fn value_to_str(v: &Value) -> Option<String> {
-    match v {
-        Value::String(s) => Some(s.clone()),
-        Value::Number(n) => Some(n.to_string()),
-        Value::Bool(b) => Some(b.to_string()),
-        _ => None,
     }
 }
 
 /// Convert a [`SigmaString`](rsigma_parser::SigmaString) to a regex pattern string.
-///
-/// Wildcards are converted: `*` → `.*`, `?` → `.`
-/// Plain text is regex-escaped.
 pub fn sigma_string_to_regex(
     parts: &[rsigma_parser::value::StringPart],
     case_insensitive: bool,
@@ -424,20 +357,16 @@ pub fn sigma_string_to_regex(
 // Expand helpers
 // ---------------------------------------------------------------------------
 
-/// Resolve all placeholders in an expand template from the event.
-fn expand_template(template: &[ExpandPart], event: &Event) -> String {
+fn expand_template(template: &[ExpandPart], event: &impl Event) -> String {
     let mut result = String::new();
     for part in template {
         match part {
             ExpandPart::Literal(s) => result.push_str(s),
             ExpandPart::Placeholder(field) => {
-                if let Some(val) = event.get_field(field) {
-                    match val {
-                        Value::String(s) => result.push_str(s),
-                        Value::Number(n) => result.push_str(&n.to_string()),
-                        Value::Bool(b) => result.push_str(&b.to_string()),
-                        _ => {}
-                    }
+                if let Some(val) = event.get_field(field)
+                    && let Some(s) = val.as_str()
+                {
+                    result.push_str(&s);
                 }
             }
         }
@@ -455,14 +384,12 @@ pub fn parse_expand_template(s: &str) -> Vec<ExpandPart> {
     for ch in s.chars() {
         if ch == '%' {
             if in_placeholder {
-                // End of placeholder
                 if !placeholder.is_empty() {
                     parts.push(ExpandPart::Placeholder(placeholder.clone()));
                     placeholder.clear();
                 }
                 in_placeholder = false;
             } else {
-                // Start of placeholder — flush current literal
                 if !current.is_empty() {
                     parts.push(ExpandPart::Literal(current.clone()));
                     current.clear();
@@ -476,9 +403,7 @@ pub fn parse_expand_template(s: &str) -> Vec<ExpandPart> {
         }
     }
 
-    // Flush remaining
     if in_placeholder && !placeholder.is_empty() {
-        // Unterminated placeholder — treat as literal
         current.push('%');
         current.push_str(&placeholder);
     }
@@ -493,50 +418,47 @@ pub fn parse_expand_template(s: &str) -> Vec<ExpandPart> {
 // Timestamp part helpers
 // ---------------------------------------------------------------------------
 
-/// Extract a time component from a JSON value (timestamp string or number).
-fn extract_timestamp_part(value: &Value, part: TimePart) -> Option<i64> {
-    let ts_str = match value {
-        Value::String(s) => s.clone(),
-        Value::Number(n) => {
-            // Interpret numeric timestamps as epoch seconds.
-            // Values above 1e12 (i.e. 1_000_000_000_000, ~= Sep 2001 in millis)
-            // are assumed to be **milliseconds** and divided by 1000.  This
-            // heuristic mirrors the approach used by pySigma and covers all
-            // real-world epoch-second timestamps (the threshold won't be
-            // reached in seconds until the year ~33658).
-            let secs = n.as_i64()?;
+fn extract_timestamp_part(value: &EventValue, part: TimePart) -> Option<i64> {
+    match value {
+        EventValue::Str(s) => parse_timestamp_str(s, part),
+        EventValue::Int(n) => {
+            let secs = if *n > 1_000_000_000_000 { n / 1000 } else { *n };
+            let dt = chrono::DateTime::from_timestamp(secs, 0)?;
+            Some(extract_part_from_datetime(&dt, part))
+        }
+        EventValue::Float(f) => {
+            let secs = *f as i64;
             let secs = if secs > 1_000_000_000_000 {
                 secs / 1000
             } else {
                 secs
             };
             let dt = chrono::DateTime::from_timestamp(secs, 0)?;
-            return Some(extract_part_from_datetime(&dt, part));
+            Some(extract_part_from_datetime(&dt, part))
         }
-        _ => return None,
-    };
+        _ => None,
+    }
+}
 
-    // Try parsing as RFC 3339 / ISO 8601
-    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&ts_str) {
+fn parse_timestamp_str(ts_str: &str, part: TimePart) -> Option<i64> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts_str) {
         return Some(extract_part_from_datetime(&dt.to_utc(), part));
     }
-    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%dT%H:%M:%S") {
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%dT%H:%M:%S") {
         let dt = naive.and_utc();
         return Some(extract_part_from_datetime(&dt, part));
     }
-    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%d %H:%M:%S") {
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%d %H:%M:%S") {
         let dt = naive.and_utc();
         return Some(extract_part_from_datetime(&dt, part));
     }
-    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(&ts_str, "%Y-%m-%dT%H:%M:%S%.f") {
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%dT%H:%M:%S%.f") {
         let dt = naive.and_utc();
         return Some(extract_part_from_datetime(&dt, part));
     }
-
     None
 }
 
-/// Extract a specific time component from a UTC DateTime.
 fn extract_part_from_datetime(dt: &chrono::DateTime<chrono::Utc>, part: TimePart) -> i64 {
     match part {
         TimePart::Minute => dt.minute() as i64,
@@ -551,9 +473,10 @@ fn extract_part_from_datetime(dt: &chrono::DateTime<chrono::Utc>, part: TimePart
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::JsonEvent;
     use serde_json::json;
 
-    fn ev() -> serde_json::Value {
+    fn empty_event() -> serde_json::Value {
         json!({})
     }
 
@@ -563,12 +486,12 @@ mod tests {
             value: "whoami".into(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("whoami"), &event));
-        assert!(m.matches(&json!("WHOAMI"), &event));
-        assert!(m.matches(&json!("Whoami"), &event));
-        assert!(!m.matches(&json!("other"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("whoami".into()), &event));
+        assert!(m.matches(&EventValue::Str("WHOAMI".into()), &event));
+        assert!(m.matches(&EventValue::Str("Whoami".into()), &event));
+        assert!(!m.matches(&EventValue::Str("other".into()), &event));
     }
 
     #[test]
@@ -577,10 +500,10 @@ mod tests {
             value: "whoami".into(),
             case_insensitive: false,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("whoami"), &event));
-        assert!(!m.matches(&json!("WHOAMI"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("whoami".into()), &event));
+        assert!(!m.matches(&EventValue::Str("WHOAMI".into()), &event));
     }
 
     #[test]
@@ -589,11 +512,11 @@ mod tests {
             value: "admin".to_lowercase(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("superadminuser"), &event));
-        assert!(m.matches(&json!("ADMIN"), &event));
-        assert!(!m.matches(&json!("user"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("superadminuser".into()), &event));
+        assert!(m.matches(&EventValue::Str("ADMIN".into()), &event));
+        assert!(!m.matches(&EventValue::Str("user".into()), &event));
     }
 
     #[test]
@@ -602,11 +525,11 @@ mod tests {
             value: "cmd".into(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("cmd.exe"), &event));
-        assert!(m.matches(&json!("CMD.EXE"), &event));
-        assert!(!m.matches(&json!("xcmd"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("cmd.exe".into()), &event));
+        assert!(m.matches(&EventValue::Str("CMD.EXE".into()), &event));
+        assert!(!m.matches(&EventValue::Str("xcmd".into()), &event));
     }
 
     #[test]
@@ -615,74 +538,73 @@ mod tests {
             value: ".exe".into(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("cmd.exe"), &event));
-        assert!(m.matches(&json!("CMD.EXE"), &event));
-        assert!(!m.matches(&json!("cmd.bat"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("cmd.exe".into()), &event));
+        assert!(m.matches(&EventValue::Str("CMD.EXE".into()), &event));
+        assert!(!m.matches(&EventValue::Str("cmd.bat".into()), &event));
     }
 
     #[test]
     fn test_regex() {
         let re = Regex::new("(?i)^test.*value$").unwrap();
         let m = CompiledMatcher::Regex(re);
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("testXYZvalue"), &event));
-        assert!(m.matches(&json!("TESTvalue"), &event));
-        assert!(!m.matches(&json!("notamatch"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("testXYZvalue".into()), &event));
+        assert!(m.matches(&EventValue::Str("TESTvalue".into()), &event));
+        assert!(!m.matches(&EventValue::Str("notamatch".into()), &event));
     }
 
     #[test]
     fn test_cidr() {
         let net: IpNet = "10.0.0.0/8".parse().unwrap();
         let m = CompiledMatcher::Cidr(net);
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("10.1.2.3"), &event));
-        assert!(!m.matches(&json!("192.168.1.1"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("10.1.2.3".into()), &event));
+        assert!(!m.matches(&EventValue::Str("192.168.1.1".into()), &event));
     }
 
     #[test]
     fn test_numeric() {
         let m = CompiledMatcher::NumericGte(100.0);
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!(100), &event));
-        assert!(m.matches(&json!(200), &event));
-        assert!(!m.matches(&json!(50), &event));
-        // String coercion
-        assert!(m.matches(&json!("150"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Int(100), &event));
+        assert!(m.matches(&EventValue::Int(200), &event));
+        assert!(!m.matches(&EventValue::Int(50), &event));
+        assert!(m.matches(&EventValue::Str("150".into()), &event));
     }
 
     #[test]
     fn test_null() {
         let m = CompiledMatcher::Null;
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&Value::Null, &event));
-        assert!(!m.matches(&json!(""), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Null, &event));
+        assert!(!m.matches(&EventValue::Str("".into()), &event));
     }
 
     #[test]
     fn test_bool() {
         let m = CompiledMatcher::BoolEq(true);
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!(true), &event));
-        assert!(!m.matches(&json!(false), &event));
-        assert!(m.matches(&json!("true"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Bool(true), &event));
+        assert!(!m.matches(&EventValue::Bool(false), &event));
+        assert!(m.matches(&EventValue::Str("true".into()), &event));
     }
 
     #[test]
     fn test_field_ref() {
         let e = json!({"src": "10.0.0.1", "dst": "10.0.0.1"});
-        let event = Event::from_value(&e);
+        let event = JsonEvent::borrow(&e);
         let m = CompiledMatcher::FieldRef {
             field: "dst".into(),
             case_insensitive: true,
         };
-        assert!(m.matches(&json!("10.0.0.1"), &event));
+        assert!(m.matches(&EventValue::Str("10.0.0.1".into()), &event));
     }
 
     #[test]
@@ -697,11 +619,11 @@ mod tests {
                 case_insensitive: false,
             },
         ]);
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("a"), &event));
-        assert!(m.matches(&json!("b"), &event));
-        assert!(!m.matches(&json!("c"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("a".into()), &event));
+        assert!(m.matches(&EventValue::Str("b".into()), &event));
+        assert!(!m.matches(&EventValue::Str("c".into()), &event));
     }
 
     #[test]
@@ -716,10 +638,10 @@ mod tests {
                 case_insensitive: false,
             },
         ]);
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("adminuser"), &event));
-        assert!(!m.matches(&json!("admin"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("adminuser".into()), &event));
+        assert!(!m.matches(&EventValue::Str("admin".into()), &event));
     }
 
     #[test]
@@ -728,11 +650,19 @@ mod tests {
             value: "target".into(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        // Match within a JSON array
-        assert!(m.matches(&json!(["other", "target", "more"]), &event));
-        assert!(!m.matches(&json!(["other", "nope"]), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        let arr = EventValue::Array(vec![
+            EventValue::Str("other".into()),
+            EventValue::Str("target".into()),
+            EventValue::Str("more".into()),
+        ]);
+        assert!(m.matches(&arr, &event));
+        let arr2 = EventValue::Array(vec![
+            EventValue::Str("other".into()),
+            EventValue::Str("nope".into()),
+        ]);
+        assert!(!m.matches(&arr2, &event));
     }
 
     #[test]
@@ -741,9 +671,9 @@ mod tests {
             value: "42".into(),
             case_insensitive: false,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!(42), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Int(42), &event));
     }
 
     // =========================================================================
@@ -752,16 +682,15 @@ mod tests {
 
     #[test]
     fn test_exact_unicode_case_insensitive() {
-        // German uppercase Ä should match lowercase ä
         let m = CompiledMatcher::Exact {
             value: "ärzte".to_lowercase(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("ÄRZTE"), &event));
-        assert!(m.matches(&json!("Ärzte"), &event));
-        assert!(m.matches(&json!("ärzte"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("ÄRZTE".into()), &event));
+        assert!(m.matches(&EventValue::Str("Ärzte".into()), &event));
+        assert!(m.matches(&EventValue::Str("ärzte".into()), &event));
     }
 
     #[test]
@@ -770,10 +699,10 @@ mod tests {
             value: "ñ".to_lowercase(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("España"), &event));
-        assert!(m.matches(&json!("ESPAÑA"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("España".into()), &event));
+        assert!(m.matches(&EventValue::Str("ESPAÑA".into()), &event));
     }
 
     #[test]
@@ -782,11 +711,11 @@ mod tests {
             value: "über".to_lowercase(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("Übersicht"), &event));
-        assert!(m.matches(&json!("ÜBERSICHT"), &event));
-        assert!(!m.matches(&json!("not-uber"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("Übersicht".into()), &event));
+        assert!(m.matches(&EventValue::Str("ÜBERSICHT".into()), &event));
+        assert!(!m.matches(&EventValue::Str("not-uber".into()), &event));
     }
 
     #[test]
@@ -795,11 +724,11 @@ mod tests {
             value: "ção".to_lowercase(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("Aplicação"), &event));
-        assert!(m.matches(&json!("APLICAÇÃO"), &event));
-        assert!(!m.matches(&json!("Aplicacao"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("Aplicação".into()), &event));
+        assert!(m.matches(&EventValue::Str("APLICAÇÃO".into()), &event));
+        assert!(!m.matches(&EventValue::Str("Aplicacao".into()), &event));
     }
 
     #[test]
@@ -808,10 +737,10 @@ mod tests {
             value: "σίγμα".to_lowercase(),
             case_insensitive: true,
         };
-        let e = ev();
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("ΣΊΓΜΑ"), &event));
-        assert!(m.matches(&json!("σίγμα"), &event));
+        let e = empty_event();
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("ΣΊΓΜΑ".into()), &event));
+        assert!(m.matches(&EventValue::Str("σίγμα".into()), &event));
     }
 
     // =========================================================================
@@ -851,9 +780,15 @@ mod tests {
             case_insensitive: true,
         };
         let e = json!({"user": "admin", "path": "C:\\Users\\admin\\Downloads"});
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("C:\\Users\\admin\\Downloads"), &event));
-        assert!(!m.matches(&json!("C:\\Users\\other\\Downloads"), &event));
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(
+            &EventValue::Str("C:\\Users\\admin\\Downloads".into()),
+            &event
+        ));
+        assert!(!m.matches(
+            &EventValue::Str("C:\\Users\\other\\Downloads".into()),
+            &event
+        ));
     }
 
     #[test]
@@ -863,10 +798,9 @@ mod tests {
             template,
             case_insensitive: false,
         };
-        // user is present but domain is not — should produce "admin@"
         let e = json!({"user": "admin"});
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("admin@"), &event));
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("admin@".into()), &event));
     }
 
     // =========================================================================
@@ -880,10 +814,9 @@ mod tests {
             inner: Box::new(CompiledMatcher::NumericEq(12.0)),
         };
         let e = json!({});
-        let event = Event::from_value(&e);
-        // 2024-07-10T12:30:00Z — hour should be 12
-        assert!(m.matches(&json!("2024-07-10T12:30:00Z"), &event));
-        assert!(!m.matches(&json!("2024-07-10T15:30:00Z"), &event));
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("2024-07-10T12:30:00Z".into()), &event));
+        assert!(!m.matches(&EventValue::Str("2024-07-10T15:30:00Z".into()), &event));
     }
 
     #[test]
@@ -893,9 +826,9 @@ mod tests {
             inner: Box::new(CompiledMatcher::NumericEq(7.0)),
         };
         let e = json!({});
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("2024-07-10T12:30:00Z"), &event));
-        assert!(!m.matches(&json!("2024-08-10T12:30:00Z"), &event));
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("2024-07-10T12:30:00Z".into()), &event));
+        assert!(!m.matches(&EventValue::Str("2024-08-10T12:30:00Z".into()), &event));
     }
 
     #[test]
@@ -905,9 +838,9 @@ mod tests {
             inner: Box::new(CompiledMatcher::NumericEq(10.0)),
         };
         let e = json!({});
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("2024-07-10T12:30:00Z"), &event));
-        assert!(!m.matches(&json!("2024-07-15T12:30:00Z"), &event));
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("2024-07-10T12:30:00Z".into()), &event));
+        assert!(!m.matches(&EventValue::Str("2024-07-15T12:30:00Z".into()), &event));
     }
 
     #[test]
@@ -917,9 +850,9 @@ mod tests {
             inner: Box::new(CompiledMatcher::NumericEq(2024.0)),
         };
         let e = json!({});
-        let event = Event::from_value(&e);
-        assert!(m.matches(&json!("2024-07-10T12:30:00Z"), &event));
-        assert!(!m.matches(&json!("2023-07-10T12:30:00Z"), &event));
+        let event = JsonEvent::borrow(&e);
+        assert!(m.matches(&EventValue::Str("2024-07-10T12:30:00Z".into()), &event));
+        assert!(!m.matches(&EventValue::Str("2023-07-10T12:30:00Z".into()), &event));
     }
 
     #[test]
@@ -929,9 +862,9 @@ mod tests {
             inner: Box::new(CompiledMatcher::NumericEq(12.0)),
         };
         let e = json!({});
-        let event = Event::from_value(&e);
+        let event = JsonEvent::borrow(&e);
         // 2024-07-10T12:30:00Z = 1720614600
-        assert!(m.matches(&json!(1720614600), &event));
+        assert!(m.matches(&EventValue::Int(1720614600), &event));
     }
 }
 
@@ -942,15 +875,14 @@ mod tests {
 #[cfg(test)]
 mod proptests {
     use super::*;
+    use crate::event::JsonEvent;
     use proptest::prelude::*;
     use rsigma_parser::value::{SpecialChar, StringPart};
     use serde_json::json;
 
-    /// Strategy to generate a random sequence of StringParts (plain text + wildcards).
     fn arb_string_parts() -> impl Strategy<Value = Vec<StringPart>> {
         prop::collection::vec(
             prop_oneof![
-                // Plain text: ASCII printable, including regex metacharacters
                 "[[:print:]]{0,20}".prop_map(StringPart::Plain),
                 Just(StringPart::Special(SpecialChar::WildcardMulti)),
                 Just(StringPart::Special(SpecialChar::WildcardSingle)),
@@ -959,22 +891,15 @@ mod proptests {
         )
     }
 
-    // -------------------------------------------------------------------------
-    // 1. Wildcard → regex compilation never panics and always produces valid regex
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn wildcard_regex_always_valid(parts in arb_string_parts(), ci in any::<bool>()) {
             let pattern = sigma_string_to_regex(&parts, ci);
-            // Must compile without error
             prop_assert!(regex::Regex::new(&pattern).is_ok(),
                 "sigma_string_to_regex produced invalid regex: {}", pattern);
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 2. Plain text roundtrip: a plain-only SigmaString matches its own text
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn plain_text_matches_itself(text in "[[:print:]]{1,30}") {
@@ -986,9 +911,6 @@ mod proptests {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 3. Plain text never accidentally matches unrelated strings via regex injection
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn plain_text_rejects_different_string(
@@ -1004,9 +926,6 @@ mod proptests {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 4. Case-insensitive Exact matcher: symmetric under case change
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn exact_ci_symmetric(s in "[[:alpha:]]{1,20}") {
@@ -1015,9 +934,9 @@ mod proptests {
                 case_insensitive: true,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let upper = json!(s.to_uppercase());
-            let lower = json!(s.to_lowercase());
+            let event = JsonEvent::borrow(&e);
+            let upper = EventValue::Str(s.to_uppercase().into());
+            let lower = EventValue::Str(s.to_lowercase().into());
             prop_assert!(m.matches(&upper, &event),
                 "CI exact should match uppercase: {:?}", s.to_uppercase());
             prop_assert!(m.matches(&lower, &event),
@@ -1025,9 +944,6 @@ mod proptests {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 5. Contains matcher agrees with str::contains
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn contains_agrees_with_stdlib(
@@ -1040,16 +956,13 @@ mod proptests {
                 case_insensitive: false,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let val = json!(haystack);
+            let event = JsonEvent::borrow(&e);
+            let val = EventValue::Str(haystack.clone().into());
             prop_assert_eq!(m.matches(&val, &event), expected,
                 "Contains({:?}) on {:?}", needle, haystack);
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 6. StartsWith matcher agrees with str::starts_with
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn startswith_agrees_with_stdlib(
@@ -1062,16 +975,13 @@ mod proptests {
                 case_insensitive: false,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let val = json!(haystack);
+            let event = JsonEvent::borrow(&e);
+            let val = EventValue::Str(haystack.clone().into());
             prop_assert_eq!(m.matches(&val, &event), expected,
                 "StartsWith({:?}) on {:?}", prefix, haystack);
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 7. EndsWith matcher agrees with str::ends_with
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn endswith_agrees_with_stdlib(
@@ -1084,16 +994,13 @@ mod proptests {
                 case_insensitive: false,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let val = json!(haystack);
+            let event = JsonEvent::borrow(&e);
+            let val = EventValue::Str(haystack.clone().into());
             prop_assert_eq!(m.matches(&val, &event), expected,
                 "EndsWith({:?}) on {:?}", suffix, haystack);
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 8. CI Contains/StartsWith/EndsWith agree with lowercased stdlib equivalents
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn ci_contains_agrees_with_lowercased(
@@ -1106,8 +1013,8 @@ mod proptests {
                 case_insensitive: true,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let val = json!(haystack);
+            let event = JsonEvent::borrow(&e);
+            let val = EventValue::Str(haystack.clone().into());
             prop_assert_eq!(m.matches(&val, &event), expected,
                 "CI Contains({:?}) on {:?}", needle, haystack);
         }
@@ -1123,8 +1030,8 @@ mod proptests {
                 case_insensitive: true,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let val = json!(haystack);
+            let event = JsonEvent::borrow(&e);
+            let val = EventValue::Str(haystack.clone().into());
             prop_assert_eq!(m.matches(&val, &event), expected,
                 "CI StartsWith({:?}) on {:?}", prefix, haystack);
         }
@@ -1140,16 +1047,13 @@ mod proptests {
                 case_insensitive: true,
             };
             let e = json!({});
-            let event = Event::from_value(&e);
-            let val = json!(haystack);
+            let event = JsonEvent::borrow(&e);
+            let val = EventValue::Str(haystack.clone().into());
             prop_assert_eq!(m.matches(&val, &event), expected,
                 "CI EndsWith({:?}) on {:?}", suffix, haystack);
         }
     }
 
-    // -------------------------------------------------------------------------
-    // 9. Wildcard * matches any string, ? matches any single char
-    // -------------------------------------------------------------------------
     proptest! {
         #[test]
         fn wildcard_star_matches_anything(s in "[[:print:]]{0,30}") {

--- a/crates/rsigma-eval/src/matcher.rs
+++ b/crates/rsigma-eval/src/matcher.rs
@@ -20,67 +20,89 @@ use crate::event::{Event, EventValue};
 #[derive(Debug, Clone)]
 pub enum CompiledMatcher {
     // -- String matchers --
+    /// Exact string equality.
     Exact {
         value: String,
         case_insensitive: bool,
     },
+    /// Substring containment.
     Contains {
         value: String,
         case_insensitive: bool,
     },
+    /// String starts with prefix.
     StartsWith {
         value: String,
         case_insensitive: bool,
     },
+    /// String ends with suffix.
     EndsWith {
         value: String,
         case_insensitive: bool,
     },
+    /// Compiled regex pattern (flags baked in at compile time).
     Regex(Regex),
 
     // -- Network --
+    /// CIDR network match for IP addresses.
     Cidr(IpNet),
 
     // -- Numeric --
+    /// Numeric equality.
     NumericEq(f64),
+    /// Numeric greater-than.
     NumericGt(f64),
+    /// Numeric greater-than-or-equal.
     NumericGte(f64),
+    /// Numeric less-than.
     NumericLt(f64),
+    /// Numeric less-than-or-equal.
     NumericLte(f64),
 
     // -- Special --
+    /// Field existence check. `true` = field must exist, `false` = must not exist.
     Exists(bool),
+    /// Compare against another field's value.
     FieldRef {
         field: String,
         case_insensitive: bool,
     },
+    /// Match null / missing values.
     Null,
+    /// Boolean equality.
     BoolEq(bool),
 
     // -- Expand --
+    /// Placeholder expansion: `%fieldname%` is resolved from the event at match time.
     Expand {
         template: Vec<ExpandPart>,
         case_insensitive: bool,
     },
 
     // -- Timestamp --
+    /// Extract a time component from a timestamp field value and match it.
     TimestampPart {
         part: TimePart,
         inner: Box<CompiledMatcher>,
     },
 
     // -- Negation --
+    /// Negated matcher: matches if the inner matcher does NOT match.
     Not(Box<CompiledMatcher>),
 
     // -- Composite --
+    /// Match if ANY child matches (OR).
     AnyOf(Vec<CompiledMatcher>),
+    /// Match if ALL children match (AND).
     AllOf(Vec<CompiledMatcher>),
 }
 
 /// A part of an expand template.
 #[derive(Debug, Clone)]
 pub enum ExpandPart {
+    /// Literal text.
     Literal(String),
+    /// A placeholder field name (between `%` delimiters).
     Placeholder(String),
 }
 
@@ -97,6 +119,8 @@ pub enum TimePart {
 
 impl CompiledMatcher {
     /// Check if this matcher matches an [`EventValue`] from an event.
+    ///
+    /// The `event` parameter is needed for `FieldRef` to access other fields.
     #[inline]
     pub fn matches(&self, value: &EventValue, event: &impl Event) -> bool {
         match self {
@@ -234,12 +258,19 @@ impl CompiledMatcher {
 
     /// Check if this matcher matches any string value in the event.
     /// Used for keyword detection (field-less matching).
+    ///
+    /// Avoids allocating a `Vec` of all strings and a `String` per value by
+    /// using `matches_str` with a short-circuiting traversal.
     #[inline]
     pub fn matches_keyword(&self, event: &impl Event) -> bool {
         event.any_string_value(&|s| self.matches_str(s))
     }
 
     /// Check if this matcher matches a plain `&str` value.
+    ///
+    /// Handles the string-matching subset of `CompiledMatcher`. Matchers that
+    /// require a full `EventValue` (numeric comparisons, field refs, etc.)
+    /// return `false` — those are never used in keyword detection.
     fn matches_str(&self, s: &str) -> bool {
         match self {
             CompiledMatcher::Exact {
@@ -295,6 +326,9 @@ impl CompiledMatcher {
 // Helper functions
 // ---------------------------------------------------------------------------
 
+/// Try to extract a string representation from an [`EventValue`] and apply a predicate.
+///
+/// Handles `Str` directly and coerces numbers/bools to string for comparison.
 fn match_str_value(value: &EventValue, pred: impl Fn(&str) -> bool) -> bool {
     match_str_value_ref(value, &pred)
 }
@@ -310,6 +344,9 @@ fn match_str_value_ref(value: &EventValue, pred: &dyn Fn(&str) -> bool) -> bool 
     }
 }
 
+/// Try to extract a numeric value and apply a predicate.
+///
+/// Handles numeric values directly and tries to parse strings as numbers.
 fn match_numeric_value(value: &EventValue, pred: impl Fn(f64) -> bool) -> bool {
     match_numeric_value_ref(value, &pred)
 }
@@ -325,6 +362,9 @@ fn match_numeric_value_ref(value: &EventValue, pred: &dyn Fn(f64) -> bool) -> bo
 }
 
 /// Convert a [`SigmaString`](rsigma_parser::SigmaString) to a regex pattern string.
+///
+/// Wildcards are converted: `*` → `.*`, `?` → `.`
+/// Plain text is regex-escaped.
 pub fn sigma_string_to_regex(
     parts: &[rsigma_parser::value::StringPart],
     case_insensitive: bool,
@@ -357,6 +397,7 @@ pub fn sigma_string_to_regex(
 // Expand helpers
 // ---------------------------------------------------------------------------
 
+/// Resolve all placeholders in an expand template from the event.
 fn expand_template(template: &[ExpandPart], event: &impl Event) -> String {
     let mut result = String::new();
     for part in template {
@@ -418,6 +459,7 @@ pub fn parse_expand_template(s: &str) -> Vec<ExpandPart> {
 // Timestamp part helpers
 // ---------------------------------------------------------------------------
 
+/// Extract a time component from an [`EventValue`] (timestamp string or number).
 fn extract_timestamp_part(value: &EventValue, part: TimePart) -> Option<i64> {
     match value {
         EventValue::Str(s) => parse_timestamp_str(s, part),
@@ -459,6 +501,7 @@ fn parse_timestamp_str(ts_str: &str, part: TimePart) -> Option<i64> {
     None
 }
 
+/// Extract a specific time component from a UTC DateTime.
 fn extract_part_from_datetime(dt: &chrono::DateTime<chrono::Utc>, part: TimePart) -> i64 {
     match part {
         TimePart::Minute => dt.minute() as i64,

--- a/crates/rsigma-eval/src/rule_index.rs
+++ b/crates/rsigma-eval/src/rule_index.rs
@@ -190,7 +190,7 @@ fn extract_from_matcher(matcher: &CompiledMatcher, field: &str, out: &mut Vec<(S
     }
 }
 
-/// Convert a JSON value to a lowercase string for index lookup.
+/// Convert an [`EventValue`] to a lowercase string for index lookup.
 ///
 /// Returns `None` for null, objects, and arrays (not meaningful for exact match).
 fn value_to_lowercase_string(value: &EventValue) -> Option<String> {

--- a/crates/rsigma-eval/src/rule_index.rs
+++ b/crates/rsigma-eval/src/rule_index.rs
@@ -10,10 +10,8 @@
 
 use std::collections::HashMap;
 
-use serde_json::Value;
-
 use crate::compiler::{CompiledDetection, CompiledDetectionItem, CompiledRule};
-use crate::event::Event;
+use crate::event::{Event, EventValue};
 use crate::matcher::CompiledMatcher;
 
 /// Pre-computed inverted index over compiled rules.
@@ -90,7 +88,7 @@ impl RuleIndex {
     /// Looks up each indexed field name in the event, then checks the field's
     /// value against the index. Returns the union of all matching rule indices
     /// plus all unindexable rules, deduplicated.
-    pub(crate) fn candidates(&self, event: &Event) -> Vec<usize> {
+    pub(crate) fn candidates(&self, event: &impl Event) -> Vec<usize> {
         if self.field_index.is_empty() {
             return (0..self.rule_count).collect();
         }
@@ -100,7 +98,7 @@ impl RuleIndex {
 
         for (field_name, value_map) in &self.field_index {
             if let Some(event_value) = event.get_field(field_name)
-                && let Some(search_key) = value_to_lowercase_string(event_value)
+                && let Some(search_key) = value_to_lowercase_string(&event_value)
                 && let Some(rule_indices) = value_map.get(&search_key)
             {
                 for &idx in rule_indices {
@@ -195,11 +193,12 @@ fn extract_from_matcher(matcher: &CompiledMatcher, field: &str, out: &mut Vec<(S
 /// Convert a JSON value to a lowercase string for index lookup.
 ///
 /// Returns `None` for null, objects, and arrays (not meaningful for exact match).
-fn value_to_lowercase_string(value: &Value) -> Option<String> {
+fn value_to_lowercase_string(value: &EventValue) -> Option<String> {
     match value {
-        Value::String(s) => Some(s.to_lowercase()),
-        Value::Number(n) => Some(n.to_string()),
-        Value::Bool(b) => Some(b.to_string()),
+        EventValue::Str(s) => Some(s.to_lowercase()),
+        EventValue::Int(n) => Some(n.to_string()),
+        EventValue::Float(f) => Some(f.to_string()),
+        EventValue::Bool(b) => Some(b.to_string()),
         _ => None,
     }
 }
@@ -208,6 +207,7 @@ fn value_to_lowercase_string(value: &Value) -> Option<String> {
 mod tests {
     use super::*;
     use crate::Engine;
+    use crate::event::JsonEvent;
     use rsigma_parser::parse_sigma_yaml;
     use serde_json::json;
 
@@ -293,7 +293,7 @@ detection:
         );
 
         let ev = json!({"EventType": "login", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert_eq!(candidates, vec![0]);
     }
@@ -313,7 +313,7 @@ detection:
         );
 
         let ev = json!({"EventType": "file_create", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert!(candidates.is_empty());
     }
@@ -333,7 +333,7 @@ detection:
         );
 
         let ev = json!({"SomeField": "whatever"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert_eq!(candidates, vec![0]);
     }
@@ -353,7 +353,7 @@ detection:
         );
 
         let ev = json!({"EventType": "login"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert_eq!(candidates, vec![0]);
     }
@@ -391,12 +391,12 @@ detection:
         assert_eq!(index.unindexable_count(), 0);
 
         let ev = json!({"EventType": "login"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert_eq!(candidates, vec![0]);
 
         let ev2 = json!({"EventType": "process_create"});
-        let event2 = Event::from_value(&ev2);
+        let event2 = JsonEvent::borrow(&ev2);
         let candidates2 = index.candidates(&event2);
         assert_eq!(candidates2, vec![2]);
     }
@@ -444,9 +444,9 @@ detection:
         let ev_logout = json!({"EventType": "logout"});
         let ev_other = json!({"EventType": "file_create"});
 
-        assert_eq!(index.candidates(&Event::from_value(&ev_login)), vec![0]);
-        assert_eq!(index.candidates(&Event::from_value(&ev_logout)), vec![0]);
-        assert!(index.candidates(&Event::from_value(&ev_other)).is_empty());
+        assert_eq!(index.candidates(&JsonEvent::borrow(&ev_login)), vec![0]);
+        assert_eq!(index.candidates(&JsonEvent::borrow(&ev_logout)), vec![0]);
+        assert!(index.candidates(&JsonEvent::borrow(&ev_other)).is_empty());
     }
 
     #[test]
@@ -464,7 +464,7 @@ detection:
         );
 
         let ev = json!({"DestinationPort": 443});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert_eq!(candidates, vec![0]);
     }
@@ -492,7 +492,7 @@ detection:
         // Event matches BOTH indexed fields for the same rule.
         // Candidate should appear only once.
         let ev = json!({"EventType": "login", "Protocol": "TCP"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let candidates = index.candidates(&event);
         assert_eq!(candidates, vec![0]);
     }

--- a/crates/rsigma-eval/tests/correlation_edge.rs
+++ b/crates/rsigma-eval/tests/correlation_edge.rs
@@ -2,7 +2,7 @@ mod helpers;
 
 use helpers::{corr_engine, corr_engine_with_config, process};
 use rsigma_eval::{
-    CorrelationAction, CorrelationConfig, CorrelationEngine, Event, TimestampFallback,
+    CorrelationAction, CorrelationConfig, CorrelationEngine, JsonEvent, TimestampFallback,
 };
 use rsigma_parser::parse_sigma_yaml;
 use serde_json::json;
@@ -281,7 +281,7 @@ fn timestamp_fallback_skip_runs_detection_but_skips_correlation() {
     // - Correlation should NOT accumulate
     for _ in 0..5 {
         let ev = json!({"EventType": "login", "User": "admin"});
-        let event = Event::from_value(&ev);
+        let event = JsonEvent::borrow(&ev);
         let r = engine.process_event(&event);
         assert_eq!(r.detections.len(), 1, "detection should fire");
         assert!(

--- a/crates/rsigma-eval/tests/helpers/mod.rs
+++ b/crates/rsigma-eval/tests/helpers/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use rsigma_eval::{
-    CorrelationConfig, CorrelationEngine, Engine, Event, MatchResult, ProcessResult,
+    CorrelationConfig, CorrelationEngine, Engine, JsonEvent, MatchResult, ProcessResult,
 };
 use rsigma_parser::parse_sigma_yaml;
 use serde_json::Value;
@@ -10,7 +10,7 @@ pub fn eval(yaml: &str, event_json: Value) -> Vec<MatchResult> {
     let collection = parse_sigma_yaml(yaml).unwrap();
     let mut engine = Engine::new();
     engine.add_collection(&collection).unwrap();
-    let event = Event::from_value(&event_json);
+    let event = JsonEvent::borrow(&event_json);
     engine.evaluate(&event)
 }
 
@@ -26,6 +26,6 @@ pub fn corr_engine_with_config(yaml: &str, config: CorrelationConfig) -> Correla
 }
 
 pub fn process(engine: &mut CorrelationEngine, event_json: Value, ts: i64) -> ProcessResult {
-    let event = Event::from_value(&event_json);
+    let event = JsonEvent::borrow(&event_json);
     engine.process_event_at(&event, ts)
 }

--- a/crates/rsigma-eval/tests/integration.rs
+++ b/crates/rsigma-eval/tests/integration.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use helpers::{corr_engine, eval, process};
-use rsigma_eval::{Engine, Event, parse_pipeline};
+use rsigma_eval::{Engine, JsonEvent, parse_pipeline};
 use rsigma_parser::parse_sigma_yaml;
 use serde_json::json;
 
@@ -150,16 +150,16 @@ level: medium
 
     // After pipeline, rule expects ECS fields
     let ev = json!({"process.command_line": "cmd /c whoami", "user.name": "attacker"});
-    let matches = engine.evaluate(&Event::from_value(&ev));
+    let matches = engine.evaluate(&JsonEvent::borrow(&ev));
     assert_eq!(matches.len(), 1);
 
     // Filter still works through the mapped field name
     let ev2 = json!({"process.command_line": "cmd /c whoami", "user.name": "SYSTEM"});
-    assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
 
     // Original field names should not match
     let ev3 = json!({"CommandLine": "cmd /c whoami", "User": "attacker"});
-    assert!(engine.evaluate(&Event::from_value(&ev3)).is_empty());
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev3)).is_empty());
 }
 
 #[test]
@@ -299,19 +299,19 @@ filter:
 
     // In test environment: global filter blocks everything
     let ev = json!({"EventID": 1, "Environment": "test", "User": "admin"});
-    assert!(engine.evaluate(&Event::from_value(&ev)).is_empty());
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev)).is_empty());
 
     // Rule A as svc_account in prod: targeted filter blocks
     let ev2 = json!({"EventID": 1, "Environment": "prod", "User": "svc_account"});
-    assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
 
     // Rule B as svc_account in prod: targeted filter does NOT apply to rule-b
     let ev3 = json!({"EventID": 4688, "Environment": "prod", "User": "svc_account"});
-    assert_eq!(engine.evaluate(&Event::from_value(&ev3)).len(), 1);
+    assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev3)).len(), 1);
 
     // Rule A as admin in prod: no filter applies
     let ev4 = json!({"EventID": 1, "Environment": "prod", "User": "admin"});
-    assert_eq!(engine.evaluate(&Event::from_value(&ev4)).len(), 1);
+    assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev4)).len(), 1);
 }
 
 #[test]
@@ -351,15 +351,15 @@ filter:
 
     // Both filters should apply: env=test is excluded
     let ev1 = json!({"EventType": "login", "Environment": "test", "User": "admin"});
-    assert!(engine.evaluate(&Event::from_value(&ev1)).is_empty());
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev1)).is_empty());
 
     // User=bot is excluded
     let ev2 = json!({"EventType": "login", "Environment": "prod", "User": "bot"});
-    assert!(engine.evaluate(&Event::from_value(&ev2)).is_empty());
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev2)).is_empty());
 
     // Neither filter matches: rule fires
     let ev3 = json!({"EventType": "login", "Environment": "prod", "User": "admin"});
-    assert_eq!(engine.evaluate(&Event::from_value(&ev3)).len(), 1);
+    assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev3)).len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Replace the concrete `Event` struct** with a generic `Event` trait and a 7-variant `EventValue` enum (`Str`, `Int`, `Float`, `Bool`, `Null`, `Array`, `Map`) with coercion helpers, enabling support for log formats beyond JSON.
- **Add concrete implementations**: `JsonEvent` (zero-copy via `Cow`), `KvEvent` (flat key-value), `PlainEvent` (raw text), and `MapEvent` (generic `HashMap`). A blanket impl for `&T where T: Event` enables transparent reference use.
- **Migrate all consumers**: `Engine`, `CorrelationEngine`, `CompiledMatcher`, `RuleIndex`, all helper functions, CLI, daemon, benchmarks, integration tests, and doc examples now use `impl Event` generics and `JsonEvent::borrow` instead of `Event::from_value`.
- **Promote `rule_index` module** to public API. Re-export `JsonEvent` from crate root.

## Breaking Changes

- `Event` is now a trait, not a struct. Replace `Event::from_value(&v)` with `JsonEvent::borrow(&v)`.
- `Event::as_value()` removed. Use `event.to_json()` to materialize as `serde_json::Value`.
- Import path: `use rsigma_eval::event::JsonEvent` or `use rsigma_eval::JsonEvent`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test` — all 750 tests pass, zero failures
- [x] All doc-tests compile and pass
- [x] Zero remaining references to `Event::from_value` or `.as_value()` in `.rs` files