### PR TITLE
feat: add rsigma-convert crate and CLI convert command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "notify",
  "predicates",
  "prometheus",
+ "rsigma-convert",
  "rsigma-eval",
  "rsigma-parser",
  "rsigma-runtime",
@@ -2930,6 +2931,21 @@ dependencies = [
  "ureq",
  "yamlpatch",
  "yamlpath",
+]
+
+[[package]]
+name = "rsigma-convert"
+version = "0.7.0"
+dependencies = [
+ "base64",
+ "ipnet",
+ "log",
+ "regex",
+ "rsigma-eval",
+ "rsigma-parser",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/rsigma-parser",
     "crates/rsigma-eval",
+    "crates/rsigma-convert",
     "crates/rsigma-runtime",
     "crates/rsigma-cli",
     "crates/rsigma-lsp",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -20,6 +20,7 @@ evtx = ["rsigma-runtime/evtx"]
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.7.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.7.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.7.0" }
 rsigma-runtime = { path = "../rsigma-runtime", version = "0.7.0", optional = true }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -305,6 +305,49 @@ enum Commands {
         #[arg(long = "syslog-tz", default_value = "+00:00")]
         syslog_tz: String,
     },
+
+    /// Convert Sigma rules to backend-native queries
+    Convert {
+        /// Path(s) to Sigma rule file(s) or directory
+        rules: Vec<PathBuf>,
+
+        /// Target backend (e.g. test)
+        #[arg(short, long)]
+        target: String,
+
+        /// Output format (backend-specific, default: "default")
+        #[arg(short, long, default_value = "default")]
+        format: String,
+
+        /// Processing pipeline YAML file(s) (repeatable)
+        #[arg(short = 'p', long = "pipeline")]
+        pipeline: Vec<PathBuf>,
+
+        /// Skip pipeline requirement check
+        #[arg(long)]
+        without_pipeline: bool,
+
+        /// Skip unsupported rules instead of failing
+        #[arg(short, long)]
+        skip_unsupported: bool,
+
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Backend options as key=value pairs (repeatable)
+        #[arg(short = 'O', long = "option")]
+        backend_options: Vec<String>,
+    },
+
+    /// List available conversion targets (backends)
+    ListTargets,
+
+    /// List available output formats for a target
+    ListFormats {
+        /// Target backend name
+        target: String,
+    },
 }
 
 fn main() {
@@ -419,6 +462,27 @@ fn main() {
             input_format,
             syslog_tz,
         ),
+        Commands::Convert {
+            rules,
+            target,
+            format,
+            pipeline,
+            without_pipeline,
+            skip_unsupported,
+            output,
+            backend_options,
+        } => cmd_convert(
+            rules,
+            target,
+            format,
+            pipeline,
+            without_pipeline,
+            skip_unsupported,
+            output,
+            backend_options,
+        ),
+        Commands::ListTargets => cmd_list_targets(),
+        Commands::ListFormats { target } => cmd_list_formats(target),
     }
 }
 
