### PR TITLE
feat: PostgreSQL/TimescaleDB backend for Sigma rule conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,23 @@ rsigma convert -r rules/ -t test
 # Convert with a processing pipeline and specific output format
 rsigma convert -r rules/ -t test -p pipelines/ecs.yml -f state
 
+# Convert to PostgreSQL SQL
+rsigma convert -r rules/ -t postgres
+
+# Convert to PostgreSQL with OCSF field mapping pipeline
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+
+# Generate PostgreSQL views for each rule
+rsigma convert -r rules/ -t postgres -f view
+
+# Generate TimescaleDB continuous aggregates
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f continuous_aggregate
+
 # List available conversion backends
 rsigma list-targets
 
 # List available output formats for a backend
-rsigma list-formats -t test
+rsigma list-formats -t postgres
 ```
 
 Or use the library directly:
@@ -198,9 +210,9 @@ See [`examples/jsonl_stdin.rs`](crates/rsigma-runtime/examples/jsonl_stdin.rs) a
     │    Engine (stateless)   │   │                     │   │  VSCode, Neovim,   │
     │                         │   │  backends/ ──>      │   │  Helix, Zed, ...   │
     │  correlation.rs ──>     │   │    TextQueryTest,   │   └────────────────────┘
-    │    sliding windows,     │   │    (PostgreSQL WIP) │
-    │    group-by, chaining,  │   └─────────────────────┘
-    │    suppression, events  │
+    │    sliding windows,     │   │    PostgreSQL/      │
+    │    group-by, chaining,  │   │    TimescaleDB      │
+    │    suppression, events  │   └─────────────────────┘
     │                         │
     │  rsigma.* custom        │
     │    attributes           │

--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ rsigma convert -r rules/ -t test -p pipelines/ecs.yml -f state
 # Convert to PostgreSQL SQL
 rsigma convert -r rules/ -t postgres
 
-# Convert to PostgreSQL with OCSF field mapping pipeline
+# Convert to PostgreSQL with OCSF field mapping pipeline (single table)
 rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+
+# Convert with per-logsource table routing (multi-table)
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
 
 # Generate PostgreSQL views for each rule
 rsigma convert -r rules/ -t postgres -f view

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -309,8 +309,11 @@ rsigma convert -r rule.yml -t test
 # Convert to PostgreSQL SQL
 rsigma convert -r rules/ -t postgres
 
-# Convert to PostgreSQL with OCSF field mapping
+# Convert to PostgreSQL with OCSF field mapping (single table)
 rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+
+# Convert with per-logsource table routing (multi-table)
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
 
 # Generate PostgreSQL views
 rsigma convert -r rules/ -t postgres -f view

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -30,6 +30,9 @@ rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"
 # Convert rules to backend-native queries
 rsigma convert -r rules/ -t test
 
+# Convert to PostgreSQL SQL
+rsigma convert -r rules/ -t postgres
+
 # List available conversion backends
 rsigma list-targets
 ```
