### PR TITLE
fix: align one-to-many field mapping with pySigma correlation semantics

### DIFF
--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -242,12 +242,66 @@ fn apply_correlation_transformation(
 ) -> Result<bool> {
     match transformation {
         Transformation::FieldNameMapping { mapping } => {
-            // Correlation fields (group_by, aliases mapping values, threshold
-            // field) are scalar — OR over multiple alternatives isn't
-            // expressible there, so we use the first listed alternative.
-            remap_correlation_fields(corr, |name| {
-                mapping.get(name).and_then(|alts| alts.first().cloned())
-            });
+            // Match pySigma's FieldMappingTransformationBase.apply() for
+            // correlation rules: group_by expands all alternatives, while
+            // aliases and threshold field reject one-to-many mappings.
+            let alias_names: std::collections::HashSet<String> =
+                corr.aliases.iter().map(|a| a.alias.clone()).collect();
+
+            // aliases: error if any mapping value has multiple alternatives
+            for alias in &mut corr.aliases {
+                for (rule_ref, field_name) in &mut alias.mapping {
+                    if let Some(alts) = mapping.get(field_name.as_str())
+                        && alts.len() > 1
+                    {
+                        return Err(EvalError::InvalidModifiers(format!(
+                            "field_name_mapping one-to-many cannot be applied to \
+                             correlation alias mapping (alias '{}', rule '{}', \
+                             field '{}' maps to {} alternatives)",
+                            alias.alias,
+                            rule_ref,
+                            field_name,
+                            alts.len(),
+                        )));
+                    } else if let Some(alts) = mapping.get(field_name.as_str()) {
+                        *field_name = alts[0].clone();
+                    }
+                }
+            }
+
+            // group_by: expand all alternatives (skip alias names)
+            corr.group_by = corr
+                .group_by
+                .iter()
+                .flat_map(|field_name| {
+                    if alias_names.contains(field_name.as_str()) {
+                        vec![field_name.clone()]
+                    } else if let Some(alts) = mapping.get(field_name.as_str()) {
+                        alts.clone()
+                    } else {
+                        vec![field_name.clone()]
+                    }
+                })
+                .collect();
+
+            // threshold field: error if multiple alternatives
+            if let rsigma_parser::CorrelationCondition::Threshold { ref mut field, .. } =
+                corr.condition
+                && let Some(f) = field.as_ref()
+                && let Some(alts) = mapping.get(f.as_str())
+            {
+                if alts.len() > 1 {
+                    return Err(EvalError::InvalidModifiers(format!(
+                        "field_name_mapping one-to-many cannot be applied to \
+                         correlation condition field reference ('{}' maps to \
+                         {} alternatives)",
+                        f,
+                        alts.len(),
+                    )));
+                }
+                *field = Some(alts[0].clone());
+            }
+
             Ok(true)
         }
 
@@ -1038,10 +1092,21 @@ fn parse_string_or_list_mapping(
             if let Some(key) = k.as_str() {
                 let values = match v {
                     serde_yaml::Value::String(s) => vec![s.clone()],
-                    serde_yaml::Value::Sequence(seq) => seq
-                        .iter()
-                        .filter_map(|item| item.as_str().map(|s| s.to_string()))
-                        .collect(),
+                    serde_yaml::Value::Sequence(seq) => {
+                        let mut strings = Vec::with_capacity(seq.len());
+                        for item in seq {
+                            if let Some(s) = item.as_str() {
+                                strings.push(s.to_string());
+                            } else {
+                                log::warn!(
+                                    "non-string item in mapping list for key '{}': {:?}; skipping",
+                                    key,
+                                    item,
+                                );
+                            }
+                        }
+                        strings
+                    }
                     _ => continue,
                 };
                 if !values.is_empty() {
@@ -1930,6 +1995,90 @@ transformations:
 
         assert_eq!(corr.group_by, vec!["source.ip", "destination.ip"]);
         assert_eq!(corr.aliases[0].mapping["rule_a"], "source.ip");
+    }
+
+    #[test]
+    fn test_correlation_field_mapping_group_by_expands_all_alternatives() {
+        let yaml = r#"
+name: Multi-field
+transformations:
+  - type: field_name_mapping
+    mapping:
+      DestinationIP:
+        - dst.ip
+        - dest.address
+      SourceIP: src.ip
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .unwrap();
+
+        // SourceIP is 1:1 (and also in an alias), DestinationIP expands
+        assert_eq!(
+            corr.group_by,
+            vec!["src.ip", "dst.ip", "dest.address"],
+            "group_by should expand all alternatives for DestinationIP"
+        );
+        // alias SourceIP should be remapped 1:1
+        assert_eq!(corr.aliases[0].mapping["rule_a"], "src.ip");
+    }
+
+    #[test]
+    fn test_correlation_field_mapping_alias_rejects_one_to_many() {
+        let yaml = r#"
+name: Alias conflict
+transformations:
+  - type: field_name_mapping
+    mapping:
+      SourceIP:
+        - src.ip
+        - source.address
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        let err = pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .expect_err("alias with one-to-many must error");
+        let msg = format!("{err}");
+        assert!(msg.contains("alias"), "error should mention alias: {msg}");
+    }
+
+    #[test]
+    fn test_correlation_field_mapping_threshold_field_rejects_one_to_many() {
+        let yaml = r#"
+name: Threshold conflict
+transformations:
+  - type: field_name_mapping
+    mapping:
+      UserName:
+        - user.name
+        - user.id
+    rule_conditions:
+      - type: is_sigma_correlation_rule
+"#;
+        let pipeline = parse_pipeline(yaml).unwrap();
+        let mut corr = make_test_correlation();
+        corr.condition = rsigma_parser::CorrelationCondition::Threshold {
+            predicates: vec![(rsigma_parser::ConditionOperator::Gte, 5)],
+            field: Some("UserName".to_string()),
+        };
+        let mut state = PipelineState::new(pipeline.vars.clone());
+        let err = pipeline
+            .apply_to_correlation(&mut corr, &mut state)
+            .expect_err("threshold field with one-to-many must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("condition field reference"),
+            "error should mention condition field: {msg}"
+        );
     }
 
     #[test]

--- a/crates/rsigma-eval/src/pipeline/transformations.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations.rs
@@ -540,12 +540,16 @@ where
 {
     match detection {
         Detection::AllOf(items) => {
-            // Compute alternative-lists for every item up-front so we can
-            // detect whether a Cartesian expansion is needed before mutating.
-            let mut alternatives: Vec<Vec<DetectionItem>> = Vec::with_capacity(items.len());
-            let mut needs_expansion = false;
-            for item in items.iter() {
-                let alts = match item.field.name.as_deref() {
+            // First pass (read-only): resolve each item's mapping result.
+            // Store either a single rename or a multi-alternative expansion.
+            enum Resolved {
+                Unchanged,
+                Renamed(String),
+                Expanded(Vec<String>),
+            }
+            let resolved: Vec<Resolved> = items
+                .iter()
+                .map(|item| match item.field.name.as_deref() {
                     Some(name)
                         if field_conditions_match(
                             name,
@@ -555,37 +559,49 @@ where
                         ) =>
                     {
                         match transform_fn(name) {
-                            Some(new_names) if !new_names.is_empty() => {
-                                if new_names.len() > 1 {
-                                    needs_expansion = true;
-                                }
-                                new_names
-                                    .into_iter()
-                                    .map(|new_name| {
-                                        let mut clone = item.clone();
-                                        clone.field.name = Some(new_name);
-                                        clone
-                                    })
-                                    .collect()
+                            Some(new_names) if new_names.len() > 1 => Resolved::Expanded(new_names),
+                            Some(mut new_names) if new_names.len() == 1 => {
+                                Resolved::Renamed(new_names.pop().unwrap())
                             }
-                            // None or empty Vec — leave item untouched.
-                            _ => vec![item.clone()],
+                            _ => Resolved::Unchanged,
                         }
                     }
-                    _ => vec![item.clone()],
-                };
-                alternatives.push(alts);
-            }
+                    _ => Resolved::Unchanged,
+                })
+                .collect();
+
+            let needs_expansion = resolved.iter().any(|r| matches!(r, Resolved::Expanded(_)));
 
             if !needs_expansion {
-                // Fast path: every list has length 1, just unwrap and replace.
-                *items = alternatives
-                    .into_iter()
-                    .map(|mut alts| alts.pop().expect("non-empty by construction"))
-                    .collect();
+                // Fast path: apply 1:1 renames in-place, no cloning.
+                for (item, res) in items.iter_mut().zip(resolved) {
+                    if let Resolved::Renamed(new_name) = res {
+                        item.field.name = Some(new_name);
+                    }
+                }
             } else {
-                // Saturating multiply so a pathological mapping cannot overflow
-                // usize before we get a chance to reject it.
+                // Build per-item alternative lists for the Cartesian product.
+                let alternatives: Vec<Vec<DetectionItem>> = items
+                    .iter()
+                    .zip(resolved)
+                    .map(|(item, res)| match res {
+                        Resolved::Expanded(names) => names
+                            .into_iter()
+                            .map(|new_name| {
+                                let mut clone = item.clone();
+                                clone.field.name = Some(new_name);
+                                clone
+                            })
+                            .collect(),
+                        Resolved::Renamed(name) => {
+                            let mut clone = item.clone();
+                            clone.field.name = Some(name);
+                            vec![clone]
+                        }
+                        Resolved::Unchanged => vec![item.clone()],
+                    })
+                    .collect();
+
                 let total = alternatives
                     .iter()
                     .map(Vec::len)


### PR DESCRIPTION
## Summary

Follow-up to PR #40 (one-to-many `field_name_mapping`). The detection item expansion (core feature) is unchanged. This PR aligns correlation rule handling with pySigma's `FieldMappingTransformationBase.apply()` and adds minor improvements:

- **Correlation `group_by`**: expand all mapping alternatives into the list instead of silently taking only the first (matches pySigma)
- **Correlation `aliases`**: return an error when a one-to-many mapping targets an alias field (pySigma raises `SigmaConfigurationError`)
- **Correlation `condition.fieldref`**: return an error when a one-to-many mapping targets the threshold field (pySigma raises `SigmaConfigurationError`)
- **YAML parsing**: warn on non-string items in `parse_string_or_list_mapping` sequences instead of silently dropping them
- **Performance**: eliminate cloning in the no-expansion fast path of `transform_detection_fields` (two-pass `Resolved` enum approach mutates in-place for 1:1 renames)

@fwosar I made these changes to follow in pySigma's footsteps.

## Test plan

- [x] 3 new unit tests: `test_correlation_field_mapping_group_by_expands_all_alternatives`, `test_correlation_field_mapping_alias_rejects_one_to_many`, `test_correlation_field_mapping_threshold_field_rejects_one_to_many`
- [x] All 7 original PR #40 tests pass unmodified (AnyOf expansion, Cartesian product, cap, fast path, 2 integration tests)
- [x] Full suite: 417 tests pass (366 unit + 51 integration/edge/error/snapshot/doc)
- [x] `cargo clippy -p rsigma-eval --all-targets -- -D warnings` clean