@@ -1975,6 +2039,154 @@ impl Painter {
 
     fn cyan(&self, s: &str) -> String {
         self.paint("36", s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convert subcommand
+// ---------------------------------------------------------------------------
+
+fn get_backend(target: &str) -> Box<dyn rsigma_convert::Backend> {
+    match target {
+        "test" => Box::new(rsigma_convert::backends::test::TextQueryTestBackend::new()),
+        "test_mandatory_pipeline" => {
+            Box::new(rsigma_convert::backends::test::MandatoryPipelineTestBackend::new())
+        }
+        _ => {
+            eprintln!("Unknown target: {target}");
+            eprintln!("Available targets: test");
+            process::exit(1);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cmd_convert(
+    rules: Vec<PathBuf>,
+    target: String,
+    format: String,
+    pipeline_paths: Vec<PathBuf>,
+    without_pipeline: bool,
+    skip_unsupported: bool,
+    output: Option<PathBuf>,
+    _backend_options: Vec<String>,
+) {
+    let collection = load_collection_multi(&rules);
+    let pipelines = load_pipelines(&pipeline_paths);
+    let backend = get_backend(&target);
+
+    if backend.requires_pipeline() && pipelines.is_empty() && !without_pipeline {
+        eprintln!(
+            "Backend '{}' requires a pipeline. Use -p or --without-pipeline.",
+            target
+        );
+        process::exit(1);
+    }
+
+    if !backend.formats().iter().any(|(f, _)| *f == format) {
+        eprintln!("Unknown format '{format}' for backend '{target}'");
+        eprintln!(
+            "Available: {}",
+            backend
+                .formats()
+                .iter()
+                .map(|(f, d)| format!("{f} ({d})"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        process::exit(1);
+    }
+
+    let result =
+        rsigma_convert::convert_collection(backend.as_ref(), &collection, &pipelines, &format);
+    match result {
+        Ok(output_data) => {
+            for (rule_title, error) in &output_data.errors {
+                if skip_unsupported {
+                    eprintln!("Warning: rule '{rule_title}' skipped: {error}");
+                } else {
+                    eprintln!("Error: rule '{rule_title}' failed: {error}");
+                }
+            }
+            if !skip_unsupported && !output_data.errors.is_empty() {
+                process::exit(1);
+            }
+            let all_queries: Vec<&str> = output_data
+                .queries
+                .iter()
+                .flat_map(|r| r.queries.iter().map(|q| q.as_str()))
+                .collect();
+            let output_str = all_queries.join("\n");
+            write_output(&output_str, output.as_deref());
+        }
+        Err(e) => {
+            eprintln!("Conversion failed: {e}");
+            process::exit(1);
+        }
+    }
+}
+
+fn cmd_list_targets() {
+    println!("Available conversion targets:");
+    println!("  test  - Backend-neutral test backend");
+}
+
+fn cmd_list_formats(target: String) {
+    let backend = get_backend(&target);
+    println!("Available formats for '{target}':");
+    for (name, desc) in backend.formats() {
+        println!("  {name}  - {desc}");
+    }
+}
+
+fn load_collection_multi(paths: &[PathBuf]) -> SigmaCollection {
+    let mut collection = SigmaCollection::new();
+    for path in paths {
+        if path.is_dir() {
+            match parse_sigma_directory(path) {
+                Ok(dir_collection) => {
+                    collection.rules.extend(dir_collection.rules);
+                    collection.correlations.extend(dir_collection.correlations);
+                    collection.filters.extend(dir_collection.filters);
+                }
+                Err(e) => {
+                    eprintln!("Error parsing directory {}: {e}", path.display());
+                    process::exit(1);
+                }
+            }
+        } else if path.is_file() {
+            match parse_sigma_file(path) {
+                Ok(file_collection) => {
+                    collection.rules.extend(file_collection.rules);
+                    collection.correlations.extend(file_collection.correlations);
+                    collection.filters.extend(file_collection.filters);
+                }
+                Err(e) => {
+                    eprintln!("Error parsing {}: {e}", path.display());
+                    process::exit(1);
+                }
+            }
+        } else {
+            eprintln!("Path not found: {}", path.display());
+            process::exit(1);
+        }
+    }
+    if collection.rules.is_empty() && collection.correlations.is_empty() {
+        eprintln!("No rules found in specified path(s)");
+        process::exit(1);
+    }
+    collection
+}
+
+fn write_output(content: &str, output: Option<&std::path::Path>) {
+    match output {
+        Some(path) => {
+            if let Err(e) = std::fs::write(path, content) {
+                eprintln!("Error writing to {}: {e}", path.display());
+                process::exit(1);
+            }
+        }
+        None => println!("{content}"),
     }
 }
 

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rsigma-convert"
+description = "Sigma rule conversion engine — convert rules to backend-native query strings"
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+rsigma-parser = { path = "../rsigma-parser", version = "0.7.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.7.0" }
+thiserror = "2"
+serde_json = "1"
+serde_yaml = "0.9"
+regex = "1"
+ipnet = "2"
+log = "0.4"
+base64 = "0.22"

--- a/crates/rsigma-convert/src/backend.rs
+++ b/crates/rsigma-convert/src/backend.rs
@@ -1,0 +1,632 @@
+use std::collections::HashMap;
+
+use rsigma_eval::pipeline::state::PipelineState;
+use rsigma_parser::*;
+
+use crate::error::{ConvertError, Result};
+use crate::state::{ConversionState, ConvertResult};
+
+// =============================================================================
+// Token precedence
+// =============================================================================
+
+/// Boolean operator token type, used for precedence-aware grouping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TokenType {
+    /// Highest precedence (binds tightest).
+    NOT = 0,
+    AND = 1,
+    OR = 2,
+}
+
+// =============================================================================
+// Backend trait
+// =============================================================================
+
+/// Core conversion trait.
+///
+/// Backends implement this to convert parsed Sigma AST nodes into
+/// backend-native query strings. The trait operates on **parsed** types
+/// from `rsigma-parser` because conversion needs the original field names,
+/// modifiers, and values — not compiled matchers.
+pub trait Backend: Send + Sync {
+    fn name(&self) -> &str;
+    fn formats(&self) -> &[(&str, &str)];
+
+    fn default_format(&self) -> &str {
+        "default"
+    }
+
+    fn requires_pipeline(&self) -> bool {
+        false
+    }
+
+    // --- Detection rule conversion ---
+
+    fn convert_rule(
+        &self,
+        rule: &SigmaRule,
+        output_format: &str,
+        pipeline_state: &PipelineState,
+    ) -> Result<Vec<String>>;
+
+    // --- Condition tree dispatch ---
+
+    fn convert_condition(
+        &self,
+        expr: &ConditionExpr,
+        detections: &HashMap<String, Detection>,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    fn convert_condition_and(&self, exprs: &[String]) -> Result<String>;
+    fn convert_condition_or(&self, exprs: &[String]) -> Result<String>;
+    fn convert_condition_not(&self, expr: &str) -> Result<String>;
+
+    // --- Detection item conversion ---
+
+    fn convert_detection(&self, det: &Detection, state: &mut ConversionState) -> Result<String>;
+
+    fn convert_detection_item(
+        &self,
+        item: &DetectionItem,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    // --- Field/value escaping ---
+
+    fn escape_and_quote_field(&self, field: &str) -> String;
+    fn convert_value_str(&self, value: &SigmaString, state: &ConversionState) -> String;
+    fn convert_value_re(&self, regex: &str, state: &ConversionState) -> String;
+
+    // --- Value-type-specific methods ---
+
+    fn convert_field_eq_str(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult>;
+
+    fn convert_field_eq_str_case_sensitive(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult>;
+
+    fn convert_field_eq_num(
+        &self,
+        field: &str,
+        value: f64,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    fn convert_field_eq_bool(
+        &self,
+        field: &str,
+        value: bool,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    fn convert_field_eq_null(&self, field: &str, state: &mut ConversionState) -> Result<String>;
+
+    fn convert_field_eq_re(
+        &self,
+        field: &str,
+        pattern: &str,
+        flags: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult>;
+
+    fn convert_field_eq_cidr(
+        &self,
+        field: &str,
+        cidr: &str,
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult>;
+
+    fn convert_field_compare(
+        &self,
+        field: &str,
+        op: &Modifier,
+        value: f64,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    fn convert_field_exists(
+        &self,
+        field: &str,
+        exists: bool,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    fn convert_field_eq_query_expr(
+        &self,
+        field: &str,
+        expr: &str,
+        id: &str,
+        state: &mut ConversionState,
+    ) -> Result<String>;
+
+    fn convert_field_ref(
+        &self,
+        field1: &str,
+        field2: &str,
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult>;
+
+    fn convert_keyword(&self, value: &SigmaValue, state: &mut ConversionState) -> Result<String>;
+
+    // --- IN-list optimization (optional) ---
+
+    fn convert_condition_as_in_expression(
+        &self,
+        _field: &str,
+        _values: &[&SigmaValue],
+        _is_or: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        Err(ConvertError::UnsupportedModifier(
+            "IN expression not supported".into(),
+        ))
+    }
+
+    // --- Query finalization ---
+
+    fn finish_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        state: &ConversionState,
+    ) -> Result<String>;
+
+    fn finalize_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        index: usize,
+        state: &ConversionState,
+        output_format: &str,
+    ) -> Result<String>;
+
+    fn finalize_output(&self, queries: Vec<String>, output_format: &str) -> Result<String>;
+
+    // --- Correlation rule conversion (optional) ---
+
+    fn supports_correlation(&self) -> bool {
+        false
+    }
+
+    fn convert_correlation_rule(
+        &self,
+        _rule: &CorrelationRule,
+        _output_format: &str,
+        _pipeline_state: &PipelineState,
+    ) -> Result<Vec<String>> {
+        Err(ConvertError::UnsupportedCorrelation(
+            "correlation rules not supported by this backend".into(),
+        ))
+    }
+}
+
+// =============================================================================
+// TextQueryConfig
+// =============================================================================
+
+/// Configuration tokens for text-based query backends.
+///
+/// Mirrors pySigma's `TextQueryBackend` class variables. Backends create a
+/// `const` or `static` instance of this struct and delegate to the
+/// `text_convert_*` free functions for the default conversion logic.
+pub struct TextQueryConfig {
+    // --- Precedence and grouping ---
+    pub precedence: (TokenType, TokenType, TokenType),
+    pub group_expression: &'static str,
+    pub token_separator: &'static str,
+
+    // --- Boolean operators ---
+    pub and_token: &'static str,
+    pub or_token: &'static str,
+    pub not_token: &'static str,
+    pub eq_token: &'static str,
+
+    // --- Negation expressions ---
+    pub not_eq_token: Option<&'static str>,
+    pub eq_expression: Option<&'static str>,
+    pub not_eq_expression: Option<&'static str>,
+    pub convert_not_as_not_eq: bool,
+
+    // --- Wildcards ---
+    pub wildcard_multi: &'static str,
+    pub wildcard_single: &'static str,
+
+    // --- String quoting and escaping ---
+    pub str_quote: &'static str,
+    pub str_quote_pattern: Option<&'static str>,
+    pub str_quote_pattern_negation: bool,
+    pub escape_char: &'static str,
+    pub add_escaped: &'static [&'static str],
+    pub filter_chars: &'static [&'static str],
+
+    // --- Field name quoting and escaping ---
+    pub field_quote: Option<&'static str>,
+    pub field_quote_pattern: Option<&'static str>,
+    pub field_quote_pattern_negation: bool,
+    pub field_escape: Option<&'static str>,
+    pub field_escape_pattern: Option<&'static str>,
+
+    // --- String match expressions ---
+    pub startswith_expression: Option<&'static str>,
+    pub not_startswith_expression: Option<&'static str>,
+    pub startswith_expression_allow_special: bool,
+    pub endswith_expression: Option<&'static str>,
+    pub not_endswith_expression: Option<&'static str>,
+    pub endswith_expression_allow_special: bool,
+    pub contains_expression: Option<&'static str>,
+    pub not_contains_expression: Option<&'static str>,
+    pub contains_expression_allow_special: bool,
+    pub wildcard_match_expression: Option<&'static str>,
+
+    // --- Case-sensitive match expressions ---
+    pub case_sensitive_match_expression: Option<&'static str>,
+    pub case_sensitive_startswith_expression: Option<&'static str>,
+    pub case_sensitive_endswith_expression: Option<&'static str>,
+    pub case_sensitive_contains_expression: Option<&'static str>,
+
+    // --- Regex ---
+    pub re_expression: Option<&'static str>,
+    pub not_re_expression: Option<&'static str>,
+    pub re_escape_char: Option<&'static str>,
+    pub re_escape: &'static [&'static str],
+    pub re_escape_escape_char: Option<&'static str>,
+
+    // --- CIDR ---
+    pub cidr_expression: Option<&'static str>,
+    pub not_cidr_expression: Option<&'static str>,
+
+    // --- Null / field existence ---
+    pub field_null_expression: &'static str,
+    pub field_exists_expression: Option<&'static str>,
+    pub field_not_exists_expression: Option<&'static str>,
+
+    // --- Compare operators ---
+    pub compare_op_expression: Option<&'static str>,
+    pub compare_ops: &'static [(&'static str, &'static str)],
+
+    // --- IN-list optimization ---
+    pub convert_or_as_in: bool,
+    pub convert_and_as_in: bool,
+    pub in_expressions_allow_wildcards: bool,
+    pub field_in_list_expression: Option<&'static str>,
+    pub or_in_operator: Option<&'static str>,
+    pub and_in_operator: Option<&'static str>,
+    pub list_separator: &'static str,
+
+    // --- Unbound/keyword ---
+    pub unbound_value_str_expression: Option<&'static str>,
+    pub unbound_value_num_expression: Option<&'static str>,
+    pub unbound_value_re_expression: Option<&'static str>,
+
+    // --- Field-to-field comparison ---
+    pub field_eq_field_expression: Option<&'static str>,
+    pub field_eq_field_escaping_quoting: bool,
+
+    // --- Deferred query parts ---
+    pub deferred_start: Option<&'static str>,
+    pub deferred_separator: Option<&'static str>,
+    pub deferred_only_query: &'static str,
+
+    // --- Bool values ---
+    pub bool_true: &'static str,
+    pub bool_false: &'static str,
+
+    // --- Query envelope ---
+    pub query_expression: &'static str,
+    pub state_defaults: &'static [(&'static str, &'static str)],
+}
+
+impl TextQueryConfig {
+    /// Check if `inner` needs parenthesisation when nested inside `outer`.
+    pub fn needs_grouping(&self, outer: TokenType, inner: TokenType) -> bool {
+        let rank = |t: TokenType| -> u8 {
+            if t == self.precedence.0 {
+                0
+            } else if t == self.precedence.1 {
+                1
+            } else {
+                2
+            }
+        };
+        rank(inner) > rank(outer)
+    }
+}
+
+// =============================================================================
+// Text-backend free functions
+// =============================================================================
+
+/// Escape and optionally quote a field name according to the config.
+pub fn text_escape_and_quote_field(cfg: &TextQueryConfig, field: &str) -> String {
+    let mut escaped = field.to_string();
+
+    if let Some(esc) = cfg.field_escape
+        && let Some(pat) = cfg.field_escape_pattern
+        && let Ok(re) = regex::Regex::new(pat)
+    {
+        escaped = re
+            .replace_all(&escaped, |_: &regex::Captures| esc)
+            .to_string();
+    }
+
+    if let Some(quote) = cfg.field_quote {
+        let should_quote = match cfg.field_quote_pattern {
+            Some(pat) => {
+                let matches = regex::Regex::new(pat)
+                    .map(|re| re.is_match(&escaped))
+                    .unwrap_or(false);
+                if cfg.field_quote_pattern_negation {
+                    !matches
+                } else {
+                    matches
+                }
+            }
+            None => true,
+        };
+        if should_quote {
+            return format!("{quote}{escaped}{quote}");
+        }
+    }
+
+    escaped
+}
+
+/// Convert a `SigmaString` to its text representation, applying escaping and quoting.
+pub fn text_convert_value_str(cfg: &TextQueryConfig, value: &SigmaString) -> String {
+    let mut result = String::new();
+    let mut has_wildcards = false;
+
+    for part in &value.parts {
+        match part {
+            StringPart::Plain(s) => {
+                let mut escaped = String::with_capacity(s.len());
+                for ch in s.chars() {
+                    let ch_str = ch.to_string();
+                    if cfg.filter_chars.contains(&ch_str.as_str()) {
+                        continue;
+                    }
+                    if ch_str == cfg.escape_char
+                        || ch_str == cfg.str_quote
+                        || cfg.add_escaped.contains(&ch_str.as_str())
+                    {
+                        escaped.push_str(cfg.escape_char);
+                    }
+                    escaped.push(ch);
+                }
+                result.push_str(&escaped);
+            }
+            StringPart::Special(SpecialChar::WildcardMulti) => {
+                result.push_str(cfg.wildcard_multi);
+                has_wildcards = true;
+            }
+            StringPart::Special(SpecialChar::WildcardSingle) => {
+                result.push_str(cfg.wildcard_single);
+                has_wildcards = true;
+            }
+        }
+    }
+
+    if !has_wildcards {
+        let should_quote = match cfg.str_quote_pattern {
+            Some(pat) => {
+                let matches = regex::Regex::new(pat)
+                    .map(|re| re.is_match(&result))
+                    .unwrap_or(false);
+                if cfg.str_quote_pattern_negation {
+                    !matches
+                } else {
+                    matches
+                }
+            }
+            None => true,
+        };
+        if should_quote {
+            return format!("{}{result}{}", cfg.str_quote, cfg.str_quote);
+        }
+    }
+
+    result
+}
+
+/// Escape a regex pattern according to the config.
+pub fn text_convert_value_re(cfg: &TextQueryConfig, regex_str: &str) -> String {
+    let mut result = regex_str.to_string();
+
+    if let Some(esc_esc) = cfg.re_escape_escape_char
+        && let Some(esc) = cfg.re_escape_char
+    {
+        result = result.replace(esc, &format!("{esc_esc}{esc}"));
+    }
+
+    if let Some(esc) = cfg.re_escape_char {
+        for pattern in cfg.re_escape {
+            result = result.replace(pattern, &format!("{esc}{pattern}"));
+        }
+    }
+
+    result
+}
+
+/// Precedence-aware grouping.
+pub fn text_convert_condition_group(
+    cfg: &TextQueryConfig,
+    expr: &str,
+    outer: TokenType,
+    inner: TokenType,
+) -> String {
+    if cfg.needs_grouping(outer, inner) {
+        cfg.group_expression.replace("{expr}", expr)
+    } else {
+        expr.to_string()
+    }
+}
+
+/// Join expressions with the AND token.
+pub fn text_convert_condition_and(cfg: &TextQueryConfig, exprs: &[String]) -> String {
+    let sep = if cfg.and_token.is_empty() {
+        cfg.token_separator.to_string()
+    } else {
+        format!(
+            "{}{}{}",
+            cfg.token_separator, cfg.and_token, cfg.token_separator
+        )
+    };
+    exprs.join(&sep)
+}
+
+/// Join expressions with the OR token.
+pub fn text_convert_condition_or(cfg: &TextQueryConfig, exprs: &[String]) -> String {
+    let sep = format!(
+        "{}{}{}",
+        cfg.token_separator, cfg.or_token, cfg.token_separator
+    );
+    exprs.join(&sep)
+}
+
+/// Negate an expression with the NOT token.
+pub fn text_convert_condition_not(cfg: &TextQueryConfig, expr: &str) -> String {
+    format!("{}{}{expr}", cfg.not_token, cfg.token_separator)
+}
+
+/// Assemble the final query from the main condition string and any deferred parts.
+pub fn text_finish_query(
+    cfg: &TextQueryConfig,
+    query: &str,
+    state: &ConversionState,
+    rule: &SigmaRule,
+) -> String {
+    let main_query = if state.has_deferred() && query.is_empty() {
+        cfg.deferred_only_query
+    } else {
+        query
+    };
+
+    let mut result = cfg.query_expression.replace("{query}", main_query);
+
+    // Substitute state defaults first, then actual state values
+    for (key, default) in cfg.state_defaults {
+        let placeholder = format!("{{{key}}}");
+        result = result.replace(&placeholder, default);
+    }
+    for (key, val) in &state.processing_state {
+        if let Some(s) = val.as_str() {
+            let placeholder = format!("{{{key}}}");
+            result = result.replace(&placeholder, s);
+        }
+    }
+
+    // Substitute rule metadata
+    result = result.replace("{rule.title}", &rule.title);
+    if let Some(id) = &rule.id {
+        result = result.replace("{rule.id}", id);
+    }
+
+    // Append deferred parts
+    if state.has_deferred() {
+        let deferred_start = cfg.deferred_start.unwrap_or("");
+        let deferred_sep = cfg.deferred_separator.unwrap_or("");
+        let parts: Vec<String> = state.deferred.iter().map(|d| d.finalize()).collect();
+        result = format!("{result}{deferred_start}{}", parts.join(deferred_sep));
+    }
+
+    result
+}
+
+/// Dispatch string matching based on modifiers and wildcard positions.
+///
+/// Returns the query fragment for a field=value comparison, handling
+/// `contains`, `startswith`, `endswith`, and wildcard patterns.
+pub fn text_convert_field_eq_str(
+    cfg: &TextQueryConfig,
+    field: &str,
+    value: &SigmaString,
+    modifiers: &[Modifier],
+    _state: &ConversionState,
+) -> Result<ConvertResult> {
+    let escaped_field = text_escape_and_quote_field(cfg, field);
+    let is_cased = modifiers.contains(&Modifier::Cased);
+    let is_contains = modifiers.contains(&Modifier::Contains);
+    let is_startswith = modifiers.contains(&Modifier::StartsWith);
+    let is_endswith = modifiers.contains(&Modifier::EndsWith);
+
+    let value_str = text_convert_value_str(cfg, value);
+
+    // Case-sensitive dispatch
+    if is_cased {
+        if is_contains && let Some(expr) = cfg.case_sensitive_contains_expression {
+            return Ok(ConvertResult::Query(
+                expr.replace("{field}", &escaped_field)
+                    .replace("{value}", &value_str),
+            ));
+        }
+        if is_startswith && let Some(expr) = cfg.case_sensitive_startswith_expression {
+            return Ok(ConvertResult::Query(
+                expr.replace("{field}", &escaped_field)
+                    .replace("{value}", &value_str),
+            ));
+        }
+        if is_endswith && let Some(expr) = cfg.case_sensitive_endswith_expression {
+            return Ok(ConvertResult::Query(
+                expr.replace("{field}", &escaped_field)
+                    .replace("{value}", &value_str),
+            ));
+        }
+        if let Some(expr) = cfg.case_sensitive_match_expression {
+            return Ok(ConvertResult::Query(
+                expr.replace("{field}", &escaped_field)
+                    .replace("{value}", &value_str),
+            ));
+        }
+    }
+
+    // Case-insensitive dispatch (default)
+    if is_contains && let Some(expr) = cfg.contains_expression {
+        return Ok(ConvertResult::Query(
+            expr.replace("{field}", &escaped_field)
+                .replace("{value}", &value_str),
+        ));
+    }
+    if is_startswith && let Some(expr) = cfg.startswith_expression {
+        return Ok(ConvertResult::Query(
+            expr.replace("{field}", &escaped_field)
+                .replace("{value}", &value_str),
+        ));
+    }
+    if is_endswith && let Some(expr) = cfg.endswith_expression {
+        return Ok(ConvertResult::Query(
+            expr.replace("{field}", &escaped_field)
+                .replace("{value}", &value_str),
+        ));
+    }
+
+    // Wildcard match fallback
+    if value.contains_wildcards()
+        && let Some(expr) = cfg.wildcard_match_expression
+    {
+        return Ok(ConvertResult::Query(
+            expr.replace("{field}", &escaped_field)
+                .replace("{value}", &value_str),
+        ));
+    }
+
+    // Exact match (default)
+    let result = if let Some(expr) = cfg.eq_expression {
+        expr.replace("{field}", &escaped_field)
+            .replace("{value}", &value_str)
+    } else {
+        format!("{escaped_field}{}{value_str}", cfg.eq_token)
+    };
+    Ok(ConvertResult::Query(result))
+}

--- a/crates/rsigma-convert/src/backends/mod.rs
+++ b/crates/rsigma-convert/src/backends/mod.rs
@@ -1,0 +1,1 @@
+pub mod test;

--- a/crates/rsigma-convert/src/backends/test.rs
+++ b/crates/rsigma-convert/src/backends/test.rs
@@ -1,0 +1,1220 @@
+//! Backend-neutral test backend modeled after pySigma's `TextQueryTestBackend`.
+//!
+//! Exercises most generic text backend features without targeting a specific SIEM.
+//! Used to validate the `Backend` trait, `TextQueryConfig`, condition walker,
+//! value escaping, modifier handling, and output formats.
+
+use std::collections::HashMap;
+
+use rsigma_eval::pipeline::state::PipelineState;
+use rsigma_parser::*;
+
+use crate::backend::*;
+use crate::condition::convert_condition_expr;
+use crate::convert::{default_convert_detection, default_convert_detection_item};
+use crate::error::{ConvertError, Result};
+use crate::state::{ConversionState, ConvertResult};
+
+// =============================================================================
+// TextQueryTestBackend config
+// =============================================================================
+
+pub static TEXT_QUERY_TEST_CONFIG: TextQueryConfig = TextQueryConfig {
+    precedence: (TokenType::NOT, TokenType::AND, TokenType::OR),
+    group_expression: "({expr})",
+    token_separator: " ",
+
+    and_token: "and",
+    or_token: "or",
+    not_token: "not",
+    eq_token: "=",
+
+    not_eq_token: Some("!="),
+    eq_expression: None,
+    not_eq_expression: None,
+    convert_not_as_not_eq: false,
+
+    wildcard_multi: "*",
+    wildcard_single: "?",
+
+    str_quote: "\"",
+    str_quote_pattern: None,
+    str_quote_pattern_negation: false,
+    escape_char: "\\",
+    add_escaped: &[":"],
+    filter_chars: &["&"],
+
+    field_quote: Some("'"),
+    field_quote_pattern: Some(r"^\w+$"),
+    field_quote_pattern_negation: true,
+    field_escape: None,
+    field_escape_pattern: None,
+
+    startswith_expression: Some("{field} startswith {value}"),
+    not_startswith_expression: None,
+    startswith_expression_allow_special: false,
+    endswith_expression: Some("{field} endswith {value}"),
+    not_endswith_expression: None,
+    endswith_expression_allow_special: false,
+    contains_expression: Some("{field} contains {value}"),
+    not_contains_expression: None,
+    contains_expression_allow_special: false,
+    wildcard_match_expression: Some("{field} match {value}"),
+
+    case_sensitive_match_expression: Some("{field} casematch {value}"),
+    case_sensitive_startswith_expression: Some("{field} startswith_cased {value}"),
+    case_sensitive_endswith_expression: Some("{field} endswith_cased {value}"),
+    case_sensitive_contains_expression: Some("{field} contains_cased {value}"),
+
+    re_expression: Some("{field}=/{regex}/"),
+    not_re_expression: None,
+    re_escape_char: Some("\\"),
+    re_escape: &["/"],
+    re_escape_escape_char: None,
+
+    cidr_expression: Some("cidrmatch(\"{value}\", {field})"),
+    not_cidr_expression: None,
+
+    field_null_expression: "{field} is null",
+    field_exists_expression: Some("exists({field})"),
+    field_not_exists_expression: Some("notexists({field})"),
+
+    compare_op_expression: Some("{field}{op}{value}"),
+    compare_ops: &[
+        ("lt", "<"),
+        ("lte", "<="),
+        ("gt", ">"),
+        ("gte", ">="),
+        ("neq", "!="),
+    ],
+
+    convert_or_as_in: true,
+    convert_and_as_in: true,
+    in_expressions_allow_wildcards: true,
+    field_in_list_expression: Some("{field} {op} ({list})"),
+    or_in_operator: Some("in"),
+    and_in_operator: Some("contains-all"),
+    list_separator: ", ",
+
+    unbound_value_str_expression: Some("_={value}"),
+    unbound_value_num_expression: Some("_={value}"),
+    unbound_value_re_expression: Some("_=/{value}/"),
+
+    field_eq_field_expression: Some("{field1}=fieldref({field2})"),
+    field_eq_field_escaping_quoting: true,
+
+    deferred_start: Some(" | "),
+    deferred_separator: Some(" | "),
+    deferred_only_query: "*",
+
+    bool_true: "1",
+    bool_false: "0",
+    query_expression: "{query}",
+    state_defaults: &[],
+};
+
+// =============================================================================
+// TextQueryTestBackend
+// =============================================================================
+
+pub struct TextQueryTestBackend {
+    pub config: &'static TextQueryConfig,
+}
+
+impl TextQueryTestBackend {
+    pub fn new() -> Self {
+        Self {
+            config: &TEXT_QUERY_TEST_CONFIG,
+        }
+    }
+}
+
+impl Default for TextQueryTestBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Backend for TextQueryTestBackend {
+    fn name(&self) -> &str {
+        "test"
+    }
+
+    fn formats(&self) -> &[(&str, &str)] {
+        &[
+            ("default", "plain query list"),
+            ("test", "wrapped query [ {query} ]"),
+            ("state", "index={state.index} ({query})"),
+            ("str", "newline-joined queries"),
+        ]
+    }
+
+    fn requires_pipeline(&self) -> bool {
+        false
+    }
+
+    // --- Detection rule conversion ---
+
+    fn convert_rule(
+        &self,
+        rule: &SigmaRule,
+        output_format: &str,
+        pipeline_state: &PipelineState,
+    ) -> Result<Vec<String>> {
+        let mut queries = Vec::new();
+
+        for (idx, cond_expr) in rule.detection.conditions.iter().enumerate() {
+            let mut state = ConversionState::new(pipeline_state.state.clone());
+            let query = self.convert_condition(cond_expr, &rule.detection.named, &mut state)?;
+            let finished = self.finish_query(rule, query, &state)?;
+            let finalized = self.finalize_query(rule, finished, idx, &state, output_format)?;
+            queries.push(finalized);
+        }
+
+        Ok(queries)
+    }
+
+    // --- Condition tree dispatch ---
+
+    fn convert_condition(
+        &self,
+        expr: &ConditionExpr,
+        detections: &HashMap<String, Detection>,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        convert_condition_expr(self, expr, detections, state)
+    }
+
+    fn convert_condition_and(&self, exprs: &[String]) -> Result<String> {
+        Ok(text_convert_condition_and(self.config, exprs))
+    }
+
+    fn convert_condition_or(&self, exprs: &[String]) -> Result<String> {
+        Ok(text_convert_condition_or(self.config, exprs))
+    }
+
+    fn convert_condition_not(&self, expr: &str) -> Result<String> {
+        Ok(text_convert_condition_not(self.config, expr))
+    }
+
+    // --- Detection ---
+
+    fn convert_detection(&self, det: &Detection, state: &mut ConversionState) -> Result<String> {
+        default_convert_detection(self, det, state)
+    }
+
+    fn convert_detection_item(
+        &self,
+        item: &DetectionItem,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        default_convert_detection_item(self, item, state)
+    }
+
+    // --- Field/value escaping ---
+
+    fn escape_and_quote_field(&self, field: &str) -> String {
+        text_escape_and_quote_field(self.config, field)
+    }
+
+    fn convert_value_str(&self, value: &SigmaString, _state: &ConversionState) -> String {
+        text_convert_value_str(self.config, value)
+    }
+
+    fn convert_value_re(&self, regex: &str, _state: &ConversionState) -> String {
+        text_convert_value_re(self.config, regex)
+    }
+
+    // --- Value-type-specific methods ---
+
+    fn convert_field_eq_str(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        text_convert_field_eq_str(self.config, field, value, modifiers, state)
+    }
+
+    fn convert_field_eq_str_case_sensitive(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let mut mods = modifiers.to_vec();
+        if !mods.contains(&Modifier::Cased) {
+            mods.push(Modifier::Cased);
+        }
+        text_convert_field_eq_str(self.config, field, value, &mods, state)
+    }
+
+    fn convert_field_eq_num(
+        &self,
+        field: &str,
+        value: f64,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        if value.fract() == 0.0 {
+            Ok(format!("{f}={}", value as i64))
+        } else {
+            Ok(format!("{f}={value}"))
+        }
+    }
+
+    fn convert_field_eq_bool(
+        &self,
+        field: &str,
+        value: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        let v = if value {
+            self.config.bool_true
+        } else {
+            self.config.bool_false
+        };
+        Ok(format!("{f}={v}"))
+    }
+
+    fn convert_field_eq_null(&self, field: &str, _state: &mut ConversionState) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        Ok(self.config.field_null_expression.replace("{field}", &f))
+    }
+
+    fn convert_field_eq_re(
+        &self,
+        field: &str,
+        pattern: &str,
+        _flags: &[Modifier],
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let f = text_escape_and_quote_field(self.config, field);
+        let re_val = text_convert_value_re(self.config, pattern);
+        let expr = self
+            .config
+            .re_expression
+            .ok_or_else(|| ConvertError::UnsupportedModifier("regex".into()))?;
+        Ok(ConvertResult::Query(
+            expr.replace("{field}", &f).replace("{regex}", &re_val),
+        ))
+    }
+
+    fn convert_field_eq_cidr(
+        &self,
+        field: &str,
+        cidr: &str,
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let f = text_escape_and_quote_field(self.config, field);
+        let expr = self
+            .config
+            .cidr_expression
+            .ok_or_else(|| ConvertError::UnsupportedModifier("cidr".into()))?;
+        Ok(ConvertResult::Query(
+            expr.replace("{field}", &f).replace("{value}", cidr),
+        ))
+    }
+
+    fn convert_field_compare(
+        &self,
+        field: &str,
+        op: &Modifier,
+        value: f64,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        let op_name = match op {
+            Modifier::Lt => "lt",
+            Modifier::Lte => "lte",
+            Modifier::Gt => "gt",
+            Modifier::Gte => "gte",
+            _ => {
+                return Err(ConvertError::UnsupportedModifier(format!(
+                    "compare op {:?}",
+                    op
+                )));
+            }
+        };
+        let op_token = self
+            .config
+            .compare_ops
+            .iter()
+            .find(|(name, _)| *name == op_name)
+            .map(|(_, token)| *token)
+            .ok_or_else(|| ConvertError::UnsupportedModifier(op_name.into()))?;
+
+        let expr = self
+            .config
+            .compare_op_expression
+            .ok_or_else(|| ConvertError::UnsupportedModifier("compare".into()))?;
+
+        let val_str = if value.fract() == 0.0 {
+            (value as i64).to_string()
+        } else {
+            value.to_string()
+        };
+        Ok(expr
+            .replace("{field}", &f)
+            .replace("{op}", op_token)
+            .replace("{value}", &val_str))
+    }
+
+    fn convert_field_exists(
+        &self,
+        field: &str,
+        exists: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        if exists {
+            let expr = self
+                .config
+                .field_exists_expression
+                .ok_or_else(|| ConvertError::UnsupportedModifier("exists".into()))?;
+            Ok(expr.replace("{field}", &f))
+        } else {
+            let expr = self
+                .config
+                .field_not_exists_expression
+                .ok_or_else(|| ConvertError::UnsupportedModifier("not exists".into()))?;
+            Ok(expr.replace("{field}", &f))
+        }
+    }
+
+    fn convert_field_eq_query_expr(
+        &self,
+        field: &str,
+        expr: &str,
+        _id: &str,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        Ok(format!("{f}={expr}"))
+    }
+
+    fn convert_field_ref(
+        &self,
+        field1: &str,
+        field2: &str,
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let expr = self
+            .config
+            .field_eq_field_expression
+            .ok_or_else(|| ConvertError::UnsupportedModifier("fieldref".into()))?;
+        let f1 = text_escape_and_quote_field(self.config, field1);
+        let f2 = if self.config.field_eq_field_escaping_quoting {
+            text_escape_and_quote_field(self.config, field2)
+        } else {
+            field2.to_string()
+        };
+        Ok(ConvertResult::Query(
+            expr.replace("{field1}", &f1).replace("{field2}", &f2),
+        ))
+    }
+
+    fn convert_keyword(&self, value: &SigmaValue, _state: &mut ConversionState) -> Result<String> {
+        match value {
+            SigmaValue::String(s) => {
+                let v = text_convert_value_str(self.config, s);
+                let expr = self
+                    .config
+                    .unbound_value_str_expression
+                    .ok_or(ConvertError::UnsupportedKeyword)?;
+                Ok(expr.replace("{value}", &v))
+            }
+            SigmaValue::Integer(n) => {
+                let expr = self
+                    .config
+                    .unbound_value_num_expression
+                    .ok_or(ConvertError::UnsupportedKeyword)?;
+                Ok(expr.replace("{value}", &n.to_string()))
+            }
+            SigmaValue::Float(f) => {
+                let expr = self
+                    .config
+                    .unbound_value_num_expression
+                    .ok_or(ConvertError::UnsupportedKeyword)?;
+                Ok(expr.replace("{value}", &f.to_string()))
+            }
+            _ => Err(ConvertError::UnsupportedKeyword),
+        }
+    }
+
+    fn convert_condition_as_in_expression(
+        &self,
+        field: &str,
+        values: &[&SigmaValue],
+        is_or: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = text_escape_and_quote_field(self.config, field);
+        let expr = self
+            .config
+            .field_in_list_expression
+            .ok_or_else(|| ConvertError::UnsupportedModifier("in-list".into()))?;
+        let op = if is_or {
+            self.config
+                .or_in_operator
+                .ok_or_else(|| ConvertError::UnsupportedModifier("or-in".into()))?
+        } else {
+            self.config
+                .and_in_operator
+                .ok_or_else(|| ConvertError::UnsupportedModifier("and-in".into()))?
+        };
+
+        let items: Vec<String> = values
+            .iter()
+            .map(|v| match v {
+                SigmaValue::String(s) => text_convert_value_str(self.config, s),
+                SigmaValue::Integer(n) => n.to_string(),
+                SigmaValue::Float(f) => f.to_string(),
+                _ => String::new(),
+            })
+            .collect();
+
+        let list = items.join(self.config.list_separator);
+        Ok(expr
+            .replace("{field}", &f)
+            .replace("{op}", op)
+            .replace("{list}", &list))
+    }
+
+    // --- Query finalization ---
+
+    fn finish_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        state: &ConversionState,
+    ) -> Result<String> {
+        Ok(text_finish_query(self.config, &query, state, rule))
+    }
+
+    fn finalize_query(
+        &self,
+        _rule: &SigmaRule,
+        query: String,
+        _index: usize,
+        state: &ConversionState,
+        output_format: &str,
+    ) -> Result<String> {
+        match output_format {
+            "default" => Ok(query),
+            "test" => Ok(format!("[ {query} ]")),
+            "state" => {
+                let index = state.get_state_str("index").unwrap_or("default_index");
+                Ok(format!("index={index} ({query})"))
+            }
+            "str" => Ok(query),
+            other => Err(ConvertError::RuleConversion(format!(
+                "unknown output format: {other}"
+            ))),
+        }
+    }
+
+    fn finalize_output(&self, queries: Vec<String>, output_format: &str) -> Result<String> {
+        match output_format {
+            "str" => Ok(queries.join("\n")),
+            _ => Ok(queries.join("\n")),
+        }
+    }
+}
+
+// =============================================================================
+// MandatoryPipelineTestBackend
+// =============================================================================
+
+/// Variant that requires a pipeline (for testing the pipeline-required error path).
+pub struct MandatoryPipelineTestBackend(TextQueryTestBackend);
+
+impl MandatoryPipelineTestBackend {
+    pub fn new() -> Self {
+        Self(TextQueryTestBackend::new())
+    }
+}
+
+impl Default for MandatoryPipelineTestBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Backend for MandatoryPipelineTestBackend {
+    fn name(&self) -> &str {
+        "test_mandatory_pipeline"
+    }
+
+    fn formats(&self) -> &[(&str, &str)] {
+        self.0.formats()
+    }
+
+    fn requires_pipeline(&self) -> bool {
+        true
+    }
+
+    fn convert_rule(
+        &self,
+        rule: &SigmaRule,
+        output_format: &str,
+        pipeline_state: &PipelineState,
+    ) -> Result<Vec<String>> {
+        self.0.convert_rule(rule, output_format, pipeline_state)
+    }
+
+    fn convert_condition(
+        &self,
+        expr: &ConditionExpr,
+        detections: &HashMap<String, Detection>,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_condition(expr, detections, state)
+    }
+
+    fn convert_condition_and(&self, exprs: &[String]) -> Result<String> {
+        self.0.convert_condition_and(exprs)
+    }
+
+    fn convert_condition_or(&self, exprs: &[String]) -> Result<String> {
+        self.0.convert_condition_or(exprs)
+    }
+
+    fn convert_condition_not(&self, expr: &str) -> Result<String> {
+        self.0.convert_condition_not(expr)
+    }
+
+    fn convert_detection(&self, det: &Detection, state: &mut ConversionState) -> Result<String> {
+        self.0.convert_detection(det, state)
+    }
+
+    fn convert_detection_item(
+        &self,
+        item: &DetectionItem,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_detection_item(item, state)
+    }
+
+    fn escape_and_quote_field(&self, field: &str) -> String {
+        self.0.escape_and_quote_field(field)
+    }
+
+    fn convert_value_str(&self, value: &SigmaString, state: &ConversionState) -> String {
+        self.0.convert_value_str(value, state)
+    }
+
+    fn convert_value_re(&self, regex: &str, state: &ConversionState) -> String {
+        self.0.convert_value_re(regex, state)
+    }
+
+    fn convert_field_eq_str(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        self.0.convert_field_eq_str(field, value, modifiers, state)
+    }
+
+    fn convert_field_eq_str_case_sensitive(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        self.0
+            .convert_field_eq_str_case_sensitive(field, value, modifiers, state)
+    }
+
+    fn convert_field_eq_num(
+        &self,
+        field: &str,
+        value: f64,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_field_eq_num(field, value, state)
+    }
+
+    fn convert_field_eq_bool(
+        &self,
+        field: &str,
+        value: bool,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_field_eq_bool(field, value, state)
+    }
+
+    fn convert_field_eq_null(&self, field: &str, state: &mut ConversionState) -> Result<String> {
+        self.0.convert_field_eq_null(field, state)
+    }
+
+    fn convert_field_eq_re(
+        &self,
+        field: &str,
+        pattern: &str,
+        flags: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        self.0.convert_field_eq_re(field, pattern, flags, state)
+    }
+
+    fn convert_field_eq_cidr(
+        &self,
+        field: &str,
+        cidr: &str,
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        self.0.convert_field_eq_cidr(field, cidr, state)
+    }
+
+    fn convert_field_compare(
+        &self,
+        field: &str,
+        op: &Modifier,
+        value: f64,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_field_compare(field, op, value, state)
+    }
+
+    fn convert_field_exists(
+        &self,
+        field: &str,
+        exists: bool,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_field_exists(field, exists, state)
+    }
+
+    fn convert_field_eq_query_expr(
+        &self,
+        field: &str,
+        expr: &str,
+        id: &str,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        self.0.convert_field_eq_query_expr(field, expr, id, state)
+    }
+
+    fn convert_field_ref(
+        &self,
+        field1: &str,
+        field2: &str,
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        self.0.convert_field_ref(field1, field2, state)
+    }
+
+    fn convert_keyword(&self, value: &SigmaValue, state: &mut ConversionState) -> Result<String> {
+        self.0.convert_keyword(value, state)
+    }
+
+    fn finish_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        state: &ConversionState,
+    ) -> Result<String> {
+        self.0.finish_query(rule, query, state)
+    }
+
+    fn finalize_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        index: usize,
+        state: &ConversionState,
+        output_format: &str,
+    ) -> Result<String> {
+        self.0
+            .finalize_query(rule, query, index, state, output_format)
+    }
+
+    fn finalize_output(&self, queries: Vec<String>, output_format: &str) -> Result<String> {
+        self.0.finalize_output(queries, output_format)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_parser::parse_sigma_yaml;
+
+    fn convert_rule_yaml(yaml: &str) -> Vec<String> {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let backend = TextQueryTestBackend::new();
+        let mut results = Vec::new();
+        for rule in &collection.rules {
+            let queries = backend
+                .convert_rule(rule, "default", &PipelineState::default())
+                .unwrap();
+            results.extend(queries);
+        }
+        results
+    }
+
+    #[test]
+    fn test_simple_eq() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine=\"whoami\""]);
+    }
+
+    #[test]
+    fn test_and_condition() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    sel1:
+        FieldA: val1
+    sel2:
+        FieldB: val2
+    condition: sel1 and sel2
+"#,
+        );
+        assert_eq!(queries, vec!["FieldA=\"val1\" and FieldB=\"val2\""]);
+    }
+
+    #[test]
+    fn test_or_condition() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    sel1:
+        FieldA: val1
+    sel2:
+        FieldB: val2
+    condition: sel1 or sel2
+"#,
+        );
+        assert_eq!(queries, vec!["FieldA=\"val1\" or FieldB=\"val2\""]);
+    }
+
+    #[test]
+    fn test_not_condition() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    filter:
+        FieldB: val2
+    condition: selection and not filter
+"#,
+        );
+        assert_eq!(queries, vec!["FieldA=\"val1\" and not FieldB=\"val2\""]);
+    }
+
+    #[test]
+    fn test_contains_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains: whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine contains \"whoami\""]);
+    }
+
+    #[test]
+    fn test_startswith_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|startswith: cmd
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine startswith \"cmd\""]);
+    }
+
+    #[test]
+    fn test_endswith_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|endswith: '.exe'
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine endswith \".exe\""]);
+    }
+
+    #[test]
+    fn test_wildcard_value() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: '*whoami*'
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine match *whoami*"]);
+    }
+
+    #[test]
+    fn test_numeric_value() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 4688
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["EventID=4688"]);
+    }
+
+    #[test]
+    fn test_boolean_value() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Enabled: true
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["Enabled=1"]);
+    }
+
+    #[test]
+    fn test_null_value() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: null
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["FieldA is null"]);
+    }
+
+    #[test]
+    fn test_exists_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA|exists: true
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["exists(FieldA)"]);
+    }
+
+    #[test]
+    fn test_not_exists_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA|exists: false
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["notexists(FieldA)"]);
+    }
+
+    #[test]
+    fn test_re_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|re: '.*whoami.*'
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine=/.*whoami.*/"]);
+    }
+
+    #[test]
+    fn test_cidr_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        SourceIP|cidr: '10.0.0.0/8'
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["cidrmatch(\"10.0.0.0/8\", SourceIP)"]);
+    }
+
+    #[test]
+    fn test_gte_modifier() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        EventCount|gte: 10
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["EventCount>=10"]);
+    }
+
+    #[test]
+    fn test_multiple_values_or() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine:
+            - whoami
+            - ipconfig
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec!["CommandLine=\"whoami\" or CommandLine=\"ipconfig\""]
+        );
+    }
+
+    #[test]
+    fn test_multiple_values_all() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|all:
+            - whoami
+            - ipconfig
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec!["CommandLine=\"whoami\" and CommandLine=\"ipconfig\""]
+        );
+    }
+
+    #[test]
+    fn test_escape_chars() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: 'value:with&special'
+    condition: selection
+"#,
+        );
+        // `:` should be escaped with `\`, `&` should be filtered
+        assert_eq!(queries, vec!["FieldA=\"value\\:withspecial\""]);
+    }
+
+    #[test]
+    fn test_output_format_test() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = TextQueryTestBackend::new();
+        let queries = backend
+            .convert_rule(&collection.rules[0], "test", &PipelineState::default())
+            .unwrap();
+        assert_eq!(queries, vec!["[ FieldA=\"val1\" ]"]);
+    }
+
+    #[test]
+    fn test_output_format_state() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = TextQueryTestBackend::new();
+        let mut ps = PipelineState::default();
+        ps.set_state(
+            "index".to_string(),
+            serde_json::Value::String("my_index".into()),
+        );
+        let queries = backend
+            .convert_rule(&collection.rules[0], "state", &ps)
+            .unwrap();
+        assert_eq!(queries, vec!["index=my_index (FieldA=\"val1\")"]);
+    }
+
+    #[test]
+    fn test_mandatory_pipeline_error() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = MandatoryPipelineTestBackend::new();
+        let result = crate::convert::convert_collection(&backend, &collection, &[], "default");
+        assert!(matches!(result, Err(ConvertError::PipelineRequired)));
+    }
+
+    #[test]
+    fn test_multiple_detection_items_and() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+        FieldB: val2
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["FieldA=\"val1\" and FieldB=\"val2\""]);
+    }
+
+    #[test]
+    fn test_keywords() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    keywords:
+        - whoami
+        - ipconfig
+    condition: keywords
+"#,
+        );
+        assert_eq!(queries, vec!["_=\"whoami\" or _=\"ipconfig\""]);
+    }
+
+    #[test]
+    fn test_case_sensitive_contains() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains|cased: Whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(queries, vec!["CommandLine contains_cased \"Whoami\""]);
+    }
+
+    #[test]
+    fn test_re_with_slash_escaping() {
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Path|re: 'C:/Windows/.*'
+    condition: selection
+"#,
+        );
+        // `:` is in add_escaped for string values, not re_escape, so it stays unescaped.
+        // `/` is in re_escape, so both slashes get escaped.
+        assert_eq!(queries, vec!["Path=/C:\\/Windows\\/.*/"]);
+    }
+}

