### PR TITLE
feat(convert): support nested JSONB paths for dotted Sigma field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f continuou
 # Custom backend options (table, schema, timestamp field, etc.)
 rsigma convert -r rules/ -t postgres -O table=security_logs -O schema=public -O timestamp_field=created_at
 
+# JSONB mode: access fields inside a JSONB column (supports nested paths properly)
+rsigma convert -r rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
+
 # Sliding window correlation format (per-row detection using window functions)
 rsigma convert -r rules/ -t postgres -f sliding_window
 

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -274,11 +274,39 @@ SELECT * FROM event_counts WHERE correlation_event_count >= 5
 |-------|------|---------|-------------|
 | `table` | `String` | `"security_events"` | Default table name (overridden by pipeline state or `postgres.table` custom attribute) |
 | `timestamp_field` | `String` | `"time"` | Timestamp column for time-windowed queries |
-| `json_field` | `Option<String>` | `None` | If set, fields are accessed via JSONB (`col->>'field'`) |
+| `json_field` | `Option<String>` | `None` | If set, fields are accessed via JSONB extraction (see [JSONB field access](#jsonb-field-access)) |
 | `case_sensitive_re` | `bool` | `false` | Use `~` instead of `~*` for regex |
 | `schema` | `Option<String>` | `None` | PostgreSQL schema name (overridden by pipeline state or `postgres.schema` custom attribute) |
 | `database` | `Option<String>` | `None` | PostgreSQL database name (connection-level metadata) |
 | `timescaledb` | `bool` | `false` | Enable TimescaleDB-specific features |
+
+### JSONB field access
+
+When `json_field` is set (e.g. `-O json_field=data`), all Sigma field references are translated to PostgreSQL JSONB extraction operators instead of bare column names.
+
+For top-level fields, the backend uses the `->>` operator:
+
+```sql
+-- Sigma field: eventType
+data->>'eventType'
+```
+
+For dotted field names (nested paths like `securityContext.isProxy`), the backend generates chained operators where intermediate segments use `->` (returns `jsonb`) and the final segment uses `->>` (returns `text`):
+
+```sql
+-- Sigma field: securityContext.isProxy
+data->'securityContext'->>'isProxy'
+
+-- Sigma field: actor.detail.alternateId
+data->'actor'->'detail'->>'alternateId'
+```
+
+This matches the nested traversal behavior of the evaluation engine (`rsigma-eval`), which splits dotted field names on `.` and walks into nested JSON objects.
+
+```bash
+# Convert rules with JSONB field access against a "data" column
+rsigma convert -r rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
+```
 
 ## License
 

--- a/crates/rsigma-convert/src/backends/postgres.rs
+++ b/crates/rsigma-convert/src/backends/postgres.rs
@@ -225,6 +225,19 @@ impl PostgresBackend {
 
     fn field_expr(&self, field: &str) -> String {
         match &self.json_field {
+            Some(json_col) if field.contains('.') => {
+                let parts: Vec<&str> = field.split('.').collect();
+                let last = parts.len() - 1;
+                let mut expr = json_col.clone();
+                for (i, part) in parts.iter().enumerate() {
+                    if i == last {
+                        expr.push_str(&format!("->>'{part}'"));
+                    } else {
+                        expr.push_str(&format!("->'{part}'"));
+                    }
+                }
+                expr
+            }
             Some(json_col) => format!("{json_col}->>'{field}'"),
             None => text_escape_and_quote_field(self.config, field),
         }
@@ -1756,6 +1769,146 @@ detection:
             vec![
                 "SELECT * FROM security_events WHERE (metadata->>'SourceIP')::inet <<= '10.0.0.0/8'::cidr"
             ]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_nested_field_access() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("data".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        securityContext.isProxy: 'true'
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                "SELECT * FROM security_events WHERE data->'securityContext'->>'isProxy' = 'true'"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_deeply_nested_field() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("data".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        a.b.c.d: val
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec!["SELECT * FROM security_events WHERE data->'a'->'b'->'c'->>'d' = 'val'"]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_nested_field_exists() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("data".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        securityContext.isProxy|exists: true
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                "SELECT * FROM security_events WHERE data->'securityContext'->>'isProxy' IS NOT NULL"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_nested_field_cidr() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("data".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        client.ipAddress|cidr: '10.0.0.0/8'
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                "SELECT * FROM security_events WHERE (data->'client'->>'ipAddress')::inet <<= '10.0.0.0/8'::cidr"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_nested_field_regex() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("data".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        actor.displayName|re: '.*admin.*'
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec![
+                "SELECT * FROM security_events WHERE data->'actor'->>'displayName' ~* '.*admin.*'"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_jsonb_flat_field_unchanged() {
+        let mut backend = PostgresBackend::new();
+        backend.json_field = Some("data".to_string());
+        let queries = convert_with(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        eventType: user.session.start
+    condition: selection
+"#,
+            &backend,
+        );
+        assert_eq!(
+            queries,
+            vec!["SELECT * FROM security_events WHERE data->>'eventType' = 'user.session.start'"]
         );
     }
 


### PR DESCRIPTION
## Summary

- When `json_field` is set, dotted Sigma field names (e.g. `securityContext.isProxy`) now generate chained `->` / `->>` PostgreSQL JSONB operators (`data->'securityContext'->>'isProxy'`) instead of a flat top-level key lookup (`data->>'securityContext.isProxy'`).
- This matches the nested traversal behavior already implemented in `rsigma-eval`'s `JsonEvent::get_field`, which splits dotted field names on `.` and walks into nested JSON objects.
- Top-level fields (no dots) are unchanged: `data->>'eventType'`.

## Test plan

- [x] `test_jsonb_nested_field_access`: two-level nested path with string equality
- [x] `test_jsonb_deeply_nested_field`: four-level nested path (`a.b.c.d`)
- [x] `test_jsonb_nested_field_exists`: `|exists` modifier on a nested path
- [x] `test_jsonb_nested_field_cidr`: `|cidr` modifier on a nested path
- [x] `test_jsonb_nested_field_regex`: `|re` modifier on a nested path
- [x] `test_jsonb_flat_field_unchanged`: regression guard for flat fields
- [x] All 78 postgres backend tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean