### PR TITLE
fix: PostgreSQL backend correctness and hardening review

### DIFF
--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -84,7 +84,7 @@ let output = convert_collection(&backend, &collection, &[], "default").unwrap();
 for result in &output.queries {
     for query in &result.queries {
         println!("{query}");
-        // Output: SELECT * FROM security_events WHERE "CommandLine" ILIKE 'whoami'
+        // Output: SELECT * FROM security_events WHERE "CommandLine" ILIKE '%whoami%'
     }
 }
 ```
@@ -102,9 +102,9 @@ for result in &output.queries {
 
 The target table and schema can be set at three levels (highest precedence first):
 
-1. **Rule-level `custom_attributes`** — `postgres.table`, `postgres.schema`, `postgres.database`
-2. **Pipeline state** — `set_state` with `key: table`, `key: schema`
-3. **Backend defaults** — `PostgresBackend.table`, `.schema`, `.database`
+1. **Rule-level `custom_attributes`**: `postgres.table`, `postgres.schema`, `postgres.database`
+2. **Pipeline state**: `set_state` with `key: table`, `key: schema`
+3. **Backend defaults**: `PostgresBackend.table`, `.schema`, `.database`
 
 Example rule with custom attributes:
 
@@ -127,8 +127,8 @@ Two OCSF processing pipelines are included:
 
 | Pipeline | Description |
 |----------|-------------|
-| `pipelines/ocsf_postgres.yml` | Single-table — all events go to `security_events` |
-| `pipelines/ocsf_postgres_multi_table.yml` | Per-logsource routing — each category gets its own table (`process_events`, `network_events`, etc.) |
+| `pipelines/ocsf_postgres.yml` | Single-table: all events go to `security_events` |
+| `pipelines/ocsf_postgres_multi_table.yml` | Per-logsource routing: each category gets its own table (`process_events`, `network_events`, etc.) |
 
 ```bash
 # Single-table pipeline

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -229,7 +229,7 @@ The PostgreSQL backend (`PostgresBackend`) leverages native PostgreSQL features 
 | `re` | `~*` (case-insensitive regex) or `~` (with `cased`) |
 | `cidr` | `field::inet <<= 'value'::cidr` |
 | `exists` | `IS NOT NULL` / `IS NULL` |
-| keywords | `to_tsvector() @@ to_tsquery()` |
+| keywords | `to_tsvector() @@ plainto_tsquery()` |
 
 Correlation rules are converted to SQL using `GROUP BY` / `HAVING` for aggregation types (`event_count`, `value_count`, `value_sum`, `value_avg`, `value_percentile`, `value_median`) and CTEs for temporal correlation. Multi-table temporal correlations automatically generate `UNION ALL` CTEs when referenced rules target different tables.
 

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -166,6 +166,8 @@ When all referenced rules share the same table, the simpler single-table approac
 
 Per-rule schemas are also tracked: if different detection rules set different schemas (via `postgres.schema` custom attribute or `set_state key: schema` in the pipeline), each leg of the UNION ALL uses the correct `schema.table`.
 
+> **Important:** The multi-table `UNION ALL` uses `SELECT *` in each leg, so PostgreSQL requires all referenced tables to have the same column count and compatible column types. This works well when tables share a normalized event schema. If your tables have different column layouts, either normalize them through pipeline field-mappings or use a single-table approach with a discriminator column (e.g. `rule_name`) instead.
+
 ### Reference schema
 
 A reference TimescaleDB schema is provided at [`schema/timescaledb_security_events.sql`](./schema/timescaledb_security_events.sql) with hypertable setup, indexes (B-tree, GIN for full-text and JSONB), compression, retention policies, and an example continuous aggregate.

