### PR TITLE
feat: Phase 3 - input format adapters and --input-format CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,12 +332,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -451,7 +488,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -493,6 +530,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -636,7 +674,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -678,6 +716,18 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -725,7 +775,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -784,6 +834,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +937,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "evtx"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775d27b3ad8889149c6b72e6101347a11b935b82049c40dd08fac06e777542c6"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "byteorder",
+ "clap",
+ "crc32fast",
+ "dialoguer",
+ "encoding",
+ "glob",
+ "goblin",
+ "indoc",
+ "jiff",
+ "log",
+ "rayon",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "skeptic",
+ "sonic-rs",
+ "tempfile",
+ "thiserror 2.0.18",
+ "utf16-simd",
+ "winstructs",
+ "zmij",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +1006,18 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "faststr"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
+dependencies = [
+ "bytes",
+ "rkyv",
+ "serde",
+ "simdutf8",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -989,7 +1157,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1070,6 +1238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1254,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "goblin"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983a6aafb3b12d4c41ea78d39e189af4298ce747353945ff5105b54a056e5cd9"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -1426,6 +1611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,10 +1749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1569,7 +1765,22 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -1613,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1831,6 +2042,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "nkeys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +2090,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1958,6 +2198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2101,7 +2361,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2131,7 +2391,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2155,6 +2415,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2260,7 +2526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2306,6 +2572,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2628,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -2457,7 +2763,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2503,6 +2809,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 
 [[package]]
 name = "reqwest"
@@ -2555,6 +2867,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytes",
+ "hashbrown 0.17.0",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2649,9 +2990,12 @@ version = "0.6.0"
 dependencies = [
  "arc-swap",
  "async-nats",
+ "chrono",
+ "evtx",
  "rsigma-eval",
  "rsigma-parser",
  "serde_json",
+ "syslog_loose",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2820,6 +3164,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3217,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2881,7 +3249,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2905,7 +3273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b992cea3194eea663ba99a042d61cea4bd1872da37021af56f6a37e0359b9d33"
 dependencies = [
  "inventory",
- "nom",
+ "nom 7.1.3",
  "regex",
  "serde",
  "serde_json",
@@ -2945,7 +3313,7 @@ checksum = "aafbefbe175fa9bf03ca83ef89beecff7d2a95aaacd5732325b90ac8c3bd7b90"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2976,7 +3344,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3025,6 +3393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,10 +3443,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
 
 [[package]]
 name = "slab"
@@ -3094,6 +3500,45 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sonic-number"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "sonic-rs"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
+dependencies = [
+ "ahash",
+ "bumpalo",
+ "bytes",
+ "cfg-if",
+ "faststr",
+ "itoa",
+ "ref-cast",
+ "serde",
+ "simdutf8",
+ "sonic-number",
+ "sonic-simd",
+ "thiserror 2.0.18",
+ "zmij",
+]
+
+[[package]]
+name = "sonic-simd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3143,6 +3588,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3169,7 +3625,17 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "syslog_loose"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ddbead3f86a91bd8c9b559ce0c5b0cbf03e774ffb7f8511eaf78375cc4a7837"
+dependencies = [
+ "chrono",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -3183,6 +3649,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3223,7 +3698,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3234,7 +3709,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3254,7 +3729,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -3298,6 +3775,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,7 +3814,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3466,7 +3958,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3595,6 +4087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3605,6 +4103,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3666,6 +4170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf16-simd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58ccaaacb51ac3f769e61e1494a3856a0ef2e6749e19f5367a9e846f8c21168"
+dependencies = [
+ "sonic-rs",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +4195,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "uuid-simd"
@@ -3811,7 +4334,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3925,7 +4448,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3936,7 +4459,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4186,6 +4709,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winstructs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc7406cd936173d9cc3a4fd5dc5b295bc59612439d72038e3d7ac4e5dd42de9"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "chrono",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,7 +4755,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4231,7 +4771,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4329,7 +4869,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4350,7 +4890,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4370,7 +4910,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4410,7 +4950,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -13,6 +13,9 @@ homepage.workspace = true
 default = ["daemon"]
 daemon = ["rsigma-runtime", "tokio", "axum", "prometheus", "notify", "rusqlite"]
 daemon-nats = ["daemon", "rsigma-runtime/nats", "async-nats", "tokio-stream"]
+logfmt = ["rsigma-runtime/logfmt"]
+cef = ["rsigma-runtime/cef"]
+evtx = ["rsigma-runtime/evtx"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -10,7 +10,8 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
 use rsigma_runtime::{
-    FileSink, LogProcessor, MetricsHook, RuntimeEngine, Sink, StdinSource, StdoutSink, spawn_source,
+    FileSink, InputFormat, LogProcessor, MetricsHook, RuntimeEngine, Sink, StdinSource, StdoutSink,
+    spawn_source,
 };
 use serde::Serialize;
 use tokio::sync::mpsc;
@@ -48,6 +49,7 @@ pub struct DaemonConfig {
     pub buffer_size: usize,
     pub batch_size: usize,
     pub drain_timeout: u64,
+    pub input_format: InputFormat,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
@@ -289,8 +291,9 @@ pub async fn run_daemon(config: DaemonConfig) {
     let engine_metrics = metrics.clone();
     let event_filter = config.event_filter.clone();
     let batch_size = config.batch_size;
+    let input_format = config.input_format.clone();
     let mut engine_handle = tokio::spawn(async move {
-        let filter_fn = |v: &serde_json::Value| crate::apply_event_filter(v, &event_filter);
+        let filter_fn = move |v: &serde_json::Value| crate::apply_event_filter(v, &event_filter);
         loop {
             let pipeline_start = std::time::Instant::now();
 
@@ -314,7 +317,7 @@ pub async fn run_daemon(config: DaemonConfig) {
             engine_metrics.observe_batch_size(batch.len() as u64);
 
             let results: Vec<ProcessResult> =
-                engine_processor.process_batch_lines(&batch, &filter_fn);
+                engine_processor.process_batch_with_format(&batch, &input_format, Some(&filter_fn));
 
             let mut shutdown = false;
             for result in results {

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -203,6 +203,18 @@ enum Commands {
         /// Seconds to wait for in-flight events to drain on shutdown (default: 5).
         #[arg(long = "drain-timeout", default_value = "5")]
         drain_timeout: u64,
+
+        /// Input log format for event parsing.
+        /// auto: try JSON → syslog → plain (default).
+        /// Explicit: json, syslog, plain, logfmt (requires logfmt feature),
+        /// cef (requires cef feature).
+        #[arg(long = "input-format", default_value = "auto")]
+        input_format: String,
+
+        /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
+        /// Only used when --input-format is syslog or auto. Defaults to UTC.
+        #[arg(long = "syslog-tz", default_value = "+00:00")]
+        syslog_tz: String,
     },
 
     /// Evaluate events against Sigma rules
@@ -280,6 +292,18 @@ enum Commands {
         /// Equivalent to the `rsigma.timestamp_field` custom attribute.
         #[arg(long = "timestamp-field")]
         timestamp_fields: Vec<String>,
+
+        /// Input log format for event parsing.
+        /// auto: try JSON → syslog → plain (default).
+        /// Explicit: json, syslog, plain, logfmt (requires logfmt feature),
+        /// cef (requires cef feature).
+        #[arg(long = "input-format", default_value = "auto")]
+        input_format: String,
+
+        /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
+        /// Only used when --input-format is syslog or auto. Defaults to UTC.
+        #[arg(long = "syslog-tz", default_value = "+00:00")]
+        syslog_tz: String,
     },
 }
 
@@ -309,6 +333,8 @@ fn main() {
             buffer_size,
             batch_size,
             drain_timeout,
+            input_format,
+            syslog_tz,
         } => cmd_daemon(
             rules,
             pipelines,
@@ -330,6 +356,8 @@ fn main() {
             buffer_size,
             batch_size,
             drain_timeout,
+            input_format,
+            syslog_tz,
         ),
         Commands::Parse { path, pretty } => cmd_parse(path, pretty),
         Commands::Validate {
@@ -372,6 +400,8 @@ fn main() {
             correlation_event_mode,
             max_correlation_events,
             timestamp_fields,
+            input_format,
+            syslog_tz,
         } => cmd_eval(
             rules,
             event,
@@ -386,6 +416,8 @@ fn main() {
             correlation_event_mode,
             max_correlation_events,
             timestamp_fields,
+            input_format,
+            syslog_tz,
         ),
     }
 }
@@ -417,6 +449,8 @@ fn cmd_daemon(
     buffer_size: usize,
     batch_size: usize,
     drain_timeout: u64,
+    input_format: String,
+    syslog_tz: String,
 ) {
     // Set up structured logging
     tracing_subscriber::fmt()
@@ -430,6 +464,7 @@ fn cmd_daemon(
 
     let pipelines = load_pipelines(&pipeline_paths);
     let event_filter = std::sync::Arc::new(build_event_filter(jq, jsonpath));
+    let parsed_input_format = parse_input_format(&input_format, &syslog_tz);
 
     let corr_config = build_correlation_config(
         suppress,
@@ -460,6 +495,7 @@ fn cmd_daemon(
         buffer_size,
         batch_size,
         drain_timeout,
+        input_format: parsed_input_format,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -1046,6 +1082,8 @@ fn cmd_eval(
     correlation_event_mode: String,
     max_correlation_events: usize,
     timestamp_fields: Vec<String>,
+    input_format: String,
+    syslog_tz: String,
 ) {
     let collection = load_collection(&rules_path);
     let pipelines = load_pipelines(&pipeline_paths);
@@ -1077,6 +1115,8 @@ fn cmd_eval(
             &event_filter,
             corr_config,
             include_event,
+            &input_format,
+            &syslog_tz,
         );
     } else {
         cmd_eval_detection_only(
@@ -1087,6 +1127,8 @@ fn cmd_eval(
             &pipelines,
             &event_filter,
             include_event,
+            &input_format,
+            &syslog_tz,
         );
     }
 }
@@ -1102,6 +1144,8 @@ fn cmd_eval_with_correlations(
     event_filter: &EventFilter,
     config: CorrelationConfig,
     include_event: bool,
+    input_format_str: &str,
+    syslog_tz_str: &str,
 ) {
     let mut engine = CorrelationEngine::new(config);
     engine.set_include_event(include_event);
@@ -1153,16 +1197,28 @@ fn cmd_eval_with_correlations(
                 process::exit(1);
             });
             let reader = BufReader::new(file);
-            let (det_count, corr_count, line_num) =
-                eval_ndjson_corr(&mut engine, reader, event_filter, pretty);
+            let (det_count, corr_count, line_num) = eval_stream_corr(
+                &mut engine,
+                reader,
+                event_filter,
+                pretty,
+                input_format_str,
+                syslog_tz_str,
+            );
             eprintln!(
                 "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
             );
         }
         EventSource::Stdin => {
             let stdin = io::stdin();
-            let (det_count, corr_count, line_num) =
-                eval_ndjson_corr(&mut engine, stdin.lock(), event_filter, pretty);
+            let (det_count, corr_count, line_num) = eval_stream_corr(
+                &mut engine,
+                stdin.lock(),
+                event_filter,
+                pretty,
+                input_format_str,
+                syslog_tz_str,
+            );
             eprintln!(
                 "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
             );
@@ -1170,16 +1226,25 @@ fn cmd_eval_with_correlations(
     }
 }
 
-/// Stream NDJSON through the correlation engine. Returns (det_count, corr_count, line_count).
-fn eval_ndjson_corr(
+/// Stream lines through the correlation engine with format-aware parsing.
+/// Returns (det_count, corr_count, line_count).
+#[allow(clippy::too_many_arguments)]
+fn eval_stream_corr(
     engine: &mut CorrelationEngine,
     reader: impl BufRead,
     event_filter: &EventFilter,
     pretty: bool,
+    input_format_str: &str,
+    syslog_tz_str: &str,
 ) -> (u64, u64, u64) {
     let mut line_num = 0u64;
     let mut det_count = 0u64;
     let mut corr_count = 0u64;
+
+    #[cfg(feature = "daemon")]
+    let format = parse_input_format(input_format_str, syslog_tz_str);
+    #[cfg(not(feature = "daemon"))]
+    let _ = (input_format_str, syslog_tz_str);
 
     for line in reader.lines() {
         line_num += 1;
@@ -1195,33 +1260,113 @@ fn eval_ndjson_corr(
             continue;
         }
 
-        let value: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("Invalid JSON on line {line_num}: {e}");
-                continue;
-            }
-        };
-
-        for payload in apply_event_filter(&value, event_filter) {
-            let event = JsonEvent::borrow(&payload);
-            let result = engine.process_event(&event);
-
-            for m in &result.detections {
-                det_count += 1;
-                print_json(m, pretty);
-            }
-            for m in &result.correlations {
-                corr_count += 1;
-                print_json(m, pretty);
-            }
+        // Format-aware parsing: use rsigma-runtime's input adapters when available.
+        #[cfg(feature = "daemon")]
+        {
+            eval_line_corr(
+                engine,
+                &line,
+                &format,
+                event_filter,
+                pretty,
+                &mut det_count,
+                &mut corr_count,
+            );
+        }
+        #[cfg(not(feature = "daemon"))]
+        {
+            eval_line_corr_json(
+                engine,
+                &line,
+                event_filter,
+                pretty,
+                &mut det_count,
+                &mut corr_count,
+            );
         }
     }
 
     (det_count, corr_count, line_num)
 }
 
+/// Evaluate a single line through the correlation engine using format-aware parsing.
+#[cfg(feature = "daemon")]
+fn eval_line_corr(
+    engine: &mut CorrelationEngine,
+    line: &str,
+    format: &rsigma_runtime::InputFormat,
+    event_filter: &EventFilter,
+    pretty: bool,
+    det_count: &mut u64,
+    corr_count: &mut u64,
+) {
+    use rsigma_eval::Event;
+
+    if let Some(decoded) = rsigma_runtime::parse_line(line, format) {
+        // For JSON events, apply the event filter (which may produce multiple payloads).
+        if matches!(decoded, rsigma_runtime::EventInputDecoded::Json(_)) {
+            let json_value = decoded.to_json();
+            for payload in apply_event_filter(&json_value, event_filter) {
+                let event = JsonEvent::borrow(&payload);
+                let result = engine.process_event(&event);
+                for m in &result.detections {
+                    *det_count += 1;
+                    print_json(m, pretty);
+                }
+                for m in &result.correlations {
+                    *corr_count += 1;
+                    print_json(m, pretty);
+                }
+            }
+        } else {
+            // Non-JSON events: evaluate directly (no event filter).
+            let result = engine.process_event(&decoded);
+            for m in &result.detections {
+                *det_count += 1;
+                print_json(m, pretty);
+            }
+            for m in &result.correlations {
+                *corr_count += 1;
+                print_json(m, pretty);
+            }
+        }
+    }
+}
+
+/// Evaluate a single line through the correlation engine (JSON-only fallback).
+#[cfg(not(feature = "daemon"))]
+fn eval_line_corr_json(
+    engine: &mut CorrelationEngine,
+    line: &str,
+    event_filter: &EventFilter,
+    pretty: bool,
+    det_count: &mut u64,
+    corr_count: &mut u64,
+) {
+    let value: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Invalid JSON: {e}");
+            return;
+        }
+    };
+
+    for payload in apply_event_filter(&value, event_filter) {
+        let event = JsonEvent::borrow(&payload);
+        let result = engine.process_event(&event);
+        for m in &result.detections {
+            *det_count += 1;
+            print_json(m, pretty);
+        }
+        for m in &result.correlations {
+            *corr_count += 1;
+            print_json(m, pretty);
+        }
+    }
+}
+
 /// Evaluation without correlations (stateless, original behavior).
+#[allow(clippy::too_many_arguments)]
 fn cmd_eval_detection_only(
     collection: SigmaCollection,
     rules_path: &std::path::Path,
@@ -1230,6 +1375,8 @@ fn cmd_eval_detection_only(
     pipelines: &[Pipeline],
     event_filter: &EventFilter,
     include_event: bool,
+    input_format_str: &str,
+    syslog_tz_str: &str,
 ) {
     let mut engine = Engine::new();
     engine.set_include_event(include_event);
@@ -1281,27 +1428,49 @@ fn cmd_eval_detection_only(
                 process::exit(1);
             });
             let reader = BufReader::new(file);
-            let (match_count, line_num) = eval_ndjson_detect(&engine, reader, event_filter, pretty);
+            let (match_count, line_num) = eval_stream_detect(
+                &engine,
+                reader,
+                event_filter,
+                pretty,
+                input_format_str,
+                syslog_tz_str,
+            );
             eprintln!("Processed {line_num} events, {match_count} matches.");
         }
         EventSource::Stdin => {
             let stdin = io::stdin();
-            let (match_count, line_num) =
-                eval_ndjson_detect(&engine, stdin.lock(), event_filter, pretty);
+            let (match_count, line_num) = eval_stream_detect(
+                &engine,
+                stdin.lock(),
+                event_filter,
+                pretty,
+                input_format_str,
+                syslog_tz_str,
+            );
             eprintln!("Processed {line_num} events, {match_count} matches.");
         }
     }
 }
 
-/// Stream NDJSON through the detection engine. Returns (match_count, line_count).
-fn eval_ndjson_detect(
+/// Stream lines through the detection engine with format-aware parsing.
+/// Returns (match_count, line_count).
+#[allow(clippy::too_many_arguments)]
+fn eval_stream_detect(
     engine: &Engine,
     reader: impl BufRead,
     event_filter: &EventFilter,
     pretty: bool,
+    input_format_str: &str,
+    syslog_tz_str: &str,
 ) -> (u64, u64) {
     let mut line_num = 0u64;
     let mut match_count = 0u64;
+
+    #[cfg(feature = "daemon")]
+    let format = parse_input_format(input_format_str, syslog_tz_str);
+    #[cfg(not(feature = "daemon"))]
+    let _ = (input_format_str, syslog_tz_str);
 
     for line in reader.lines() {
         line_num += 1;
@@ -1317,26 +1486,81 @@ fn eval_ndjson_detect(
             continue;
         }
 
-        let value: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("Invalid JSON on line {line_num}: {e}");
-                continue;
-            }
-        };
-
-        for payload in apply_event_filter(&value, event_filter) {
-            let event = JsonEvent::borrow(&payload);
-            let matches = engine.evaluate(&event);
-
-            for m in &matches {
-                match_count += 1;
-                print_json(m, pretty);
-            }
+        #[cfg(feature = "daemon")]
+        {
+            eval_line_detect(
+                engine,
+                &line,
+                &format,
+                event_filter,
+                pretty,
+                &mut match_count,
+            );
+        }
+        #[cfg(not(feature = "daemon"))]
+        {
+            eval_line_detect_json(engine, &line, event_filter, pretty, &mut match_count);
         }
     }
 
     (match_count, line_num)
+}
+
+/// Evaluate a single line through the detection engine using format-aware parsing.
+#[cfg(feature = "daemon")]
+fn eval_line_detect(
+    engine: &Engine,
+    line: &str,
+    format: &rsigma_runtime::InputFormat,
+    event_filter: &EventFilter,
+    pretty: bool,
+    match_count: &mut u64,
+) {
+    use rsigma_eval::Event;
+
+    if let Some(decoded) = rsigma_runtime::parse_line(line, format) {
+        if matches!(decoded, rsigma_runtime::EventInputDecoded::Json(_)) {
+            let json_value = decoded.to_json();
+            for payload in apply_event_filter(&json_value, event_filter) {
+                let event = JsonEvent::borrow(&payload);
+                for m in &engine.evaluate(&event) {
+                    *match_count += 1;
+                    print_json(m, pretty);
+                }
+            }
+        } else {
+            for m in &engine.evaluate(&decoded) {
+                *match_count += 1;
+                print_json(m, pretty);
+            }
+        }
+    }
+}
+
+/// Evaluate a single line through the detection engine (JSON-only fallback).
+#[cfg(not(feature = "daemon"))]
+fn eval_line_detect_json(
+    engine: &Engine,
+    line: &str,
+    event_filter: &EventFilter,
+    pretty: bool,
+    match_count: &mut u64,
+) {
+    let value: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Invalid JSON: {e}");
+            return;
+        }
+    };
+
+    for payload in apply_event_filter(&value, event_filter) {
+        let event = JsonEvent::borrow(&payload);
+        for m in &engine.evaluate(&event) {
+            *match_count += 1;
+            print_json(m, pretty);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1447,6 +1671,75 @@ fn print_warnings(errors: &[String]) {
             eprintln!("  - {err}");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Input format parsing
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daemon")]
+fn parse_input_format(format_str: &str, syslog_tz: &str) -> rsigma_runtime::InputFormat {
+    use rsigma_runtime::InputFormat;
+    use rsigma_runtime::input::SyslogConfig;
+
+    let tz_secs = parse_tz_offset(syslog_tz);
+
+    match format_str {
+        "auto" => InputFormat::Auto,
+        "json" => InputFormat::Json,
+        "syslog" => InputFormat::Syslog(SyslogConfig {
+            default_tz_offset_secs: tz_secs,
+        }),
+        "plain" => InputFormat::Plain,
+        #[cfg(feature = "logfmt")]
+        "logfmt" => InputFormat::Logfmt,
+        #[cfg(feature = "cef")]
+        "cef" => InputFormat::Cef,
+        other => {
+            eprintln!("Unknown input format: '{other}'");
+            eprintln!("Supported formats: auto, json, syslog, plain");
+            #[cfg(feature = "logfmt")]
+            eprintln!("  (with logfmt feature): logfmt");
+            #[cfg(feature = "cef")]
+            eprintln!("  (with cef feature): cef");
+            process::exit(1);
+        }
+    }
+}
+
+/// Parse a timezone offset string like "+05:00" or "-08:00" into seconds east of UTC.
+#[cfg(feature = "daemon")]
+fn parse_tz_offset(s: &str) -> i32 {
+    let s = s.trim();
+    if s == "UTC" || s == "utc" || s == "Z" || s == "+00:00" {
+        return 0;
+    }
+
+    let (sign, rest) = if let Some(rest) = s.strip_prefix('+') {
+        (1i32, rest)
+    } else if let Some(rest) = s.strip_prefix('-') {
+        (-1i32, rest)
+    } else {
+        eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
+        process::exit(1);
+    };
+
+    let parts: Vec<&str> = rest.split(':').collect();
+    if parts.len() != 2 {
+        eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
+        process::exit(1);
+    }
+
+    let hours: i32 = parts[0].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid timezone offset hours: '{}'", parts[0]);
+        process::exit(1);
+    });
+    let minutes: i32 = parts[1].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid timezone offset minutes: '{}'", parts[1]);
+        process::exit(1);
+    });
+
+    sign * (hours * 3600 + minutes * 60)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -114,7 +114,7 @@ pub use correlation_engine::{
 };
 pub use engine::Engine;
 pub use error::{EvalError, Result};
-pub use event::{Event, JsonEvent};
+pub use event::{Event, EventValue, JsonEvent, KvEvent, MapEvent, PlainEvent};
 pub use matcher::CompiledMatcher;
 pub use pipeline::{
     Pipeline, apply_pipelines, merge_pipelines, parse_pipeline, parse_pipeline_file,

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 [features]
 default = []
 nats = ["async-nats", "tokio-stream"]
+logfmt = []
+cef = []
+evtx = ["dep:evtx"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
@@ -21,10 +24,13 @@ serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
 arc-swap = "1"
+syslog_loose = "0.23"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 # optional
 tokio-stream = { version = "0.1", optional = true }
 async-nats = { version = "0.47", optional = true }
+evtx = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/rsigma-runtime/src/input/auto.rs
+++ b/crates/rsigma-runtime/src/input/auto.rs
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn mixed_format_batch() {
-        let lines = vec![
+        let lines = [
             r#"{"EventID": 1}"#,
             "<34>Oct 11 22:14:15 host su: test",
             "plain log line",

--- a/crates/rsigma-runtime/src/input/auto.rs
+++ b/crates/rsigma-runtime/src/input/auto.rs
@@ -1,0 +1,111 @@
+//! Auto-detection input adapter.
+//!
+//! Attempts formats in order:
+//! 1. JSON — if `serde_json::from_str` succeeds → [`JsonEvent`]
+//! 2. Syslog — if [`syslog_loose`] extracts meaningful fields → [`KvEvent`]
+//! 3. Plain text — fallback → [`PlainEvent`]
+//!
+//! Auto-detection is per-line, so mixed-format input works.
+//! logfmt and CEF are **not** part of auto-detect because their syntax is
+//! too ambiguous for reliable detection (any line with `=` could be logfmt).
+
+use super::{EventInputDecoded, SyslogConfig, parse_json, parse_plain, parse_syslog};
+
+/// Auto-detect the format of a single line and parse it.
+pub fn auto_detect(line: &str) -> EventInputDecoded {
+    // 1. Try JSON first (fast: just check if it starts with '{' or '[').
+    let trimmed = line.trim_start();
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && let Some(decoded) = parse_json(line)
+    {
+        return decoded;
+    }
+
+    // 2. Try syslog: if the line starts with '<' (priority), it's likely syslog.
+    if trimmed.starts_with('<') {
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        // Check if syslog extracted meaningful fields (not just _raw).
+        if has_syslog_fields(&decoded) {
+            return decoded;
+        }
+    }
+
+    // 3. Fall back to plain text.
+    parse_plain(line)
+}
+
+/// Check if the syslog adapter extracted meaningful structured fields
+/// beyond just `_raw`.
+fn has_syslog_fields(decoded: &EventInputDecoded) -> bool {
+    match decoded {
+        EventInputDecoded::Kv(kv) => kv.fields().iter().any(|(k, _)| k != "_raw"),
+        // If it produced a JsonEvent (embedded JSON), that's meaningful.
+        EventInputDecoded::Json(_) => true,
+        EventInputDecoded::Plain(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::Event;
+
+    #[test]
+    fn auto_detect_json() {
+        let decoded = auto_detect(r#"{"EventID": 1, "host": "web01"}"#);
+        assert!(matches!(decoded, EventInputDecoded::Json(_)));
+        assert!(decoded.get_field("EventID").is_some());
+    }
+
+    #[test]
+    fn auto_detect_syslog() {
+        let decoded = auto_detect("<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick");
+        // Should detect as syslog, not plain.
+        assert!(
+            matches!(
+                decoded,
+                EventInputDecoded::Kv(_) | EventInputDecoded::Json(_)
+            ),
+            "Expected Kv or Json for syslog, got Plain"
+        );
+    }
+
+    #[test]
+    fn auto_detect_plain() {
+        let decoded = auto_detect("ERROR: something went wrong on server");
+        assert!(matches!(decoded, EventInputDecoded::Plain(_)));
+    }
+
+    #[test]
+    fn auto_detect_syslog_wrapped_json() {
+        let decoded = auto_detect(r#"<134>1 2024-01-15T10:30:00Z host app - - - {"key": "value"}"#);
+        // Should extract the embedded JSON.
+        assert!(
+            matches!(decoded, EventInputDecoded::Json(_)),
+            "Expected embedded JSON to be extracted"
+        );
+    }
+
+    #[test]
+    fn auto_detect_invalid_json_falls_through() {
+        let decoded = auto_detect("{not valid json}");
+        // Doesn't start with '<' so not syslog either → plain.
+        assert!(matches!(decoded, EventInputDecoded::Plain(_)));
+    }
+
+    #[test]
+    fn mixed_format_batch() {
+        let lines = vec![
+            r#"{"EventID": 1}"#,
+            "<34>Oct 11 22:14:15 host su: test",
+            "plain log line",
+        ];
+        let results: Vec<_> = lines.iter().map(|l| auto_detect(l)).collect();
+        assert!(matches!(results[0], EventInputDecoded::Json(_)));
+        assert!(matches!(
+            results[1],
+            EventInputDecoded::Kv(_) | EventInputDecoded::Json(_)
+        ));
+        assert!(matches!(results[2], EventInputDecoded::Plain(_)));
+    }
+}

--- a/crates/rsigma-runtime/src/input/cef.rs
+++ b/crates/rsigma-runtime/src/input/cef.rs
@@ -1,0 +1,67 @@
+//! CEF (Common Event Format) input adapter (behind `cef` feature).
+//!
+//! Wraps the hand-rolled [`crate::parse::cef`] parser. CEF header fields and
+//! extension key-value pairs are merged into a single [`KvEvent`].
+//!
+//! ## CEF-over-syslog
+//!
+//! If the input line contains a syslog prefix before the `CEF:` marker,
+//! [`crate::parse::cef::find_cef_start`] locates the CEF portion and only
+//! that part is parsed. The syslog envelope is discarded (use the syslog
+//! adapter if you need the envelope fields too).
+
+use rsigma_eval::KvEvent;
+
+use super::EventInputDecoded;
+
+/// Parse a CEF line into a KvEvent. Returns `None` if the line is not valid CEF.
+pub fn parse_cef(line: &str) -> Option<EventInputDecoded> {
+    // Handle CEF-over-syslog: find where CEF: starts.
+    let cef_input = match crate::parse::cef::find_cef_start(line) {
+        Some(offset) => &line[offset..],
+        None => return None,
+    };
+
+    let record = crate::parse::cef::parse(cef_input).ok()?;
+
+    let mut fields = Vec::with_capacity(7 + record.extensions.len());
+    fields.push(("cef_version".to_string(), record.version.to_string()));
+    fields.push(("deviceVendor".to_string(), record.device_vendor));
+    fields.push(("deviceProduct".to_string(), record.device_product));
+    fields.push(("deviceVersion".to_string(), record.device_version));
+    fields.push(("signatureId".to_string(), record.signature_id));
+    fields.push(("name".to_string(), record.name));
+    fields.push(("severity".to_string(), record.severity));
+    fields.extend(record.extensions);
+
+    Some(EventInputDecoded::Kv(KvEvent::new(fields)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::Event;
+
+    #[test]
+    fn basic_cef() {
+        let line = "CEF:0|Security|IDS|1.0|100|Attack|9|src=10.0.0.1 dst=192.168.1.1";
+        let decoded = parse_cef(line).unwrap();
+        assert!(decoded.get_field("deviceVendor").is_some());
+        assert!(decoded.get_field("src").is_some());
+        assert!(decoded.get_field("dst").is_some());
+    }
+
+    #[test]
+    fn cef_over_syslog() {
+        let line =
+            "<134>Feb 14 19:04:54 fw01 CEF:0|Palo Alto|PAN-OS|10|THREAT|threat|7|src=10.0.0.1";
+        let decoded = parse_cef(line).unwrap();
+        assert!(decoded.get_field("deviceVendor").is_some());
+        assert!(decoded.get_field("src").is_some());
+    }
+
+    #[test]
+    fn not_cef_returns_none() {
+        assert!(parse_cef("just a regular log line").is_none());
+    }
+}

--- a/crates/rsigma-runtime/src/input/json.rs
+++ b/crates/rsigma-runtime/src/input/json.rs
@@ -1,0 +1,45 @@
+//! JSON / NDJSON / GELF input adapter.
+//!
+//! GELF is just JSON with conventions (`version`, `host`, `short_message`,
+//! underscore-prefixed custom fields) — no special parser needed.
+
+use rsigma_eval::JsonEvent;
+
+use super::EventInputDecoded;
+
+/// Parse a line as JSON. Returns `None` on parse failure.
+pub fn parse_json(line: &str) -> Option<EventInputDecoded> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    Some(EventInputDecoded::Json(JsonEvent::owned(value)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::Event;
+
+    #[test]
+    fn valid_json_object() {
+        let decoded = parse_json(r#"{"EventID": 1, "host": "web01"}"#).unwrap();
+        assert!(decoded.get_field("EventID").is_some());
+        assert!(decoded.get_field("host").is_some());
+    }
+
+    #[test]
+    fn invalid_json_returns_none() {
+        assert!(parse_json("not json").is_none());
+    }
+
+    #[test]
+    fn gelf_message() {
+        let gelf = r#"{"version":"1.1","host":"example.org","short_message":"A short message","_user_id":"9001"}"#;
+        let decoded = parse_json(gelf).unwrap();
+        assert!(decoded.get_field("version").is_some());
+        assert!(decoded.get_field("_user_id").is_some());
+    }
+
+    #[test]
+    fn empty_string_returns_none() {
+        assert!(parse_json("").is_none());
+    }
+}

--- a/crates/rsigma-runtime/src/input/logfmt.rs
+++ b/crates/rsigma-runtime/src/input/logfmt.rs
@@ -1,0 +1,34 @@
+//! logfmt input adapter (behind `logfmt` feature).
+//!
+//! Wraps the hand-rolled [`crate::parse::logfmt`] parser and returns a
+//! [`KvEvent`].
+
+use rsigma_eval::KvEvent;
+
+use super::EventInputDecoded;
+
+/// Parse a logfmt line into a KvEvent.
+pub fn parse_logfmt(line: &str) -> EventInputDecoded {
+    let pairs = crate::parse::logfmt::parse(line);
+    EventInputDecoded::Kv(KvEvent::new(pairs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::Event;
+
+    #[test]
+    fn basic_logfmt() {
+        let decoded = parse_logfmt("level=info msg=hello duration=12ms");
+        assert!(decoded.get_field("level").is_some());
+        assert!(decoded.get_field("msg").is_some());
+        assert!(decoded.get_field("duration").is_some());
+    }
+
+    #[test]
+    fn quoted_values() {
+        let decoded = parse_logfmt(r#"level=error msg="disk full" host=web01"#);
+        assert!(decoded.any_string_value(&|s| s.contains("disk full")));
+    }
+}

--- a/crates/rsigma-runtime/src/input/mod.rs
+++ b/crates/rsigma-runtime/src/input/mod.rs
@@ -1,0 +1,115 @@
+//! Input format adapters for the rsigma runtime.
+//!
+//! Each adapter parses a raw log line into a typed [`EventInputDecoded`] that
+//! implements [`rsigma_eval::Event`]. The [`InputFormat`] enum selects which
+//! adapter to use, and [`parse_line`] is the main dispatch function.
+//!
+//! Always-on formats: JSON/GELF, syslog (RFC 3164/5424), plain text, auto-detect.
+//! Feature-gated formats: logfmt (`logfmt`), CEF (`cef`), EVTX (`evtx`).
+
+use std::borrow::Cow;
+
+use rsigma_eval::{Event, EventValue, JsonEvent, KvEvent, PlainEvent};
+use serde_json::Value;
+
+mod auto;
+#[cfg(feature = "cef")]
+mod cef;
+mod json;
+#[cfg(feature = "logfmt")]
+mod logfmt;
+mod plain;
+mod syslog;
+
+#[cfg(feature = "cef")]
+pub use self::cef::parse_cef;
+pub use self::json::parse_json;
+#[cfg(feature = "logfmt")]
+pub use self::logfmt::parse_logfmt;
+pub use self::syslog::{SyslogConfig, parse_syslog};
+pub use auto::auto_detect;
+pub use plain::parse_plain;
+
+/// Selects which input format adapter to use for raw log lines.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum InputFormat {
+    /// Try JSON → syslog → plain (default).
+    #[default]
+    Auto,
+    /// NDJSON / GELF.
+    Json,
+    /// Syslog RFC 3164 / 5424.
+    Syslog(SyslogConfig),
+    /// Raw text (keyword matching only).
+    Plain,
+    /// logfmt `key=value` pairs (requires `logfmt` feature).
+    #[cfg(feature = "logfmt")]
+    Logfmt,
+    /// ArcSight Common Event Format (requires `cef` feature).
+    #[cfg(feature = "cef")]
+    Cef,
+}
+
+/// A decoded event ready for Sigma rule evaluation.
+///
+/// Static dispatch enum — avoids `Box<dyn Event>` on the hot path while
+/// supporting all input formats through a single type.
+#[derive(Debug)]
+pub enum EventInputDecoded {
+    Json(JsonEvent<'static>),
+    Kv(KvEvent),
+    Plain(PlainEvent),
+}
+
+impl Event for EventInputDecoded {
+    fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
+        match self {
+            EventInputDecoded::Json(e) => e.get_field(path),
+            EventInputDecoded::Kv(e) => e.get_field(path),
+            EventInputDecoded::Plain(e) => e.get_field(path),
+        }
+    }
+
+    fn any_string_value(&self, pred: &dyn Fn(&str) -> bool) -> bool {
+        match self {
+            EventInputDecoded::Json(e) => e.any_string_value(pred),
+            EventInputDecoded::Kv(e) => e.any_string_value(pred),
+            EventInputDecoded::Plain(e) => e.any_string_value(pred),
+        }
+    }
+
+    fn all_string_values(&self) -> Vec<Cow<'_, str>> {
+        match self {
+            EventInputDecoded::Json(e) => e.all_string_values(),
+            EventInputDecoded::Kv(e) => e.all_string_values(),
+            EventInputDecoded::Plain(e) => e.all_string_values(),
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        match self {
+            EventInputDecoded::Json(e) => e.to_json(),
+            EventInputDecoded::Kv(e) => e.to_json(),
+            EventInputDecoded::Plain(e) => e.to_json(),
+        }
+    }
+}
+
+/// Parse a raw log line using the specified format.
+///
+/// Returns `None` if the line is empty or whitespace-only.
+pub fn parse_line(line: &str, format: &InputFormat) -> Option<EventInputDecoded> {
+    if line.trim().is_empty() {
+        return None;
+    }
+    Some(match format {
+        InputFormat::Auto => auto_detect(line),
+        InputFormat::Json => parse_json(line)?,
+        InputFormat::Syslog(config) => parse_syslog(line, config),
+        InputFormat::Plain => parse_plain(line),
+        #[cfg(feature = "logfmt")]
+        InputFormat::Logfmt => parse_logfmt(line),
+        #[cfg(feature = "cef")]
+        InputFormat::Cef => parse_cef(line)?,
+    })
+}

--- a/crates/rsigma-runtime/src/input/plain.rs
+++ b/crates/rsigma-runtime/src/input/plain.rs
@@ -1,0 +1,31 @@
+//! Plain text input adapter.
+//!
+//! One event per line. Only keyword matching works against plain events
+//! (`get_field` always returns `None`).
+
+use rsigma_eval::PlainEvent;
+
+use super::EventInputDecoded;
+
+/// Wrap a raw line as a plain text event.
+pub fn parse_plain(line: &str) -> EventInputDecoded {
+    EventInputDecoded::Plain(PlainEvent::new(line.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::Event;
+
+    #[test]
+    fn plain_keyword_match() {
+        let decoded = parse_plain("ERROR: disk full on /dev/sda1");
+        assert!(decoded.any_string_value(&|s| s.contains("disk full")));
+    }
+
+    #[test]
+    fn plain_no_fields() {
+        let decoded = parse_plain("some log line");
+        assert!(decoded.get_field("anything").is_none());
+    }
+}

--- a/crates/rsigma-runtime/src/input/syslog.rs
+++ b/crates/rsigma-runtime/src/input/syslog.rs
@@ -1,0 +1,200 @@
+//! Syslog RFC 3164 / 5424 input adapter.
+//!
+//! Wraps [`syslog_loose::parse_message`] and extracts structured data, header
+//! fields, and the message body into a [`KvEvent`].
+//!
+//! ## Edge cases handled
+//!
+//! - **Embedded JSON in msg**: if the `msg` field parses as a JSON object,
+//!   the adapter returns a `JsonEvent` with the syslog header fields merged in.
+//! - **Year resolution (RFC 3164)**: timestamps lack a year; defaults to
+//!   current year with December→January rollover logic.
+//! - **Timezone**: RFC 3164 may lack timezone info; configurable default (UTC).
+
+use rsigma_eval::{JsonEvent, KvEvent};
+use syslog_loose::Message;
+
+use super::EventInputDecoded;
+
+/// Configuration for the syslog adapter.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyslogConfig {
+    /// Default timezone offset in seconds east of UTC for RFC 3164 messages
+    /// that lack timezone information.
+    pub default_tz_offset_secs: i32,
+}
+
+/// Parse a syslog line into an event.
+///
+/// If the syslog `msg` body contains a valid JSON object, returns a
+/// `JsonEvent` with syslog headers merged in. Otherwise returns a `KvEvent`
+/// with syslog fields as key-value pairs.
+pub fn parse_syslog(line: &str, config: &SyslogConfig) -> EventInputDecoded {
+    let tz = chrono::FixedOffset::east_opt(config.default_tz_offset_secs)
+        .unwrap_or(chrono::FixedOffset::east_opt(0).unwrap());
+
+    let parsed = syslog_loose::parse_message_with_year_tz(
+        line,
+        resolve_year,
+        Some(tz),
+        syslog_loose::Variant::Either,
+    );
+
+    build_event_from_message(&parsed)
+}
+
+/// Build an EventInputDecoded from a parsed syslog message.
+fn build_event_from_message(parsed: &Message<&str>) -> EventInputDecoded {
+    let msg_str = parsed.msg.trim();
+
+    // Try to parse the message body as JSON.
+    if let Ok(mut json_obj) = serde_json::from_str::<serde_json::Value>(msg_str)
+        && let Some(obj) = json_obj.as_object_mut()
+    {
+        inject_syslog_headers(parsed, obj);
+        return EventInputDecoded::Json(JsonEvent::owned(serde_json::Value::Object(obj.clone())));
+    }
+
+    // Not JSON — build a KvEvent from syslog fields.
+    let mut fields = Vec::new();
+
+    if let Some(ts) = &parsed.timestamp {
+        fields.push(("timestamp".to_string(), ts.to_rfc3339()));
+    }
+    if let Some(host) = &parsed.hostname {
+        fields.push(("hostname".to_string(), host.to_string()));
+    }
+    if let Some(app) = &parsed.appname {
+        fields.push(("appname".to_string(), app.to_string()));
+    }
+    if let Some(pid) = &parsed.procid {
+        fields.push(("procid".to_string(), pid.to_string()));
+    }
+    if let Some(mid) = &parsed.msgid {
+        fields.push(("msgid".to_string(), mid.to_string()));
+    }
+    if let Some(facility) = &parsed.facility {
+        fields.push(("facility".to_string(), format!("{facility:?}")));
+    }
+    if let Some(severity) = &parsed.severity {
+        fields.push(("severity".to_string(), format!("{severity:?}")));
+    }
+
+    // Extract RFC 5424 structured data key-value pairs.
+    for elem in &parsed.structured_data {
+        for (key, val) in elem.params() {
+            let prefixed_key = format!("{}.{}", elem.id, key);
+            fields.push((prefixed_key, val));
+        }
+    }
+
+    if !msg_str.is_empty() {
+        fields.push(("_raw".to_string(), msg_str.to_string()));
+    }
+
+    EventInputDecoded::Kv(KvEvent::new(fields))
+}
+
+/// Inject syslog header fields into a JSON object (for embedded-JSON case).
+fn inject_syslog_headers(
+    parsed: &Message<&str>,
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+) {
+    if let Some(ts) = &parsed.timestamp {
+        obj.entry("syslog_timestamp")
+            .or_insert_with(|| serde_json::Value::String(ts.to_rfc3339()));
+    }
+    if let Some(host) = &parsed.hostname {
+        obj.entry("syslog_hostname")
+            .or_insert_with(|| serde_json::Value::String(host.to_string()));
+    }
+    if let Some(app) = &parsed.appname {
+        obj.entry("syslog_appname")
+            .or_insert_with(|| serde_json::Value::String(app.to_string()));
+    }
+    if let Some(facility) = &parsed.facility {
+        obj.entry("syslog_facility")
+            .or_insert_with(|| serde_json::Value::String(format!("{facility:?}")));
+    }
+    if let Some(severity) = &parsed.severity {
+        obj.entry("syslog_severity")
+            .or_insert_with(|| serde_json::Value::String(format!("{severity:?}")));
+    }
+}
+
+/// Year resolver for RFC 3164 timestamps.
+///
+/// `IncompleteDate` is `(month, day, hour, minute, second)`. Uses the current
+/// year, with December→January rollover: if the parsed month is January and
+/// we're in December, assume next year (and vice versa).
+fn resolve_year(date: syslog_loose::IncompleteDate) -> i32 {
+    let now = chrono::Utc::now();
+    let current_year = chrono::Datelike::year(&now);
+    let current_month = chrono::Datelike::month(&now);
+    let parsed_month = date.0;
+
+    if current_month == 12 && parsed_month == 1 {
+        current_year + 1
+    } else if current_month == 1 && parsed_month == 12 {
+        current_year - 1
+    } else {
+        current_year
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::Event;
+
+    #[test]
+    fn rfc5424_basic() {
+        let line = "<165>1 2024-01-15T10:30:00.000Z web01 myapp 1234 ID47 - Connection established";
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        assert!(decoded.get_field("hostname").is_some());
+        assert!(decoded.get_field("appname").is_some());
+        assert!(decoded.get_field("_raw").is_some());
+    }
+
+    #[test]
+    fn rfc3164_basic() {
+        let line = "<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8";
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        assert!(decoded.any_string_value(&|s| s.contains("su root")));
+    }
+
+    #[test]
+    fn syslog_wrapped_json() {
+        let line =
+            r#"<134>1 2024-01-15T10:30:00Z docker01 myapp - - - {"EventID": 1, "user": "admin"}"#;
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        assert!(decoded.get_field("EventID").is_some());
+        assert!(decoded.get_field("user").is_some());
+    }
+
+    #[test]
+    fn rfc5424_structured_data() {
+        let line = r#"<165>1 2024-01-15T10:30:00Z host app - ID1 [exampleSDID@32473 iut="3" eventSource="App" eventID="1011"] message"#;
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        let json = decoded.to_json();
+        let json_str = serde_json::to_string(&json).unwrap();
+        assert!(json_str.contains("eventSource") || json_str.contains("_raw"));
+    }
+
+    #[test]
+    fn empty_msg() {
+        let line = "<13>1 2024-01-15T10:30:00Z host app - - -";
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        assert!(decoded.get_field("hostname").is_some());
+    }
+
+    #[test]
+    fn custom_timezone() {
+        let config = SyslogConfig {
+            default_tz_offset_secs: 5 * 3600, // UTC+5
+        };
+        let line = "<34>Oct 11 22:14:15 mymachine su: test message";
+        let decoded = parse_syslog(line, &config);
+        assert!(decoded.any_string_value(&|s| s.contains("test message")));
+    }
+}

--- a/crates/rsigma-runtime/src/lib.rs
+++ b/crates/rsigma-runtime/src/lib.rs
@@ -55,7 +55,7 @@ pub use error::RuntimeError;
 pub use input::{EventInputDecoded, InputFormat, parse_line};
 pub use io::{EventSource, FileSink, Sink, StdinSource, StdoutSink, spawn_source};
 pub use metrics::{MetricsHook, NoopMetrics};
-pub use processor::LogProcessor;
+pub use processor::{EventFilter, LogProcessor};
 
 pub use rsigma_eval::ProcessResult;
 

--- a/crates/rsigma-runtime/src/lib.rs
+++ b/crates/rsigma-runtime/src/lib.rs
@@ -44,6 +44,7 @@
 
 pub mod engine;
 pub mod error;
+pub mod input;
 pub mod io;
 pub mod metrics;
 pub mod parse;
@@ -51,6 +52,7 @@ pub mod processor;
 
 pub use engine::{EngineStats, RuntimeEngine};
 pub use error::RuntimeError;
+pub use input::{EventInputDecoded, InputFormat, parse_line};
 pub use io::{EventSource, FileSink, Sink, StdinSource, StdoutSink, spawn_source};
 pub use metrics::{MetricsHook, NoopMetrics};
 pub use processor::LogProcessor;

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -5,7 +5,14 @@ use arc_swap::ArcSwap;
 use rsigma_eval::{JsonEvent, ProcessResult};
 
 use crate::engine::RuntimeEngine;
+use crate::input::{EventInputDecoded, InputFormat, parse_line};
 use crate::metrics::MetricsHook;
+
+/// Closure that extracts multiple payloads from a single JSON value.
+///
+/// Used by the daemon's event filter (e.g. jq/jsonpath) to explode a JSON
+/// object into sub-events (e.g. `.records[]`). Only applies to JSON input.
+pub type EventFilter = dyn Fn(&serde_json::Value) -> Vec<serde_json::Value>;
 
 /// Thread-safe handle to the engine, swappable atomically for hot-reload.
 ///
@@ -57,7 +64,7 @@ impl LogProcessor {
     pub fn process_batch_lines(
         &self,
         batch: &[String],
-        event_filter: &dyn Fn(&serde_json::Value) -> Vec<serde_json::Value>,
+        event_filter: &EventFilter,
     ) -> Vec<ProcessResult> {
         let engine_guard = self.engine.load();
         let mut engine = engine_guard.lock().unwrap();
@@ -88,12 +95,7 @@ impl LogProcessor {
         }
 
         if flat.is_empty() {
-            return (0..batch.len())
-                .map(|_| ProcessResult {
-                    detections: vec![],
-                    correlations: vec![],
-                })
-                .collect();
+            return empty_results(batch.len());
         }
 
         // Phase 2: Batch evaluation — parallel detection + sequential correlation
@@ -111,14 +113,115 @@ impl LogProcessor {
             .set_correlation_state_entries(stats.state_entries as u64);
 
         // Phase 3: Merge results per input line and update metrics
-        let mut line_results: Vec<ProcessResult> = (0..batch.len())
-            .map(|_| ProcessResult {
-                detections: vec![],
-                correlations: vec![],
-            })
-            .collect();
+        let mut line_results = empty_results(batch.len());
 
         for ((line_idx, _), result) in flat.iter().zip(batch_results) {
+            self.metrics.on_events_processed(1);
+            self.metrics.observe_processing_latency(per_event_latency);
+            self.metrics
+                .on_detection_matches(result.detections.len() as u64);
+            self.metrics
+                .on_correlation_matches(result.correlations.len() as u64);
+
+            line_results[*line_idx].detections.extend(result.detections);
+            line_results[*line_idx]
+                .correlations
+                .extend(result.correlations);
+        }
+
+        line_results
+    }
+
+    /// Process a batch of raw input lines using the specified input format.
+    ///
+    /// Unlike [`process_batch_lines`](Self::process_batch_lines), this method
+    /// supports all input formats (JSON, syslog, plain, logfmt, CEF). The
+    /// `event_filter` only applies to JSON-decoded events (it extracts multiple
+    /// payloads from one JSON object, e.g. a `records[]` array). Non-JSON
+    /// formats produce exactly one event per line.
+    ///
+    /// Returns one `ProcessResult` per input line.
+    pub fn process_batch_with_format(
+        &self,
+        batch: &[String],
+        format: &InputFormat,
+        event_filter: Option<&EventFilter>,
+    ) -> Vec<ProcessResult> {
+        let engine_guard = self.engine.load();
+        let mut engine = engine_guard.lock().unwrap();
+
+        // Phase 1: Parse each line into decoded events, tracking line origin.
+        // For JSON with an event_filter, one line can produce multiple events.
+        let mut decoded_events: Vec<(usize, EventInputDecoded)> = Vec::with_capacity(batch.len());
+
+        for (line_idx, line) in batch.iter().enumerate() {
+            match format {
+                InputFormat::Json | InputFormat::Auto => {
+                    // For JSON/auto with event_filter: parse as JSON first to apply filter.
+                    if let Some(filter) = event_filter {
+                        if let Some(EventInputDecoded::Json(_)) = parse_line(line, format) {
+                            // Re-parse as raw JSON to apply filter.
+                            match serde_json::from_str::<serde_json::Value>(line) {
+                                Ok(value) => {
+                                    let payloads = filter(&value);
+                                    for payload in payloads {
+                                        decoded_events.push((
+                                            line_idx,
+                                            EventInputDecoded::Json(JsonEvent::owned(payload)),
+                                        ));
+                                    }
+                                }
+                                Err(e) => {
+                                    self.metrics.on_parse_error();
+                                    tracing::debug!(error = %e, "Parse error on input");
+                                }
+                            }
+                        } else if let Some(decoded) = parse_line(line, format) {
+                            // Auto-detect fell through to syslog/plain — no filter.
+                            decoded_events.push((line_idx, decoded));
+                        } else {
+                            self.metrics.on_parse_error();
+                            tracing::debug!("Failed to parse input line");
+                        }
+                    } else if let Some(decoded) = parse_line(line, format) {
+                        decoded_events.push((line_idx, decoded));
+                    } else {
+                        self.metrics.on_parse_error();
+                        tracing::debug!("Failed to parse input line");
+                    }
+                }
+                _ => {
+                    // Non-JSON formats: one event per line, no filter.
+                    if let Some(decoded) = parse_line(line, format) {
+                        decoded_events.push((line_idx, decoded));
+                    } else {
+                        self.metrics.on_parse_error();
+                        tracing::debug!("Failed to parse input line");
+                    }
+                }
+            }
+        }
+
+        if decoded_events.is_empty() {
+            return empty_results(batch.len());
+        }
+
+        // Phase 2: Batch evaluation — parallel detection + sequential correlation
+        let event_refs: Vec<&EventInputDecoded> = decoded_events.iter().map(|(_, e)| e).collect();
+
+        let start = Instant::now();
+        let batch_results = engine.process_batch(&event_refs);
+        let elapsed = start.elapsed().as_secs_f64();
+        let per_event_latency = elapsed / event_refs.len() as f64;
+
+        let stats = engine.stats();
+        self.metrics
+            .set_correlation_state_entries(stats.state_entries as u64);
+
+        // Phase 3: Merge results per input line and update metrics
+        let mut line_results = empty_results(batch.len());
+
+        for ((line_idx, _), result) in decoded_events.iter().zip(batch_results) {
             self.metrics.on_events_processed(1);
             self.metrics.observe_processing_latency(per_event_latency);
             self.metrics
@@ -201,6 +304,16 @@ impl LogProcessor {
         let engine = snapshot.lock().unwrap();
         engine.stats()
     }
+}
+
+/// Produce a vec of empty `ProcessResult`, one per input line.
+fn empty_results(count: usize) -> Vec<ProcessResult> {
+    (0..count)
+        .map(|_| ProcessResult {
+            detections: vec![],
+            correlations: vec![],
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -608,5 +721,214 @@ detection:
         }
 
         std::mem::forget(dir);
+    }
+
+    // --- Tests for process_batch_with_format ---
+
+    #[test]
+    fn format_json_matches() {
+        let proc = make_processor(
+            r#"
+title: Test Rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection
+"#,
+        );
+
+        let batch = vec![r#"{"EventID": 1}"#.to_string()];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Json, None);
+        assert_eq!(results.len(), 1);
+        assert!(
+            !results[0].detections.is_empty(),
+            "JSON EventID=1 should match"
+        );
+    }
+
+    #[test]
+    fn format_syslog_extracts_fields() {
+        let proc = make_processor(
+            r#"
+title: Syslog Test
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        hostname: mymachine
+    condition: selection
+"#,
+        );
+
+        let batch = vec!["<34>Oct 11 22:14:15 mymachine su: test message".to_string()];
+        let results = proc.process_batch_with_format(
+            &batch,
+            &InputFormat::Syslog(crate::input::SyslogConfig::default()),
+            None,
+        );
+        assert_eq!(results.len(), 1);
+        assert!(
+            !results[0].detections.is_empty(),
+            "syslog hostname=mymachine should match"
+        );
+    }
+
+    #[test]
+    fn format_plain_keyword_match() {
+        let proc = make_processor(
+            r#"
+title: Keyword Test
+status: test
+logsource:
+    category: test
+detection:
+    keywords:
+        - "disk full"
+    condition: keywords
+"#,
+        );
+
+        let batch = vec!["ERROR: disk full on /dev/sda1".to_string()];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Plain, None);
+        assert_eq!(results.len(), 1);
+        assert!(
+            !results[0].detections.is_empty(),
+            "plain keyword 'disk full' should match"
+        );
+    }
+
+    #[test]
+    fn format_auto_detects_json() {
+        let proc = make_processor(
+            r#"
+title: Test Rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection
+"#,
+        );
+
+        let batch = vec![r#"{"EventID": 1}"#.to_string()];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Auto, None);
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].detections.is_empty());
+    }
+
+    #[test]
+    fn format_json_with_event_filter() {
+        let proc = make_processor(
+            r#"
+title: Test Rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection
+"#,
+        );
+
+        let filter = |v: &serde_json::Value| -> Vec<serde_json::Value> {
+            if let Some(records) = v.get("records").and_then(|r| r.as_array()) {
+                records.clone()
+            } else {
+                vec![v.clone()]
+            }
+        };
+
+        let batch = vec![r#"{"records": [{"EventID": 1}, {"EventID": 2}]}"#.to_string()];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Json, Some(&filter));
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].detections.len(),
+            1,
+            "only EventID=1 from records array should match"
+        );
+    }
+
+    #[test]
+    fn format_empty_lines_skipped() {
+        let proc = make_processor(
+            r#"
+title: Test Rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection
+"#,
+        );
+
+        let batch = vec![
+            "".to_string(),
+            "   ".to_string(),
+            r#"{"EventID": 1}"#.to_string(),
+        ];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Json, None);
+        assert_eq!(results.len(), 3);
+        assert!(results[0].detections.is_empty());
+        assert!(results[1].detections.is_empty());
+        assert!(!results[2].detections.is_empty());
+    }
+
+    #[cfg(feature = "logfmt")]
+    #[test]
+    fn format_logfmt_matches() {
+        let proc = make_processor(
+            r#"
+title: Logfmt Test
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        level: error
+    condition: selection
+"#,
+        );
+
+        let batch = vec!["level=error msg=something host=web01".to_string()];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Logfmt, None);
+        assert_eq!(results.len(), 1);
+        assert!(
+            !results[0].detections.is_empty(),
+            "logfmt level=error should match"
+        );
+    }
+
+    #[cfg(feature = "cef")]
+    #[test]
+    fn format_cef_matches() {
+        let proc = make_processor(
+            r#"
+title: CEF Test
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        deviceVendor: Security
+    condition: selection
+"#,
+        );
+
+        let batch = vec!["CEF:0|Security|IDS|1.0|100|Attack|9|src=10.0.0.1".to_string()];
+        let results = proc.process_batch_with_format(&batch, &InputFormat::Cef, None);
+        assert_eq!(results.len(), 1);
+        assert!(
+            !results[0].detections.is_empty(),
+            "CEF deviceVendor=Security should match"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Input format adapters** in `rsigma-runtime/src/input/`: typed parsers for JSON/GELF, syslog (RFC 3164/5424), plain text, logfmt, CEF, and auto-detect. Each returns an `EventInputDecoded` enum implementing `Event` — static dispatch, no vtable on the hot path.
- **`EventInputDecoded` enum**: `Json(JsonEvent)` | `Kv(KvEvent)` | `Plain(PlainEvent)` — the unified event type that flows through the engine.
- **`process_batch_with_format()`** on `LogProcessor`: format-aware batch processing. Event filters (jq/jsonpath) only apply to JSON-decoded events; non-JSON formats produce one event per line.
- **`--input-format auto|json|syslog|plain[|logfmt|cef]`** on both `rsigma daemon` and `rsigma eval`. Default: `auto` (try JSON → syslog → plain).
- **`--syslog-tz +HH:MM`** for RFC 3164 timezone. Default: UTC.
- **Feature flags**: `logfmt`, `cef`, `evtx` features on rsigma-cli forwarded to rsigma-runtime.
- **Syslog edge cases**: embedded JSON (Docker/K8s logs), year resolution for RFC 3164, configurable timezone, RFC 5424 structured data.
- **CEF-over-syslog**: auto-strips syslog envelope when parsing CEF.
- **Exports `KvEvent`, `PlainEvent`, `MapEvent`, `EventValue`** from rsigma-eval's public API.

New dependencies: `syslog_loose 0.23`, `chrono 0.4` (always on); `evtx 0.11` (behind `evtx` feature).

## Test plan

- [x] `cargo test -p rsigma-runtime --no-default-features` — 77 unit + 3 doc tests
- [x] `cargo test -p rsigma-runtime --features logfmt` — 80 tests
- [x] `cargo test -p rsigma-runtime --features cef` — 81 tests
- [x] `cargo test -p rsigma-runtime --all-features` — 84 tests
- [x] `cargo test --workspace --all-features` — full workspace green
- [x] `cargo check -p rsigma --no-default-features` — builds without daemon
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] Per-adapter unit tests: JSON, syslog (RFC 3164/5424, embedded JSON, structured data), plain, logfmt, CEF, CEF-over-syslog, auto-detect (mixed format batch)
- [x] `process_batch_with_format` tests: JSON, syslog, plain, logfmt, CEF, auto, empty lines, event filter interaction