@@ -291,6 +294,8 @@ Convert Sigma rules into query strings for a specific backend (SQL, SPL, KQL, Lu
 | `--pipeline` / `-p` | repeatable | `[]` | Processing pipeline YAML file(s) |
 | `--format` / `-f` | string | `"default"` | Output format (see `list-formats`) |
 
+Available backends: `test`, `postgres` (aliases: `postgresql`, `pg`).
+
 ```bash
 # Convert rules using the test backend
 rsigma convert -r rules/ -t test
@@ -300,6 +305,18 @@ rsigma convert -r rules/ -t test -p pipelines/ecs.yml -f state
 
 # Convert a single rule
 rsigma convert -r rule.yml -t test
+
+# Convert to PostgreSQL SQL
+rsigma convert -r rules/ -t postgres
+
+# Convert to PostgreSQL with OCSF field mapping
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+
+# Generate PostgreSQL views
+rsigma convert -r rules/ -t postgres -f view
+
+# Generate TimescaleDB continuous aggregates
+rsigma convert -r rules/ -t postgres -f continuous_aggregate
 ```
 
 ### `list-targets`: List available conversion backends
@@ -308,6 +325,9 @@ List all registered conversion backend targets.
 
 ```bash
 rsigma list-targets
+# Output:
+#   test      Backend-neutral text queries for testing
+#   postgres  PostgreSQL/TimescaleDB SQL
 ```
 
 ### `list-formats`: List output formats for a backend
@@ -319,7 +339,12 @@ List the output formats supported by a specific backend.
 | `--target` / `-t` | string | required | Backend target name |
 
 ```bash
-rsigma list-formats -t test
+rsigma list-formats -t postgres
+# Output:
+#   default              Plain PostgreSQL SQL
+#   view                 CREATE OR REPLACE VIEW for each rule
+#   timescaledb          TimescaleDB-optimized queries with time_bucket()
+#   continuous_aggregate CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)
 ```
 
 ### `condition`: Parse a condition expression

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -2048,13 +2048,16 @@ impl Painter {
 
 fn get_backend(target: &str) -> Box<dyn rsigma_convert::Backend> {
     match target {
+        "postgres" | "postgresql" | "pg" => {
+            Box::new(rsigma_convert::backends::postgres::PostgresBackend::new())
+        }
         "test" => Box::new(rsigma_convert::backends::test::TextQueryTestBackend::new()),
         "test_mandatory_pipeline" => {
             Box::new(rsigma_convert::backends::test::MandatoryPipelineTestBackend::new())
         }
         _ => {
             eprintln!("Unknown target: {target}");
-            eprintln!("Available targets: test");
+            eprintln!("Available targets: postgres, test");
             process::exit(1);
         }
     }
@@ -2128,7 +2131,8 @@ fn cmd_convert(
 
 fn cmd_list_targets() {
     println!("Available conversion targets:");
-    println!("  test  - Backend-neutral test backend");
+    println!("  postgres  - PostgreSQL/TimescaleDB (aliases: postgresql, pg)");
+    println!("  test      - Backend-neutral test backend");
 }
 
 fn cmd_list_formats(target: String) {

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -16,8 +16,18 @@ The crate provides a generic conversion framework that any backend can plug into
 - **Orchestrator** via `convert_collection()`, which applies pipelines, converts each rule, and collects results and errors.
 - **Deferred expressions** through the `DeferredExpression` trait and `DeferredTextExpression` for backends that need post-query appendages (e.g. Splunk `| regex`, `| where`).
 - **Test backend** with `TextQueryTestBackend` and `MandatoryPipelineTestBackend` for backend-neutral foundation testing.
+- **PostgreSQL/TimescaleDB backend** with native `ILIKE`, regex (`~*`), CIDR (`inet`/`cidr`), full-text search (`tsvector`/`tsquery`), JSONB field access, correlation via CTEs and window functions, and TimescaleDB-specific output formats (continuous aggregates, `time_bucket` queries, view generation).
+
+## Backends
+
+| Backend | Target names | Description |
+|---------|-------------|-------------|
+| Test | `test` | Backend-neutral text queries for foundation testing |
+| PostgreSQL | `postgres`, `postgresql`, `pg` | Native PostgreSQL SQL with TimescaleDB support |
 
 ## Usage
+
+### Test backend
 
 ```rust
 use rsigma_parser::parse_sigma_yaml;
@@ -47,6 +57,60 @@ for result in &output.queries {
     }
 }
 ```
+
+### PostgreSQL backend
+
+```rust
+use rsigma_parser::parse_sigma_yaml;
+use rsigma_convert::{convert_collection, Backend};
+use rsigma_convert::backends::postgres::PostgresBackend;
+
+let yaml = r#"
+title: Detect Whoami
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+level: medium
+"#;
+
+let collection = parse_sigma_yaml(yaml).unwrap();
+let backend = PostgresBackend::new();
+
+let output = convert_collection(&backend, &collection, &[], "default").unwrap();
+for result in &output.queries {
+    for query in &result.queries {
+        println!("{query}");
+        // Output: SELECT * FROM security_events WHERE "CommandLine" ILIKE 'whoami'
+    }
+}
+```
+
+### PostgreSQL output formats
+
+| Format | Description |
+|--------|-------------|
+| `default` | Plain `SELECT * FROM {table} WHERE ...` queries |
+| `view` | `CREATE OR REPLACE VIEW sigma_{id} AS SELECT ...` |
+| `timescaledb` | Queries with `time_bucket()` for TimescaleDB optimization |
+| `continuous_aggregate` | `CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)` |
+
+### PostgreSQL with OCSF pipeline
+
+An OCSF processing pipeline is included at `pipelines/ocsf_postgres.yml` that maps common Sigma field names (Windows Sysmon, authentication, network, DNS, etc.) to OCSF-normalized column names.
+
+```bash
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f view
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f continuous_aggregate
+```
+
+### Reference schema
+
+A reference TimescaleDB schema is provided at [`schema/timescaledb_security_events.sql`](./schema/timescaledb_security_events.sql) with hypertable setup, indexes (B-tree, GIN for full-text and JSONB), compression, retention policies, and an example continuous aggregate.
 
 ## Backend Trait
 
@@ -93,7 +157,36 @@ For text-based query backends (the vast majority), create a `TextQueryConfig` wi
 3. Override specific methods for backend-specific behavior (e.g. deferred regex for Splunk, SQL-specific CIDR handling for PostgreSQL).
 4. Register your backend in the CLI's `get_backend()` registry.
 
-See `backends/test.rs` for a complete reference implementation.
+See `backends/test.rs` for a complete reference implementation and `backends/postgres.rs` for a production backend with SQL-specific overrides.
+
+## PostgreSQL Backend Details
+
+The PostgreSQL backend (`PostgresBackend`) leverages native PostgreSQL features that map cleanly to Sigma modifiers:
+
+| Sigma Modifier | PostgreSQL SQL |
+|----------------|---------------|
+| `contains` | `ILIKE` (case-insensitive) |
+| `startswith` / `endswith` | `ILIKE` |
+| `cased` | `LIKE` (case-sensitive) |
+| `re` | `~*` (case-insensitive regex) or `~` (with `cased`) |
+| `cidr` | `field::inet <<= 'value'::cidr` |
+| `exists` | `IS NOT NULL` / `IS NULL` |
+| keywords | `to_tsvector() @@ to_tsquery()` |
+
+Correlation rules are converted to SQL using `GROUP BY` / `HAVING` for aggregation types (`event_count`, `value_count`, `value_sum`, `value_avg`) and CTEs for temporal correlation.
+
+### Configuration
+
+`PostgresBackend` fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `table` | `String` | `"security_events"` | Default table name (overridden by pipeline state) |
+| `timestamp_field` | `String` | `"time"` | Timestamp column for time-windowed queries |
+| `json_field` | `Option<String>` | `None` | If set, fields are accessed via JSONB (`col->>'field'`) |
+| `case_sensitive_re` | `bool` | `false` | Use `~` instead of `~*` for regex |
+| `schema` | `Option<String>` | `None` | PostgreSQL schema name (e.g. `public`, `audit`) |
+| `timescaledb` | `bool` | `false` | Enable TimescaleDB-specific features |
 
 ## License
 

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -98,15 +98,73 @@ for result in &output.queries {
 | `timescaledb` | Queries with `time_bucket()` for TimescaleDB optimization |
 | `continuous_aggregate` | `CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)` |
 
-### PostgreSQL with OCSF pipeline
+### Custom table, schema, and database
 
-An OCSF processing pipeline is included at `pipelines/ocsf_postgres.yml` that maps common Sigma field names (Windows Sysmon, authentication, network, DNS, etc.) to OCSF-normalized column names.
+The target table and schema can be set at three levels (highest precedence first):
+
+1. **Rule-level `custom_attributes`** — `postgres.table`, `postgres.schema`, `postgres.database`
+2. **Pipeline state** — `set_state` with `key: table`, `key: schema`
+3. **Backend defaults** — `PostgresBackend.table`, `.schema`, `.database`
+
+Example rule with custom attributes:
+
+```yaml
+title: Process Creation
+logsource:
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+custom_attributes:
+    postgres.table: process_events
+    postgres.schema: siem
+```
+
+### OCSF pipelines
+
+Two OCSF processing pipelines are included:
+
+| Pipeline | Description |
+|----------|-------------|
+| `pipelines/ocsf_postgres.yml` | Single-table — all events go to `security_events` |
+| `pipelines/ocsf_postgres_multi_table.yml` | Per-logsource routing — each category gets its own table (`process_events`, `network_events`, etc.) |
 
 ```bash
+# Single-table pipeline
 rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+
+# Multi-table pipeline (per-logsource routing)
+rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
+
+# With output format
 rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f view
 rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f continuous_aggregate
 ```
+
+### Multi-table temporal correlations
+
+When a temporal correlation rule references detection rules that target different tables (via per-logsource pipeline routing or custom attributes), the backend automatically generates a `UNION ALL` CTE:
+
+```sql
+-- Rules targeting different tables produce UNION ALL
+WITH matched AS (
+    SELECT *, 'process_rule' AS rule_name FROM process_events
+        WHERE time >= NOW() - INTERVAL '300 seconds'
+    UNION ALL
+    SELECT *, 'network_rule' AS rule_name FROM network_events
+        WHERE time >= NOW() - INTERVAL '300 seconds'
+)
+SELECT "User", COUNT(DISTINCT rule_name) AS distinct_rules,
+    MIN(time) AS first_seen, MAX(time) AS last_seen
+FROM matched
+GROUP BY "User"
+HAVING COUNT(DISTINCT rule_name) >= 2
+```
+
+When all referenced rules share the same table, the simpler single-table approach is used instead.
+
+Per-rule schemas are also tracked: if different detection rules set different schemas (via `postgres.schema` custom attribute or `set_state key: schema` in the pipeline), each leg of the UNION ALL uses the correct `schema.table`.
 
 ### Reference schema
 
@@ -173,7 +231,7 @@ The PostgreSQL backend (`PostgresBackend`) leverages native PostgreSQL features 
 | `exists` | `IS NOT NULL` / `IS NULL` |
 | keywords | `to_tsvector() @@ to_tsquery()` |
 
-Correlation rules are converted to SQL using `GROUP BY` / `HAVING` for aggregation types (`event_count`, `value_count`, `value_sum`, `value_avg`) and CTEs for temporal correlation.
+Correlation rules are converted to SQL using `GROUP BY` / `HAVING` for aggregation types (`event_count`, `value_count`, `value_sum`, `value_avg`, `value_percentile`, `value_median`) and CTEs for temporal correlation. Multi-table temporal correlations automatically generate `UNION ALL` CTEs when referenced rules target different tables.
 
 ### Configuration
 
@@ -181,11 +239,12 @@ Correlation rules are converted to SQL using `GROUP BY` / `HAVING` for aggregati
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `table` | `String` | `"security_events"` | Default table name (overridden by pipeline state) |
+| `table` | `String` | `"security_events"` | Default table name (overridden by pipeline state or `postgres.table` custom attribute) |
 | `timestamp_field` | `String` | `"time"` | Timestamp column for time-windowed queries |
 | `json_field` | `Option<String>` | `None` | If set, fields are accessed via JSONB (`col->>'field'`) |
 | `case_sensitive_re` | `bool` | `false` | Use `~` instead of `~*` for regex |
-| `schema` | `Option<String>` | `None` | PostgreSQL schema name (e.g. `public`, `audit`) |
+| `schema` | `Option<String>` | `None` | PostgreSQL schema name (overridden by pipeline state or `postgres.schema` custom attribute) |
+| `database` | `Option<String>` | `None` | PostgreSQL database name (connection-level metadata) |
 | `timescaledb` | `bool` | `false` | Enable TimescaleDB-specific features |
 
 ## License

--- a/crates/rsigma-convert/pipelines/ocsf_postgres.yml
+++ b/crates/rsigma-convert/pipelines/ocsf_postgres.yml
@@ -1,0 +1,147 @@
+# OCSF-based processing pipeline for PostgreSQL/TimescaleDB security events schema.
+#
+# Maps common Sigma rule field names (Windows Sysmon, generic process creation,
+# network connection, authentication) to the OCSF-normalized column names used
+# in the reference TimescaleDB `security_events` schema.
+#
+# Usage:
+#   rsigma convert -t postgres -p pipelines/ocsf_postgres.yml rules/
+
+name: ocsf_postgres
+priority: 10
+
+transformations:
+  # ---- Process Creation (Sysmon EventID 1, category: process_creation) ----
+  - id: process_fields
+    type: field_name_mapping
+    mapping:
+      CommandLine: process_command_line
+      Image: process_file_path
+      OriginalFileName: process_original_name
+      ParentImage: parent_process_file_path
+      ParentCommandLine: parent_process_command_line
+      User: actor_user_name
+      IntegrityLevel: process_integrity_level
+      Hashes: process_file_hash
+      CurrentDirectory: process_current_directory
+      ProcessId: process_pid
+      ParentProcessId: parent_process_pid
+      Company: process_file_company
+      Description: process_file_description
+      Product: process_file_product
+      FileVersion: process_file_version
+    rule_conditions:
+      - type: logsource
+        category: process_creation
+
+  # ---- Network Connection (Sysmon EventID 3, category: network_connection) ----
+  - id: network_fields
+    type: field_name_mapping
+    mapping:
+      SourceIp: src_ip
+      SourcePort: src_port
+      DestinationIp: dst_ip
+      DestinationPort: dst_port
+      DestinationHostname: dst_hostname
+      Protocol: network_protocol
+      Initiated: network_direction
+      Image: process_file_path
+      User: actor_user_name
+    rule_conditions:
+      - type: logsource
+        category: network_connection
+
+  # ---- File events (Sysmon EventID 11, category: file_event) ----
+  - id: file_fields
+    type: field_name_mapping
+    mapping:
+      TargetFilename: file_path
+      Image: process_file_path
+      User: actor_user_name
+    rule_conditions:
+      - type: logsource
+        category: file_event
+
+  # ---- Registry events (Sysmon EventID 12/13/14, category: registry_event) ----
+  - id: registry_fields
+    type: field_name_mapping
+    mapping:
+      TargetObject: registry_key
+      Details: registry_value
+      Image: process_file_path
+      EventType: event_type
+    rule_conditions:
+      - type: logsource
+        category: registry_event
+
+  # ---- DNS queries (Sysmon EventID 22, category: dns_query) ----
+  - id: dns_fields
+    type: field_name_mapping
+    mapping:
+      QueryName: dns_query_name
+      QueryResults: dns_answer
+      Image: process_file_path
+      QueryStatus: dns_response_code
+    rule_conditions:
+      - type: logsource
+        category: dns_query
+
+  # ---- Authentication / Login (category: authentication) ----
+  - id: auth_fields
+    type: field_name_mapping
+    mapping:
+      TargetUserName: actor_user_name
+      TargetDomainName: actor_user_domain
+      LogonType: auth_logon_type
+      IpAddress: src_ip
+      IpPort: src_port
+      WorkstationName: src_hostname
+      SubjectUserName: subject_user_name
+      SubjectDomainName: subject_user_domain
+      AuthenticationPackageName: auth_package
+      TargetServerName: dst_hostname
+    rule_conditions:
+      - type: logsource
+        category: authentication
+
+  # ---- Proxy / Web (category: proxy) ----
+  - id: proxy_fields
+    type: field_name_mapping
+    mapping:
+      c-uri: http_url
+      c-useragent: http_user_agent
+      cs-method: http_method
+      r-dns: dst_hostname
+      cs-host: http_host
+      cs-referrer: http_referrer
+      sc-status: http_status_code
+      src_ip: src_ip
+      dst_ip: dst_ip
+    rule_conditions:
+      - type: logsource
+        category: proxy
+
+  # ---- Firewall (category: firewall) ----
+  - id: firewall_fields
+    type: field_name_mapping
+    mapping:
+      src_ip: src_ip
+      dst_ip: dst_ip
+      src_port: src_port
+      dst_port: dst_port
+      action: action
+    rule_conditions:
+      - type: logsource
+        category: firewall
+
+  # ---- Global: EventID mapping (always applies) ----
+  - id: event_id
+    type: field_name_mapping
+    mapping:
+      EventID: event_id
+
+  # ---- Set target table in pipeline state ----
+  - id: set_table
+    type: set_state
+    key: table
+    value: security_events

--- a/crates/rsigma-convert/pipelines/ocsf_postgres_multi_table.yml
+++ b/crates/rsigma-convert/pipelines/ocsf_postgres_multi_table.yml
@@ -1,0 +1,216 @@
+# OCSF-based processing pipeline for PostgreSQL/TimescaleDB with per-logsource
+# table routing.
+#
+# This variant of the OCSF pipeline maps each logsource category to a dedicated
+# table. Use this when your TimescaleDB schema uses separate hypertables per
+# event type for better partition pruning and compression ratios.
+#
+# Usage:
+#   rsigma convert -t postgres -p pipelines/ocsf_postgres_multi_table.yml rules/
+#
+# When used with temporal correlation rules that reference detection rules from
+# different categories, the PostgreSQL backend automatically generates UNION ALL
+# CTEs to query across the per-category tables.
+
+name: ocsf_postgres_multi_table
+priority: 10
+
+transformations:
+  # ---- Process Creation (Sysmon EventID 1, category: process_creation) ----
+  - id: process_fields
+    type: field_name_mapping
+    mapping:
+      CommandLine: process_command_line
+      Image: process_file_path
+      OriginalFileName: process_original_name
+      ParentImage: parent_process_file_path
+      ParentCommandLine: parent_process_command_line
+      User: actor_user_name
+      IntegrityLevel: process_integrity_level
+      Hashes: process_file_hash
+      CurrentDirectory: process_current_directory
+      ProcessId: process_pid
+      ParentProcessId: parent_process_pid
+      Company: process_file_company
+      Description: process_file_description
+      Product: process_file_product
+      FileVersion: process_file_version
+    rule_conditions:
+      - type: logsource
+        category: process_creation
+
+  - id: process_table
+    type: set_state
+    key: table
+    value: process_events
+    rule_conditions:
+      - type: logsource
+        category: process_creation
+
+  # ---- Network Connection (Sysmon EventID 3, category: network_connection) ----
+  - id: network_fields
+    type: field_name_mapping
+    mapping:
+      SourceIp: src_ip
+      SourcePort: src_port
+      DestinationIp: dst_ip
+      DestinationPort: dst_port
+      DestinationHostname: dst_hostname
+      Protocol: network_protocol
+      Initiated: network_direction
+      Image: process_file_path
+      User: actor_user_name
+    rule_conditions:
+      - type: logsource
+        category: network_connection
+
+  - id: network_table
+    type: set_state
+    key: table
+    value: network_events
+    rule_conditions:
+      - type: logsource
+        category: network_connection
+
+  # ---- File events (Sysmon EventID 11, category: file_event) ----
+  - id: file_fields
+    type: field_name_mapping
+    mapping:
+      TargetFilename: file_path
+      Image: process_file_path
+      User: actor_user_name
+    rule_conditions:
+      - type: logsource
+        category: file_event
+
+  - id: file_table
+    type: set_state
+    key: table
+    value: file_events
+    rule_conditions:
+      - type: logsource
+        category: file_event
+
+  # ---- Registry events (Sysmon EventID 12/13/14, category: registry_event) ----
+  - id: registry_fields
+    type: field_name_mapping
+    mapping:
+      TargetObject: registry_key
+      Details: registry_value
+      Image: process_file_path
+      EventType: event_type
+    rule_conditions:
+      - type: logsource
+        category: registry_event
+
+  - id: registry_table
+    type: set_state
+    key: table
+    value: registry_events
+    rule_conditions:
+      - type: logsource
+        category: registry_event
+
+  # ---- DNS queries (Sysmon EventID 22, category: dns_query) ----
+  - id: dns_fields
+    type: field_name_mapping
+    mapping:
+      QueryName: dns_query_name
+      QueryResults: dns_answer
+      Image: process_file_path
+      QueryStatus: dns_response_code
+    rule_conditions:
+      - type: logsource
+        category: dns_query
+
+  - id: dns_table
+    type: set_state
+    key: table
+    value: dns_events
+    rule_conditions:
+      - type: logsource
+        category: dns_query
+
+  # ---- Authentication / Login (category: authentication) ----
+  - id: auth_fields
+    type: field_name_mapping
+    mapping:
+      TargetUserName: actor_user_name
+      TargetDomainName: actor_user_domain
+      LogonType: auth_logon_type
+      IpAddress: src_ip
+      IpPort: src_port
+      WorkstationName: src_hostname
+      SubjectUserName: subject_user_name
+      SubjectDomainName: subject_user_domain
+      AuthenticationPackageName: auth_package
+      TargetServerName: dst_hostname
+    rule_conditions:
+      - type: logsource
+        category: authentication
+
+  - id: auth_table
+    type: set_state
+    key: table
+    value: auth_events
+    rule_conditions:
+      - type: logsource
+        category: authentication
+
+  # ---- Proxy / Web (category: proxy) ----
+  - id: proxy_fields
+    type: field_name_mapping
+    mapping:
+      c-uri: http_url
+      c-useragent: http_user_agent
+      cs-method: http_method
+      r-dns: dst_hostname
+      cs-host: http_host
+      cs-referrer: http_referrer
+      sc-status: http_status_code
+      src_ip: src_ip
+      dst_ip: dst_ip
+    rule_conditions:
+      - type: logsource
+        category: proxy
+
+  - id: proxy_table
+    type: set_state
+    key: table
+    value: proxy_events
+    rule_conditions:
+      - type: logsource
+        category: proxy
+
+  # ---- Firewall (category: firewall) ----
+  - id: firewall_fields
+    type: field_name_mapping
+    mapping:
+      src_ip: src_ip
+      dst_ip: dst_ip
+      src_port: src_port
+      dst_port: dst_port
+      action: action
+    rule_conditions:
+      - type: logsource
+        category: firewall
+
+  - id: firewall_table
+    type: set_state
+    key: table
+    value: firewall_events
+    rule_conditions:
+      - type: logsource
+        category: firewall
+
+  # ---- Global: EventID mapping (always applies) ----
+  - id: event_id
+    type: field_name_mapping
+    mapping:
+      EventID: event_id
+
+  # ---- Fallback table for uncategorized rules ----
+  - id: fallback_table
+    type: set_state
+    key: table
+    value: security_events

--- a/crates/rsigma-convert/schema/timescaledb_security_events.sql
+++ b/crates/rsigma-convert/schema/timescaledb_security_events.sql
@@ -1,0 +1,226 @@
+-- =============================================================================
+-- Reference TimescaleDB Schema for Security Telemetry (OCSF-aligned)
+-- =============================================================================
+--
+-- This schema is designed for a Lakewatch-style open SIEM backed by
+-- PostgreSQL + TimescaleDB.  It stores normalized security events using
+-- column names derived from the Open Cybersecurity Schema Framework (OCSF).
+--
+-- The `security_events` hypertable is the single landing table for all
+-- event categories.  Category-specific fields that are NULL for unrelated
+-- events are stored efficiently by TimescaleDB's columnar compression.
+--
+-- Usage:
+--   psql -d siem -f timescaledb_security_events.sql
+--
+-- Prerequisites:
+--   CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- ---------------------------------------------------------------------------
+-- 1. Core hypertable
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS security_events (
+    -- Timestamp (partition key)
+    time                      TIMESTAMPTZ NOT NULL,
+
+    -- Event metadata
+    event_id                  BIGINT,
+    event_type                TEXT,
+    category                  TEXT,         -- OCSF activity class: process, network, auth …
+    severity                  SMALLINT,     -- 0=info, 1=low, 2=medium, 3=high, 4=critical
+    rule_name                 TEXT,         -- Sigma rule title that matched (populated by eval)
+    rule_id                   TEXT,         -- Sigma rule UUID
+
+    -- Source host
+    src_hostname              TEXT,
+    src_ip                    INET,
+    src_port                  INT,
+
+    -- Destination host
+    dst_hostname              TEXT,
+    dst_ip                    INET,
+    dst_port                  INT,
+
+    -- Actor
+    actor_user_name           TEXT,
+    actor_user_domain         TEXT,
+    subject_user_name         TEXT,
+    subject_user_domain       TEXT,
+
+    -- Process (OCSF process activity)
+    process_pid               INT,
+    process_file_path         TEXT,
+    process_command_line      TEXT,
+    process_original_name     TEXT,
+    process_integrity_level   TEXT,
+    process_file_hash         TEXT,
+    process_current_directory TEXT,
+    process_file_company      TEXT,
+    process_file_description  TEXT,
+    process_file_product      TEXT,
+    process_file_version      TEXT,
+
+    -- Parent process
+    parent_process_pid        INT,
+    parent_process_file_path  TEXT,
+    parent_process_command_line TEXT,
+
+    -- File activity
+    file_path                 TEXT,
+
+    -- Registry activity (Windows)
+    registry_key              TEXT,
+    registry_value            TEXT,
+
+    -- DNS
+    dns_query_name            TEXT,
+    dns_answer                TEXT,
+    dns_response_code         TEXT,
+
+    -- Network
+    network_protocol          TEXT,
+    network_direction         TEXT,
+
+    -- HTTP / Proxy
+    http_url                  TEXT,
+    http_user_agent           TEXT,
+    http_method               TEXT,
+    http_host                 TEXT,
+    http_referrer             TEXT,
+    http_status_code          INT,
+
+    -- Authentication
+    auth_logon_type           TEXT,
+    auth_package              TEXT,
+
+    -- Firewall / action
+    action                    TEXT,
+
+    -- Raw / overflow
+    metadata                  JSONB,
+
+    -- Full-text search (auto-populated by trigger or GENERATED column)
+    search_vector             TSVECTOR
+);
+
+-- Convert to hypertable (idempotent: errors if already a hypertable)
+SELECT create_hypertable(
+    'security_events',
+    by_range('time'),
+    if_not_exists => TRUE
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Indexes
+-- ---------------------------------------------------------------------------
+
+-- B-tree indexes for high-cardinality equality / range filters
+CREATE INDEX IF NOT EXISTS idx_se_src_ip
+    ON security_events (src_ip, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_dst_ip
+    ON security_events (dst_ip, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_actor
+    ON security_events (actor_user_name, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_process_path
+    ON security_events (process_file_path, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_event_id
+    ON security_events (event_id, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_category
+    ON security_events (category, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_rule_name
+    ON security_events (rule_name, time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_se_dns_query
+    ON security_events (dns_query_name, time DESC);
+
+-- GIN index for full-text search
+CREATE INDEX IF NOT EXISTS idx_se_search_vector
+    ON security_events USING GIN (search_vector);
+
+-- GIN index for JSONB metadata queries
+CREATE INDEX IF NOT EXISTS idx_se_metadata
+    ON security_events USING GIN (metadata jsonb_path_ops);
+
+-- ---------------------------------------------------------------------------
+-- 3. Trigger: auto-populate search_vector
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION security_events_search_vector_update()
+RETURNS trigger AS $$
+BEGIN
+    NEW.search_vector :=
+        to_tsvector('simple', coalesce(NEW.process_command_line, '')) ||
+        to_tsvector('simple', coalesce(NEW.process_file_path, ''))   ||
+        to_tsvector('simple', coalesce(NEW.actor_user_name, ''))     ||
+        to_tsvector('simple', coalesce(NEW.dns_query_name, ''))      ||
+        to_tsvector('simple', coalesce(NEW.http_url, ''))            ||
+        to_tsvector('simple', coalesce(NEW.file_path, ''))           ||
+        to_tsvector('simple', coalesce(NEW.registry_key, ''));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER trg_se_search_vector
+    BEFORE INSERT OR UPDATE ON security_events
+    FOR EACH ROW
+    EXECUTE FUNCTION security_events_search_vector_update();
+
+-- ---------------------------------------------------------------------------
+-- 4. TimescaleDB compression policy
+-- ---------------------------------------------------------------------------
+-- Compress chunks older than 7 days.  Segmenting by category keeps queries
+-- that filter on category fast even after compression.
+
+ALTER TABLE security_events SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'category',
+    timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy(
+    'security_events',
+    compress_after => INTERVAL '7 days',
+    if_not_exists => TRUE
+);
+
+-- ---------------------------------------------------------------------------
+-- 5. Retention policy
+-- ---------------------------------------------------------------------------
+-- Drop chunks older than 90 days by default.  Adjust to match your
+-- compliance requirements.
+
+SELECT add_retention_policy(
+    'security_events',
+    drop_after => INTERVAL '90 days',
+    if_not_exists => TRUE
+);
+
+-- ---------------------------------------------------------------------------
+-- 6. Example continuous aggregate: hourly event counts by category
+-- ---------------------------------------------------------------------------
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS security_events_hourly
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 hour', time) AS bucket,
+    category,
+    rule_name,
+    COUNT(*) AS event_count
+FROM security_events
+GROUP BY bucket, category, rule_name
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy(
+    'security_events_hourly',
+    start_offset    => INTERVAL '3 hours',
+    end_offset      => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour',
+    if_not_exists => TRUE
+);

--- a/crates/rsigma-convert/src/backends/mod.rs
+++ b/crates/rsigma-convert/src/backends/mod.rs
@@ -1,1 +1,2 @@
+pub mod postgres;
 pub mod test;

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -6,7 +6,7 @@
 //! `tsvector`/`tsquery` for full-text keyword search, and JSONB for
 //! semi-structured event data.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use rsigma_eval::pipeline::state::PipelineState;
 use rsigma_parser::*;
@@ -126,6 +126,8 @@ pub struct PostgresBackend {
     pub case_sensitive_re: bool,
     /// PostgreSQL schema name (e.g. `public`).
     pub schema: Option<String>,
+    /// PostgreSQL database name (connection-level metadata, not used in queries).
+    pub database: Option<String>,
     /// Enable TimescaleDB-specific features.
     pub timescaledb: bool,
 }
@@ -139,14 +141,56 @@ impl PostgresBackend {
             json_field: None,
             case_sensitive_re: false,
             schema: None,
+            database: None,
             timescaledb: false,
         }
     }
 
-    fn qualified_table(&self) -> String {
-        match &self.schema {
-            Some(s) => format!("{s}.{}", self.table),
-            None => self.table.clone(),
+    /// Resolve the fully qualified table name `[schema.]table` using this
+    /// precedence for each component:
+    ///
+    /// **table**: `custom_attributes["postgres.table"]` > `state["table"]` > `self.table`
+    /// **schema**: `custom_attributes["postgres.schema"]` > `state["schema"]` > `self.schema`
+    fn resolve_table(
+        &self,
+        custom_attrs: &HashMap<String, serde_yaml::Value>,
+        state: &HashMap<String, serde_json::Value>,
+    ) -> String {
+        let table = custom_attrs
+            .get("postgres.table")
+            .and_then(|v| v.as_str())
+            .or(state.get("table").and_then(|v| v.as_str()))
+            .unwrap_or(&self.table);
+
+        let schema = custom_attrs
+            .get("postgres.schema")
+            .and_then(|v| v.as_str())
+            .or(state.get("schema").and_then(|v| v.as_str()))
+            .or(self.schema.as_deref())
+            .filter(|s| !s.is_empty());
+
+        match schema {
+            Some(s) => format!("{s}.{table}"),
+            None => table.to_string(),
+        }
+    }
+
+    /// Qualify a raw table name with schema. Precedence:
+    /// `per_rule_schema` > `state["schema"]` > `self.schema` > none.
+    fn qualify_table_name(
+        &self,
+        table: &str,
+        state: &HashMap<String, serde_json::Value>,
+        per_rule_schema: Option<&str>,
+    ) -> String {
+        let schema = per_rule_schema
+            .or(state.get("schema").and_then(|v| v.as_str()))
+            .or(self.schema.as_deref())
+            .filter(|s| !s.is_empty());
+
+        match schema {
+            Some(s) => format!("{s}.{table}"),
+            None => table.to_string(),
         }
     }
 
@@ -316,8 +360,6 @@ impl Backend for PostgresBackend {
         let has_wildcards = value.contains_wildcards();
 
         let like_op = if is_cased { "LIKE" } else { "ILIKE" };
-        let not_like_op = if is_cased { "NOT LIKE" } else { "NOT ILIKE" };
-        let _ = not_like_op;
 
         if is_contains || is_startswith || is_endswith || has_wildcards {
             let val = self.build_like_value(value);
@@ -537,11 +579,7 @@ impl Backend for PostgresBackend {
         query: String,
         state: &ConversionState,
     ) -> Result<String> {
-        let table = state.get_state_str("table").unwrap_or(&self.table);
-        let qualified = match &self.schema {
-            Some(s) if state.get_state_str("table").is_none() => format!("{s}.{table}"),
-            _ => table.to_string(),
-        };
+        let qualified = self.resolve_table(&rule.custom_attributes, &state.processing_state);
 
         let is_timescaledb = state
             .get_state_str("_output_format")
@@ -625,9 +663,9 @@ impl Backend for PostgresBackend {
         &self,
         rule: &CorrelationRule,
         output_format: &str,
-        _pipeline_state: &PipelineState,
+        pipeline_state: &PipelineState,
     ) -> Result<Vec<String>> {
-        let table = self.qualified_table();
+        let table = self.resolve_table(&rule.custom_attributes, &pipeline_state.state);
         let ts = &self.timestamp_field;
         let use_time_bucket =
             output_format == "timescaledb" || output_format == "continuous_aggregate";
@@ -661,6 +699,13 @@ impl Backend for PostgresBackend {
                 .and_then(|a| a.mapping.values().next().map(|s| s.as_str()))
         });
 
+        // Build per-rule table mapping from _rule_tables injected by convert_collection
+        let rule_tables: HashMap<String, String> = pipeline_state
+            .state
+            .get("_rule_tables")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
         let query = match rule.correlation_type {
             CorrelationType::EventCount => {
                 format!(
@@ -686,24 +731,18 @@ impl Backend for PostgresBackend {
                     having_clause = having_clause.replace("{agg}", &agg)
                 )
             }
-            CorrelationType::Temporal | CorrelationType::TemporalOrdered => {
-                let rule_names = rule.rules.join("', '");
-                let agg = "COUNT(DISTINCT rule_name)";
-                format!(
-                    "WITH matched AS (\
-                     SELECT *, rule_name FROM {table} \
-                     WHERE rule_name IN ('{rule_names}') \
-                     AND {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
-                     ) \
-                     SELECT {group_by_select}\
-                     {agg} AS distinct_rules, \
-                     MIN({ts}) AS first_seen, MAX({ts}) AS last_seen \
-                     FROM matched\
-                     {group_by_clause} \
-                     HAVING {having_clause}",
-                    having_clause = having_clause.replace("{agg}", agg)
-                )
-            }
+            CorrelationType::Temporal | CorrelationType::TemporalOrdered => self
+                .build_temporal_query(
+                    rule,
+                    &table,
+                    ts,
+                    window_secs,
+                    &group_by_select,
+                    &group_by_clause,
+                    &having_clause,
+                    &rule_tables,
+                    pipeline_state,
+                )?,
             CorrelationType::ValueSum => {
                 let field = value_field
                     .map(|f| self.field_expr(f))
@@ -783,6 +822,95 @@ impl PostgresBackend {
             CorrelationCondition::Extended(_) => Err(ConvertError::UnsupportedCorrelation(
                 "extended boolean conditions not yet supported for PostgreSQL".into(),
             )),
+        }
+    }
+
+    /// Build a temporal or temporal_ordered correlation query.
+    ///
+    /// When all referenced rules target the same table, produces a single-table
+    /// CTE filtering on `rule_name IN (...)`. When rules target different tables
+    /// (from `_rule_tables` pipeline state), produces a `UNION ALL` CTE with one
+    /// leg per rule.
+    #[allow(clippy::too_many_arguments)]
+    fn build_temporal_query(
+        &self,
+        rule: &CorrelationRule,
+        default_table: &str,
+        ts: &str,
+        window_secs: u64,
+        group_by_select: &str,
+        group_by_clause: &str,
+        having_clause: &str,
+        rule_tables: &HashMap<String, String>,
+        pipeline_state: &PipelineState,
+    ) -> Result<String> {
+        let agg = "COUNT(DISTINCT rule_name)";
+        let having = having_clause.replace("{agg}", agg);
+
+        let rule_schemas: HashMap<String, String> = pipeline_state
+            .state
+            .get("_rule_schemas")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        // Collect per-rule tables, qualifying each with its own schema
+        let mut table_to_rules: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for rule_ref in &rule.rules {
+            let raw_table = rule_tables.get(rule_ref).map(|s| s.as_str());
+            let per_rule_schema = rule_schemas.get(rule_ref).map(|s| s.as_str());
+            let qualified = match raw_table {
+                Some(t) => self.qualify_table_name(t, &pipeline_state.state, per_rule_schema),
+                None => default_table.to_string(),
+            };
+            table_to_rules
+                .entry(qualified)
+                .or_default()
+                .push(rule_ref.clone());
+        }
+
+        if table_to_rules.len() <= 1 {
+            // Single table — filter by rule_name column
+            let rule_names = rule.rules.join("', '");
+            Ok(format!(
+                "WITH matched AS (\
+                 SELECT *, rule_name FROM {default_table} \
+                 WHERE rule_name IN ('{rule_names}') \
+                 AND {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                 ) \
+                 SELECT {group_by_select}\
+                 {agg} AS distinct_rules, \
+                 MIN({ts}) AS first_seen, MAX({ts}) AS last_seen \
+                 FROM matched\
+                 {group_by_clause} \
+                 HAVING {having}"
+            ))
+        } else {
+            // Multi-table — UNION ALL CTE with one leg per rule
+            let union_parts: Vec<String> = table_to_rules
+                .iter()
+                .flat_map(|(tbl, rules)| {
+                    rules.iter().map(move |rule_ref| {
+                        format!(
+                            "SELECT *, '{rule_ref}' AS rule_name FROM {tbl} \
+                             WHERE {ts} >= NOW() - INTERVAL '{window_secs} seconds'"
+                        )
+                    })
+                })
+                .collect();
+
+            let union_cte = union_parts.join(" UNION ALL ");
+
+            Ok(format!(
+                "WITH matched AS (\
+                 {union_cte}\
+                 ) \
+                 SELECT {group_by_select}\
+                 {agg} AS distinct_rules, \
+                 MIN({ts}) AS first_seen, MAX({ts}) AS last_seen \
+                 FROM matched\
+                 {group_by_clause} \
+                 HAVING {having}"
+            ))
         }
     }
 }
@@ -1503,6 +1631,555 @@ detection:
                  SELECT time_bucket('1 hour', time) AS bucket, * \
                  FROM security_events WHERE \"FieldA\" = 'val1' WITH NO DATA"
             ]
+        );
+    }
+
+    // --- resolve_table precedence ---
+
+    #[test]
+    fn test_resolve_table_defaults() {
+        let backend = PostgresBackend::new();
+        let attrs = HashMap::new();
+        let state = HashMap::new();
+        assert_eq!(backend.resolve_table(&attrs, &state), "security_events");
+    }
+
+    #[test]
+    fn test_resolve_table_backend_schema() {
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("audit".to_string());
+        let attrs = HashMap::new();
+        let state = HashMap::new();
+        assert_eq!(
+            backend.resolve_table(&attrs, &state),
+            "audit.security_events"
+        );
+    }
+
+    #[test]
+    fn test_resolve_table_state_overrides_default() {
+        let backend = PostgresBackend::new();
+        let attrs = HashMap::new();
+        let mut state = HashMap::new();
+        state.insert("table".to_string(), serde_json::json!("process_events"));
+        assert_eq!(backend.resolve_table(&attrs, &state), "process_events");
+    }
+
+    #[test]
+    fn test_resolve_table_state_with_backend_schema() {
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("audit".to_string());
+        let attrs = HashMap::new();
+        let mut state = HashMap::new();
+        state.insert("table".to_string(), serde_json::json!("process_events"));
+        assert_eq!(
+            backend.resolve_table(&attrs, &state),
+            "audit.process_events"
+        );
+    }
+
+    #[test]
+    fn test_resolve_table_state_schema_overrides_backend() {
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("audit".to_string());
+        let attrs = HashMap::new();
+        let mut state = HashMap::new();
+        state.insert("table".to_string(), serde_json::json!("process_events"));
+        state.insert("schema".to_string(), serde_json::json!("siem"));
+        assert_eq!(backend.resolve_table(&attrs, &state), "siem.process_events");
+    }
+
+    #[test]
+    fn test_resolve_table_custom_attrs_override_all() {
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("audit".to_string());
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "postgres.table".to_string(),
+            serde_yaml::Value::String("my_events".to_string()),
+        );
+        attrs.insert(
+            "postgres.schema".to_string(),
+            serde_yaml::Value::String("custom".to_string()),
+        );
+        let mut state = HashMap::new();
+        state.insert("table".to_string(), serde_json::json!("pipeline_events"));
+        state.insert("schema".to_string(), serde_json::json!("siem"));
+        assert_eq!(backend.resolve_table(&attrs, &state), "custom.my_events");
+    }
+
+    #[test]
+    fn test_resolve_table_custom_table_only() {
+        let backend = PostgresBackend::new();
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "postgres.table".to_string(),
+            serde_yaml::Value::String("my_events".to_string()),
+        );
+        let state = HashMap::new();
+        assert_eq!(backend.resolve_table(&attrs, &state), "my_events");
+    }
+
+    #[test]
+    fn test_resolve_table_empty_schema_treated_as_none() {
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("audit".to_string());
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "postgres.schema".to_string(),
+            serde_yaml::Value::String(String::new()),
+        );
+        let state = HashMap::new();
+        // Empty schema in custom_attrs removes the schema prefix
+        assert_eq!(backend.resolve_table(&attrs, &state), "security_events");
+    }
+
+    // --- Custom attributes in detection rules ---
+
+    #[test]
+    fn test_custom_table_via_custom_attributes() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+custom_attributes:
+    postgres.table: custom_events
+    postgres.schema: siem
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_rule(&collection.rules[0], "default", &PipelineState::default())
+            .unwrap();
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM siem.custom_events WHERE "FieldA" = 'val1'"#]
+        );
+    }
+
+    // --- Pipeline state table override ---
+
+    #[test]
+    fn test_pipeline_state_table_override() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let mut pipeline_state = PipelineState::default();
+        pipeline_state.set_state("table".to_string(), serde_json::json!("process_events"));
+        let queries = backend
+            .convert_rule(&collection.rules[0], "default", &pipeline_state)
+            .unwrap();
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM process_events WHERE "FieldA" = 'val1'"#]
+        );
+    }
+
+    // --- Correlation with pipeline state ---
+
+    #[test]
+    fn test_correlation_uses_pipeline_state_table() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Brute Force
+correlation:
+    type: event_count
+    rules:
+        - failed_login
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 10
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let mut pipeline_state = PipelineState::default();
+        pipeline_state.set_state("table".to_string(), serde_json::json!("auth_events"));
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        assert_eq!(queries.len(), 1);
+        assert!(queries[0].contains("FROM auth_events"));
+    }
+
+    #[test]
+    fn test_correlation_custom_attributes_table() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Brute Force
+correlation:
+    type: event_count
+    rules:
+        - failed_login
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 10
+custom_attributes:
+    postgres.table: login_events
+    postgres.schema: auth
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_correlation_rule(
+                &collection.correlations[0],
+                "default",
+                &PipelineState::default(),
+            )
+            .unwrap();
+        assert_eq!(queries.len(), 1);
+        assert!(
+            queries[0].contains("FROM auth.login_events"),
+            "expected table auth.login_events in: {}",
+            queries[0]
+        );
+    }
+
+    // --- Multi-table UNION ALL for temporal correlations ---
+
+    #[test]
+    fn test_temporal_single_table_unchanged() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Multi-Stage Attack
+correlation:
+    type: temporal
+    rules:
+        - rule_a
+        - rule_b
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_correlation_rule(
+                &collection.correlations[0],
+                "default",
+                &PipelineState::default(),
+            )
+            .unwrap();
+        assert_eq!(queries.len(), 1);
+        // No UNION ALL — single table approach
+        assert!(
+            queries[0].contains("rule_name IN ('rule_a', 'rule_b')"),
+            "expected single-table approach in: {}",
+            queries[0]
+        );
+        assert!(
+            !queries[0].contains("UNION ALL"),
+            "should not contain UNION ALL in single-table mode"
+        );
+    }
+
+    #[test]
+    fn test_temporal_multi_table_union_all() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Multi-Stage Attack
+correlation:
+    type: temporal
+    rules:
+        - rule_a
+        - rule_b
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let mut pipeline_state = PipelineState::default();
+
+        // Inject _rule_tables mapping different rules to different tables
+        let rule_tables = serde_json::json!({
+            "rule_a": "process_events",
+            "rule_b": "network_events"
+        });
+        pipeline_state.set_state("_rule_tables".to_string(), rule_tables);
+
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        assert_eq!(queries.len(), 1);
+        let q = &queries[0];
+        assert!(q.contains("UNION ALL"), "expected UNION ALL in: {q}");
+        assert!(
+            q.contains("FROM network_events"),
+            "expected network_events in: {q}"
+        );
+        assert!(
+            q.contains("FROM process_events"),
+            "expected process_events in: {q}"
+        );
+        assert!(
+            q.contains("'rule_a' AS rule_name"),
+            "expected rule_a label in: {q}"
+        );
+        assert!(
+            q.contains("'rule_b' AS rule_name"),
+            "expected rule_b label in: {q}"
+        );
+    }
+
+    #[test]
+    fn test_temporal_multi_table_with_backend_schema() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Multi-Stage Attack
+correlation:
+    type: temporal
+    rules:
+        - rule_a
+        - rule_b
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+"#,
+        )
+        .unwrap();
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("siem".to_string());
+        let mut pipeline_state = PipelineState::default();
+
+        let rule_tables = serde_json::json!({
+            "rule_a": "process_events",
+            "rule_b": "network_events"
+        });
+        pipeline_state.set_state("_rule_tables".to_string(), rule_tables);
+
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        let q = &queries[0];
+        assert!(
+            q.contains("FROM siem.network_events"),
+            "expected siem.network_events in: {q}"
+        );
+        assert!(
+            q.contains("FROM siem.process_events"),
+            "expected siem.process_events in: {q}"
+        );
+    }
+
+    #[test]
+    fn test_temporal_multi_table_per_rule_schemas() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Cross-Schema Correlation
+correlation:
+    type: temporal
+    rules:
+        - rule_a
+        - rule_b
+        - rule_c
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let mut pipeline_state = PipelineState::default();
+
+        pipeline_state.set_state(
+            "_rule_tables".to_string(),
+            serde_json::json!({
+                "rule_a": "process_events",
+                "rule_b": "network_events",
+                "rule_c": "auth_events"
+            }),
+        );
+        pipeline_state.set_state(
+            "_rule_schemas".to_string(),
+            serde_json::json!({
+                "rule_a": "siem",
+                "rule_b": "network",
+                "rule_c": "iam"
+            }),
+        );
+
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        let q = &queries[0];
+        assert!(q.contains("UNION ALL"), "expected UNION ALL in: {q}");
+        assert!(
+            q.contains("FROM iam.auth_events"),
+            "expected iam.auth_events in: {q}"
+        );
+        assert!(
+            q.contains("FROM network.network_events"),
+            "expected network.network_events in: {q}"
+        );
+        assert!(
+            q.contains("FROM siem.process_events"),
+            "expected siem.process_events in: {q}"
+        );
+    }
+
+    #[test]
+    fn test_temporal_mixed_per_rule_and_default_schema() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Mixed Schema Correlation
+correlation:
+    type: temporal
+    rules:
+        - rule_a
+        - rule_b
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+"#,
+        )
+        .unwrap();
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("default_schema".to_string());
+        let mut pipeline_state = PipelineState::default();
+
+        pipeline_state.set_state(
+            "_rule_tables".to_string(),
+            serde_json::json!({
+                "rule_a": "process_events",
+                "rule_b": "network_events"
+            }),
+        );
+        // Only rule_a has an explicit schema; rule_b falls back to backend default
+        pipeline_state.set_state(
+            "_rule_schemas".to_string(),
+            serde_json::json!({
+                "rule_a": "custom"
+            }),
+        );
+
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        let q = &queries[0];
+        assert!(
+            q.contains("FROM custom.process_events"),
+            "rule_a should use per-rule schema 'custom' in: {q}"
+        );
+        assert!(
+            q.contains("FROM default_schema.network_events"),
+            "rule_b should fall back to backend schema 'default_schema' in: {q}"
+        );
+    }
+
+    #[test]
+    fn test_temporal_same_table_in_rule_tables() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Multi-Stage Attack
+correlation:
+    type: temporal
+    rules:
+        - rule_a
+        - rule_b
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let mut pipeline_state = PipelineState::default();
+
+        // Both rules point to the same table — single-table path
+        let rule_tables = serde_json::json!({
+            "rule_a": "security_events",
+            "rule_b": "security_events"
+        });
+        pipeline_state.set_state("_rule_tables".to_string(), rule_tables);
+
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        let q = &queries[0];
+        assert!(
+            !q.contains("UNION ALL"),
+            "same table should use single-table path, got: {q}"
+        );
+        assert!(
+            q.contains("rule_name IN ('rule_a', 'rule_b')"),
+            "expected single-table approach in: {q}"
+        );
+    }
+
+    #[test]
+    fn test_non_temporal_ignores_multi_table() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: High Event Count
+correlation:
+    type: event_count
+    rules:
+        - rule_a
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 100
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let mut pipeline_state = PipelineState::default();
+
+        // Even though _rule_tables has multiple tables, event_count uses the default table
+        let rule_tables = serde_json::json!({
+            "rule_a": "process_events",
+            "rule_b": "network_events"
+        });
+        pipeline_state.set_state("_rule_tables".to_string(), rule_tables);
+
+        let queries = backend
+            .convert_correlation_rule(&collection.correlations[0], "default", &pipeline_state)
+            .unwrap();
+        let q = &queries[0];
+        assert!(
+            !q.contains("UNION ALL"),
+            "event_count should not use UNION ALL: {q}"
+        );
+        assert!(
+            q.contains("FROM security_events"),
+            "event_count uses default table: {q}"
         );
     }
 }

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -1,0 +1,1508 @@
+//! PostgreSQL/TimescaleDB backend for Sigma rule conversion.
+//!
+//! Converts Sigma detection rules into PostgreSQL SQL queries, leveraging
+//! PostgreSQL-native features: `ILIKE` for case-insensitive matching,
+//! `~*`/`~` for regex, `inet`/`cidr` for network address matching,
+//! `tsvector`/`tsquery` for full-text keyword search, and JSONB for
+//! semi-structured event data.
+
+use std::collections::HashMap;
+
+use rsigma_eval::pipeline::state::PipelineState;
+use rsigma_parser::*;
+
+use crate::backend::*;
+use crate::condition::convert_condition_expr;
+use crate::convert::{default_convert_detection, default_convert_detection_item};
+use crate::error::{ConvertError, Result};
+use crate::state::{ConversionState, ConvertResult};
+
+// =============================================================================
+// PostgreSQL TextQueryConfig
+// =============================================================================
+
+pub static POSTGRES_CONFIG: TextQueryConfig = TextQueryConfig {
+    precedence: (TokenType::NOT, TokenType::AND, TokenType::OR),
+    group_expression: "({expr})",
+    token_separator: " ",
+
+    and_token: "AND",
+    or_token: "OR",
+    not_token: "NOT",
+    eq_token: " = ",
+
+    not_eq_token: Some(" <> "),
+    eq_expression: None,
+    not_eq_expression: None,
+    convert_not_as_not_eq: false,
+
+    wildcard_multi: "%",
+    wildcard_single: "_",
+
+    str_quote: "'",
+    str_quote_pattern: None,
+    str_quote_pattern_negation: false,
+    escape_char: "'",
+    add_escaped: &[],
+    filter_chars: &[],
+
+    field_quote: Some("\""),
+    field_quote_pattern: Some(r"^[a-z_][a-z0-9_]*$"),
+    field_quote_pattern_negation: true,
+    field_escape: None,
+    field_escape_pattern: None,
+
+    startswith_expression: Some("{field} ILIKE {value}"),
+    not_startswith_expression: Some("{field} NOT ILIKE {value}"),
+    startswith_expression_allow_special: false,
+    endswith_expression: Some("{field} ILIKE {value}"),
+    not_endswith_expression: Some("{field} NOT ILIKE {value}"),
+    endswith_expression_allow_special: false,
+    contains_expression: Some("{field} ILIKE {value}"),
+    not_contains_expression: Some("{field} NOT ILIKE {value}"),
+    contains_expression_allow_special: false,
+    wildcard_match_expression: Some("{field} ILIKE {value}"),
+
+    case_sensitive_match_expression: Some("{field} LIKE {value}"),
+    case_sensitive_startswith_expression: Some("{field} LIKE {value}"),
+    case_sensitive_endswith_expression: Some("{field} LIKE {value}"),
+    case_sensitive_contains_expression: Some("{field} LIKE {value}"),
+
+    re_expression: Some("{field} ~* {regex}"),
+    not_re_expression: Some("{field} !~* {regex}"),
+    re_escape_char: None,
+    re_escape: &[],
+    re_escape_escape_char: None,
+
+    cidr_expression: Some("{field}::inet <<= {value}::cidr"),
+    not_cidr_expression: Some("NOT ({field}::inet <<= {value}::cidr)"),
+
+    field_null_expression: "{field} IS NULL",
+    field_exists_expression: Some("{field} IS NOT NULL"),
+    field_not_exists_expression: Some("{field} IS NULL"),
+
+    compare_op_expression: Some("{field} {op} {value}"),
+    compare_ops: &[("gt", ">"), ("gte", ">="), ("lt", "<"), ("lte", "<=")],
+
+    convert_or_as_in: true,
+    convert_and_as_in: false,
+    in_expressions_allow_wildcards: false,
+    field_in_list_expression: Some("{field} {op} ({list})"),
+    or_in_operator: Some("IN"),
+    and_in_operator: None,
+    list_separator: ", ",
+
+    unbound_value_str_expression: None,
+    unbound_value_num_expression: None,
+    unbound_value_re_expression: None,
+
+    field_eq_field_expression: Some("{field1} = {field2}"),
+    field_eq_field_escaping_quoting: true,
+
+    deferred_start: None,
+    deferred_separator: None,
+    deferred_only_query: "",
+
+    bool_true: "true",
+    bool_false: "false",
+    query_expression: "SELECT * FROM {table} WHERE {query}",
+    state_defaults: &[("table", "security_events")],
+};
+
+// =============================================================================
+// PostgresBackend
+// =============================================================================
+
+/// PostgreSQL/TimescaleDB backend for Sigma rule conversion.
+pub struct PostgresBackend {
+    pub config: &'static TextQueryConfig,
+    /// Default table name (overridden by pipeline state `table` key).
+    pub table: String,
+    /// Timestamp column name for time-windowed queries.
+    pub timestamp_field: String,
+    /// If set, fields are accessed via JSONB extraction (`metadata->>'fieldName'`).
+    pub json_field: Option<String>,
+    /// Use case-sensitive regex (`~`) instead of case-insensitive (`~*`).
+    pub case_sensitive_re: bool,
+    /// PostgreSQL schema name (e.g. `public`).
+    pub schema: Option<String>,
+    /// Enable TimescaleDB-specific features.
+    pub timescaledb: bool,
+}
+
+impl PostgresBackend {
+    pub fn new() -> Self {
+        Self {
+            config: &POSTGRES_CONFIG,
+            table: "security_events".to_string(),
+            timestamp_field: "time".to_string(),
+            json_field: None,
+            case_sensitive_re: false,
+            schema: None,
+            timescaledb: false,
+        }
+    }
+
+    fn qualified_table(&self) -> String {
+        match &self.schema {
+            Some(s) => format!("{s}.{}", self.table),
+            None => self.table.clone(),
+        }
+    }
+
+    fn field_expr(&self, field: &str) -> String {
+        match &self.json_field {
+            Some(json_col) => format!("{json_col}->>'{field}'"),
+            None => text_escape_and_quote_field(self.config, field),
+        }
+    }
+
+    /// Escape a string value for use in a SQL single-quoted literal.
+    /// PostgreSQL uses `''` to escape single quotes inside string literals.
+    fn escape_sql_str(&self, s: &str) -> String {
+        s.replace('\'', "''")
+    }
+
+    /// Build a SigmaString value into a SQL string literal with proper escaping
+    /// and wildcard translation for LIKE/ILIKE.
+    fn build_like_value(&self, value: &SigmaString) -> String {
+        let mut result = String::with_capacity(value.original.len() + 2);
+        result.push('\'');
+        for part in &value.parts {
+            match part {
+                StringPart::Plain(s) => {
+                    for ch in s.chars() {
+                        match ch {
+                            '\'' => result.push_str("''"),
+                            '%' => result.push_str("\\%"),
+                            '_' => result.push_str("\\_"),
+                            '\\' => result.push_str("\\\\"),
+                            _ => result.push(ch),
+                        }
+                    }
+                }
+                StringPart::Special(SpecialChar::WildcardMulti) => result.push('%'),
+                StringPart::Special(SpecialChar::WildcardSingle) => result.push('_'),
+            }
+        }
+        result.push('\'');
+        result
+    }
+
+    /// Build a plain SQL string literal from a SigmaString (no wildcards).
+    fn build_plain_value(&self, value: &SigmaString) -> String {
+        let plain = value.as_plain().unwrap_or_else(|| value.original.clone());
+        format!("'{}'", self.escape_sql_str(&plain))
+    }
+}
+
+impl Default for PostgresBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Backend for PostgresBackend {
+    fn name(&self) -> &str {
+        "postgres"
+    }
+
+    fn formats(&self) -> &[(&str, &str)] {
+        &[
+            ("default", "Plain PostgreSQL SQL"),
+            ("view", "CREATE OR REPLACE VIEW for each rule"),
+            (
+                "timescaledb",
+                "TimescaleDB-optimized queries with time_bucket()",
+            ),
+            (
+                "continuous_aggregate",
+                "CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)",
+            ),
+        ]
+    }
+
+    fn requires_pipeline(&self) -> bool {
+        false
+    }
+
+    // --- Detection rule conversion ---
+
+    fn convert_rule(
+        &self,
+        rule: &SigmaRule,
+        output_format: &str,
+        pipeline_state: &PipelineState,
+    ) -> Result<Vec<String>> {
+        let mut queries = Vec::new();
+        for (idx, cond_expr) in rule.detection.conditions.iter().enumerate() {
+            let mut state = ConversionState::new(pipeline_state.state.clone());
+            state
+                .processing_state
+                .insert("_output_format".to_string(), output_format.into());
+            let query = self.convert_condition(cond_expr, &rule.detection.named, &mut state)?;
+            let finished = self.finish_query(rule, query, &state)?;
+            let finalized = self.finalize_query(rule, finished, idx, &state, output_format)?;
+            queries.push(finalized);
+        }
+        Ok(queries)
+    }
+
+    // --- Condition tree dispatch ---
+
+    fn convert_condition(
+        &self,
+        expr: &ConditionExpr,
+        detections: &HashMap<String, Detection>,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        convert_condition_expr(self, expr, detections, state)
+    }
+
+    fn convert_condition_and(&self, exprs: &[String]) -> Result<String> {
+        Ok(text_convert_condition_and(self.config, exprs))
+    }
+
+    fn convert_condition_or(&self, exprs: &[String]) -> Result<String> {
+        Ok(text_convert_condition_or(self.config, exprs))
+    }
+
+    fn convert_condition_not(&self, expr: &str) -> Result<String> {
+        Ok(text_convert_condition_not(self.config, expr))
+    }
+
+    // --- Detection ---
+
+    fn convert_detection(&self, det: &Detection, state: &mut ConversionState) -> Result<String> {
+        default_convert_detection(self, det, state)
+    }
+
+    fn convert_detection_item(
+        &self,
+        item: &DetectionItem,
+        state: &mut ConversionState,
+    ) -> Result<String> {
+        default_convert_detection_item(self, item, state)
+    }
+
+    // --- Field/value escaping ---
+
+    fn escape_and_quote_field(&self, field: &str) -> String {
+        self.field_expr(field)
+    }
+
+    fn convert_value_str(&self, value: &SigmaString, _state: &ConversionState) -> String {
+        self.build_like_value(value)
+    }
+
+    fn convert_value_re(&self, regex: &str, _state: &ConversionState) -> String {
+        format!("'{}'", self.escape_sql_str(regex))
+    }
+
+    // --- Value-type-specific methods ---
+
+    fn convert_field_eq_str(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let f = self.field_expr(field);
+        let is_cased = modifiers.contains(&Modifier::Cased);
+        let is_contains = modifiers.contains(&Modifier::Contains);
+        let is_startswith = modifiers.contains(&Modifier::StartsWith);
+        let is_endswith = modifiers.contains(&Modifier::EndsWith);
+        let has_wildcards = value.contains_wildcards();
+
+        let like_op = if is_cased { "LIKE" } else { "ILIKE" };
+        let not_like_op = if is_cased { "NOT LIKE" } else { "NOT ILIKE" };
+        let _ = not_like_op;
+
+        if is_contains || is_startswith || is_endswith || has_wildcards {
+            let val = self.build_like_value(value);
+            return Ok(ConvertResult::Query(format!("{f} {like_op} {val}")));
+        }
+
+        let val = self.build_plain_value(value);
+        Ok(ConvertResult::Query(format!("{f} = {val}")))
+    }
+
+    fn convert_field_eq_str_case_sensitive(
+        &self,
+        field: &str,
+        value: &SigmaString,
+        modifiers: &[Modifier],
+        state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let mut mods = modifiers.to_vec();
+        if !mods.contains(&Modifier::Cased) {
+            mods.push(Modifier::Cased);
+        }
+        self.convert_field_eq_str(field, value, &mods, state)
+    }
+
+    fn convert_field_eq_num(
+        &self,
+        field: &str,
+        value: f64,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = self.field_expr(field);
+        if value.fract() == 0.0 {
+            Ok(format!("{f} = {}", value as i64))
+        } else {
+            Ok(format!("{f} = {value}"))
+        }
+    }
+
+    fn convert_field_eq_bool(
+        &self,
+        field: &str,
+        value: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = self.field_expr(field);
+        let v = if value {
+            self.config.bool_true
+        } else {
+            self.config.bool_false
+        };
+        Ok(format!("{f} = {v}"))
+    }
+
+    fn convert_field_eq_null(&self, field: &str, _state: &mut ConversionState) -> Result<String> {
+        let f = self.field_expr(field);
+        Ok(format!("{f} IS NULL"))
+    }
+
+    fn convert_field_eq_re(
+        &self,
+        field: &str,
+        pattern: &str,
+        flags: &[Modifier],
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let f = self.field_expr(field);
+        let escaped_pattern = self.escape_sql_str(pattern);
+        let is_cased = flags.contains(&Modifier::Cased) || self.case_sensitive_re;
+        let op = if is_cased { "~" } else { "~*" };
+        Ok(ConvertResult::Query(format!(
+            "{f} {op} '{escaped_pattern}'"
+        )))
+    }
+
+    fn convert_field_eq_cidr(
+        &self,
+        field: &str,
+        cidr: &str,
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let f = self.field_expr(field);
+        Ok(ConvertResult::Query(format!(
+            "{f}::inet <<= '{cidr}'::cidr"
+        )))
+    }
+
+    fn convert_field_compare(
+        &self,
+        field: &str,
+        op: &Modifier,
+        value: f64,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = self.field_expr(field);
+        let op_token = match op {
+            Modifier::Lt => "<",
+            Modifier::Lte => "<=",
+            Modifier::Gt => ">",
+            Modifier::Gte => ">=",
+            _ => {
+                return Err(ConvertError::UnsupportedModifier(format!(
+                    "compare op {op:?}"
+                )));
+            }
+        };
+        let val_str = if value.fract() == 0.0 {
+            (value as i64).to_string()
+        } else {
+            value.to_string()
+        };
+        Ok(format!("{f} {op_token} {val_str}"))
+    }
+
+    fn convert_field_exists(
+        &self,
+        field: &str,
+        exists: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = self.field_expr(field);
+        if exists {
+            Ok(format!("{f} IS NOT NULL"))
+        } else {
+            Ok(format!("{f} IS NULL"))
+        }
+    }
+
+    fn convert_field_eq_query_expr(
+        &self,
+        field: &str,
+        expr: &str,
+        _id: &str,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        let f = self.field_expr(field);
+        let resolved = expr.replace("{field}", &f);
+        Ok(resolved)
+    }
+
+    fn convert_field_ref(
+        &self,
+        field1: &str,
+        field2: &str,
+        _state: &mut ConversionState,
+    ) -> Result<ConvertResult> {
+        let f1 = self.field_expr(field1);
+        let f2 = self.field_expr(field2);
+        Ok(ConvertResult::Query(format!("{f1} = {f2}")))
+    }
+
+    fn convert_keyword(&self, value: &SigmaValue, _state: &mut ConversionState) -> Result<String> {
+        match value {
+            SigmaValue::String(s) => {
+                let plain = s.as_plain().unwrap_or_else(|| s.original.clone());
+                let escaped = self.escape_sql_str(&plain);
+                let search_target = match &self.json_field {
+                    Some(json_col) => format!("{json_col}::text"),
+                    None => "ROW(*)::text".to_string(),
+                };
+                Ok(format!(
+                    "to_tsvector('simple', {search_target}) @@ to_tsquery('simple', '{escaped}')"
+                ))
+            }
+            SigmaValue::Integer(n) => {
+                let search_target = match &self.json_field {
+                    Some(json_col) => format!("{json_col}::text"),
+                    None => "ROW(*)::text".to_string(),
+                };
+                Ok(format!(
+                    "to_tsvector('simple', {search_target}) @@ to_tsquery('simple', '{n}')"
+                ))
+            }
+            SigmaValue::Float(f) => {
+                let search_target = match &self.json_field {
+                    Some(json_col) => format!("{json_col}::text"),
+                    None => "ROW(*)::text".to_string(),
+                };
+                Ok(format!(
+                    "to_tsvector('simple', {search_target}) @@ to_tsquery('simple', '{f}')"
+                ))
+            }
+            _ => Err(ConvertError::UnsupportedKeyword),
+        }
+    }
+
+    fn convert_condition_as_in_expression(
+        &self,
+        field: &str,
+        values: &[&SigmaValue],
+        is_or: bool,
+        _state: &mut ConversionState,
+    ) -> Result<String> {
+        if !is_or {
+            return Err(ConvertError::UnsupportedModifier(
+                "AND IN-list not supported for PostgreSQL".into(),
+            ));
+        }
+        let f = self.field_expr(field);
+        let items: Vec<String> = values
+            .iter()
+            .map(|v| match v {
+                SigmaValue::String(s) => self.build_plain_value(s),
+                SigmaValue::Integer(n) => n.to_string(),
+                SigmaValue::Float(f) => f.to_string(),
+                _ => String::new(),
+            })
+            .collect();
+        let list = items.join(", ");
+        Ok(format!("{f} IN ({list})"))
+    }
+
+    // --- Query finalization ---
+
+    fn finish_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        state: &ConversionState,
+    ) -> Result<String> {
+        let table = state.get_state_str("table").unwrap_or(&self.table);
+        let qualified = match &self.schema {
+            Some(s) if state.get_state_str("table").is_none() => format!("{s}.{table}"),
+            _ => table.to_string(),
+        };
+
+        let is_timescaledb = state
+            .get_state_str("_output_format")
+            .is_some_and(|f| f == "timescaledb" || f == "continuous_aggregate");
+
+        let select_cols = if is_timescaledb {
+            format!(
+                "time_bucket('1 hour', {}) AS bucket, *",
+                self.timestamp_field
+            )
+        } else {
+            "*".to_string()
+        };
+
+        let custom_tmpl = state.get_state_str("query_expression_template");
+
+        let effective_tmpl = match custom_tmpl {
+            Some(t) => t.to_string(),
+            None if is_timescaledb => {
+                format!("SELECT {select_cols} FROM {{table}} WHERE {{query}}")
+            }
+            None => self.config.query_expression.to_string(),
+        };
+
+        let mut result = effective_tmpl.replace("{query}", &query);
+        result = result.replace("{table}", &qualified);
+        result = result.replace("{rule.title}", &rule.title);
+        if let Some(id) = &rule.id {
+            result = result.replace("{rule.id}", id);
+        }
+
+        Ok(result)
+    }
+
+    fn finalize_query(
+        &self,
+        rule: &SigmaRule,
+        query: String,
+        _index: usize,
+        _state: &ConversionState,
+        output_format: &str,
+    ) -> Result<String> {
+        let view_name = || match &rule.id {
+            Some(id) => format!("sigma_{}", id.replace('-', "_")),
+            None => format!(
+                "sigma_{}",
+                rule.title.to_lowercase().replace([' ', '-'], "_")
+            ),
+        };
+
+        match output_format {
+            "default" | "timescaledb" => Ok(query),
+            "view" => Ok(format!("CREATE OR REPLACE VIEW {} AS {query}", view_name())),
+            "continuous_aggregate" => Ok(format!(
+                "CREATE MATERIALIZED VIEW {} \
+                 WITH (timescaledb.continuous) AS {query} \
+                 WITH NO DATA",
+                view_name()
+            )),
+            other => Err(ConvertError::RuleConversion(format!(
+                "unknown output format: {other}"
+            ))),
+        }
+    }
+
+    fn finalize_output(&self, queries: Vec<String>, output_format: &str) -> Result<String> {
+        let sep = match output_format {
+            "view" | "continuous_aggregate" => ";\n\n",
+            _ => "\n",
+        };
+        Ok(queries.join(sep))
+    }
+
+    // --- Correlation ---
+
+    fn supports_correlation(&self) -> bool {
+        true
+    }
+
+    fn convert_correlation_rule(
+        &self,
+        rule: &CorrelationRule,
+        output_format: &str,
+        _pipeline_state: &PipelineState,
+    ) -> Result<Vec<String>> {
+        let table = self.qualified_table();
+        let ts = &self.timestamp_field;
+        let use_time_bucket =
+            output_format == "timescaledb" || output_format == "continuous_aggregate";
+
+        let mut group_by_cols: Vec<String> =
+            rule.group_by.iter().map(|g| self.field_expr(g)).collect();
+        if use_time_bucket {
+            group_by_cols.insert(0, format!("time_bucket('1 hour', {ts})"));
+        }
+        let group_by_clause = if group_by_cols.is_empty() {
+            String::new()
+        } else {
+            format!(" GROUP BY {}", group_by_cols.join(", "))
+        };
+        let group_by_select = if group_by_cols.is_empty() {
+            String::new()
+        } else {
+            format!("{}, ", group_by_cols.join(", "))
+        };
+
+        let window_secs = rule.timespan.seconds;
+        let having_clause = self.build_having_clause(&rule.condition)?;
+
+        let field_from_condition = match &rule.condition {
+            CorrelationCondition::Threshold { field, .. } => field.clone(),
+            _ => None,
+        };
+        let value_field = field_from_condition.as_deref().or_else(|| {
+            rule.aliases
+                .first()
+                .and_then(|a| a.mapping.values().next().map(|s| s.as_str()))
+        });
+
+        let query = match rule.correlation_type {
+            CorrelationType::EventCount => {
+                format!(
+                    "SELECT {group_by_select}COUNT(*) AS event_count \
+                     FROM {table} \
+                     WHERE {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                     {group_by_clause} \
+                     HAVING {having_clause}",
+                    having_clause = having_clause.replace("{agg}", "COUNT(*)")
+                )
+            }
+            CorrelationType::ValueCount => {
+                let field = value_field
+                    .map(|f| self.field_expr(f))
+                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let agg = format!("COUNT(DISTINCT {field})");
+                format!(
+                    "SELECT {group_by_select}{agg} AS value_count \
+                     FROM {table} \
+                     WHERE {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                     {group_by_clause} \
+                     HAVING {having_clause}",
+                    having_clause = having_clause.replace("{agg}", &agg)
+                )
+            }
+            CorrelationType::Temporal | CorrelationType::TemporalOrdered => {
+                let rule_names = rule.rules.join("', '");
+                let agg = "COUNT(DISTINCT rule_name)";
+                format!(
+                    "WITH matched AS (\
+                     SELECT *, rule_name FROM {table} \
+                     WHERE rule_name IN ('{rule_names}') \
+                     AND {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                     ) \
+                     SELECT {group_by_select}\
+                     {agg} AS distinct_rules, \
+                     MIN({ts}) AS first_seen, MAX({ts}) AS last_seen \
+                     FROM matched\
+                     {group_by_clause} \
+                     HAVING {having_clause}",
+                    having_clause = having_clause.replace("{agg}", agg)
+                )
+            }
+            CorrelationType::ValueSum => {
+                let field = value_field
+                    .map(|f| self.field_expr(f))
+                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let agg = format!("SUM({field})");
+                format!(
+                    "SELECT {group_by_select}{agg} AS value_sum \
+                     FROM {table} \
+                     WHERE {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                     {group_by_clause} \
+                     HAVING {having_clause}",
+                    having_clause = having_clause.replace("{agg}", &agg)
+                )
+            }
+            CorrelationType::ValueAvg => {
+                let field = value_field
+                    .map(|f| self.field_expr(f))
+                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let agg = format!("AVG({field})");
+                format!(
+                    "SELECT {group_by_select}{agg} AS value_avg \
+                     FROM {table} \
+                     WHERE {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                     {group_by_clause} \
+                     HAVING {having_clause}",
+                    having_clause = having_clause.replace("{agg}", &agg)
+                )
+            }
+            CorrelationType::ValuePercentile | CorrelationType::ValueMedian => {
+                let field = value_field
+                    .map(|f| self.field_expr(f))
+                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let percentile = if rule.correlation_type == CorrelationType::ValueMedian {
+                    0.5
+                } else {
+                    0.95
+                };
+                let agg = format!("PERCENTILE_CONT({percentile}) WITHIN GROUP (ORDER BY {field})");
+                format!(
+                    "SELECT {group_by_select}\
+                     {agg} AS pct_value \
+                     FROM {table} \
+                     WHERE {ts} >= NOW() - INTERVAL '{window_secs} seconds'\
+                     {group_by_clause} \
+                     HAVING {having_clause}",
+                    having_clause = having_clause.replace("{agg}", &agg)
+                )
+            }
+        };
+
+        Ok(vec![query])
+    }
+}
+
+impl PostgresBackend {
+    /// Build HAVING clause from correlation condition predicates.
+    /// Uses `{agg}` as placeholder for the aggregate expression.
+    fn build_having_clause(&self, cond: &CorrelationCondition) -> Result<String> {
+        match cond {
+            CorrelationCondition::Threshold { predicates, .. } => {
+                let parts: Vec<String> = predicates
+                    .iter()
+                    .map(|(op, val)| {
+                        let op_str = match op {
+                            ConditionOperator::Lt => "<",
+                            ConditionOperator::Lte => "<=",
+                            ConditionOperator::Gt => ">",
+                            ConditionOperator::Gte => ">=",
+                            ConditionOperator::Eq => "=",
+                            ConditionOperator::Neq => "<>",
+                        };
+                        format!("{{agg}} {op_str} {val}")
+                    })
+                    .collect();
+                Ok(parts.join(" AND "))
+            }
+            CorrelationCondition::Extended(_) => Err(ConvertError::UnsupportedCorrelation(
+                "extended boolean conditions not yet supported for PostgreSQL".into(),
+            )),
+        }
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_parser::parse_sigma_yaml;
+
+    fn convert(yaml: &str) -> Vec<String> {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let backend = PostgresBackend::new();
+        let mut results = Vec::new();
+        for rule in &collection.rules {
+            let queries = backend
+                .convert_rule(rule, "default", &PipelineState::default())
+                .unwrap();
+            results.extend(queries);
+        }
+        results
+    }
+
+    fn convert_with(yaml: &str, backend: &PostgresBackend) -> Vec<String> {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut results = Vec::new();
+        for rule in &collection.rules {
+            let queries = backend
+                .convert_rule(rule, "default", &PipelineState::default())
+                .unwrap();
+            results.extend(queries);
+        }
+        results
+    }
+
+    // --- Basic detection ---
+    // Note: PostgreSQL quoted identifiers use double quotes for mixed-case field names.
+    // Fields matching ^[a-z_][a-z0-9_]*$ are unquoted; others get "quoted".
+
+    #[test]
+    fn test_simple_eq() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" = 'whoami'"#]
+        );
+    }
+
+    #[test]
+    fn test_lowercase_field_unquoted() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        action: login
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec!["SELECT * FROM security_events WHERE action = 'login'"]
+        );
+    }
+
+    #[test]
+    fn test_and_condition() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    sel1:
+        FieldA: val1
+    sel2:
+        FieldB: val2
+    condition: sel1 and sel2
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "FieldA" = 'val1' AND "FieldB" = 'val2'"#]
+        );
+    }
+
+    #[test]
+    fn test_or_condition() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    sel1:
+        FieldA: val1
+    sel2:
+        FieldB: val2
+    condition: sel1 or sel2
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "FieldA" = 'val1' OR "FieldB" = 'val2'"#]
+        );
+    }
+
+    #[test]
+    fn test_not_condition() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    filter:
+        FieldB: val2
+    condition: selection and not filter
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                r#"SELECT * FROM security_events WHERE "FieldA" = 'val1' AND NOT "FieldB" = 'val2'"#
+            ]
+        );
+    }
+
+    // --- ILIKE modifiers ---
+
+    #[test]
+    fn test_contains() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains: whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE 'whoami'"#]
+        );
+    }
+
+    #[test]
+    fn test_startswith() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|startswith: cmd
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE 'cmd'"#]
+        );
+    }
+
+    #[test]
+    fn test_endswith() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|endswith: '.exe'
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE '.exe'"#]
+        );
+    }
+
+    #[test]
+    fn test_cased_contains() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains|cased: Whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" LIKE 'Whoami'"#]
+        );
+    }
+
+    #[test]
+    fn test_wildcard_value() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: '*whoami*'
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE '%whoami%'"#]
+        );
+    }
+
+    // --- Regex ---
+
+    #[test]
+    fn test_regex() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|re: '.*whoami.*'
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ~* '.*whoami.*'"#]
+        );
+    }
+
+    #[test]
+    fn test_regex_case_sensitive() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|re|cased: '^Whoami$'
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ~ '^Whoami$'"#]
+        );
+    }
+
+    // --- CIDR ---
+
+    #[test]
+    fn test_cidr() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        SourceIP|cidr: '10.0.0.0/8'
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "SourceIP"::inet <<= '10.0.0.0/8'::cidr"#]
+        );
+    }
+
+    // --- Numeric, Boolean, Null ---
+
+    #[test]
+    fn test_numeric() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 4688
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "EventID" = 4688"#]
+        );
+    }
+
+    #[test]
+    fn test_boolean() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Enabled: true
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "Enabled" = true"#]
+        );
+    }
+
+    #[test]
+    fn test_null() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: null
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "FieldA" IS NULL"#]
+        );
+    }
+
+    // --- Exists ---
+
+    #[test]
+    fn test_exists() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA|exists: true
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "FieldA" IS NOT NULL"#]
+        );
+    }
+
+    #[test]
+    fn test_not_exists() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA|exists: false
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "FieldA" IS NULL"#]
+        );
+    }
+
+    // --- Compare operators ---
+
+    #[test]
+    fn test_gte() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        EventCount|gte: 10
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "EventCount" >= 10"#]
+        );
+    }
+
+    #[test]
+    fn test_lt() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Score|lt: 5
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "Score" < 5"#]
+        );
+    }
+
+    // --- Multiple values ---
+
+    #[test]
+    fn test_multiple_values_or() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine:
+            - whoami
+            - ipconfig
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                r#"SELECT * FROM security_events WHERE "CommandLine" = 'whoami' OR "CommandLine" = 'ipconfig'"#
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_values_all() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|all:
+            - whoami
+            - ipconfig
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                r#"SELECT * FROM security_events WHERE "CommandLine" = 'whoami' AND "CommandLine" = 'ipconfig'"#
+            ]
+        );
+    }
+
+    // --- Keywords (full-text search) ---
+
+    #[test]
+    fn test_keywords() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    keywords:
+        - whoami
+        - ipconfig
+    condition: keywords
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                "SELECT * FROM security_events WHERE \
+                 to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'whoami') OR \
+                 to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'ipconfig')"
+            ]
+        );
+    }
+
+    // --- SQL injection prevention (single-quote escaping) ---
+
+    #[test]
+    fn test_single_quote_escaping() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: "it's a test"
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" = 'it''s a test'"#]
+        );
+    }
+
+    // --- JSONB field access ---
+
+    #[test]
+    fn test_jsonb_field_access() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("metadata".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: whoami
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec!["SELECT * FROM security_events WHERE metadata->>'CommandLine' = 'whoami'"]
+        );
+    }
+
+    // --- Output formats ---
+
+    #[test]
+    fn test_view_format() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+id: 12345678-1234-1234-1234-123456789abc
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_rule(&collection.rules[0], "view", &PipelineState::default())
+            .unwrap();
+        assert_eq!(
+            queries,
+            vec![
+                r#"CREATE OR REPLACE VIEW sigma_12345678_1234_1234_1234_123456789abc AS SELECT * FROM security_events WHERE "FieldA" = 'val1'"#
+            ]
+        );
+    }
+
+    // --- Schema prefix ---
+
+    #[test]
+    fn test_schema_prefix() {
+        let mut backend = PostgresBackend::new();
+        backend.schema = Some("audit".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM audit.security_events WHERE "FieldA" = 'val1'"#]
+        );
+    }
+
+    // --- Multiple detection items (AND) ---
+
+    #[test]
+    fn test_multiple_detection_items_and() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+        FieldB: val2
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "FieldA" = 'val1' AND "FieldB" = 'val2'"#]
+        );
+    }
+
+    // --- LIKE wildcard escaping ---
+
+    #[test]
+    fn test_like_wildcard_escaping() {
+        let queries = convert(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Path|contains: '100%'
+    condition: selection
+"#,
+        );
+        assert_eq!(
+            queries,
+            vec![r#"SELECT * FROM security_events WHERE "Path" ILIKE '100\%'"#]
+        );
+    }
+
+    // --- TimescaleDB output formats ---
+
+    #[test]
+    fn test_timescaledb_format() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_rule(
+                &collection.rules[0],
+                "timescaledb",
+                &PipelineState::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            queries,
+            vec![
+                r#"SELECT time_bucket('1 hour', time) AS bucket, * FROM security_events WHERE "FieldA" = 'val1'"#
+            ]
+        );
+    }
+
+    #[test]
+    fn test_continuous_aggregate_format() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: Test Rule
+id: abcdef01-2345-6789-abcd-ef0123456789
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_rule(
+                &collection.rules[0],
+                "continuous_aggregate",
+                &PipelineState::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            queries,
+            vec![
+                "CREATE MATERIALIZED VIEW sigma_abcdef01_2345_6789_abcd_ef0123456789 \
+                 WITH (timescaledb.continuous) AS \
+                 SELECT time_bucket('1 hour', time) AS bucket, * \
+                 FROM security_events WHERE \"FieldA\" = 'val1' WITH NO DATA"
+            ]
+        );
+    }
+}