--- a/crates/rsigma-convert/src/backend.rs
+++ b/crates/rsigma-convert/src/backend.rs
@@ -47,7 +47,7 @@ pub enum TokenType {
 /// Backends implement this to convert parsed Sigma AST nodes into
 /// backend-native query strings. The trait operates on **parsed** types
 /// from `rsigma-parser` because conversion needs the original field names,
-/// modifiers, and values — not compiled matchers.
+/// modifiers, and values rather than compiled matchers.
 pub trait Backend: Send + Sync {
     fn name(&self) -> &str;
     fn formats(&self) -> &[(&str, &str)];

--- a/crates/rsigma-convert/src/backend.rs
+++ b/crates/rsigma-convert/src/backend.rs
@@ -1,10 +1,29 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use rsigma_eval::pipeline::state::PipelineState;
 use rsigma_parser::*;
 
 use crate::error::{ConvertError, Result};
 use crate::state::{ConversionState, ConvertResult};
+
+/// Process-wide cache for compiled regexes keyed by pattern string.
+static REGEX_CACHE: Mutex<Option<HashMap<&'static str, regex::Regex>>> = Mutex::new(None);
+
+fn get_cached_regex(pattern: &'static str) -> Option<regex::Regex> {
+    let mut guard = REGEX_CACHE.lock().unwrap();
+    let cache = guard.get_or_insert_with(HashMap::new);
+    if let Some(re) = cache.get(pattern) {
+        return Some(re.clone());
+    }
+    match regex::Regex::new(pattern) {
+        Ok(re) => {
+            cache.insert(pattern, re.clone());
+            Some(re)
+        }
+        Err(_) => None,
+    }
+}
 
 // =============================================================================
 // Token precedence
@@ -354,7 +373,7 @@ pub fn text_escape_and_quote_field(cfg: &TextQueryConfig, field: &str) -> String
 
     if let Some(esc) = cfg.field_escape
         && let Some(pat) = cfg.field_escape_pattern
-        && let Ok(re) = regex::Regex::new(pat)
+        && let Some(re) = get_cached_regex(pat)
     {
         escaped = re
             .replace_all(&escaped, |_: &regex::Captures| esc)
@@ -364,7 +383,7 @@ pub fn text_escape_and_quote_field(cfg: &TextQueryConfig, field: &str) -> String
     if let Some(quote) = cfg.field_quote {
         let should_quote = match cfg.field_quote_pattern {
             Some(pat) => {
-                let matches = regex::Regex::new(pat)
+                let matches = get_cached_regex(pat)
                     .map(|re| re.is_match(&escaped))
                     .unwrap_or(false);
                 if cfg.field_quote_pattern_negation {
@@ -421,7 +440,7 @@ pub fn text_convert_value_str(cfg: &TextQueryConfig, value: &SigmaString) -> Str
     if !has_wildcards {
         let should_quote = match cfg.str_quote_pattern {
             Some(pat) => {
-                let matches = regex::Regex::new(pat)
+                let matches = get_cached_regex(pat)
                     .map(|re| re.is_match(&result))
                     .unwrap_or(false);
                 if cfg.str_quote_pattern_negation {

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -233,6 +233,28 @@ impl PostgresBackend {
         result
     }
 
+    /// Add `%` wildcards to a LIKE value based on modifier semantics.
+    /// The value is already a quoted `'...'` string from `build_like_value`.
+    fn wrap_like_wildcards(
+        &self,
+        quoted: &str,
+        is_contains: bool,
+        is_startswith: bool,
+        is_endswith: bool,
+    ) -> String {
+        if !is_contains && !is_startswith && !is_endswith {
+            return quoted.to_string();
+        }
+        let inner = &quoted[1..quoted.len() - 1];
+        let prefix = if is_contains || is_endswith { "%" } else { "" };
+        let suffix = if is_contains || is_startswith {
+            "%"
+        } else {
+            ""
+        };
+        format!("'{prefix}{inner}{suffix}'")
+    }
+
     /// Build a plain SQL string literal from a SigmaString (no wildcards).
     fn build_plain_value(&self, value: &SigmaString) -> String {
         let plain = value.as_plain().unwrap_or_else(|| value.original.clone());
@@ -362,7 +384,8 @@ impl Backend for PostgresBackend {
         let like_op = if is_cased { "LIKE" } else { "ILIKE" };
 
         if is_contains || is_startswith || is_endswith || has_wildcards {
-            let val = self.build_like_value(value);
+            let inner = self.build_like_value(value);
+            let val = self.wrap_like_wildcards(&inner, is_contains, is_startswith, is_endswith);
             return Ok(ConvertResult::Query(format!("{f} {like_op} {val}")));
         }
 
@@ -1064,7 +1087,7 @@ detection:
         );
         assert_eq!(
             queries,
-            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE 'whoami'"#]
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE '%whoami%'"#]
         );
     }
 
@@ -1083,7 +1106,7 @@ detection:
         );
         assert_eq!(
             queries,
-            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE 'cmd'"#]
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE 'cmd%'"#]
         );
     }
 
@@ -1102,7 +1125,7 @@ detection:
         );
         assert_eq!(
             queries,
-            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE '.exe'"#]
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE '%.exe'"#]
         );
     }
 
@@ -1121,7 +1144,7 @@ detection:
         );
         assert_eq!(
             queries,
-            vec![r#"SELECT * FROM security_events WHERE "CommandLine" LIKE 'Whoami'"#]
+            vec![r#"SELECT * FROM security_events WHERE "CommandLine" LIKE '%Whoami%'"#]
         );
     }
 
@@ -1581,7 +1604,7 @@ detection:
         );
         assert_eq!(
             queries,
-            vec![r#"SELECT * FROM security_events WHERE "Path" ILIKE '100\%'"#]
+            vec![r#"SELECT * FROM security_events WHERE "Path" ILIKE '%100\%%'"#]
         );
     }
 

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -511,36 +511,27 @@ impl Backend for PostgresBackend {
     }
 
     fn convert_keyword(&self, value: &SigmaValue, _state: &mut ConversionState) -> Result<String> {
+        let search_target = match &self.json_field {
+            Some(json_col) => format!("{json_col}::text"),
+            None => "ROW(*)::text".to_string(),
+        };
         match value {
             SigmaValue::String(s) => {
                 let plain = s.as_plain().unwrap_or_else(|| s.original.clone());
+                if plain.is_empty() {
+                    return Err(ConvertError::UnsupportedKeyword);
+                }
                 let escaped = self.escape_sql_str(&plain);
-                let search_target = match &self.json_field {
-                    Some(json_col) => format!("{json_col}::text"),
-                    None => "ROW(*)::text".to_string(),
-                };
                 Ok(format!(
-                    "to_tsvector('simple', {search_target}) @@ to_tsquery('simple', '{escaped}')"
+                    "to_tsvector('simple', {search_target}) @@ plainto_tsquery('simple', '{escaped}')"
                 ))
             }
-            SigmaValue::Integer(n) => {
-                let search_target = match &self.json_field {
-                    Some(json_col) => format!("{json_col}::text"),
-                    None => "ROW(*)::text".to_string(),
-                };
-                Ok(format!(
-                    "to_tsvector('simple', {search_target}) @@ to_tsquery('simple', '{n}')"
-                ))
-            }
-            SigmaValue::Float(f) => {
-                let search_target = match &self.json_field {
-                    Some(json_col) => format!("{json_col}::text"),
-                    None => "ROW(*)::text".to_string(),
-                };
-                Ok(format!(
-                    "to_tsvector('simple', {search_target}) @@ to_tsquery('simple', '{f}')"
-                ))
-            }
+            SigmaValue::Integer(n) => Ok(format!(
+                "to_tsvector('simple', {search_target}) @@ plainto_tsquery('simple', '{n}')"
+            )),
+            SigmaValue::Float(f) => Ok(format!(
+                "to_tsvector('simple', {search_target}) @@ plainto_tsquery('simple', '{f}')"
+            )),
             _ => Err(ConvertError::UnsupportedKeyword),
         }
     }
@@ -1421,8 +1412,8 @@ detection:
             queries,
             vec![
                 "SELECT * FROM security_events WHERE \
-                 to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'whoami') OR \
-                 to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'ipconfig')"
+                 to_tsvector('simple', ROW(*)::text) @@ plainto_tsquery('simple', 'whoami') OR \
+                 to_tsvector('simple', ROW(*)::text) @@ plainto_tsquery('simple', 'ipconfig')"
             ]
         );
     }

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -901,7 +901,7 @@ impl PostgresBackend {
         }
 
         if table_to_rules.len() <= 1 {
-            // Single table — filter by rule_name column
+            // Single table: filter by rule_name column
             let rule_names = rule.rules.join("', '");
             Ok(format!(
                 "WITH matched AS (\
@@ -917,7 +917,7 @@ impl PostgresBackend {
                  HAVING {having}"
             ))
         } else {
-            // Multi-table — UNION ALL CTE with one leg per rule
+            // Multi-table: UNION ALL CTE with one leg per rule
             let union_parts: Vec<String> = table_to_rules
                 .iter()
                 .flat_map(|(tbl, rules)| {
@@ -1968,7 +1968,7 @@ correlation:
             )
             .unwrap();
         assert_eq!(queries.len(), 1);
-        // No UNION ALL — single table approach
+        // No UNION ALL, uses single table approach
         assert!(
             queries[0].contains("rule_name IN ('rule_a', 'rule_b')"),
             "expected single-table approach in: {}",
@@ -2204,7 +2204,7 @@ correlation:
         let backend = PostgresBackend::new();
         let mut pipeline_state = PipelineState::default();
 
-        // Both rules point to the same table — single-table path
+        // Both rules point to the same table so the single-table path is used
         let rule_tables = serde_json::json!({
             "rule_a": "security_events",
             "rule_b": "security_events"

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -854,6 +854,15 @@ impl PostgresBackend {
     /// CTE filtering on `rule_name IN (...)`. When rules target different tables
     /// (from `_rule_tables` pipeline state), produces a `UNION ALL` CTE with one
     /// leg per rule.
+    ///
+    /// **Schema compatibility requirement:** The multi-table path uses
+    /// `SELECT * ... UNION ALL SELECT * ...`. PostgreSQL requires all legs of a
+    /// `UNION ALL` to produce the same number of columns with compatible types.
+    /// This works when all referenced tables share an identical schema (e.g. a
+    /// normalized event schema). If the tables have different column layouts the
+    /// query will fail at execution time. Callers should ensure that pipeline
+    /// field-mappings normalize the schemas, or use a single-table approach with
+    /// a discriminator column instead.
     #[allow(clippy::too_many_arguments)]
     fn build_temporal_query(
         &self,

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -636,12 +636,20 @@ impl Backend for PostgresBackend {
         _state: &ConversionState,
         output_format: &str,
     ) -> Result<String> {
-        let view_name = || match &rule.id {
-            Some(id) => format!("sigma_{}", id.replace('-', "_")),
-            None => format!(
-                "sigma_{}",
-                rule.title.to_lowercase().replace([' ', '-'], "_")
-            ),
+        let view_name = || {
+            let raw = match &rule.id {
+                Some(id) => id.replace('-', "_"),
+                None => rule.title.to_lowercase().replace([' ', '-'], "_"),
+            };
+            let sanitized: String = raw
+                .chars()
+                .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if sanitized.is_empty() {
+                "sigma_rule".to_string()
+            } else {
+                format!("sigma_{sanitized}")
+            }
         };
 
         match output_format {
@@ -1538,6 +1546,31 @@ detection:
             vec![
                 r#"CREATE OR REPLACE VIEW sigma_12345678_1234_1234_1234_123456789abc AS SELECT * FROM security_events WHERE "FieldA" = 'val1'"#
             ]
+        );
+    }
+
+    #[test]
+    fn test_view_format_title_sanitization() {
+        let collection = parse_sigma_yaml(
+            r#"
+title: "Suspicious Process: cmd.exe /c (T1059.003)"
+logsource:
+    category: test
+detection:
+    selection:
+        FieldA: val1
+    condition: selection
+"#,
+        )
+        .unwrap();
+        let backend = PostgresBackend::new();
+        let queries = backend
+            .convert_rule(&collection.rules[0], "view", &PipelineState::default())
+            .unwrap();
+        assert!(
+            queries[0].starts_with(
+                "CREATE OR REPLACE VIEW sigma_suspicious_process_cmdexe_c_t1059003 AS"
+            )
         );
     }
 

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -74,8 +74,8 @@ pub static POSTGRES_CONFIG: TextQueryConfig = TextQueryConfig {
     re_escape: &[],
     re_escape_escape_char: None,
 
-    cidr_expression: Some("{field}::inet <<= {value}::cidr"),
-    not_cidr_expression: Some("NOT ({field}::inet <<= {value}::cidr)"),
+    cidr_expression: Some("({field})::inet <<= {value}::cidr"),
+    not_cidr_expression: Some("NOT (({field})::inet <<= {value}::cidr)"),
 
     field_null_expression: "{field} IS NULL",
     field_exists_expression: Some("{field} IS NOT NULL"),
@@ -442,7 +442,7 @@ impl Backend for PostgresBackend {
     ) -> Result<ConvertResult> {
         let f = self.field_expr(field);
         Ok(ConvertResult::Query(format!(
-            "{f}::inet <<= '{cidr}'::cidr"
+            "({f})::inet <<= '{cidr}'::cidr"
         )))
     }
 
@@ -1201,7 +1201,9 @@ detection:
         );
         assert_eq!(
             queries,
-            vec![r#"SELECT * FROM security_events WHERE "SourceIP"::inet <<= '10.0.0.0/8'::cidr"#]
+            vec![
+                r#"SELECT * FROM security_events WHERE ("SourceIP")::inet <<= '10.0.0.0/8'::cidr"#
+            ]
         );
     }
 
@@ -1460,6 +1462,30 @@ detection:
         assert_eq!(
             queries,
             vec!["SELECT * FROM security_events WHERE metadata->>'CommandLine' = 'whoami'"]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_cidr() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("metadata".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        SourceIP|cidr: '10.0.0.0/8'
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                "SELECT * FROM security_events WHERE (metadata->>'SourceIP')::inet <<= '10.0.0.0/8'::cidr"
+            ]
         );
     }
 

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -414,7 +414,7 @@ impl Backend for PostgresBackend {
         _state: &mut ConversionState,
     ) -> Result<String> {
         let f = self.field_expr(field);
-        if value.fract() == 0.0 {
+        if value.fract() == 0.0 && (i64::MIN as f64..=i64::MAX as f64).contains(&value) {
             Ok(format!("{f} = {}", value as i64))
         } else {
             Ok(format!("{f} = {value}"))
@@ -488,11 +488,12 @@ impl Backend for PostgresBackend {
                 )));
             }
         };
-        let val_str = if value.fract() == 0.0 {
-            (value as i64).to_string()
-        } else {
-            value.to_string()
-        };
+        let val_str =
+            if value.fract() == 0.0 && (i64::MIN as f64..=i64::MAX as f64).contains(&value) {
+                (value as i64).to_string()
+            } else {
+                value.to_string()
+            };
         Ok(format!("{f} {op_token} {val_str}"))
     }
 

--- a/crates/rsigma-convert/tests/golden/postgres/cidr.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/cidr.sql
@@ -1,1 +1,1 @@
-SELECT * FROM security_events WHERE "SourceIP"::inet <<= '10.0.0.0/8'::cidr
+SELECT * FROM security_events WHERE ("SourceIP")::inet <<= '10.0.0.0/8'::cidr

--- a/crates/rsigma-convert/tests/golden/postgres/custom_table.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/custom_table.sql
@@ -1,1 +1,1 @@
-SELECT * FROM siem.process_events WHERE "CommandLine" ILIKE 'whoami'
+SELECT * FROM siem.process_events WHERE "CommandLine" ILIKE '%whoami%'

--- a/crates/rsigma-convert/tests/golden/postgres/ilike_contains.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/ilike_contains.sql
@@ -1,1 +1,1 @@
-SELECT * FROM security_events WHERE "CommandLine" ILIKE 'whoami'
+SELECT * FROM security_events WHERE "CommandLine" ILIKE '%whoami%'

--- a/crates/rsigma-convert/tests/golden/postgres/keywords_fulltext.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/keywords_fulltext.sql
@@ -1,1 +1,1 @@
-SELECT * FROM security_events WHERE to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'whoami') OR to_tsvector('simple', ROW(*)::text) @@ to_tsquery('simple', 'ipconfig')
+SELECT * FROM security_events WHERE to_tsvector('simple', ROW(*)::text) @@ plainto_tsquery('simple', 'whoami') OR to_tsvector('simple', ROW(*)::text) @@ plainto_tsquery('simple', 'ipconfig')

--- a/crates/rsigma-convert/tests/golden/postgres/like_cased.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/like_cased.sql
@@ -1,1 +1,1 @@
-SELECT * FROM security_events WHERE "CommandLine" LIKE 'Whoami'
+SELECT * FROM security_events WHERE "CommandLine" LIKE '%Whoami%'

--- a/crates/rsigma-convert/tests/golden/postgres/multi_field_detection.sql
+++ b/crates/rsigma-convert/tests/golden/postgres/multi_field_detection.sql
@@ -1,1 +1,1 @@
-SELECT * FROM security_events WHERE "Image" ILIKE '\\cmd.exe' AND "CommandLine" ILIKE '/c' OR "CommandLine" ILIKE '/k'
+SELECT * FROM security_events WHERE "Image" ILIKE '%\\cmd.exe' AND "CommandLine" ILIKE '%/c%' OR "CommandLine" ILIKE '%/k%'


### PR DESCRIPTION
## Summary

- **SQL injection prevention**: Replace `to_tsquery` with `plainto_tsquery` in keyword conversion to prevent tsquery operator injection via user-controlled values
- **CIDR operator precedence**: Wrap field expressions in parentheses before `::inet` cast so JSONB extraction (`->>'field'`) binds correctly
- **LIKE wildcard injection**: Add `%` wildcards for `|contains`, `|startswith`, and `|endswith` modifiers, which the parser stores as flags without injecting wildcards into `SigmaString`
- **Regex caching**: Cache compiled regexes in `text_escape_and_quote_field` and `text_convert_value_str` via a process-wide `Mutex<HashMap>` to avoid recompilation on every call
- **View name sanitization**: Strip non-alphanumeric/underscore characters from rule titles when generating `CREATE VIEW` names in `finalize_query`
- **Numeric cast guard**: Add range check before `f64`-to-`i64` cast in `convert_field_eq_num` and `convert_field_compare` to prevent silent truncation of out-of-range values
- **UNION ALL schema docs**: Document the `SELECT *` schema compatibility requirement for multi-table temporal correlations in both code comments and README

## Test plan

- [x] All 83 unit tests pass (`cargo test --package rsigma-convert`)
- [x] All 11 golden tests updated and passing
- [x] New unit tests added: `test_jsonb_cidr`, `test_view_format_title_sanitization`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (full workspace)