--- a/crates/rsigma-convert/src/condition.rs
+++ b/crates/rsigma-convert/src/condition.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+
+use rsigma_parser::*;
+
+use crate::backend::Backend;
+use crate::error::{ConvertError, Result};
+use crate::state::ConversionState;
+
+/// Recursively walk a `ConditionExpr` tree and convert each node into a query fragment.
+pub fn convert_condition_expr(
+    backend: &dyn Backend,
+    expr: &ConditionExpr,
+    detections: &HashMap<String, Detection>,
+    state: &mut ConversionState,
+) -> Result<String> {
+    match expr {
+        ConditionExpr::Identifier(name) => {
+            let det = detections.get(name).ok_or_else(|| {
+                ConvertError::RuleConversion(format!("detection '{name}' not found"))
+            })?;
+            backend.convert_detection(det, state)
+        }
+
+        ConditionExpr::And(exprs) => {
+            let parts: Vec<String> = exprs
+                .iter()
+                .map(|e| convert_condition_expr(backend, e, detections, state))
+                .collect::<Result<Vec<_>>>()?;
+            backend.convert_condition_and(&parts)
+        }
+
+        ConditionExpr::Or(exprs) => {
+            let parts: Vec<String> = exprs
+                .iter()
+                .map(|e| convert_condition_expr(backend, e, detections, state))
+                .collect::<Result<Vec<_>>>()?;
+            backend.convert_condition_or(&parts)
+        }
+
+        ConditionExpr::Not(inner) => {
+            let part = convert_condition_expr(backend, inner, detections, state)?;
+            backend.convert_condition_not(&part)
+        }
+
+        ConditionExpr::Selector {
+            quantifier,
+            pattern,
+        } => {
+            let names: Vec<&String> = match pattern {
+                SelectorPattern::Them => {
+                    detections.keys().filter(|n| !n.starts_with('_')).collect()
+                }
+                SelectorPattern::Pattern(pat) => detections
+                    .keys()
+                    .filter(|n| pattern_matches(pat, n))
+                    .collect(),
+            };
+
+            if names.is_empty() {
+                return Err(ConvertError::RuleConversion(
+                    "selector matched no detections".into(),
+                ));
+            }
+
+            let parts: Vec<String> = names
+                .iter()
+                .map(|name| {
+                    let det = detections.get(*name).unwrap();
+                    backend.convert_detection(det, state)
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            match quantifier {
+                Quantifier::Any | Quantifier::Count(1) => backend.convert_condition_or(&parts),
+                Quantifier::All => backend.convert_condition_and(&parts),
+                Quantifier::Count(n) => Err(ConvertError::RuleConversion(format!(
+                    "'{n} of' quantifier not supported in conversion"
+                ))),
+            }
+        }
+    }
+}
+
+/// Simple wildcard match on detection names (supports `*` glob at end, start, or middle).
+fn pattern_matches(pattern: &str, name: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return name.starts_with(prefix);
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return name.ends_with(suffix);
+    }
+    if let Some((prefix, suffix)) = pattern.split_once('*') {
+        return name.starts_with(prefix) && name.ends_with(suffix);
+    }
+    pattern == name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pattern_matches_star_suffix() {
+        assert!(pattern_matches("selection_*", "selection_main"));
+        assert!(pattern_matches("selection_*", "selection_"));
+        assert!(!pattern_matches("selection_*", "filter_main"));
+    }
+
+    #[test]
+    fn test_pattern_matches_star_prefix() {
+        assert!(pattern_matches("*_main", "selection_main"));
+        assert!(!pattern_matches("*_main", "selection_alt"));
+    }
+
+    #[test]
+    fn test_pattern_matches_star_middle() {
+        assert!(pattern_matches("sel*main", "selection_main"));
+        assert!(!pattern_matches("sel*main", "filter_main"));
+    }
+
+    #[test]
+    fn test_pattern_matches_exact() {
+        assert!(pattern_matches("selection", "selection"));
+        assert!(!pattern_matches("selection", "filter"));
+    }
+
+    #[test]
+    fn test_pattern_matches_star_only() {
+        assert!(pattern_matches("*", "anything"));
+    }
+}

--- a/crates/rsigma-convert/src/convert.rs
+++ b/crates/rsigma-convert/src/convert.rs
@@ -1,0 +1,243 @@
+use rsigma_eval::pipeline::{Pipeline, apply_pipelines_to_correlation, apply_pipelines_with_state};
+use rsigma_parser::SigmaCollection;
+
+use crate::backend::Backend;
+use crate::error::{ConvertError, Result};
+use crate::output::{ConversionOutput, ConversionResult};
+use crate::state::ConversionState;
+
+/// Convert a collection of Sigma rules using the given backend and pipelines.
+///
+/// Applies each pipeline to every rule, then delegates to the backend for
+/// conversion. Errors from individual rules are collected rather than aborting
+/// the entire batch.
+pub fn convert_collection(
+    backend: &dyn Backend,
+    collection: &SigmaCollection,
+    pipelines: &[Pipeline],
+    output_format: &str,
+) -> Result<ConversionOutput> {
+    if backend.requires_pipeline() && pipelines.is_empty() {
+        return Err(ConvertError::PipelineRequired);
+    }
+
+    let mut output = ConversionOutput::new();
+
+    for rule in &collection.rules {
+        let mut rule = rule.clone();
+        let pipeline_state = if !pipelines.is_empty() {
+            apply_pipelines_with_state(pipelines, &mut rule)?
+        } else {
+            Default::default()
+        };
+
+        match backend.convert_rule(&rule, output_format, &pipeline_state) {
+            Ok(queries) => {
+                output.queries.push(ConversionResult {
+                    rule_title: rule.title.clone(),
+                    rule_id: rule.id.clone(),
+                    queries,
+                });
+            }
+            Err(e) => {
+                output.errors.push((rule.title.clone(), e));
+            }
+        }
+    }
+
+    if backend.supports_correlation() {
+        for corr in &collection.correlations {
+            let mut corr = corr.clone();
+            if !pipelines.is_empty() {
+                apply_pipelines_to_correlation(pipelines, &mut corr)?;
+            }
+            let pipeline_state = Default::default();
+            match backend.convert_correlation_rule(&corr, output_format, &pipeline_state) {
+                Ok(queries) => {
+                    output.queries.push(ConversionResult {
+                        rule_title: corr.title.clone(),
+                        rule_id: corr.id.clone(),
+                        queries,
+                    });
+                }
+                Err(e) => {
+                    output.errors.push((corr.title.clone(), e));
+                }
+            }
+        }
+    }
+
+    Ok(output)
+}
+
+/// Default detection-item dispatch logic.
+///
+/// Used by backends that don't need custom item-level handling.
+pub fn default_convert_detection_item(
+    backend: &dyn Backend,
+    item: &rsigma_parser::DetectionItem,
+    state: &mut ConversionState,
+) -> Result<String> {
+    let field_name = item
+        .field
+        .name
+        .as_deref()
+        .ok_or(ConvertError::MissingFieldName)?;
+    let modifiers = &item.field.modifiers;
+
+    if item.field.has_modifier(rsigma_parser::Modifier::Exists) {
+        let expect = match item.values.first() {
+            Some(rsigma_parser::SigmaValue::Bool(b)) => *b,
+            _ => true,
+        };
+        return backend.convert_field_exists(field_name, expect, state);
+    }
+
+    if item.field.has_modifier(rsigma_parser::Modifier::FieldRef) {
+        let ref_field = match item.values.first() {
+            Some(rsigma_parser::SigmaValue::String(s)) => {
+                s.as_plain().unwrap_or_else(|| s.original.clone())
+            }
+            _ => {
+                return Err(ConvertError::UnsupportedValue(
+                    "fieldref requires string".into(),
+                ));
+            }
+        };
+        return match backend.convert_field_ref(field_name, &ref_field, state)? {
+            crate::state::ConvertResult::Query(q) => Ok(q),
+            crate::state::ConvertResult::Deferred(d) => {
+                state.add_deferred(d);
+                Ok(String::new())
+            }
+        };
+    }
+
+    if item.field.has_modifier(rsigma_parser::Modifier::Re) {
+        let pattern = match item.values.first() {
+            Some(rsigma_parser::SigmaValue::String(s)) => s.original.clone(),
+            _ => return Err(ConvertError::UnsupportedValue("re requires string".into())),
+        };
+        return match backend.convert_field_eq_re(field_name, &pattern, modifiers, state)? {
+            crate::state::ConvertResult::Query(q) => Ok(q),
+            crate::state::ConvertResult::Deferred(d) => {
+                state.add_deferred(d);
+                Ok(String::new())
+            }
+        };
+    }
+
+    if item.field.has_modifier(rsigma_parser::Modifier::Cidr) {
+        let cidr_str = match item.values.first() {
+            Some(rsigma_parser::SigmaValue::String(s)) => s.original.clone(),
+            _ => {
+                return Err(ConvertError::UnsupportedValue(
+                    "cidr requires string".into(),
+                ));
+            }
+        };
+        return match backend.convert_field_eq_cidr(field_name, &cidr_str, state)? {
+            crate::state::ConvertResult::Query(q) => Ok(q),
+            crate::state::ConvertResult::Deferred(d) => {
+                state.add_deferred(d);
+                Ok(String::new())
+            }
+        };
+    }
+
+    for m in [
+        rsigma_parser::Modifier::Gt,
+        rsigma_parser::Modifier::Gte,
+        rsigma_parser::Modifier::Lt,
+        rsigma_parser::Modifier::Lte,
+    ] {
+        if item.field.has_modifier(m) {
+            let num = match item.values.first() {
+                Some(rsigma_parser::SigmaValue::Integer(n)) => *n as f64,
+                Some(rsigma_parser::SigmaValue::Float(f)) => *f,
+                _ => {
+                    return Err(ConvertError::UnsupportedValue(
+                        "comparison requires number".into(),
+                    ));
+                }
+            };
+            return backend.convert_field_compare(field_name, &m, num, state);
+        }
+    }
+
+    let use_all = item.field.has_modifier(rsigma_parser::Modifier::All);
+
+    let value_parts: Vec<String> = item
+        .values
+        .iter()
+        .map(|v| match v {
+            rsigma_parser::SigmaValue::String(s) => {
+                match backend.convert_field_eq_str(field_name, s, modifiers, state)? {
+                    crate::state::ConvertResult::Query(q) => Ok(q),
+                    crate::state::ConvertResult::Deferred(d) => {
+                        state.add_deferred(d);
+                        Ok(String::new())
+                    }
+                }
+            }
+            rsigma_parser::SigmaValue::Integer(n) => {
+                backend.convert_field_eq_num(field_name, *n as f64, state)
+            }
+            rsigma_parser::SigmaValue::Float(f) => {
+                backend.convert_field_eq_num(field_name, *f, state)
+            }
+            rsigma_parser::SigmaValue::Bool(b) => {
+                backend.convert_field_eq_bool(field_name, *b, state)
+            }
+            rsigma_parser::SigmaValue::Null => backend.convert_field_eq_null(field_name, state),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Filter out empty strings from deferred results
+    let value_parts: Vec<String> = value_parts.into_iter().filter(|s| !s.is_empty()).collect();
+
+    if value_parts.is_empty() {
+        return Ok(String::new());
+    }
+
+    if value_parts.len() == 1 {
+        Ok(value_parts.into_iter().next().unwrap())
+    } else if use_all {
+        backend.convert_condition_and(&value_parts)
+    } else {
+        backend.convert_condition_or(&value_parts)
+    }
+}
+
+/// Default detection dispatch logic.
+///
+/// Used by backends that don't need custom detection-level handling.
+pub fn default_convert_detection(
+    backend: &dyn Backend,
+    det: &rsigma_parser::Detection,
+    state: &mut ConversionState,
+) -> Result<String> {
+    match det {
+        rsigma_parser::Detection::AllOf(items) => {
+            let parts: Vec<String> = items
+                .iter()
+                .map(|item| backend.convert_detection_item(item, state))
+                .collect::<Result<Vec<_>>>()?;
+            backend.convert_condition_and(&parts)
+        }
+        rsigma_parser::Detection::AnyOf(dets) => {
+            let parts: Vec<String> = dets
+                .iter()
+                .map(|d| backend.convert_detection(d, state))
+                .collect::<Result<Vec<_>>>()?;
+            backend.convert_condition_or(&parts)
+        }
+        rsigma_parser::Detection::Keywords(values) => {
+            let parts: Vec<String> = values
+                .iter()
+                .map(|v| backend.convert_keyword(v, state))
+                .collect::<Result<Vec<_>>>()?;
+            backend.convert_condition_or(&parts)
+        }
+    }
+}

--- a/crates/rsigma-convert/src/error.rs
+++ b/crates/rsigma-convert/src/error.rs
@@ -1,0 +1,36 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConvertError {
+    #[error("backend does not support modifier: {0}")]
+    UnsupportedModifier(String),
+
+    #[error("backend does not support keyword/unbound detection")]
+    UnsupportedKeyword,
+
+    #[error("backend does not support correlation type: {0}")]
+    UnsupportedCorrelation(String),
+
+    #[error("backend requires a processing pipeline")]
+    PipelineRequired,
+
+    #[error("field name is required but missing")]
+    MissingFieldName,
+
+    #[error("unsupported value type: {0}")]
+    UnsupportedValue(String),
+
+    #[error("CIDR parse error: {0}")]
+    CidrParse(String),
+
+    #[error("regex error: {0}")]
+    Regex(String),
+
+    #[error("rule conversion failed: {0}")]
+    RuleConversion(String),
+
+    #[error("pipeline error: {0}")]
+    Pipeline(#[from] rsigma_eval::error::EvalError),
+}
+
+pub type Result<T> = std::result::Result<T, ConvertError>;

--- a/crates/rsigma-convert/src/lib.rs
+++ b/crates/rsigma-convert/src/lib.rs
@@ -1,0 +1,33 @@
+//! # rsigma-convert
+//!
+//! Sigma rule conversion engine for transforming parsed Sigma rules into
+//! backend-native query strings (SQL, SPL, KQL, Lucene, etc.).
+//!
+//! This crate provides:
+//!
+//! - A [`Backend`] trait that backends implement to produce query strings.
+//! - A [`TextQueryConfig`] struct carrying tokens, operators, and expressions
+//!   for text-based query backends (the vast majority).
+//! - A condition-expression tree walker that recurses over [`ConditionExpr`]
+//!   and dispatches to the backend's conversion methods.
+//! - An orchestrator ([`convert_collection`]) that applies pipelines, converts
+//!   each rule, and collects results/errors.
+//! - Deferred-expression support for backends that need post-query appendages
+//!   (e.g. Splunk `| regex`, `| where`).
+//!
+//! [`ConditionExpr`]: rsigma_parser::ConditionExpr
+
+pub mod backend;
+pub mod backends;
+pub mod condition;
+pub mod convert;
+pub mod error;
+pub mod output;
+pub mod state;
+
+pub use backend::{Backend, TextQueryConfig, TokenType};
+pub use condition::convert_condition_expr;
+pub use convert::convert_collection;
+pub use error::{ConvertError, Result};
+pub use output::{ConversionOutput, ConversionResult};
+pub use state::{ConversionState, ConvertResult, DeferredExpression, DeferredTextExpression};

--- a/crates/rsigma-convert/src/output.rs
+++ b/crates/rsigma-convert/src/output.rs
@@ -1,0 +1,31 @@
+use crate::error::ConvertError;
+
+/// Output from converting a single Sigma rule.
+#[derive(Debug)]
+pub struct ConversionResult {
+    pub rule_title: String,
+    pub rule_id: Option<String>,
+    pub queries: Vec<String>,
+}
+
+/// Aggregated output from converting a collection of rules.
+#[derive(Debug)]
+pub struct ConversionOutput {
+    pub queries: Vec<ConversionResult>,
+    pub errors: Vec<(String, ConvertError)>,
+}
+
+impl ConversionOutput {
+    pub fn new() -> Self {
+        Self {
+            queries: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+}
+
+impl Default for ConversionOutput {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/rsigma-convert/src/state.rs
+++ b/crates/rsigma-convert/src/state.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+
+/// Trait for deferred query expressions that are finalized after main condition conversion.
+///
+/// In pySigma, deferred expressions postpone part of the query (e.g. Splunk `| regex`,
+/// `| where`) to the `finish_query` phase. Each backend can define custom deferred types.
+pub trait DeferredExpression: std::fmt::Debug + Send + Sync {
+    fn finalize(&self) -> String;
+    fn negate(&mut self);
+    fn is_negated(&self) -> bool;
+}
+
+/// Simple template-based deferred expression (covers most text-backend cases).
+#[derive(Debug, Clone)]
+pub struct DeferredTextExpression {
+    pub template: String,
+    pub field: String,
+    pub value: String,
+    pub negated: bool,
+    /// `(positive_op, negated_op)` substituted into `{op}` in the template.
+    pub operators: (&'static str, &'static str),
+}
+
+impl DeferredExpression for DeferredTextExpression {
+    fn finalize(&self) -> String {
+        let op = if self.negated {
+            self.operators.1
+        } else {
+            self.operators.0
+        };
+        self.template
+            .replace("{field}", &self.field)
+            .replace("{value}", &self.value)
+            .replace("{op}", op)
+    }
+
+    fn negate(&mut self) {
+        self.negated = !self.negated;
+    }
+
+    fn is_negated(&self) -> bool {
+        self.negated
+    }
+}
+
+/// Return type for conversion methods that may produce a direct string or a deferred expression.
+#[derive(Debug)]
+pub enum ConvertResult {
+    Query(String),
+    Deferred(Box<dyn DeferredExpression>),
+}
+
+/// Per-condition conversion state carried through the conversion of a single rule condition.
+#[derive(Debug, Default)]
+pub struct ConversionState {
+    /// Key-value state inherited from pipeline `SetState` transformations.
+    pub processing_state: HashMap<String, serde_json::Value>,
+    /// Deferred query parts to be appended after the main condition.
+    pub deferred: Vec<Box<dyn DeferredExpression>>,
+}
+
+impl ConversionState {
+    pub fn new(processing_state: HashMap<String, serde_json::Value>) -> Self {
+        Self {
+            processing_state,
+            deferred: Vec::new(),
+        }
+    }
+
+    pub fn add_deferred(&mut self, expr: Box<dyn DeferredExpression>) {
+        self.deferred.push(expr);
+    }
+
+    pub fn has_deferred(&self) -> bool {
+        !self.deferred.is_empty()
+    }
+
+    pub fn get_state_str(&self, key: &str) -> Option<&str> {
+        self.processing_state.get(key)?.as_str()
+    }
+}

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -117,6 +117,7 @@ pub use error::{EvalError, Result};
 pub use event::{Event, EventValue, JsonEvent, KvEvent, MapEvent, PlainEvent};
 pub use matcher::CompiledMatcher;
 pub use pipeline::{
-    Pipeline, apply_pipelines, merge_pipelines, parse_pipeline, parse_pipeline_file,
+    Pipeline, apply_pipelines, apply_pipelines_with_state, merge_pipelines, parse_pipeline,
+    parse_pipeline_file,
 };
 pub use result::{FieldMatch, MatchResult};

--- a/crates/rsigma-eval/src/pipeline/finalizers.rs
+++ b/crates/rsigma-eval/src/pipeline/finalizers.rs
@@ -26,6 +26,49 @@ pub enum Finalizer {
 }
 
 impl Finalizer {
+    /// Apply this finalizer to a list of query strings, producing a single output string.
+    ///
+    /// - `Concat`: joins queries with a separator and wraps in prefix/suffix.
+    /// - `Json`: serializes as a JSON array, optionally pretty-printed.
+    /// - `Template`: applies a template per query, replacing `{query}` and `{index}`.
+    pub fn apply(&self, queries: Vec<String>) -> String {
+        match self {
+            Finalizer::Concat {
+                separator,
+                prefix,
+                suffix,
+            } => {
+                format!("{prefix}{}{suffix}", queries.join(separator))
+            }
+            Finalizer::Json { indent } => match indent {
+                Some(n) => {
+                    let indent_str = " ".repeat(*n);
+                    let items: Vec<String> = queries
+                        .iter()
+                        .map(|q| {
+                            format!(
+                                "{indent_str}{}",
+                                serde_json::to_string(q).unwrap_or_default()
+                            )
+                        })
+                        .collect();
+                    format!("[\n{}\n]", items.join(",\n"))
+                }
+                None => serde_json::to_string(&queries).unwrap_or_else(|_| "[]".to_string()),
+            },
+            Finalizer::Template { template } => queries
+                .iter()
+                .enumerate()
+                .map(|(i, q)| {
+                    template
+                        .replace("{query}", q)
+                        .replace("{index}", &i.to_string())
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }
+    }
+
     /// Parse a finalizer from a YAML mapping.
     pub fn from_yaml(mapping: &serde_yaml::Value) -> Option<Self> {
         let obj = mapping.as_mapping()?;
@@ -143,5 +186,70 @@ template: "source={source} ({query})"
         } else {
             panic!("Expected Template");
         }
+    }
+
+    #[test]
+    fn test_concat_apply() {
+        let f = Finalizer::Concat {
+            separator: " OR ".to_string(),
+            prefix: "(".to_string(),
+            suffix: ")".to_string(),
+        };
+        let result = f.apply(vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(result, "(a OR b)");
+    }
+
+    #[test]
+    fn test_concat_apply_single() {
+        let f = Finalizer::Concat {
+            separator: " OR ".to_string(),
+            prefix: String::new(),
+            suffix: String::new(),
+        };
+        let result = f.apply(vec!["only".to_string()]);
+        assert_eq!(result, "only");
+    }
+
+    #[test]
+    fn test_concat_apply_empty() {
+        let f = Finalizer::Concat {
+            separator: ", ".to_string(),
+            prefix: "[".to_string(),
+            suffix: "]".to_string(),
+        };
+        let result = f.apply(vec![]);
+        assert_eq!(result, "[]");
+    }
+
+    #[test]
+    fn test_json_apply_no_indent() {
+        let f = Finalizer::Json { indent: None };
+        let result = f.apply(vec!["query1".to_string(), "query2".to_string()]);
+        assert_eq!(result, r#"["query1","query2"]"#);
+    }
+
+    #[test]
+    fn test_json_apply_with_indent() {
+        let f = Finalizer::Json { indent: Some(2) };
+        let result = f.apply(vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(result, "[\n  \"a\",\n  \"b\"\n]");
+    }
+
+    #[test]
+    fn test_template_apply() {
+        let f = Finalizer::Template {
+            template: "search {query}".to_string(),
+        };
+        let result = f.apply(vec!["x=1".to_string(), "y=2".to_string()]);
+        assert_eq!(result, "search x=1\nsearch y=2");
+    }
+
+    #[test]
+    fn test_template_apply_with_index() {
+        let f = Finalizer::Template {
+            template: "[{index}] {query}".to_string(),
+        };
+        let result = f.apply(vec!["first".to_string(), "second".to_string()]);
+        assert_eq!(result, "[0] first\n[1] second");
     }
 }

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -1131,6 +1131,28 @@ pub fn apply_pipelines(pipelines: &[Pipeline], rule: &mut SigmaRule) -> Result<(
     Ok(())
 }
 
+/// Apply multiple pipelines to a rule, returning the merged [`PipelineState`].
+///
+/// Unlike [`apply_pipelines`], this function accumulates state from all pipelines
+/// into a single `PipelineState` so that conversion backends can read values set
+/// by `SetState` and `QueryExpressionPlaceholders` transformations.
+pub fn apply_pipelines_with_state(
+    pipelines: &[Pipeline],
+    rule: &mut SigmaRule,
+) -> Result<PipelineState> {
+    let mut merged = PipelineState::default();
+    for pipeline in pipelines {
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline.apply(rule, &mut state)?;
+        for (k, v) in state.state {
+            merged.state.insert(k, v);
+        }
+        merged.applied_items.extend(state.applied_items);
+        merged.vars.extend(state.vars);
+    }
+    Ok(merged)
+}
+
 /// Apply multiple pipelines to a correlation rule in priority order.
 pub fn apply_pipelines_to_correlation(
     pipelines: &[Pipeline],

--- a/crates/rsigma-eval/src/pipeline/transformations.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations.rs
@@ -284,9 +284,12 @@ impl Transformation {
                 Ok(true)
             }
 
-            Transformation::QueryExpressionPlaceholders { .. } => {
-                // No-op for eval mode
-                Ok(false)
+            Transformation::QueryExpressionPlaceholders { expression } => {
+                state.set_state(
+                    "query_expression_template".to_string(),
+                    serde_json::Value::String(expression.clone()),
+                );
+                Ok(true)
             }
 
             Transformation::SetState { key, value } => {
@@ -2374,14 +2377,16 @@ mod tests {
     }
 
     #[test]
-    fn test_query_expression_placeholders_noop() {
+    fn test_query_expression_placeholders_stores_in_state() {
         let mut rule = make_test_rule();
         let mut state = PipelineState::default();
         let t = Transformation::QueryExpressionPlaceholders {
             expression: "{field}={value}".to_string(),
         };
         let result = t.apply(&mut rule, &mut state, &[], &[], false).unwrap();
-        assert!(!result); // no-op returns false
+        assert!(result);
+        let stored = state.get_state("query_expression_template").unwrap();
+        assert_eq!(stored.as_str().unwrap(), "{field}={value}");
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- Add pipeline convert prerequisites to `rsigma-eval`: `Finalizer::apply()`, `QueryExpressionPlaceholders` state passthrough, and `apply_pipelines_with_state()`
- Introduce new `rsigma-convert` crate with `Backend` trait (~30 methods), `TextQueryConfig` (~90 fields), condition tree walker, collection orchestrator, deferred expression support, and `TextQueryTestBackend` (31 tests)
- Add `rsigma convert`, `rsigma list-targets`, and `rsigma list-formats` CLI commands with a registry-style backend lookup

## Details

### Phase 0: Pipeline prerequisites (`rsigma-eval`)
- `Finalizer::apply()` for concat, json, and template output finalization
- `QueryExpressionPlaceholders` now stores expression in `PipelineState` (was a no-op)
- `apply_pipelines_with_state()` returns merged `PipelineState` for backend use

### Phase 1: `rsigma-convert` crate
- `Backend` trait mirroring pySigma's dispatch: condition tree, detection items, field/value escaping, regex, CIDR, compare, exists, fieldref, keywords, IN-list, deferred expressions, query finalization
- `TextQueryConfig` struct covering precedence, boolean operators, wildcards, string/field quoting, match expressions (startswith/endswith/contains + case-sensitive variants), regex/CIDR templates, compare ops, IN-list optimization, unbound values, deferred parts, and query envelope
- `convert_condition_expr()` tree walker with selector/quantifier support
- `convert_collection()` orchestrator with pipeline integration and error collection
- `TextQueryTestBackend` and `MandatoryPipelineTestBackend` for foundation validation

### Phase 3: CLI commands
- `rsigma convert <rules> -t <target> [-f format] [-p pipeline]`
- `rsigma list-targets` and `rsigma list-formats <target>`
- Registry initially registers test backend; PostgreSQL backend deferred to its own plan

## Test plan

- [x] 31 unit tests in `rsigma-convert` covering all conversion paths
- [x] All existing workspace tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Smoke-tested `rsigma convert`, `rsigma list-targets`, `rsigma list-formats` CLI commands