### PR TITLE
chore: release v0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,18 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: sleep 30
 
+      - name: Publish rsigma-runtime
+        run: |
+          echo "::notice::Publishing rsigma-runtime (dry-run: ${DRY_RUN})"
+          cargo publish ${DRY_RUN} -p rsigma-runtime
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
+
+      - name: Wait for crates.io index update
+        if: github.event_name != 'workflow_dispatch'
+        run: sleep 30
+
       - name: Publish rsigma
         run: |
           echo "::notice::Publishing rsigma (dry-run: ${DRY_RUN})"

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -54,7 +54,7 @@ cargo bench -p rsigma-runtime -- --baseline before
 | `runtime_vs_raw` | Overhead comparison: raw `Engine::evaluate` vs `LogProcessor` pipeline |
 | `runtime_rule_scaling` | `LogProcessor` throughput scaling across 100–1000 rules |
 
-## Baseline results (v0.6.0)
+## Baseline results (v0.7.0)
 
 Recorded on Apple M4 Pro, macOS, `cargo bench -p rsigma-runtime` with
 `--release` (Criterion default). 100 synthetic detection rules, seeded RNG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "async-nats",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "globset",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RSigma
 
-A complete Rust toolkit for the [Sigma](https://github.com/SigmaHQ/sigma) detection standard — parser, evaluation engine, linter, CLI, and LSP. rsigma parses Sigma YAML rules into a strongly-typed AST, compiles them into optimized matchers, and evaluates them directly against JSON log events in real time. It runs detection and stateful correlation logic in-process with memory-efficient compressed event storage, supports pySigma-compatible processing pipelines for field mapping and backend configuration, and streams results from NDJSON input — no external SIEM required. A built-in linter validates rules against 66 checks derived from the Sigma v2.1.0 specification with four severity levels, a full suppression system, and auto-fix support (`--fix`) for 13 safe rules. An LSP server provides real-time diagnostics, completions, hover documentation, and quick-fix code actions in any editor.
+A complete Rust toolkit for the [Sigma](https://github.com/SigmaHQ/sigma) detection standard, including parser, evaluation engine, streaming runtime, linter, CLI, and LSP. RSigma parses Sigma YAML rules into a strongly-typed AST, compiles them into optimized matchers, and evaluates them against log events in real time. It accepts JSON, syslog (RFC 3164/5424), logfmt, CEF, and plain text, with auto-detection by default, and runs detection and stateful correlation logic in-process with memory-efficient compressed event storage. pySigma-compatible processing pipelines handle field mapping and backend configuration. No external SIEM required. A built-in linter validates rules against 66 checks derived from the Sigma v2.1.0 specification with four severity levels, a full suppression system, and auto-fix support (`--fix`) for 13 safe rules. An LSP server provides real-time diagnostics, completions, hover documentation, and quick-fix code actions in any editor.
 
 | Crate | Description |
 |-------|-------------|
@@ -55,6 +55,18 @@ rsigma daemon -r rules/ --batch-size 64 --buffer-size 50000 --drain-timeout 10
 
 # With a processing pipeline for field mapping
 rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
+
+# Multi-format input (auto-detect is the default: JSON → syslog → plain)
+rsigma daemon -r rules/ --input-format auto
+
+# Explicit syslog with timezone offset
+tail -f /var/log/syslog | rsigma eval -r rules/ --input-format syslog --syslog-tz +0530
+
+# logfmt (requires logfmt feature)
+rsigma eval -r rules/ --input-format logfmt < app.log
+
+# CEF / ArcSight (requires cef feature)
+rsigma eval -r rules/ --input-format cef < arcsight.log
 ```
 
 Or use the library directly:

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -18,9 +18,9 @@ cef = ["rsigma-runtime/cef"]
 evtx = ["rsigma-runtime/evtx"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.6.0", features = ["parallel"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.6.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.7.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.7.0", features = ["parallel"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.7.0", optional = true }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 parallel = ["rayon"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.7.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.6.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.7.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.7.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -17,8 +17,8 @@ cef = []
 evtx = ["dep:evtx"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.6.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.6.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.7.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.7.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std"] }
 serde_json = "1"
 thiserror = "2"


### PR DESCRIPTION
## Summary

Bump all crate versions from 0.6.0 to 0.7.0 and prepare for release.

- Workspace version: `0.6.0` → `0.7.0`
- All inter-crate dependency versions updated
- `publish.yml`: added `rsigma-runtime` publish step (between `rsigma-eval` and `rsigma`)
- `BENCHMARKS.md`: updated baseline label from v0.6.0 to v0.7.0
- `README.md`: updated opening paragraph and Quick Start with multi-format input support (syslog, logfmt, CEF, auto-detect)

### Pre-release checklist

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes
- [x] `publish.yml` includes `rsigma-runtime` in correct dependency order
- [x] README reflects multi-format input support
- [ ] Register `rsigma-runtime` for trusted publishing on crates.io
- [ ] Create GitHub Release with tag `v0.7.0` after merge (release notes drafted)