### PR TITLE
feat: implement pySigma parity gaps

### DIFF
--- a/crates/rsigma-cli/tests/cli.rs
+++ b/crates/rsigma-cli/tests/cli.rs
@@ -110,7 +110,7 @@ filter:
         - 00000000-0000-0000-0000-000000000020
     selection:
         TargetFilename|endswith: "\\trusted.exe"
-    condition: selection
+    condition: not selection
 "#;
 
 const PIPELINE_YAML: &str = r#"

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -713,7 +713,9 @@ impl Backend for PostgresBackend {
         let having_clause = self.build_having_clause(&rule.condition)?;
 
         let field_from_condition = match &rule.condition {
-            CorrelationCondition::Threshold { field, .. } => field.clone(),
+            CorrelationCondition::Threshold { field, .. } => {
+                field.as_ref().and_then(|f| f.first().cloned())
+            }
             _ => None,
         };
         let value_field = field_from_condition.as_deref().or_else(|| {
@@ -801,7 +803,12 @@ impl Backend for PostgresBackend {
                 let percentile = if rule.correlation_type == CorrelationType::ValueMedian {
                     0.5
                 } else {
-                    0.95
+                    match &rule.condition {
+                        CorrelationCondition::Threshold { percentile, .. } => {
+                            percentile.map(|p| p as f64 / 100.0).unwrap_or(0.95)
+                        }
+                        _ => 0.95,
+                    }
                 };
                 let agg = format!("PERCENTILE_CONT({percentile}) WITHIN GROUP (ORDER BY {field})");
                 format!(

--- a/crates/rsigma-eval/src/correlation.rs
+++ b/crates/rsigma-eval/src/correlation.rs
@@ -108,10 +108,14 @@ impl GroupByField {
 /// Compiled threshold condition with one or more predicates (supports ranges).
 #[derive(Debug, Clone)]
 pub struct CompiledCondition {
-    /// Optional field name for value_count, value_sum, value_avg, value_percentile.
-    pub field: Option<String>,
+    /// Optional field name(s) for value_count, value_sum, value_avg, value_percentile.
+    /// When multiple fields are present, value_count counts distinct tuples.
+    pub field: Option<Vec<String>>,
     /// One or more predicates to satisfy (all must be true for the condition to match).
     pub predicates: Vec<(ConditionOperator, f64)>,
+    /// Percentile rank (0-100) for `value_percentile` type.
+    /// `None` means use the default (50).
+    pub percentile: Option<u64>,
 }
 
 impl CompiledCondition {
@@ -666,12 +670,7 @@ impl WindowState {
                     return None;
                 }
                 values.sort_by(|a, b| a.partial_cmp(b).expect("NaN filtered"));
-                // Extract the percentile rank from the condition's first predicate
-                let percentile_rank = condition
-                    .predicates
-                    .first()
-                    .map(|(_, threshold)| *threshold)
-                    .unwrap_or(50.0);
+                let percentile_rank = condition.percentile.map(|p| p as f64).unwrap_or(50.0);
                 let pval = percentile_linear_interp(&values, percentile_rank);
                 return Some(pval);
             }
@@ -894,13 +893,18 @@ fn compile_condition(
     corr_type: CorrelationType,
 ) -> Result<(CompiledCondition, Option<ConditionExpr>)> {
     match cond {
-        CorrelationCondition::Threshold { predicates, field } => Ok((
+        CorrelationCondition::Threshold {
+            predicates,
+            field,
+            percentile,
+        } => Ok((
             CompiledCondition {
                 field: field.clone(),
                 predicates: predicates
                     .iter()
                     .map(|(op, count)| (*op, *count as f64))
                     .collect(),
+                percentile: *percentile,
             },
             None,
         )),
@@ -913,6 +917,7 @@ fn compile_condition(
                         CompiledCondition {
                             field: None,
                             predicates: vec![(ConditionOperator::Gte, 1.0)],
+                            percentile: None,
                         },
                         Some(expr.clone()),
                     ))
@@ -979,6 +984,7 @@ mod tests {
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 100.0)],
+            percentile: None,
         };
         assert!(!cond.check(99.0));
         assert!(cond.check(100.0));
@@ -993,6 +999,7 @@ mod tests {
                 (ConditionOperator::Gt, 100.0),
                 (ConditionOperator::Lte, 200.0),
             ],
+            percentile: None,
         };
         assert!(!cond.check(100.0));
         assert!(cond.check(101.0));
@@ -1009,6 +1016,7 @@ mod tests {
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 5.0)],
+            percentile: None,
         };
         assert_eq!(
             state.check_condition(&cond, CorrelationType::EventCount, &[], None),
@@ -1027,6 +1035,7 @@ mod tests {
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 5.0)],
+            percentile: None,
         };
         assert_eq!(
             state.check_condition(&cond, CorrelationType::EventCount, &[], None),
@@ -1043,8 +1052,9 @@ mod tests {
         state.push_value_count(1003, "user3".to_string());
 
         let cond = CompiledCondition {
-            field: Some("User".to_string()),
+            field: Some(vec!["User".to_string()]),
             predicates: vec![(ConditionOperator::Gte, 3.0)],
+            percentile: None,
         };
         assert_eq!(
             state.check_condition(&cond, CorrelationType::ValueCount, &[], None),
@@ -1061,6 +1071,7 @@ mod tests {
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 2.0)],
+            percentile: None,
         };
         assert!(
             state
@@ -1092,6 +1103,7 @@ mod tests {
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 3.0)],
+            percentile: None,
         };
         assert!(
             state
@@ -1111,6 +1123,7 @@ mod tests {
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 2.0)],
+            percentile: None,
         };
         assert!(
             state
@@ -1126,8 +1139,9 @@ mod tests {
         state.push_numeric(1001, 600.0);
 
         let cond = CompiledCondition {
-            field: Some("bytes_sent".to_string()),
+            field: Some(vec!["bytes_sent".to_string()]),
             predicates: vec![(ConditionOperator::Gt, 1000.0)],
+            percentile: None,
         };
         assert_eq!(
             state.check_condition(&cond, CorrelationType::ValueSum, &[], None),
@@ -1143,8 +1157,9 @@ mod tests {
         state.push_numeric(1002, 300.0);
 
         let cond = CompiledCondition {
-            field: Some("bytes".to_string()),
+            field: Some(vec!["bytes".to_string()]),
             predicates: vec![(ConditionOperator::Gte, 200.0)],
+            percentile: None,
         };
         assert_eq!(
             state.check_condition(&cond, CorrelationType::ValueAvg, &[], None),
@@ -1160,8 +1175,9 @@ mod tests {
         state.push_numeric(1002, 30.0);
 
         let cond = CompiledCondition {
-            field: Some("latency".to_string()),
+            field: Some(vec!["latency".to_string()]),
             predicates: vec![(ConditionOperator::Gte, 20.0)],
+            percentile: None,
         };
         assert_eq!(
             state.check_condition(&cond, CorrelationType::ValueMedian, &[], None),
@@ -1289,6 +1305,7 @@ level: high
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 1.0)],
+            percentile: None,
         };
         let expr = ConditionExpr::And(vec![
             ConditionExpr::Identifier("rule_a".to_string()),
@@ -1363,9 +1380,9 @@ level: high
         }
 
         let cond = CompiledCondition {
-            field: Some("latency".to_string()),
-            // The condition threshold is used as the percentile rank
+            field: Some(vec!["latency".to_string()]),
             predicates: vec![(ConditionOperator::Lte, 50.0)],
+            percentile: None,
         };
         // 50th percentile of 1..100 should be ~50.5
         let result = state.check_condition(&cond, CorrelationType::ValuePercentile, &[], None);
@@ -1403,8 +1420,9 @@ level: high
     fn test_value_percentile_empty_window() {
         let state = WindowState::new_for(CorrelationType::ValuePercentile);
         let cond = CompiledCondition {
-            field: Some("latency".to_string()),
+            field: Some(vec!["latency".to_string()]),
             predicates: vec![(ConditionOperator::Lte, 50.0)],
+            percentile: None,
         };
         // Empty window should return None
         assert!(
@@ -1477,6 +1495,7 @@ level: high
         let cond = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 2.0)],
+            percentile: None,
         };
         // Without extended expr: 2 of 3 rules fired, meets gte 2
         assert_eq!(
@@ -1488,6 +1507,7 @@ level: high
         let cond3 = CompiledCondition {
             field: None,
             predicates: vec![(ConditionOperator::Gte, 3.0)],
+            percentile: None,
         };
         assert!(
             state
@@ -1721,11 +1741,15 @@ level: high
             author: None,
             date: None,
             modified: None,
+            related: vec![],
             references: vec![],
             taxonomy: None,
+            license: None,
             tags: vec![],
+            fields: vec![],
             falsepositives: vec![],
             level: Some(Level::High),
+            scope: vec![],
             correlation_type: CorrelationType::EventCount,
             rules: vec!["rule-1".to_string()],
             group_by: vec!["User".to_string()],
@@ -1733,6 +1757,7 @@ level: high
             condition: CorrelationCondition::Threshold {
                 predicates: vec![(ConditionOperator::Gte, 5)],
                 field: None,
+                percentile: None,
             },
             aliases: vec![],
             generate: false,

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -2666,7 +2666,7 @@ filter:
         - failed-auth
     selection:
         User|startswith: 'svc_'
-    condition: selection
+    condition: not selection
 ---
 title: Brute Force
 correlation:

--- a/crates/rsigma-eval/src/correlation_engine.rs
+++ b/crates/rsigma-eval/src/correlation_engine.rs
@@ -862,7 +862,8 @@ impl CorrelationEngine {
                 state.push_event_count(ts);
             }
             CorrelationType::ValueCount => {
-                if let Some(ref field_name) = corr.condition.field
+                if let Some(ref fields) = corr.condition.field
+                    && let Some(field_name) = fields.first()
                     && let Some(val) = event.get_field(field_name)
                     && let Some(s) = value_to_string_for_count(&val)
                 {
@@ -876,7 +877,8 @@ impl CorrelationEngine {
             | CorrelationType::ValueAvg
             | CorrelationType::ValuePercentile
             | CorrelationType::ValueMedian => {
-                if let Some(ref field_name) = corr.condition.field
+                if let Some(ref fields) = corr.condition.field
+                    && let Some(field_name) = fields.first()
                     && let Some(val) = event.get_field(field_name)
                     && let Some(n) = value_to_f64_ev(&val)
                 {

--- a/crates/rsigma-eval/src/engine.rs
+++ b/crates/rsigma-eval/src/engine.rs
@@ -4,7 +4,9 @@
 //! against them. It supports optional logsource-based pre-filtering to
 //! reduce the number of rules evaluated per event.
 
-use rsigma_parser::{ConditionExpr, FilterRule, LogSource, SigmaCollection, SigmaRule};
+use rsigma_parser::{
+    ConditionExpr, FilterRule, FilterRuleTarget, LogSource, SigmaCollection, SigmaRule,
+};
 
 use crate::compiler::{CompiledRule, compile_detection, compile_rule, evaluate_rule};
 use crate::error::Result;
@@ -182,33 +184,38 @@ impl Engine {
         let fc = self.filter_counter;
         self.filter_counter += 1;
 
-        // Build the filter condition expression: AND of all filter detections
-        // Keys are namespaced with the filter counter to avoid collisions when
-        // multiple filters share detection names (e.g. both use "selection").
-        let filter_cond = if filter_detections.len() == 1 {
-            ConditionExpr::Identifier(format!("__filter_{fc}_{}", filter_detections[0].0))
+        // Rewrite the filter's own condition expression with namespaced identifiers
+        // so that `selection` becomes `__filter_0_selection`, etc.
+        let rewritten_cond = if let Some(cond_expr) = filter.detection.conditions.first() {
+            rewrite_condition_identifiers(cond_expr, fc)
         } else {
-            ConditionExpr::And(
-                filter_detections
-                    .iter()
-                    .map(|(name, _)| ConditionExpr::Identifier(format!("__filter_{fc}_{name}")))
-                    .collect(),
-            )
+            // No explicit condition: AND all detections (legacy fallback)
+            if filter_detections.len() == 1 {
+                ConditionExpr::Identifier(format!("__filter_{fc}_{}", filter_detections[0].0))
+            } else {
+                ConditionExpr::And(
+                    filter_detections
+                        .iter()
+                        .map(|(name, _)| ConditionExpr::Identifier(format!("__filter_{fc}_{name}")))
+                        .collect(),
+                )
+            }
         };
 
         // Find and modify referenced rules
         let mut matched_any = false;
         for rule in &mut self.rules {
-            let rule_matches = filter.rules.is_empty() // empty = applies to all
-                || filter.rules.iter().any(|r| {
-                    rule.id.as_deref() == Some(r.as_str())
-                        || rule.title == *r
-                });
+            let rule_matches = match &filter.rules {
+                FilterRuleTarget::Any => true,
+                FilterRuleTarget::Specific(refs) => refs
+                    .iter()
+                    .any(|r| rule.id.as_deref() == Some(r.as_str()) || rule.title == *r),
+            };
 
             // Also check logsource compatibility if the filter specifies one
             if rule_matches {
                 if let Some(ref filter_ls) = filter.logsource
-                    && !logsource_compatible(&rule.logsource, filter_ls)
+                    && !filter_logsource_contains(filter_ls, &rule.logsource)
                 {
                     continue;
                 }
@@ -219,22 +226,19 @@ impl Engine {
                         .insert(format!("__filter_{fc}_{name}"), compiled.clone());
                 }
 
-                // Wrap each existing condition: original AND NOT filter
+                // Wrap each existing rule condition with the filter condition
                 rule.conditions = rule
                     .conditions
                     .iter()
-                    .map(|cond| {
-                        ConditionExpr::And(vec![
-                            cond.clone(),
-                            ConditionExpr::Not(Box::new(filter_cond.clone())),
-                        ])
-                    })
+                    .map(|cond| ConditionExpr::And(vec![cond.clone(), rewritten_cond.clone()]))
                     .collect();
                 matched_any = true;
             }
         }
 
-        if !filter.rules.is_empty() && !matched_any {
+        if let FilterRuleTarget::Specific(_) = &filter.rules
+            && !matched_any
+        {
             log::warn!(
                 "filter '{}' references rules {:?} but none matched any loaded rule",
                 filter.title,
@@ -335,21 +339,53 @@ impl Default for Engine {
 /// The rule matches if every non-`None` field in the rule's logsource has
 /// the same value in the event's logsource. Fields the rule doesn't specify
 /// are ignored (wildcard).
-/// Symmetric compatibility check: two logsources are compatible if every field
-/// that *both* specify has the same value (case-insensitive). Fields that only
-/// one side specifies are ignored — e.g. a filter with `product: windows` is
-/// compatible with a rule that has `category: process_creation, product: windows`.
-fn logsource_compatible(a: &LogSource, b: &LogSource) -> bool {
-    fn field_compatible(a: &Option<String>, b: &Option<String>) -> bool {
-        match (a, b) {
-            (Some(va), Some(vb)) => va.eq_ignore_ascii_case(vb),
-            _ => true, // one or both unspecified — no conflict
+/// Asymmetric containment check for filter-to-rule matching: every field the
+/// filter specifies must be present and equal in the rule. Fields the filter
+/// omits are treated as wildcards (match any rule). This means a filter with
+/// only `product: windows` applies to rules that have `product: windows`
+/// regardless of their category/service, but a filter with
+/// `category: process_creation` does NOT apply to a rule that lacks a category.
+fn filter_logsource_contains(filter_ls: &LogSource, rule_ls: &LogSource) -> bool {
+    fn field_matches(filter_field: &Option<String>, rule_field: &Option<String>) -> bool {
+        match filter_field {
+            None => true,
+            Some(fv) => match rule_field {
+                Some(rv) => fv.eq_ignore_ascii_case(rv),
+                None => false,
+            },
         }
     }
 
-    field_compatible(&a.category, &b.category)
-        && field_compatible(&a.product, &b.product)
-        && field_compatible(&a.service, &b.service)
+    field_matches(&filter_ls.category, &rule_ls.category)
+        && field_matches(&filter_ls.product, &rule_ls.product)
+        && field_matches(&filter_ls.service, &rule_ls.service)
+}
+
+/// Rewrite all `Identifier` nodes in a condition expression tree, prefixing
+/// each name with `__filter_{counter}_` so it references the namespaced
+/// detection keys injected into the target rule.
+fn rewrite_condition_identifiers(expr: &ConditionExpr, counter: usize) -> ConditionExpr {
+    match expr {
+        ConditionExpr::Identifier(name) => {
+            ConditionExpr::Identifier(format!("__filter_{counter}_{name}"))
+        }
+        ConditionExpr::And(children) => ConditionExpr::And(
+            children
+                .iter()
+                .map(|c| rewrite_condition_identifiers(c, counter))
+                .collect(),
+        ),
+        ConditionExpr::Or(children) => ConditionExpr::Or(
+            children
+                .iter()
+                .map(|c| rewrite_condition_identifiers(c, counter))
+                .collect(),
+        ),
+        ConditionExpr::Not(child) => {
+            ConditionExpr::Not(Box::new(rewrite_condition_identifiers(child, counter)))
+        }
+        ConditionExpr::Selector { .. } => expr.clone(),
+    }
 }
 
 /// Asymmetric check: every field specified in `rule_ls` must be present and
@@ -573,7 +609,7 @@ filter:
         - rule-001
     selection:
         User: 'SYSTEM'
-    condition: selection
+    condition: not selection
 "#;
         let collection = parse_sigma_yaml(yaml).unwrap();
         assert_eq!(collection.rules.len(), 1);
@@ -611,7 +647,7 @@ filter:
     rules: []
     selection:
         Environment: 'test'
-    condition: selection
+    condition: not selection
 "#;
         let collection = parse_sigma_yaml(yaml).unwrap();
         let mut engine = Engine::new();
@@ -683,7 +719,7 @@ filter:
         - Detect Mimikatz
     selection:
         ParentImage|endswith: '\admin_toolkit.exe'
-    condition: selection
+    condition: not selection
 "#;
         let collection = parse_sigma_yaml(yaml).unwrap();
         let mut engine = Engine::new();
@@ -702,7 +738,7 @@ filter:
 
     #[test]
     fn test_filter_multiple_detections() {
-        // Filter with multiple detection items (AND)
+        // Filter with multiple detection items (AND exclusion)
         let yaml = r#"
 title: Suspicious Network
 id: net-001
@@ -722,7 +758,7 @@ filter:
         DestinationIp|startswith: '10.'
     trusted_user:
         User: 'svc_account'
-    condition: trusted_dst and trusted_user
+    condition: not (trusted_dst and trusted_user)
 "#;
         let collection = parse_sigma_yaml(yaml).unwrap();
         let mut engine = Engine::new();
@@ -772,7 +808,7 @@ filter:
     rules: []
     selection:
         Environment: 'test'
-    condition: selection
+    condition: not selection
 "#;
         let collection = parse_sigma_yaml(yaml).unwrap();
         let mut engine = Engine::new();

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -287,19 +287,22 @@ fn apply_correlation_transformation(
             // threshold field: error if multiple alternatives
             if let rsigma_parser::CorrelationCondition::Threshold { ref mut field, .. } =
                 corr.condition
-                && let Some(f) = field.as_ref()
-                && let Some(alts) = mapping.get(f.as_str())
+                && let Some(fields) = field.as_mut()
             {
-                if alts.len() > 1 {
-                    return Err(EvalError::InvalidModifiers(format!(
-                        "field_name_mapping one-to-many cannot be applied to \
-                         correlation condition field reference ('{}' maps to \
-                         {} alternatives)",
-                        f,
-                        alts.len(),
-                    )));
+                for f in fields.iter_mut() {
+                    if let Some(alts) = mapping.get(f.as_str()) {
+                        if alts.len() > 1 {
+                            return Err(EvalError::InvalidModifiers(format!(
+                                "field_name_mapping one-to-many cannot be applied to \
+                                 correlation condition field reference ('{}' maps to \
+                                 {} alternatives)",
+                                f,
+                                alts.len(),
+                            )));
+                        }
+                        *f = alts[0].clone();
+                    }
                 }
-                *field = Some(alts[0].clone());
             }
 
             Ok(true)
@@ -370,10 +373,13 @@ fn remap_correlation_fields(corr: &mut CorrelationRule, mapper: impl Fn(&str) ->
     }
 
     if let rsigma_parser::CorrelationCondition::Threshold { ref mut field, .. } = corr.condition
-        && let Some(f) = field.as_ref()
-        && let Some(new_name) = mapper(f)
+        && let Some(fields) = field.as_mut()
     {
-        *field = Some(new_name);
+        for f in fields.iter_mut() {
+            if let Some(new_name) = mapper(f) {
+                *f = new_name;
+            }
+        }
     }
 }
 
@@ -1947,11 +1953,15 @@ transformations:
             author: None,
             date: None,
             modified: None,
+            related: vec![],
             references: vec![],
             taxonomy: None,
+            license: None,
             tags: vec![],
+            fields: vec![],
             falsepositives: vec![],
             level: None,
+            scope: vec![],
             correlation_type: rsigma_parser::CorrelationType::EventCount,
             rules: vec!["rule_a".to_string()],
             group_by: vec!["SourceIP".to_string(), "DestinationIP".to_string()],
@@ -1959,6 +1969,7 @@ transformations:
             condition: rsigma_parser::CorrelationCondition::Threshold {
                 predicates: vec![(rsigma_parser::ConditionOperator::Gte, 10)],
                 field: None,
+                percentile: None,
             },
             aliases: vec![rsigma_parser::FieldAlias {
                 alias: "src_ip".to_string(),
@@ -2068,7 +2079,8 @@ transformations:
         let mut corr = make_test_correlation();
         corr.condition = rsigma_parser::CorrelationCondition::Threshold {
             predicates: vec![(rsigma_parser::ConditionOperator::Gte, 5)],
-            field: Some("UserName".to_string()),
+            field: Some(vec!["UserName".to_string()]),
+            percentile: None,
         };
         let mut state = PipelineState::new(pipeline.vars.clone());
         let err = pipeline
@@ -2185,7 +2197,8 @@ transformations:
         let mut corr = make_test_correlation();
         corr.condition = rsigma_parser::CorrelationCondition::Threshold {
             predicates: vec![(rsigma_parser::ConditionOperator::Gte, 5)],
-            field: Some("UserName".to_string()),
+            field: Some(vec!["UserName".to_string()]),
+            percentile: None,
         };
 
         let mut state = PipelineState::new(pipeline.vars.clone());
@@ -2194,7 +2207,7 @@ transformations:
             .unwrap();
 
         if let rsigma_parser::CorrelationCondition::Threshold { field, .. } = &corr.condition {
-            assert_eq!(field.as_deref(), Some("user.name"));
+            assert_eq!(field.as_deref(), Some(["user.name".to_string()].as_slice()));
         } else {
             panic!("Expected Threshold");
         }

--- a/crates/rsigma-eval/tests/integration.rs
+++ b/crates/rsigma-eval/tests/integration.rs
@@ -376,7 +376,7 @@ filter:
     rules: []
     env_match:
         Environment: test
-    condition: env_match
+    condition: not env_match
 ---
 title: Targeted Filter
 filter:
@@ -384,7 +384,7 @@ filter:
         - rule-a
     svc_match:
         User: svc_account
-    condition: svc_match
+    condition: not svc_match
 "#;
     let collection = parse_sigma_yaml(yaml).unwrap();
     let mut engine = Engine::new();
@@ -428,7 +428,7 @@ filter:
         - rule-a
     selection:
         Environment: test
-    condition: selection
+    condition: not selection
 ---
 title: Filter User
 filter:
@@ -436,7 +436,7 @@ filter:
         - rule-a
     selection:
         User: bot
-    condition: selection
+    condition: not selection
 "#;
     let collection = parse_sigma_yaml(yaml).unwrap();
     let mut engine = Engine::new();

--- a/crates/rsigma-parser/src/ast.rs
+++ b/crates/rsigma-parser/src/ast.rs
@@ -597,6 +597,15 @@ pub struct CorrelationRule {
 // Filter Rule
 // =============================================================================
 
+/// Which rules a filter applies to.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum FilterRuleTarget {
+    /// The filter applies to every loaded rule.
+    Any,
+    /// The filter applies only to rules matching these IDs or titles.
+    Specific(Vec<String>),
+}
+
 /// A Sigma filter rule that modifies the detection logic of referenced rules.
 ///
 /// Filters add additional conditions (typically exclusions) to existing rules
@@ -622,8 +631,8 @@ pub struct FilterRule {
     pub scope: Vec<String>,
     pub logsource: Option<LogSource>,
 
-    /// Rules this filter applies to (by ID or name).
-    pub rules: Vec<String>,
+    /// Rules this filter applies to (by ID or name), or all rules.
+    pub rules: FilterRuleTarget,
     /// The filter detection section.
     pub detection: Detections,
 

--- a/crates/rsigma-parser/src/ast.rs
+++ b/crates/rsigma-parser/src/ast.rs
@@ -72,6 +72,7 @@ impl FromStr for Level {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RelationType {
+    Correlation,
     Derived,
     Obsolete,
     Merged,
@@ -83,6 +84,7 @@ impl FromStr for RelationType {
     type Err = ();
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
+            "correlation" => Ok(RelationType::Correlation),
             "derived" => Ok(RelationType::Derived),
             "obsolete" => Ok(RelationType::Obsolete),
             "merged" => Ok(RelationType::Merged),
@@ -524,8 +526,12 @@ pub enum CorrelationCondition {
     Threshold {
         /// One or more (operator, value) predicates. All must be satisfied.
         predicates: Vec<(ConditionOperator, u64)>,
-        /// Optional field reference (required for `value_count` type).
-        field: Option<String>,
+        /// Optional field reference(s) (required for `value_count` type).
+        /// A single string is normalized to a one-element vec.
+        field: Option<Vec<String>>,
+        /// Percentile rank (0-100) for `value_percentile` type.
+        /// Defaults to 50 if not specified.
+        percentile: Option<u64>,
     },
     /// Extended boolean condition for temporal types: `"rule_a and rule_b"`
     Extended(ConditionExpr),
@@ -557,11 +563,15 @@ pub struct CorrelationRule {
     pub author: Option<String>,
     pub date: Option<String>,
     pub modified: Option<String>,
+    pub related: Vec<Related>,
     pub references: Vec<String>,
     pub taxonomy: Option<String>,
+    pub license: Option<String>,
     pub tags: Vec<String>,
+    pub fields: Vec<String>,
     pub falsepositives: Vec<String>,
     pub level: Option<Level>,
+    pub scope: Vec<String>,
 
     // Correlation-specific fields
     pub correlation_type: CorrelationType,
@@ -596,17 +606,30 @@ pub struct FilterRule {
     pub title: String,
     pub id: Option<String>,
     pub name: Option<String>,
+    pub taxonomy: Option<String>,
     pub status: Option<Status>,
     pub description: Option<String>,
     pub author: Option<String>,
     pub date: Option<String>,
     pub modified: Option<String>,
+    pub related: Vec<Related>,
+    pub license: Option<String>,
+    pub references: Vec<String>,
+    pub tags: Vec<String>,
+    pub fields: Vec<String>,
+    pub falsepositives: Vec<String>,
+    pub level: Option<Level>,
+    pub scope: Vec<String>,
     pub logsource: Option<LogSource>,
 
     /// Rules this filter applies to (by ID or name).
     pub rules: Vec<String>,
     /// The filter detection section.
     pub detection: Detections,
+
+    /// Custom attributes attached to the filter rule.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub custom_attributes: HashMap<String, serde_yaml::Value>,
 }
 
 // =============================================================================

--- a/crates/rsigma-parser/src/lib.rs
+++ b/crates/rsigma-parser/src/lib.rs
@@ -62,9 +62,9 @@ pub mod value;
 // Re-export the most commonly used types and functions at crate root
 pub use ast::{
     ConditionExpr, ConditionOperator, CorrelationCondition, CorrelationRule, CorrelationType,
-    Detection, DetectionItem, Detections, FieldAlias, FieldSpec, FilterRule, Level, LogSource,
-    Modifier, Quantifier, Related, RelationType, SelectorPattern, SigmaCollection, SigmaDocument,
-    SigmaRule, Status,
+    Detection, DetectionItem, Detections, FieldAlias, FieldSpec, FilterRule, FilterRuleTarget,
+    Level, LogSource, Modifier, Quantifier, Related, RelationType, SelectorPattern,
+    SigmaCollection, SigmaDocument, SigmaRule, Status,
 };
 pub use condition::parse_condition;
 pub use error::{Result, SigmaParserError, SourceLocation};

--- a/crates/rsigma-parser/src/lint.rs
+++ b/crates/rsigma-parser/src/lint.rs
@@ -1656,22 +1656,21 @@ fn lint_filter_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
     };
 
     // ── filter.rules ─────────────────────────────────────────────────────
+    // `rules` is optional: omitted means "apply to all rules".
+    // Valid forms: a sequence of rule IDs/names, the string "any", or omitted.
     if let Some(rules_val) = filter.get(key("rules")) {
-        if let Some(seq) = rules_val.as_sequence()
-            && seq.is_empty()
-        {
-            warnings.push(warning(
-                LintRule::EmptyFilterRules,
-                "filter.rules should have at least one entry",
-                "/filter/rules",
-            ));
+        match rules_val {
+            serde_yaml::Value::Sequence(_) => {}
+            serde_yaml::Value::String(s) if s.eq_ignore_ascii_case("any") => {}
+            serde_yaml::Value::String(_) => {}
+            _ => {
+                warnings.push(err(
+                    LintRule::MissingFilterRules,
+                    "filter.rules must be a sequence of rule IDs, a single rule ID string, or 'any'",
+                    "/filter/rules",
+                ));
+            }
         }
-    } else {
-        warnings.push(err(
-            LintRule::MissingFilterRules,
-            "missing required field 'filter.rules'",
-            "/filter/rules",
-        ));
     }
 
     // ── filter.selection ─────────────────────────────────────────────────
@@ -3052,7 +3051,7 @@ filter:
     }
 
     #[test]
-    fn missing_filter_rules() {
+    fn filter_without_rules_is_valid() {
         let w = lint(
             r#"
 title: Test
@@ -3064,7 +3063,58 @@ filter:
     condition: selection
 "#,
         );
+        assert!(!has_rule(&w, LintRule::MissingFilterRules));
+    }
+
+    #[test]
+    fn filter_rules_invalid_type() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+filter:
+    rules: 123
+    selection:
+        User: admin
+    condition: selection
+"#,
+        );
         assert!(has_rule(&w, LintRule::MissingFilterRules));
+    }
+
+    #[test]
+    fn filter_rules_any_string_is_valid() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+filter:
+    rules: any
+    selection:
+        User: admin
+    condition: selection
+"#,
+        );
+        assert!(!has_rule(&w, LintRule::MissingFilterRules));
+    }
+
+    #[test]
+    fn filter_rules_empty_sequence_is_valid() {
+        let w = lint(
+            r#"
+title: Test
+logsource:
+    category: test
+filter:
+    rules: []
+    selection:
+        User: admin
+    condition: selection
+"#,
+        );
+        assert!(!has_rule(&w, LintRule::EmptyFilterRules));
     }
 
     #[test]

--- a/crates/rsigma-parser/src/lint.rs
+++ b/crates/rsigma-parser/src/lint.rs
@@ -541,7 +541,14 @@ const VALID_STATUSES: &[&str] = &[
 const VALID_LEVELS: &[&str] = &["informational", "low", "medium", "high", "critical"];
 
 /// Valid related types.
-const VALID_RELATED_TYPES: &[&str] = &["derived", "obsolete", "merged", "renamed", "similar"];
+const VALID_RELATED_TYPES: &[&str] = &[
+    "correlation",
+    "derived",
+    "obsolete",
+    "merged",
+    "renamed",
+    "similar",
+];
 
 /// Valid correlation types.
 const VALID_CORRELATION_TYPES: &[&str] = &[
@@ -603,14 +610,31 @@ const KNOWN_KEYS_DETECTION: &[&str] = &[
 /// Extra top-level keys valid for correlation rules.
 const KNOWN_KEYS_CORRELATION: &[&str] = &[
     "correlation",
-    "level",
-    "generate",
-    "falsepositives",
     "custom_attributes",
+    "falsepositives",
+    "fields",
+    "generate",
+    "level",
+    "license",
+    "related",
+    "scope",
 ];
 
 /// Extra top-level keys valid for filter rules.
-const KNOWN_KEYS_FILTER: &[&str] = &["logsource", "filter"];
+const KNOWN_KEYS_FILTER: &[&str] = &[
+    "custom_attributes",
+    "falsepositives",
+    "fields",
+    "filter",
+    "level",
+    "license",
+    "logsource",
+    "references",
+    "related",
+    "scope",
+    "tags",
+    "taxonomy",
+];
 
 /// Tag pattern: `^[a-z0-9_-]+\.[a-z0-9._-]+$`
 fn is_valid_tag(s: &str) -> bool {

--- a/crates/rsigma-parser/src/parser.rs
+++ b/crates/rsigma-parser/src/parser.rs
@@ -803,14 +803,22 @@ fn parse_filter_rule(value: &Value) -> Result<FilterRule> {
     let filter_mapping = filter_val.and_then(|v| v.as_mapping());
     let rules = match filter_mapping {
         Some(fm) => match fm.get(val_key("rules")) {
-            Some(Value::Sequence(seq)) => seq
-                .iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect(),
-            Some(Value::String(s)) => vec![s.clone()],
-            _ => Vec::new(),
+            Some(Value::String(s)) if s.eq_ignore_ascii_case("any") => FilterRuleTarget::Any,
+            Some(Value::String(s)) => FilterRuleTarget::Specific(vec![s.clone()]),
+            Some(Value::Sequence(seq)) => {
+                let list: Vec<String> = seq
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+                if list.is_empty() {
+                    FilterRuleTarget::Any
+                } else {
+                    FilterRuleTarget::Specific(list)
+                }
+            }
+            _ => FilterRuleTarget::Any,
         },
-        _ => Vec::new(),
+        _ => FilterRuleTarget::Any,
     };
 
     // Parse detection from filter.selection + filter.condition

--- a/crates/rsigma-parser/src/parser.rs
+++ b/crates/rsigma-parser/src/parser.rs
@@ -630,12 +630,16 @@ fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
         "date",
         "description",
         "falsepositives",
+        "fields",
         "generate",
         "id",
         "level",
+        "license",
         "modified",
         "name",
         "references",
+        "related",
+        "scope",
         "status",
         "tags",
         "taxonomy",
@@ -652,11 +656,15 @@ fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
         author: get_str(m, "author").map(|s| s.to_string()),
         date: get_str(m, "date").map(|s| s.to_string()),
         modified: get_str(m, "modified").map(|s| s.to_string()),
+        related: parse_related(m.get(val_key("related"))),
         references: get_str_list(m, "references"),
         taxonomy: get_str(m, "taxonomy").map(|s| s.to_string()),
+        license: get_str(m, "license").map(|s| s.to_string()),
         tags: get_str_list(m, "tags"),
+        fields: get_str_list(m, "fields"),
         falsepositives: get_str_list(m, "falsepositives"),
         level: get_str(m, "level").and_then(|s| s.parse().ok()),
+        scope: get_str_list(m, "scope"),
         correlation_type,
         rules,
         group_by,
@@ -706,9 +714,29 @@ fn parse_correlation_condition(
                 ));
             }
 
-            let field = get_str(cm, "field").map(|s| s.to_string());
+            let field = match cm.get(val_key("field")) {
+                Some(Value::String(s)) => Some(vec![s.clone()]),
+                Some(Value::Sequence(seq)) => {
+                    let fields: Vec<String> = seq
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect();
+                    if fields.is_empty() {
+                        None
+                    } else {
+                        Some(fields)
+                    }
+                }
+                _ => None,
+            };
 
-            Ok(CorrelationCondition::Threshold { predicates, field })
+            let percentile = cm.get(val_key("percentile")).and_then(|v| v.as_u64());
+
+            Ok(CorrelationCondition::Threshold {
+                predicates,
+                field,
+                percentile,
+            })
         }
         Some(Value::String(expr_str)) => {
             // Extended condition for temporal types: "rule_a and rule_b"
@@ -722,6 +750,7 @@ fn parse_correlation_condition(
                     Ok(CorrelationCondition::Threshold {
                         predicates: vec![(ConditionOperator::Gte, 1)],
                         field: None,
+                        percentile: None,
                     })
                 }
                 _ => Err(SigmaParserError::InvalidCorrelation(
@@ -807,18 +836,52 @@ fn parse_filter_rule(value: &Value) -> Result<FilterRule> {
         .map(parse_logsource)
         .transpose()?;
 
+    let standard_filter_keys: &[&str] = &[
+        "author",
+        "custom_attributes",
+        "date",
+        "description",
+        "falsepositives",
+        "fields",
+        "filter",
+        "id",
+        "level",
+        "license",
+        "logsource",
+        "modified",
+        "name",
+        "references",
+        "related",
+        "scope",
+        "status",
+        "tags",
+        "taxonomy",
+        "title",
+    ];
+    let custom_attributes = collect_custom_attributes(m, standard_filter_keys);
+
     Ok(FilterRule {
         title,
         id: get_str(m, "id").map(|s| s.to_string()),
         name: get_str(m, "name").map(|s| s.to_string()),
+        taxonomy: get_str(m, "taxonomy").map(|s| s.to_string()),
         status: get_str(m, "status").and_then(|s| s.parse().ok()),
         description: get_str(m, "description").map(|s| s.to_string()),
         author: get_str(m, "author").map(|s| s.to_string()),
         date: get_str(m, "date").map(|s| s.to_string()),
         modified: get_str(m, "modified").map(|s| s.to_string()),
+        related: parse_related(m.get(val_key("related"))),
+        license: get_str(m, "license").map(|s| s.to_string()),
+        references: get_str_list(m, "references"),
+        tags: get_str_list(m, "tags"),
+        fields: get_str_list(m, "fields"),
+        falsepositives: get_str_list(m, "falsepositives"),
+        level: get_str(m, "level").and_then(|s| s.parse().ok()),
+        scope: get_str_list(m, "scope"),
         logsource,
         rules,
         detection,
+        custom_attributes,
     })
 }
 
@@ -1506,7 +1569,9 @@ correlation:
         let corr = &collection.correlations[0];
 
         match &corr.condition {
-            CorrelationCondition::Threshold { predicates, field } => {
+            CorrelationCondition::Threshold {
+                predicates, field, ..
+            } => {
                 assert_eq!(predicates.len(), 2);
                 // Check we got both operators (order doesn't matter, but they come from iteration)
                 let has_gt = predicates
@@ -1554,9 +1619,14 @@ correlation:
         let corr = &collection.correlations[0];
 
         match &corr.condition {
-            CorrelationCondition::Threshold { predicates, field } => {
+            CorrelationCondition::Threshold {
+                predicates, field, ..
+            } => {
                 assert_eq!(predicates.len(), 2);
-                assert_eq!(field.as_deref(), Some("TargetUser"));
+                assert_eq!(
+                    field.as_deref(),
+                    Some(["TargetUser".to_string()].as_slice())
+                );
             }
             _ => panic!("Expected threshold condition"),
         }


### PR DESCRIPTION
## Summary

Close all 8 pySigma parity gaps in correlation and filter rule handling. The work is split into two phases.

**Phase 0: Structural additions (no behavioral change)**

- Add `Correlation` variant to `RelationType` enum and linter's `VALID_RELATED_TYPES`
- Add `related`, `license`, `fields`, `scope` to `CorrelationRule` struct, parser, and `KNOWN_KEYS_CORRELATION`
- Add 10 missing `SigmaRuleBase` fields to `FilterRule` with `standard_filter_keys` exclusion from `custom_attributes`
- Widen `CorrelationCondition::Threshold.field` from `Option<String>` to `Option<Vec<String>>`, propagated through parser, `CompiledCondition`, correlation engine, pipeline field mapping, and Postgres backend
- Add `percentile: Option<u64>` to `CorrelationCondition::Threshold`, used in `ValuePercentile` eval and Postgres `PERCENTILE_CONT()` generation

**Phase 1: Behavioral fixes**

- Introduce `FilterRuleTarget` enum (`Any`/`Specific`). `rules: any`, `rules: []`, and omitted `rules` all map to `Any`
- Replace symmetric `logsource_compatible` with asymmetric `filter_logsource_contains` for filter-to-rule matching
- Use the filter's own condition expression via `rewrite_condition_identifiers` instead of hardcoding `AND NOT`. Exclusion filters now require `condition: not selection` in YAML, matching pySigma semantics

**Lint fixup**: Update `filter.rules` validation to accept all valid forms (omitted, empty, `"any"`, single string, sequence) and only error on invalid types.

## Breaking change

Filter rules that previously used `condition: selection` for exclusion now need `condition: not selection`. The old behavior silently hardcoded `AND NOT` regardless of the filter's condition expression. This was a bug: it ignored the filter's actual condition and prevented inclusion filters or multi-selection OR conditions from working.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (all 393 tests pass, including CLI integration tests)
- [x] Sigma corpus regression: `rsigma validate` on SigmaHQ/sigma full ruleset
- [x] Spot-check Postgres backend golden tests for correlation condition changes