--- a/crates/rsigma-convert/src/convert.rs
+++ b/crates/rsigma-convert/src/convert.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use rsigma_eval::pipeline::{Pipeline, apply_pipelines_to_correlation, apply_pipelines_with_state};
 use rsigma_parser::SigmaCollection;
 
@@ -11,6 +13,12 @@ use crate::state::ConversionState;
 /// Applies each pipeline to every rule, then delegates to the backend for
 /// conversion. Errors from individual rules are collected rather than aborting
 /// the entire batch.
+///
+/// For backends that support correlation, a rule-to-table mapping is built from
+/// each detection rule's pipeline state and `postgres.table` custom attribute.
+/// This mapping is injected into the correlation pipeline state under
+/// `_rule_tables` so that temporal correlations can generate multi-table
+/// `UNION ALL` queries when referenced rules target different tables.
 pub fn convert_collection(
     backend: &dyn Backend,
     collection: &SigmaCollection,
@@ -22,6 +30,8 @@ pub fn convert_collection(
     }
 
     let mut output = ConversionOutput::new();
+    let mut rule_table_map: HashMap<String, String> = HashMap::new();
+    let mut rule_schema_map: HashMap<String, String> = HashMap::new();
 
     for rule in &collection.rules {
         let mut rule = rule.clone();
@@ -30,6 +40,34 @@ pub fn convert_collection(
         } else {
             Default::default()
         };
+
+        // Record rule → table/schema for multi-table correlation support.
+        // custom_attributes["postgres.*"] takes precedence over pipeline state.
+        let resolved_table = rule
+            .custom_attributes
+            .get("postgres.table")
+            .and_then(|v| v.as_str())
+            .or_else(|| pipeline_state.state.get("table").and_then(|v| v.as_str()));
+
+        if let Some(table) = resolved_table {
+            if let Some(id) = &rule.id {
+                rule_table_map.insert(id.clone(), table.to_string());
+            }
+            rule_table_map.insert(rule.title.clone(), table.to_string());
+        }
+
+        let resolved_schema = rule
+            .custom_attributes
+            .get("postgres.schema")
+            .and_then(|v| v.as_str())
+            .or_else(|| pipeline_state.state.get("schema").and_then(|v| v.as_str()));
+
+        if let Some(schema) = resolved_schema {
+            if let Some(id) = &rule.id {
+                rule_schema_map.insert(id.clone(), schema.to_string());
+            }
+            rule_schema_map.insert(rule.title.clone(), schema.to_string());
+        }
 
         match backend.convert_rule(&rule, output_format, &pipeline_state) {
             Ok(queries) => {
@@ -48,10 +86,23 @@ pub fn convert_collection(
     if backend.supports_correlation() {
         for corr in &collection.correlations {
             let mut corr = corr.clone();
-            if !pipelines.is_empty() {
-                apply_pipelines_to_correlation(pipelines, &mut corr)?;
+            let mut pipeline_state = if !pipelines.is_empty() {
+                apply_pipelines_to_correlation(pipelines, &mut corr)?
+            } else {
+                Default::default()
+            };
+
+            if !rule_table_map.is_empty() {
+                let map_value = serde_json::to_value(&rule_table_map)
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                pipeline_state.set_state("_rule_tables".to_string(), map_value);
             }
-            let pipeline_state = Default::default();
+            if !rule_schema_map.is_empty() {
+                let map_value = serde_json::to_value(&rule_schema_map)
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                pipeline_state.set_state("_rule_schemas".to_string(), map_value);
+            }
+
             match backend.convert_correlation_rule(&corr, output_format, &pipeline_state) {
                 Ok(queries) => {
                     output.queries.push(ConversionResult {

--- a/crates/rsigma-convert/tests/golden/postgres/and_or_not.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/and_or_not.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "FieldA" = 'val1' AND NOT "FieldB" = 'val2'

--- a/crates/rsigma-convert/tests/golden/postgres/and_or_not.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/and_or_not.yml
@@ -1,0 +1,9 @@
+title: AND OR NOT Conditions
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    filter:
+        FieldB: val2
+    condition: selection and not filter

--- a/crates/rsigma-convert/tests/golden/postgres/cidr.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/cidr.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "SourceIP"::inet <<= '10.0.0.0/8'::cidr

--- a/crates/rsigma-convert/tests/golden/postgres/cidr.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/cidr.yml
@@ -1,0 +1,7 @@
+title: CIDR Test
+logsource:
+    category: test
+detection:
+    selection:
+        SourceIP|cidr: '10.0.0.0/8'
+    condition: selection

--- a/crates/rsigma-convert/tests/golden/postgres/custom_table.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/custom_table.sql
@@ -1,0 +1,1 @@
+SELECT * FROM siem.process_events WHERE "CommandLine" ILIKE 'whoami'

--- a/crates/rsigma-convert/tests/golden/postgres/custom_table.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/custom_table.yml
@@ -1,0 +1,11 @@
+title: Process Creation with Custom Table
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+custom_attributes:
+    postgres.table: process_events
+    postgres.schema: siem

--- a/crates/rsigma-convert/tests/golden/postgres/exists_null_bool.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/exists_null_bool.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "FieldA" IS NOT NULL AND "FieldB" IS NULL AND "Enabled" = true

--- a/crates/rsigma-convert/tests/golden/postgres/exists_null_bool.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/exists_null_bool.yml
@@ -1,0 +1,11 @@
+title: Exists Null Bool Test
+logsource:
+    category: test
+detection:
+    sel_exists:
+        FieldA|exists: true
+    sel_null:
+        FieldB: null
+    sel_bool:
+        Enabled: true
+    condition: sel_exists and sel_null and sel_bool

--- a/crates/rsigma-convert/tests/golden/postgres/ilike_contains.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/ilike_contains.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "CommandLine" ILIKE 'whoami'

--- a/crates/rsigma-convert/tests/golden/postgres/ilike_contains.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/ilike_contains.yml
@@ -1,0 +1,7 @@
+title: ILIKE Contains Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains: whoami
+    condition: selection

--- a/crates/rsigma-convert/tests/golden/postgres/keywords_fulltext.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/keywords_fulltext.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'whoami') OR to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'ipconfig')

--- a/crates/rsigma-convert/tests/golden/postgres/keywords_fulltext.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/keywords_fulltext.yml
@@ -1,0 +1,8 @@
+title: Full-Text Search Keywords Test
+logsource:
+    category: test
+detection:
+    keywords:
+        - whoami
+        - ipconfig
+    condition: keywords

--- a/crates/rsigma-convert/tests/golden/postgres/like_cased.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/like_cased.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "CommandLine" LIKE 'Whoami'

--- a/crates/rsigma-convert/tests/golden/postgres/like_cased.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/like_cased.yml
@@ -1,0 +1,7 @@
+title: LIKE Case-Sensitive Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains|cased: Whoami
+    condition: selection

--- a/crates/rsigma-convert/tests/golden/postgres/multi_field_detection.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/multi_field_detection.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "Image" ILIKE '\\cmd.exe' AND "CommandLine" ILIKE '/c' OR "CommandLine" ILIKE '/k'

--- a/crates/rsigma-convert/tests/golden/postgres/multi_field_detection.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/multi_field_detection.yml
@@ -1,0 +1,11 @@
+title: Multi-Field Detection
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\cmd.exe'
+        CommandLine|contains:
+            - '/c'
+            - '/k'
+    condition: selection

--- a/crates/rsigma-convert/tests/golden/postgres/regex.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/regex.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "CommandLine" ~* '.*whoami.*'

--- a/crates/rsigma-convert/tests/golden/postgres/regex.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/regex.yml
@@ -1,0 +1,7 @@
+title: Regex Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|re: '.*whoami.*'
+    condition: selection

--- a/crates/rsigma-convert/tests/golden/postgres/simple_eq.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/simple_eq.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "CommandLine" = 'whoami'

--- a/crates/rsigma-convert/tests/golden/postgres/simple_eq.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/simple_eq.yml
@@ -1,0 +1,7 @@
+title: Simple Equality Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: whoami
+    condition: selection

--- a/crates/rsigma-convert/tests/golden/postgres/wildcard.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/wildcard.sql
@@ -1,0 +1,1 @@
+SELECT * FROM security_events WHERE "CommandLine" ILIKE '%cmd%whoami%'

--- a/crates/rsigma-convert/tests/golden/postgres/wildcard.yml
+++ b/crates/rsigma-convert/tests/golden/postgres/wildcard.yml
@@ -1,0 +1,7 @@
+title: Wildcard Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine: '*cmd*whoami*'
+    condition: selection

--- a/crates/rsigma-convert/tests/golden_postgres.rs
+++ b/crates/rsigma-convert/tests/golden_postgres.rs
@@ -90,3 +90,8 @@ fn golden_exists_null_bool() {
 fn golden_multi_field_detection() {
     run_golden("multi_field_detection");
 }
+
+#[test]
+fn golden_custom_table() {
+    run_golden("custom_table");
+}

--- a/crates/rsigma-convert/tests/golden_postgres.rs
+++ b/crates/rsigma-convert/tests/golden_postgres.rs
@@ -1,0 +1,92 @@
+//! Golden tests for the PostgreSQL backend.
+//!
+//! Each test case consists of a `.yml` Sigma rule and a `.sql` expected output
+//! file in `tests/golden/postgres/`. The test parses the YAML, converts through
+//! the PostgreSQL backend, and asserts exact string equality with the expected SQL.
+
+use rsigma_convert::Backend;
+use rsigma_convert::backends::postgres::PostgresBackend;
+use rsigma_eval::pipeline::state::PipelineState;
+use rsigma_parser::parse_sigma_yaml;
+use std::fs;
+use std::path::Path;
+
+fn run_golden(name: &str) {
+    let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/golden/postgres");
+    let yaml_path = base.join(format!("{name}.yml"));
+    let sql_path = base.join(format!("{name}.sql"));
+
+    let yaml = fs::read_to_string(&yaml_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", yaml_path.display()));
+    let expected = fs::read_to_string(&sql_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", sql_path.display()));
+    let expected = expected.trim_end();
+
+    let collection = parse_sigma_yaml(&yaml)
+        .unwrap_or_else(|e| panic!("failed to parse {}: {e}", yaml_path.display()));
+    let backend = PostgresBackend::new();
+
+    let mut results = Vec::new();
+    for rule in &collection.rules {
+        let queries = backend
+            .convert_rule(rule, "default", &PipelineState::default())
+            .unwrap_or_else(|e| panic!("conversion failed for {name}: {e}"));
+        results.extend(queries);
+    }
+
+    let actual = results.join("\n");
+    assert_eq!(
+        actual, expected,
+        "\n\nGolden test mismatch for '{name}':\n  actual:   {actual}\n  expected: {expected}\n"
+    );
+}
+
+#[test]
+fn golden_simple_eq() {
+    run_golden("simple_eq");
+}
+
+#[test]
+fn golden_and_or_not() {
+    run_golden("and_or_not");
+}
+
+#[test]
+fn golden_ilike_contains() {
+    run_golden("ilike_contains");
+}
+
+#[test]
+fn golden_like_cased() {
+    run_golden("like_cased");
+}
+
+#[test]
+fn golden_regex() {
+    run_golden("regex");
+}
+
+#[test]
+fn golden_cidr() {
+    run_golden("cidr");
+}
+
+#[test]
+fn golden_keywords_fulltext() {
+    run_golden("keywords_fulltext");
+}
+
+#[test]
+fn golden_wildcard() {
+    run_golden("wildcard");
+}
+
+#[test]
+fn golden_exists_null_bool() {
+    run_golden("exists_null_bool");
+}
+
+#[test]
+fn golden_multi_field_detection() {
+    run_golden("multi_field_detection");
+}

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -1153,16 +1153,23 @@ pub fn apply_pipelines_with_state(
     Ok(merged)
 }
 
-/// Apply multiple pipelines to a correlation rule in priority order.
+/// Apply multiple pipelines to a correlation rule in priority order,
+/// returning the merged pipeline state.
 pub fn apply_pipelines_to_correlation(
     pipelines: &[Pipeline],
     corr: &mut CorrelationRule,
-) -> Result<()> {
+) -> Result<PipelineState> {
+    let mut merged = PipelineState::default();
     for pipeline in pipelines {
         let mut state = PipelineState::new(pipeline.vars.clone());
         pipeline.apply_to_correlation(corr, &mut state)?;
+        for (k, v) in state.state {
+            merged.state.insert(k, v);
+        }
+        merged.applied_items.extend(state.applied_items);
+        merged.vars.extend(state.vars);
     }
-    Ok(())
+    Ok(merged)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add a full PostgreSQL/TimescaleDB backend (`PostgresBackend`) to `rsigma-convert` with native SQL generation for all Sigma detection modifiers (`ILIKE`, regex `~*`/`~`, CIDR `::inet <<= ::cidr`, full-text search `tsvector/tsquery`, JSONB field access), all 8 correlation types, and 4 output formats (`default`, `view`, `timescaledb`, `continuous_aggregate`)
- Implement unified table/schema resolution (`resolve_table()`) with precedence: `custom_attributes["postgres.*"]` > pipeline state > backend defaults, supporting per-rule schema tracking for multi-table temporal correlations via `UNION ALL` CTEs
- Add OCSF processing pipelines: single-table (`ocsf_postgres.yml`) and multi-table per-logsource routing (`ocsf_postgres_multi_table.yml`), plus a reference TimescaleDB hypertable schema with indexes, compression, and retention policies
- Return `PipelineState` from `apply_pipelines_to_correlation()` (was `()`) so correlation rules receive pipeline state; build rule-to-table/schema mappings in `convert_collection()` for multi-table correlation support

## Test plan

- [x] 81 unit tests in `postgres.rs` covering detection modifiers, resolve_table precedence (8 tests), custom attributes, pipeline state overrides, correlation types, multi-table UNION ALL (4 tests), per-rule schemas (2 tests)
- [x] 11 golden tests comparing generated SQL against expected `.sql` fixtures
- [x] All existing tests pass across the workspace (eval, parser, runtime, convert, CLI)
- [x] Zero clippy warnings
- [ ] Manual: `rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml` with temporal correlation rules across logsource categories