### PR TITLE
feat(daemon): smart correlation state restoration during replay

### DIFF
--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -59,3 +59,5 @@ bytes = "1"
 futures = "0.3"
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["nats"] }
+rusqlite = { version = "0.34", features = ["bundled"] }
+serde_json = "1"

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -68,6 +68,7 @@ pub(crate) fn cmd_eval(
         correlation_event_mode,
         max_correlation_events,
         timestamp_fields,
+        "wallclock",
     );
 
     if has_correlations {

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::time::Instant;
 
 use axum::extract::State;
@@ -27,8 +28,21 @@ struct DlqEntry {
 use super::health::HealthState;
 use super::metrics::Metrics;
 use super::reload;
-use super::store::SqliteStateStore;
+use super::store::{SourcePosition, SqliteStateStore};
 use crate::EventFilter;
+
+/// Controls whether correlation state is restored from SQLite on startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateRestoreMode {
+    /// Decide automatically. For NATS replay, compare the replay start point
+    /// against the stored source position: restore when replaying forward,
+    /// skip when replaying backward. For non-NATS and Resume, always restore.
+    Auto,
+    /// Unconditionally clear state (`--clear-state`).
+    ForceClear,
+    /// Unconditionally restore state (`--keep-state`).
+    ForceKeep,
+}
 
 #[derive(Clone)]
 struct AppState {
@@ -62,9 +76,8 @@ pub struct DaemonConfig {
     #[cfg(feature = "daemon-nats")]
     pub replay_policy: rsigma_runtime::ReplayPolicy,
     #[cfg(feature = "daemon-nats")]
-    pub clear_correlation_state: bool,
-    #[cfg(feature = "daemon-nats")]
     pub consumer_group: Option<String>,
+    pub state_restore_mode: StateRestoreMode,
     pub drain_timeout: u64,
     pub input_format: InputFormat,
 }
@@ -115,28 +128,38 @@ pub async fn run_daemon(config: DaemonConfig) {
     }
 
     // Restore correlation state from SQLite (after rules are loaded).
-    // When replaying (--replay-from-*), skip restoration to avoid double-counting.
-    #[allow(unused_mut)]
-    let mut skip_state_restore = false;
-    #[cfg(feature = "daemon-nats")]
-    if config.clear_correlation_state {
-        skip_state_restore = true;
-        tracing::info!("Correlation state cleared for replay mode");
-    }
-    if !skip_state_restore && let Some(ref store) = state_store {
+    //
+    // The decision depends on `state_restore_mode`:
+    // - ForceClear: always skip (--clear-state).
+    // - ForceKeep: always restore (--keep-state).
+    // - Auto: for NATS replay, compare the replay start point against the
+    //   stored source position to avoid double-counting when replaying
+    //   backward, while preserving cross-boundary correlations when
+    //   replaying forward. For non-NATS and Resume, always restore.
+    if let Some(ref store) = state_store {
         match store.load().await {
-            Ok(Some(snapshot)) => {
-                if processor.import_state(&snapshot) {
-                    let entries = snapshot.windows.values().map(|g| g.len()).sum::<usize>();
-                    tracing::info!(
-                        state_entries = entries,
-                        "Correlation state restored from database"
-                    );
+            Ok(Some((snapshot, stored_position))) => {
+                let should_restore = decide_state_restore(
+                    config.state_restore_mode,
+                    stored_position,
+                    #[cfg(feature = "daemon-nats")]
+                    &config.replay_policy,
+                );
+                if should_restore {
+                    if processor.import_state(&snapshot) {
+                        let entries = snapshot.windows.values().map(|g| g.len()).sum::<usize>();
+                        tracing::info!(
+                            state_entries = entries,
+                            "Correlation state restored from database"
+                        );
+                    } else {
+                        tracing::warn!(
+                            snapshot_version = snapshot.version,
+                            "Incompatible snapshot version, starting with fresh state"
+                        );
+                    }
                 } else {
-                    tracing::warn!(
-                        snapshot_version = snapshot.version,
-                        "Incompatible snapshot version, starting with fresh state"
-                    );
+                    tracing::info!("Correlation state cleared (not restoring)");
                 }
             }
             Ok(None) => {
@@ -243,11 +266,18 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
     });
 
+    // High-water mark for the last acked NATS stream position.
+    // Updated by the ack task, read by the periodic/shutdown state saver.
+    let high_water_seq = Arc::new(AtomicU64::new(0));
+    let high_water_ts = Arc::new(AtomicI64::new(0));
+
     // Spawn periodic state saver
     if let Some(ref store) = state_store {
         let save_processor = processor.clone();
         let save_store = store.clone();
         let save_interval_secs = config.state_save_interval;
+        let save_hw_seq = high_water_seq.clone();
+        let save_hw_ts = high_water_ts.clone();
         tokio::spawn(async move {
             let mut interval =
                 tokio::time::interval(tokio::time::Duration::from_secs(save_interval_secs));
@@ -255,7 +285,8 @@ pub async fn run_daemon(config: DaemonConfig) {
             loop {
                 interval.tick().await;
                 if let Some(snapshot) = save_processor.export_state() {
-                    if let Err(e) = save_store.save(&snapshot).await {
+                    let position = source_position_from_atomics(&save_hw_seq, &save_hw_ts);
+                    if let Err(e) = save_store.save(&snapshot, position.as_ref()).await {
                         tracing::warn!(error = %e, "Failed to save periodic state snapshot");
                     } else {
                         tracing::debug!("Periodic state snapshot saved");
@@ -494,8 +525,17 @@ pub async fn run_daemon(config: DaemonConfig) {
     });
 
     // Ack task: resolves ack tokens after the sink confirms delivery.
+    // For NATS tokens, extracts the stream sequence before acking to maintain
+    // the high-water mark used by the state saver.
+    #[cfg(feature = "daemon-nats")]
+    let (ack_hw_seq, ack_hw_ts) = (high_water_seq.clone(), high_water_ts.clone());
     let ack_handle = tokio::spawn(async move {
         while let Some(token) = ack_rx.recv().await {
+            #[cfg(feature = "daemon-nats")]
+            if let Some((seq, ts)) = token.nats_stream_position() {
+                ack_hw_seq.fetch_max(seq, Ordering::Relaxed);
+                ack_hw_ts.fetch_max(ts, Ordering::Relaxed);
+            }
             token.ack().await;
         }
     });
@@ -544,8 +584,18 @@ pub async fn run_daemon(config: DaemonConfig) {
     if let Some(ref store) = state_store
         && let Some(snapshot) = processor.export_state()
     {
-        match store.save(&snapshot).await {
-            Ok(()) => tracing::info!("Correlation state saved to database on shutdown"),
+        let position = source_position_from_atomics(&high_water_seq, &high_water_ts);
+        match store.save(&snapshot, position.as_ref()).await {
+            Ok(()) => {
+                if let Some(ref pos) = position {
+                    tracing::info!(
+                        source_sequence = pos.sequence,
+                        "Correlation state saved to database on shutdown"
+                    );
+                } else {
+                    tracing::info!("Correlation state saved to database on shutdown");
+                }
+            }
             Err(e) => tracing::error!(error = %e, "Failed to save state on shutdown"),
         }
     }
@@ -621,6 +671,110 @@ fn parse_nats_url(url: &str) -> (String, String) {
         }
         None => (format!("nats://{without_scheme}"), ">".to_string()),
     }
+}
+
+// ---------------------------------------------------------------------------
+// State restore decision
+// ---------------------------------------------------------------------------
+
+/// Decide whether to restore correlation state from SQLite.
+fn decide_state_restore(
+    mode: StateRestoreMode,
+    stored_position: Option<SourcePosition>,
+    #[cfg(feature = "daemon-nats")] replay_policy: &rsigma_runtime::ReplayPolicy,
+) -> bool {
+    match mode {
+        StateRestoreMode::ForceClear => {
+            tracing::info!("State restore skipped (--clear-state)");
+            false
+        }
+        StateRestoreMode::ForceKeep => {
+            tracing::info!("State restore forced (--keep-state)");
+            true
+        }
+        StateRestoreMode::Auto => {
+            #[cfg(feature = "daemon-nats")]
+            {
+                use rsigma_runtime::ReplayPolicy;
+                match replay_policy {
+                    ReplayPolicy::Resume => true,
+                    ReplayPolicy::Latest => {
+                        tracing::info!("State restore skipped (--replay-from-latest starts fresh)");
+                        false
+                    }
+                    ReplayPolicy::FromSequence(replay_seq) => match stored_position {
+                        Some(pos) if *replay_seq > pos.sequence => {
+                            tracing::info!(
+                                replay_from = replay_seq,
+                                stored_sequence = pos.sequence,
+                                "Restoring state (replay starts after stored position)"
+                            );
+                            true
+                        }
+                        Some(pos) => {
+                            tracing::info!(
+                                replay_from = replay_seq,
+                                stored_sequence = pos.sequence,
+                                "State restore skipped (replay starts at or before stored position, would double-count)"
+                            );
+                            false
+                        }
+                        None => {
+                            tracing::info!(
+                                "State restore skipped (no stored position to compare against replay)"
+                            );
+                            false
+                        }
+                    },
+                    ReplayPolicy::FromTime(replay_time) => {
+                        let replay_ts = replay_time.unix_timestamp();
+                        match stored_position {
+                            Some(pos) if replay_ts > pos.timestamp => {
+                                tracing::info!(
+                                    replay_from_ts = replay_ts,
+                                    stored_ts = pos.timestamp,
+                                    "Restoring state (replay starts after stored timestamp)"
+                                );
+                                true
+                            }
+                            Some(pos) => {
+                                tracing::info!(
+                                    replay_from_ts = replay_ts,
+                                    stored_ts = pos.timestamp,
+                                    "State restore skipped (replay starts at or before stored timestamp, would double-count)"
+                                );
+                                false
+                            }
+                            None => {
+                                tracing::info!(
+                                    "State restore skipped (no stored position to compare against replay)"
+                                );
+                                false
+                            }
+                        }
+                    }
+                }
+            }
+            #[cfg(not(feature = "daemon-nats"))]
+            {
+                let _ = stored_position;
+                true
+            }
+        }
+    }
+}
+
+/// Build a `SourcePosition` from the high-water mark atomics.
+/// Returns `None` if no NATS messages have been acked yet (sequence == 0).
+fn source_position_from_atomics(seq: &AtomicU64, ts: &AtomicI64) -> Option<SourcePosition> {
+    let s = seq.load(Ordering::Relaxed);
+    if s == 0 {
+        return None;
+    }
+    Some(SourcePosition {
+        sequence: s,
+        timestamp: ts.load(Ordering::Relaxed),
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -914,3 +914,137 @@ async fn ingest_events(State(state): State<AppState>, body: String) -> Response 
     )
         .into_response()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn force_clear_always_skips() {
+        let result = decide_state_restore(
+            StateRestoreMode::ForceClear,
+            Some(SourcePosition {
+                sequence: 100,
+                timestamp: 1000,
+            }),
+            #[cfg(feature = "daemon-nats")]
+            &rsigma_runtime::ReplayPolicy::Resume,
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn force_keep_always_restores() {
+        let result = decide_state_restore(
+            StateRestoreMode::ForceKeep,
+            None,
+            #[cfg(feature = "daemon-nats")]
+            &rsigma_runtime::ReplayPolicy::Latest,
+        );
+        assert!(result);
+    }
+
+    #[cfg(feature = "daemon-nats")]
+    mod nats_auto {
+        use super::*;
+        use rsigma_runtime::ReplayPolicy;
+
+        #[test]
+        fn resume_restores() {
+            assert!(decide_state_restore(
+                StateRestoreMode::Auto,
+                None,
+                &ReplayPolicy::Resume,
+            ));
+        }
+
+        #[test]
+        fn latest_skips() {
+            assert!(!decide_state_restore(
+                StateRestoreMode::Auto,
+                Some(SourcePosition {
+                    sequence: 100,
+                    timestamp: 1000,
+                }),
+                &ReplayPolicy::Latest,
+            ));
+        }
+
+        #[test]
+        fn forward_sequence_restores() {
+            assert!(decide_state_restore(
+                StateRestoreMode::Auto,
+                Some(SourcePosition {
+                    sequence: 100,
+                    timestamp: 1000,
+                }),
+                &ReplayPolicy::FromSequence(101),
+            ));
+        }
+
+        #[test]
+        fn backward_sequence_skips() {
+            assert!(!decide_state_restore(
+                StateRestoreMode::Auto,
+                Some(SourcePosition {
+                    sequence: 100,
+                    timestamp: 1000,
+                }),
+                &ReplayPolicy::FromSequence(50),
+            ));
+        }
+
+        #[test]
+        fn equal_sequence_skips() {
+            assert!(!decide_state_restore(
+                StateRestoreMode::Auto,
+                Some(SourcePosition {
+                    sequence: 100,
+                    timestamp: 1000,
+                }),
+                &ReplayPolicy::FromSequence(100),
+            ));
+        }
+
+        #[test]
+        fn forward_time_restores() {
+            let future = time::OffsetDateTime::from_unix_timestamp(2000).unwrap();
+            assert!(decide_state_restore(
+                StateRestoreMode::Auto,
+                Some(SourcePosition {
+                    sequence: 100,
+                    timestamp: 1000,
+                }),
+                &ReplayPolicy::FromTime(future),
+            ));
+        }
+
+        #[test]
+        fn backward_time_skips() {
+            let past = time::OffsetDateTime::from_unix_timestamp(500).unwrap();
+            assert!(!decide_state_restore(
+                StateRestoreMode::Auto,
+                Some(SourcePosition {
+                    sequence: 100,
+                    timestamp: 1000,
+                }),
+                &ReplayPolicy::FromTime(past),
+            ));
+        }
+
+        #[test]
+        fn no_stored_position_skips_on_replay() {
+            assert!(!decide_state_restore(
+                StateRestoreMode::Auto,
+                None,
+                &ReplayPolicy::FromSequence(42),
+            ));
+        }
+    }
+
+    #[cfg(not(feature = "daemon-nats"))]
+    #[test]
+    fn auto_without_nats_restores() {
+        assert!(decide_state_restore(StateRestoreMode::Auto, None));
+    }
+}

--- a/crates/rsigma-cli/src/daemon/store.rs
+++ b/crates/rsigma-cli/src/daemon/store.rs
@@ -3,6 +3,20 @@ use std::sync::{Arc, Mutex};
 
 use rsigma_eval::CorrelationSnapshot;
 
+/// Position of the last acked event from the source stream.
+///
+/// Stored alongside the correlation snapshot so the daemon can make an
+/// informed decision about whether to restore state during replay:
+/// restoring is safe when the replay starts *after* the stored position,
+/// but would cause double-counting when replaying backwards.
+#[derive(Debug, Clone, Copy)]
+pub struct SourcePosition {
+    /// JetStream stream sequence of the last acked message.
+    pub sequence: u64,
+    /// Unix timestamp (seconds) of the last acked message's `published` time.
+    pub timestamp: i64,
+}
+
 /// SQLite-backed state store for persisting correlation state across restarts.
 ///
 /// Follows the same pattern as helr's `SqliteStateStore`: a single
@@ -30,14 +44,49 @@ impl SqliteStateStore {
         )
         .map_err(|e| format!("init sqlite schema: {e}"))?;
 
+        Self::migrate(&conn)?;
+
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })
     }
 
-    /// Save a correlation snapshot to the database.
+    /// Add columns introduced after the initial schema.
+    fn migrate(conn: &rusqlite::Connection) -> Result<(), String> {
+        let has_column = |col: &str| -> Result<bool, String> {
+            let mut stmt = conn
+                .prepare("PRAGMA table_info(rsigma_correlation_state)")
+                .map_err(|e| format!("pragma table_info: {e}"))?;
+            let names: Vec<String> = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .map_err(|e| format!("query pragma: {e}"))?
+                .filter_map(|r| r.ok())
+                .collect();
+            Ok(names.iter().any(|n| n == col))
+        };
+
+        if !has_column("source_sequence")? {
+            conn.execute_batch(
+                r#"
+                ALTER TABLE rsigma_correlation_state
+                    ADD COLUMN source_sequence INTEGER;
+                ALTER TABLE rsigma_correlation_state
+                    ADD COLUMN source_timestamp INTEGER;
+                "#,
+            )
+            .map_err(|e| format!("migrate source position columns: {e}"))?;
+        }
+
+        Ok(())
+    }
+
+    /// Save a correlation snapshot (and optional source position) to the database.
     /// Replaces any existing snapshot (single-row table).
-    pub async fn save(&self, snapshot: &CorrelationSnapshot) -> Result<(), String> {
+    pub async fn save(
+        &self,
+        snapshot: &CorrelationSnapshot,
+        position: Option<&SourcePosition>,
+    ) -> Result<(), String> {
         let json =
             serde_json::to_string(snapshot).map_err(|e| format!("serialize snapshot: {e}"))?;
         let conn = self.conn.clone();
@@ -45,13 +94,19 @@ impl SqliteStateStore {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
+        let seq = position.map(|p| p.sequence as i64);
+        let ts = position.map(|p| p.timestamp);
 
         tokio::task::spawn_blocking(move || {
             let c = conn.lock().map_err(|_| "state store lock poisoned")?;
             c.execute(
-                "INSERT INTO rsigma_correlation_state (id, snapshot, updated_at) VALUES (1, ?1, ?2)
-                 ON CONFLICT (id) DO UPDATE SET snapshot = ?1, updated_at = ?2",
-                rusqlite::params![&json, updated_at],
+                "INSERT INTO rsigma_correlation_state
+                    (id, snapshot, updated_at, source_sequence, source_timestamp)
+                 VALUES (1, ?1, ?2, ?3, ?4)
+                 ON CONFLICT (id) DO UPDATE SET
+                    snapshot = ?1, updated_at = ?2,
+                    source_sequence = ?3, source_timestamp = ?4",
+                rusqlite::params![&json, updated_at, seq, ts],
             )
             .map_err(|e| format!("save snapshot: {e}"))?;
             Ok(())
@@ -60,21 +115,42 @@ impl SqliteStateStore {
         .map_err(|e| format!("spawn_blocking: {e}"))?
     }
 
-    /// Load the most recent correlation snapshot from the database.
+    /// Load the most recent correlation snapshot and source position from the database.
     /// Returns `None` if no snapshot has been saved yet.
-    pub async fn load(&self) -> Result<Option<CorrelationSnapshot>, String> {
+    pub async fn load(
+        &self,
+    ) -> Result<Option<(CorrelationSnapshot, Option<SourcePosition>)>, String> {
         let conn = self.conn.clone();
         tokio::task::spawn_blocking(move || {
             let c = conn.lock().map_err(|_| "state store lock poisoned")?;
             let mut stmt = c
-                .prepare("SELECT snapshot FROM rsigma_correlation_state WHERE id = 1")
+                .prepare(
+                    "SELECT snapshot, source_sequence, source_timestamp
+                     FROM rsigma_correlation_state WHERE id = 1",
+                )
                 .map_err(|e| format!("prepare load: {e}"))?;
             let mut rows = stmt.query([]).map_err(|e| format!("query: {e}"))?;
             if let Some(row) = rows.next().map_err(|e| format!("next: {e}"))? {
-                let json: String = row.get(0).map_err(|e| format!("get: {e}"))?;
+                let json: String = row.get(0).map_err(|e| format!("get snapshot: {e}"))?;
                 let snapshot: CorrelationSnapshot = serde_json::from_str(&json)
                     .map_err(|e| format!("deserialize snapshot: {e}"))?;
-                Ok(Some(snapshot))
+
+                let seq: Option<i64> = row
+                    .get(1)
+                    .map_err(|e| format!("get source_sequence: {e}"))?;
+                let ts: Option<i64> = row
+                    .get(2)
+                    .map_err(|e| format!("get source_timestamp: {e}"))?;
+
+                let position = match (seq, ts) {
+                    (Some(s), Some(t)) => Some(SourcePosition {
+                        sequence: s as u64,
+                        timestamp: t,
+                    }),
+                    _ => None,
+                };
+
+                Ok(Some((snapshot, position)))
             } else {
                 Ok(None)
             }

--- a/crates/rsigma-cli/src/daemon/store.rs
+++ b/crates/rsigma-cli/src/daemon/store.rs
@@ -159,3 +159,131 @@ impl SqliteStateStore {
         .map_err(|e| format!("spawn_blocking: {e}"))?
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn empty_snapshot() -> CorrelationSnapshot {
+        CorrelationSnapshot {
+            version: 1,
+            windows: HashMap::new(),
+            last_alert: HashMap::new(),
+            event_buffers: HashMap::new(),
+            event_ref_buffers: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_without_position() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.db");
+        let store = SqliteStateStore::open(&db).unwrap();
+
+        let snap = empty_snapshot();
+        store.save(&snap, None).await.unwrap();
+
+        let (loaded, pos) = store.load().await.unwrap().unwrap();
+        assert_eq!(loaded.version, 1);
+        assert!(pos.is_none());
+    }
+
+    #[tokio::test]
+    async fn round_trip_with_position() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.db");
+        let store = SqliteStateStore::open(&db).unwrap();
+
+        let snap = empty_snapshot();
+        let pos = SourcePosition {
+            sequence: 42,
+            timestamp: 1714500000,
+        };
+        store.save(&snap, Some(&pos)).await.unwrap();
+
+        let (loaded, loaded_pos) = store.load().await.unwrap().unwrap();
+        assert_eq!(loaded.version, 1);
+        let p = loaded_pos.unwrap();
+        assert_eq!(p.sequence, 42);
+        assert_eq!(p.timestamp, 1714500000);
+    }
+
+    #[tokio::test]
+    async fn position_updates_on_subsequent_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.db");
+        let store = SqliteStateStore::open(&db).unwrap();
+
+        let snap = empty_snapshot();
+        let pos1 = SourcePosition {
+            sequence: 10,
+            timestamp: 1000,
+        };
+        store.save(&snap, Some(&pos1)).await.unwrap();
+
+        let pos2 = SourcePosition {
+            sequence: 50,
+            timestamp: 5000,
+        };
+        store.save(&snap, Some(&pos2)).await.unwrap();
+
+        let (_, loaded_pos) = store.load().await.unwrap().unwrap();
+        let p = loaded_pos.unwrap();
+        assert_eq!(p.sequence, 50);
+        assert_eq!(p.timestamp, 5000);
+    }
+
+    #[tokio::test]
+    async fn migration_from_old_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Create old-format database without source position columns.
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                r#"
+                PRAGMA journal_mode = WAL;
+                CREATE TABLE rsigma_correlation_state (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    snapshot TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL
+                );
+                "#,
+            )
+            .unwrap();
+            let snap = empty_snapshot();
+            let json = serde_json::to_string(&snap).unwrap();
+            conn.execute(
+                "INSERT INTO rsigma_correlation_state (id, snapshot, updated_at) VALUES (1, ?1, ?2)",
+                rusqlite::params![&json, 1000i64],
+            )
+            .unwrap();
+        }
+
+        // Open with SqliteStateStore, which should auto-migrate.
+        let store = SqliteStateStore::open(&db_path).unwrap();
+        let (loaded, pos) = store.load().await.unwrap().unwrap();
+        assert_eq!(loaded.version, 1);
+        assert!(pos.is_none(), "old rows should have NULL source columns");
+
+        // Saving with position should work on the migrated schema.
+        let new_pos = SourcePosition {
+            sequence: 99,
+            timestamp: 9999,
+        };
+        store.save(&loaded, Some(&new_pos)).await.unwrap();
+        let (_, loaded_pos) = store.load().await.unwrap().unwrap();
+        assert_eq!(loaded_pos.unwrap().sequence, 99);
+    }
+
+    #[tokio::test]
+    async fn empty_database_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.db");
+        let store = SqliteStateStore::open(&db).unwrap();
+
+        assert!(store.load().await.unwrap().is_none());
+    }
+}

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -274,10 +274,24 @@ enum Commands {
         #[arg(long = "replay-from-latest", conflicts_with_all = ["replay_from_sequence", "replay_from_time"])]
         replay_from_latest: bool,
 
-        /// Clear correlation state when replaying (auto-enabled with --replay-from-*).
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "clear-state")]
+        /// Clear correlation state on startup. When used with --replay-from-*,
+        /// forces a clean slate even if the replay starts after the stored position.
+        #[arg(long = "clear-state", conflicts_with = "keep_state")]
         clear_state: bool,
+
+        /// Force restore correlation state even during replay. Use when you know
+        /// the replay starts after the last processed position (forward catch-up)
+        /// and want to preserve cross-boundary correlation windows.
+        #[arg(long = "keep-state", conflicts_with = "clear_state")]
+        keep_state: bool,
+
+        /// Behavior when no timestamp field is found in an event.
+        /// 'wallclock' (default): use wall-clock time for correlation windows.
+        /// 'skip': run detections but skip correlation state updates for that
+        /// event. Recommended for forensic replay of logs without timestamps.
+        #[arg(long = "timestamp-fallback", default_value = "wallclock",
+               value_parser = ["wallclock", "skip"])]
+        timestamp_fallback: String,
 
         /// Consumer group name for NATS JetStream load balancing.
         /// Multiple daemon instances using the same group name share the
@@ -471,8 +485,9 @@ fn main() {
             replay_from_time,
             #[cfg(feature = "daemon-nats")]
             replay_from_latest,
-            #[cfg(feature = "daemon-nats")]
             clear_state,
+            keep_state,
+            timestamp_fallback,
             #[cfg(feature = "daemon-nats")]
             consumer_group,
         } => {
@@ -504,9 +519,13 @@ fn main() {
                 rsigma_runtime::ReplayPolicy::Resume
             };
 
-            #[cfg(feature = "daemon-nats")]
-            let clear_correlation_state =
-                clear_state || !matches!(replay_policy, rsigma_runtime::ReplayPolicy::Resume);
+            let state_restore_mode = if clear_state {
+                daemon::server::StateRestoreMode::ForceClear
+            } else if keep_state {
+                daemon::server::StateRestoreMode::ForceKeep
+            } else {
+                daemon::server::StateRestoreMode::Auto
+            };
 
             cmd_daemon(
                 rules,
@@ -522,6 +541,7 @@ fn main() {
                 correlation_event_mode,
                 max_correlation_events,
                 timestamp_fields,
+                timestamp_fallback,
                 state_db,
                 state_save_interval,
                 input,
@@ -532,12 +552,11 @@ fn main() {
                 dlq,
                 input_format,
                 syslog_tz,
+                state_restore_mode,
                 #[cfg(feature = "daemon-nats")]
                 nats_auth,
                 #[cfg(feature = "daemon-nats")]
                 replay_policy,
-                #[cfg(feature = "daemon-nats")]
-                clear_correlation_state,
                 #[cfg(feature = "daemon-nats")]
                 consumer_group,
             )
@@ -658,6 +677,7 @@ fn cmd_daemon(
     correlation_event_mode: String,
     max_correlation_events: usize,
     timestamp_fields: Vec<String>,
+    timestamp_fallback: String,
     state_db: Option<PathBuf>,
     state_save_interval: u64,
     input: String,
@@ -668,9 +688,9 @@ fn cmd_daemon(
     dlq: Option<String>,
     input_format: String,
     syslog_tz: String,
+    state_restore_mode: daemon::server::StateRestoreMode,
     #[cfg(feature = "daemon-nats")] nats_auth: NatsAuthArgs,
     #[cfg(feature = "daemon-nats")] replay_policy: rsigma_runtime::ReplayPolicy,
-    #[cfg(feature = "daemon-nats")] clear_correlation_state: bool,
     #[cfg(feature = "daemon-nats")] consumer_group: Option<String>,
 ) {
     // Set up structured logging
@@ -694,6 +714,7 @@ fn cmd_daemon(
         correlation_event_mode,
         max_correlation_events,
         timestamp_fields,
+        &timestamp_fallback,
     );
 
     let addr: std::net::SocketAddr = api_addr.parse().unwrap_or_else(|e| {
@@ -736,9 +757,8 @@ fn cmd_daemon(
         #[cfg(feature = "daemon-nats")]
         replay_policy,
         #[cfg(feature = "daemon-nats")]
-        clear_correlation_state,
-        #[cfg(feature = "daemon-nats")]
         consumer_group,
+        state_restore_mode,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -954,6 +974,7 @@ pub(crate) fn build_correlation_config(
     correlation_event_mode: String,
     max_correlation_events: usize,
     extra_timestamp_fields: Vec<String>,
+    timestamp_fallback: &str,
 ) -> CorrelationConfig {
     let suppress_secs = suppress.map(|s| match rsigma_parser::Timespan::parse(&s) {
         Ok(ts) => ts.seconds,
@@ -979,12 +1000,18 @@ pub(crate) fn build_correlation_config(
             process::exit(1);
         });
 
+    let ts_fallback = match timestamp_fallback {
+        "skip" => rsigma_eval::TimestampFallback::Skip,
+        _ => rsigma_eval::TimestampFallback::WallClock,
+    };
+
     let mut config = CorrelationConfig {
         suppress: suppress_secs,
         action_on_match,
         emit_detections: !no_detections,
         correlation_event_mode: event_mode,
         max_correlation_events,
+        timestamp_fallback: ts_fallback,
         ..Default::default()
     };
 

--- a/crates/rsigma-cli/tests/cli_daemon.rs
+++ b/crates/rsigma-cli/tests/cli_daemon.rs
@@ -3,6 +3,7 @@
 mod common;
 
 use common::{SIMPLE_RULE, rsigma, temp_file};
+use rusqlite::params;
 use tempfile::TempDir;
 
 const DAEMON_CORRELATION_RULES: &str = r#"
@@ -547,4 +548,325 @@ level: high
 
     assert!(output.status.success());
     insta::assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r#"{"rule_title":"Error Detected","rule_id":"00000000-0000-0000-0000-000000000097","level":"high","tags":[],"matched_selections":["keywords"],"matched_fields":[]}"#);
+}
+
+// ---------------------------------------------------------------------------
+// State restore mode tests
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_clear_state_prevents_restore() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Run 1: send 2 events to build state (below threshold)
+    let events_run1 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                        {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events_run1)
+        .assert()
+        .success();
+
+    // Run 2: send 1 event with --clear-state. State is wiped, so total is 1, not 3.
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+            "--clear-state",
+        ])
+        .write_stdin("{\"EventType\":\"login\",\"User\":\"admin\"}\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.trim().is_empty(),
+        "--clear-state should prevent restore, so correlation should not fire: {stdout}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_keep_state_forces_restore() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Run 1: send 2 events (below threshold)
+    let events_run1 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                        {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events_run1)
+        .assert()
+        .success();
+
+    // Run 2: send 1 event with --keep-state. Restored 2 + 1 = 3, should fire.
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+            "--keep-state",
+        ])
+        .write_stdin("{\"EventType\":\"login\",\"User\":\"admin\"}\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Many Logins\""),
+        "--keep-state should restore correlation state: {stdout}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_clear_state_and_keep_state_conflict() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+
+    rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--clear-state",
+            "--keep-state",
+        ])
+        .write_stdin("")
+        .assert()
+        .failure();
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_timestamp_fallback_skip() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Send 4 events WITHOUT timestamps with --timestamp-fallback skip.
+    // Detection fires (stateless), but correlation should not count them
+    // because events without parseable timestamps are skipped.
+    let events = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+            "--timestamp-fallback",
+            "skip",
+        ])
+        .write_stdin(events)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Many Logins"),
+        "--timestamp-fallback skip should prevent correlation from firing: {stdout}"
+    );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_timestamp_fallback_wallclock_default() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Same events without timestamps, but default (wallclock) fallback.
+    // Correlation should fire because wallclock substitutes current time.
+    let events = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Many Logins\""),
+        "default wallclock fallback should allow correlation to fire: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Schema migration test
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daemon")]
+#[test]
+fn daemon_state_db_migration_from_old_schema() {
+    let rules = temp_file(".yml", DAEMON_CORRELATION_RULES);
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Step 1: Create a state DB with the OLD schema (no source_sequence/source_timestamp)
+    // by running the daemon once to get a valid snapshot, then stripping the new columns.
+    let events = "{\"EventType\":\"login\",\"User\":\"admin\"}\n\
+                   {\"EventType\":\"login\",\"User\":\"admin\"}\n";
+    rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+        ])
+        .write_stdin(events)
+        .assert()
+        .success();
+
+    // Extract the snapshot, then recreate the DB with old schema
+    let snapshot: String = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.query_row(
+            "SELECT snapshot FROM rsigma_correlation_state WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+
+    // Recreate with old schema (no source_sequence/source_timestamp columns)
+    std::fs::remove_file(&db_path).unwrap();
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             CREATE TABLE rsigma_correlation_state (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 snapshot TEXT NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO rsigma_correlation_state (id, snapshot, updated_at) VALUES (1, ?1, ?2)",
+            params![&snapshot, 1000i64],
+        )
+        .unwrap();
+    }
+
+    // Verify old schema has no source columns
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(rsigma_correlation_state)")
+            .unwrap();
+        let columns: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert!(
+            !columns.contains(&"source_sequence".to_string()),
+            "old schema should not have source_sequence"
+        );
+    }
+
+    // Step 2: Run daemon with --keep-state on the old DB.
+    // It should auto-migrate and restore the snapshot.
+    let output = rsigma()
+        .args([
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--state-db",
+            db_path.to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+            "--no-detections",
+            "--keep-state",
+        ])
+        .write_stdin("{\"EventType\":\"login\",\"User\":\"admin\"}\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"rule_title\":\"Many Logins\""),
+        "migrated DB should restore state (2 from old + 1 new = 3): {stdout}"
+    );
+
+    // Step 3: Verify schema was migrated (new columns exist)
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(rsigma_correlation_state)")
+        .unwrap();
+    let columns: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+    assert!(
+        columns.contains(&"source_sequence".to_string()),
+        "schema should be migrated to include source_sequence"
+    );
+    assert!(
+        columns.contains(&"source_timestamp".to_string()),
+        "schema should be migrated to include source_timestamp"
+    );
 }

--- a/crates/rsigma-cli/tests/cli_daemon_http.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_http.rs
@@ -102,10 +102,15 @@ fn http_get(url: &str) -> (u16, String) {
 }
 
 fn http_post(url: &str, body: &str) -> (u16, String) {
-    let resp = ureq::post(url).send(body).expect("HTTP POST failed");
-    let status = resp.status().as_u16();
-    let body = resp.into_body().read_to_string().unwrap();
-    (status, body)
+    match ureq::post(url).send(body) {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            let body = resp.into_body().read_to_string().unwrap();
+            (status, body)
+        }
+        Err(ureq::Error::StatusCode(code)) => (code, String::new()),
+        Err(e) => panic!("HTTP POST failed: {e}"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -178,8 +183,19 @@ fn reload_triggers_successfully() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
 
-    let (status, body) = http_post(&daemon.url("/api/v1/reload"), "");
-    assert_eq!(status, 200);
+    // The file watcher may fill the reload channel on startup (especially on
+    // macOS where FSEvents fires multiple events). Retry until the debounce
+    // drains the channel and a slot opens.
+    let mut status = 0;
+    let mut body = String::new();
+    for _ in 0..10 {
+        (status, body) = http_post(&daemon.url("/api/v1/reload"), "");
+        if status == 200 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    assert_eq!(status, 200, "reload should succeed after retries, got {status}");
     let v: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(v["status"], "reload_triggered");
 }

--- a/crates/rsigma-cli/tests/cli_daemon_http.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_http.rs
@@ -195,7 +195,10 @@ fn reload_triggers_successfully() {
         }
         std::thread::sleep(Duration::from_millis(500));
     }
-    assert_eq!(status, 200, "reload should succeed after retries, got {status}");
+    assert_eq!(
+        status, 200,
+        "reload should succeed after retries, got {status}"
+    );
     let v: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(v["status"], "reload_triggered");
 }

--- a/crates/rsigma-cli/tests/cli_daemon_nats.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_nats.rs
@@ -14,6 +14,7 @@ mod common;
 
 use common::{SIMPLE_RULE, temp_file};
 use futures::StreamExt;
+use rusqlite::params;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -347,4 +348,421 @@ async fn daemon_nats_fanout() {
         msgs_a[0], msgs_b[0],
         "both sinks should get identical output"
     );
+}
+
+// ---------------------------------------------------------------------------
+// State restore with NATS source position tests
+// ---------------------------------------------------------------------------
+
+/// Helper: read source_sequence and source_timestamp from the state DB.
+fn read_source_position(db_path: &std::path::Path) -> (Option<i64>, Option<i64>) {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT source_sequence, source_timestamp FROM rsigma_correlation_state WHERE id = 1",
+        [],
+        |row| {
+            Ok((
+                row.get::<_, Option<i64>>(0).unwrap(),
+                row.get::<_, Option<i64>>(1).unwrap(),
+            ))
+        },
+    )
+    .unwrap()
+}
+
+/// Helper: read the correlation snapshot JSON from the state DB.
+fn read_snapshot_json(db_path: &std::path::Path) -> Option<String> {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT snapshot FROM rsigma_correlation_state WHERE id = 1",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+/// Process events through NATS, then verify the DB stores source_sequence
+/// and source_timestamp from the JetStream message metadata.
+#[tokio::test]
+async fn daemon_nats_state_persists_source_position() {
+    skip_without_docker!();
+    let (_container, nats_url) = start_nats_jetstream().await;
+    let rule = temp_file(".yml", BRUTE_FORCE_RULES);
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    let input = format!("{nats_url}/e2e.state.pos.in");
+    let output = format!("{nats_url}/e2e.state.pos.out");
+
+    let client = async_nats::connect(&nats_url).await.unwrap();
+    let mut output_sub = client
+        .subscribe("e2e.state.pos.out".to_string())
+        .await
+        .unwrap();
+
+    let mut daemon = DaemonProcess::spawn(&[
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--input",
+        &input,
+        "--output",
+        &output,
+        "--api-addr",
+        "127.0.0.1:0",
+        "--state-db",
+        db_path.to_str().unwrap(),
+        "--state-save-interval",
+        "1",
+        "--no-detections",
+    ]);
+    daemon.wait_for_ready("Sink started");
+
+    for i in 1..=2 {
+        publish_and_flush(
+            &client,
+            "e2e.state.pos.in",
+            &format!(r#"{{"EventType":"login_failure","src_ip":"10.0.0.1","n":{i}}}"#),
+        )
+        .await;
+    }
+
+    // Wait for the periodic save to persist (interval=1s, plus processing time)
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    daemon.kill();
+
+    let (seq, ts) = read_source_position(&db_path);
+    assert!(
+        seq.is_some(),
+        "source_sequence should be stored after NATS processing"
+    );
+    assert!(
+        ts.is_some(),
+        "source_timestamp should be stored after NATS processing"
+    );
+    assert!(
+        seq.unwrap() >= 2,
+        "source_sequence should be >= 2 (processed 2 messages), got {:?}",
+        seq
+    );
+
+    // Verify that a snapshot was actually saved
+    let snap = read_snapshot_json(&db_path);
+    assert!(snap.is_some(), "snapshot should be saved in DB");
+
+    // Drain output subscriber
+    let _ = collect_messages(&mut output_sub, 10, Duration::from_millis(100)).await;
+}
+
+/// Forward replay (replay_from_sequence > stored) should restore state.
+/// The daemon preserves correlation windows because the replay starts where
+/// it left off, so there is no double-counting risk.
+#[tokio::test]
+async fn daemon_nats_forward_replay_restores_state() {
+    skip_without_docker!();
+    let (_container, nats_url) = start_nats_jetstream().await;
+    let rule = temp_file(".yml", BRUTE_FORCE_RULES);
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    let input = format!("{nats_url}/e2e.fwd.in");
+    let output = format!("{nats_url}/e2e.fwd.out");
+
+    let client = async_nats::connect(&nats_url).await.unwrap();
+
+    // --- Run 1: process 2 events, build correlation state ---
+    let mut output_sub = client.subscribe("e2e.fwd.out".to_string()).await.unwrap();
+
+    let mut daemon = DaemonProcess::spawn(&[
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--input",
+        &input,
+        "--output",
+        &output,
+        "--api-addr",
+        "127.0.0.1:0",
+        "--state-db",
+        db_path.to_str().unwrap(),
+        "--state-save-interval",
+        "1",
+        "--no-detections",
+    ]);
+    daemon.wait_for_ready("Sink started");
+
+    for i in 1..=2 {
+        publish_and_flush(
+            &client,
+            "e2e.fwd.in",
+            &format!(r#"{{"EventType":"login_failure","src_ip":"10.0.0.1","n":{i}}}"#),
+        )
+        .await;
+    }
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    daemon.kill();
+
+    let (stored_seq, _) = read_source_position(&db_path);
+    let stored_seq = stored_seq.expect("sequence should be stored after run 1");
+    let _ = collect_messages(&mut output_sub, 10, Duration::from_millis(100)).await;
+    drop(output_sub);
+
+    // --- Run 2: forward replay (seq > stored), send 1 more event ---
+    let replay_seq = stored_seq + 1;
+    let mut output_sub2 = client.subscribe("e2e.fwd.out".to_string()).await.unwrap();
+
+    let mut daemon2 = DaemonProcess::spawn(&[
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--input",
+        &input,
+        "--output",
+        &output,
+        "--api-addr",
+        "127.0.0.1:0",
+        "--state-db",
+        db_path.to_str().unwrap(),
+        "--no-detections",
+        "--replay-from-sequence",
+        &replay_seq.to_string(),
+    ]);
+    daemon2.wait_for_ready("Sink started");
+
+    // Publish 1 more event: restored 2 + new 1 = 3 >= threshold
+    publish_and_flush(
+        &client,
+        "e2e.fwd.in",
+        r#"{"EventType":"login_failure","src_ip":"10.0.0.1","n":3}"#,
+    )
+    .await;
+
+    let msgs = collect_messages(&mut output_sub2, 1, Duration::from_secs(10)).await;
+    daemon2.kill();
+
+    assert!(
+        !msgs.is_empty(),
+        "forward replay should restore state, correlation should fire with 2+1=3 events"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&msgs[0]).unwrap();
+    assert_eq!(
+        parsed["rule_title"].as_str().unwrap(),
+        "Brute Force",
+        "correlation rule should fire"
+    );
+}
+
+/// Backward replay (replay_from_sequence <= stored) should clear state.
+/// Replaying events that were already counted would cause double-counting,
+/// so the daemon starts fresh.
+///
+/// Strategy: run 1 builds 2 events of state (below threshold of 3). Run 2
+/// uses `--replay-from-sequence 1` (backward). We publish 3 new events.
+/// If state was correctly cleared, only the new events count (threshold met
+/// at 3). If state was incorrectly preserved, 2 old + 3 new = 5, which
+/// would fire the correlation at a different aggregated_value.
+#[tokio::test]
+async fn daemon_nats_backward_replay_clears_state() {
+    skip_without_docker!();
+    let (_container, nats_url) = start_nats_jetstream().await;
+    let rule = temp_file(".yml", BRUTE_FORCE_RULES);
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    let input = format!("{nats_url}/e2e.bwd.in");
+    let output = format!("{nats_url}/e2e.bwd.out");
+
+    let client = async_nats::connect(&nats_url).await.unwrap();
+
+    // --- Run 1: process 2 events, build state ---
+    let mut output_sub = client.subscribe("e2e.bwd.out".to_string()).await.unwrap();
+
+    let mut daemon = DaemonProcess::spawn(&[
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--input",
+        &input,
+        "--output",
+        &output,
+        "--api-addr",
+        "127.0.0.1:0",
+        "--state-db",
+        db_path.to_str().unwrap(),
+        "--state-save-interval",
+        "1",
+        "--no-detections",
+    ]);
+    daemon.wait_for_ready("Sink started");
+
+    for i in 1..=2 {
+        publish_and_flush(
+            &client,
+            "e2e.bwd.in",
+            &format!(r#"{{"EventType":"login_failure","src_ip":"10.0.0.1","n":{i}}}"#),
+        )
+        .await;
+    }
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    daemon.kill();
+
+    let (stored_seq, _) = read_source_position(&db_path);
+    assert!(stored_seq.is_some(), "should have stored sequence");
+    let _ = collect_messages(&mut output_sub, 10, Duration::from_millis(100)).await;
+    drop(output_sub);
+
+    // --- Run 2: backward replay from seq=1 (<= stored), publish 3 new events ---
+    let mut output_sub2 = client.subscribe("e2e.bwd.out".to_string()).await.unwrap();
+
+    let mut daemon2 = DaemonProcess::spawn(&[
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--input",
+        &input,
+        "--output",
+        &output,
+        "--api-addr",
+        "127.0.0.1:0",
+        "--state-db",
+        db_path.to_str().unwrap(),
+        "--no-detections",
+        "--replay-from-sequence",
+        "1",
+    ]);
+    daemon2.wait_for_ready("Sink started");
+
+    // Publish 3 new events. The JetStream stream also has the 2 old events,
+    // but the durable consumer may or may not redeliver them. Either way:
+    //   - State cleared + old 2 replayed + new 3 = 5 total from fresh start
+    //   - State cleared + only new 3 = 3 total from fresh start
+    // Both scenarios fire the correlation (threshold >= 3).
+    // If state was INCORRECTLY preserved, count would be 2 + all delivered.
+    for i in 3..=5 {
+        publish_and_flush(
+            &client,
+            "e2e.bwd.in",
+            &format!(r#"{{"EventType":"login_failure","src_ip":"10.0.0.1","n":{i}}}"#),
+        )
+        .await;
+    }
+
+    let msgs = collect_messages(&mut output_sub2, 2, Duration::from_secs(10)).await;
+    daemon2.kill();
+
+    // The key assertion: correlation fires. If state was preserved (bug),
+    // the correlation would have fired earlier with the first new event
+    // (2 restored + 1 = 3) and potentially fire again at different counts,
+    // giving us extra messages with aggregated_value != 3. With a clean
+    // state, the first firing happens at exactly 3 events.
+    assert!(
+        !msgs.is_empty(),
+        "backward replay + 3 new events should fire correlation"
+    );
+    let first: serde_json::Value = serde_json::from_str(&msgs[0]).unwrap();
+    assert_eq!(first["rule_title"].as_str().unwrap(), "Brute Force");
+
+    // The first correlation's aggregated_value tells us if state was clean.
+    // With fresh state, it fires at exactly 3.0 (the threshold).
+    let agg = first["aggregated_value"].as_f64().unwrap();
+    assert_eq!(
+        agg, 3.0,
+        "first correlation should fire at exactly threshold (3.0), \
+         got {agg} which suggests state was not properly cleared"
+    );
+}
+
+/// Schema migration with NATS: old-format DB (no source position columns)
+/// should be auto-migrated when daemon starts, and new position data should
+/// be stored after processing.
+#[tokio::test]
+async fn daemon_nats_state_db_migration_stores_position() {
+    skip_without_docker!();
+    let (_container, nats_url) = start_nats_jetstream().await;
+    let rule = temp_file(".yml", BRUTE_FORCE_RULES);
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("state.db");
+
+    // Create old-format DB with a valid (empty) snapshot
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             CREATE TABLE rsigma_correlation_state (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 snapshot TEXT NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        let snap = r#"{"version":1,"windows":{},"last_alert":{},"event_buffers":{},"event_ref_buffers":{}}"#;
+        conn.execute(
+            "INSERT INTO rsigma_correlation_state (id, snapshot, updated_at) VALUES (1, ?1, ?2)",
+            params![snap, 1000i64],
+        )
+        .unwrap();
+    }
+
+    let input = format!("{nats_url}/e2e.mig.in");
+    let output = format!("{nats_url}/e2e.mig.out");
+
+    let client = async_nats::connect(&nats_url).await.unwrap();
+    let mut output_sub = client.subscribe("e2e.mig.out".to_string()).await.unwrap();
+
+    let mut daemon = DaemonProcess::spawn(&[
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--input",
+        &input,
+        "--output",
+        &output,
+        "--api-addr",
+        "127.0.0.1:0",
+        "--state-db",
+        db_path.to_str().unwrap(),
+        "--state-save-interval",
+        "1",
+        "--no-detections",
+    ]);
+    daemon.wait_for_ready("Sink started");
+
+    publish_and_flush(
+        &client,
+        "e2e.mig.in",
+        r#"{"EventType":"login_failure","src_ip":"10.0.0.1"}"#,
+    )
+    .await;
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    daemon.kill();
+
+    // Verify schema was migrated and source position is now stored
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(rsigma_correlation_state)")
+        .unwrap();
+    let columns: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+    assert!(
+        columns.contains(&"source_sequence".to_string()),
+        "schema should be migrated: {columns:?}"
+    );
+
+    let (seq, ts) = read_source_position(&db_path);
+    assert!(
+        seq.is_some(),
+        "source_sequence should be populated after processing"
+    );
+    assert!(
+        ts.is_some(),
+        "source_timestamp should be populated after processing"
+    );
+
+    let _ = collect_messages(&mut output_sub, 10, Duration::from_millis(100)).await;
 }

--- a/crates/rsigma-runtime/src/io/mod.rs
+++ b/crates/rsigma-runtime/src/io/mod.rs
@@ -51,6 +51,21 @@ impl AckToken {
             }
         }
     }
+
+    /// Extract the NATS JetStream stream sequence and published timestamp.
+    ///
+    /// Returns `None` for non-NATS tokens or if message info parsing fails.
+    /// The tuple is `(stream_sequence, published_unix_timestamp_secs)`.
+    #[cfg(feature = "nats")]
+    pub fn nats_stream_position(&self) -> Option<(u64, i64)> {
+        match self {
+            AckToken::Noop => None,
+            AckToken::Nats(msg) => msg
+                .info()
+                .ok()
+                .map(|info| (info.stream_sequence, info.published.unix_timestamp())),
+        }
+    }
 }
 
 /// An event payload bundled with its acknowledgment token.


### PR DESCRIPTION
## Summary

- Replace the blanket "skip state on any replay" heuristic with position-aware auto-restore. The daemon now tracks the NATS JetStream high-water mark (stream sequence + published timestamp) in SQLite alongside the correlation snapshot and compares the replay start point against it on restart: forward replay restores state (preserving cross-boundary correlation windows), backward replay skips state (avoiding double-counting).
- Add `--keep-state` / `--clear-state` as explicit operator overrides for cases where the automatic decision is not what you want.
- Wire `--timestamp-fallback wallclock|skip` to the CLI so forensic replay over logs without standard timestamp fields can opt into "detections only, no correlation updates."

### Behavior matrix

| Scenario | Old behavior | New behavior |
|---|---|---|
| `Resume` (default) | Restore | Restore (unchanged) |
| `--replay-from-sequence N` where N > stored | **Skip** | **Restore** (forward catch-up) |
| `--replay-from-sequence N` where N <= stored | Skip | Skip (unchanged) |
| `--replay-from-time T` where T > stored | **Skip** | **Restore** (forward catch-up) |
| `--replay-from-time T` where T <= stored | Skip | Skip (unchanged) |
| `--replay-from-latest` | Skip | Skip (unchanged) |
| `--clear-state` | Skip | Skip (unchanged) |
| `--keep-state` (new) | N/A | Restore (explicit override) |
| No stored position + any replay | Skip | Skip (unchanged, safe default) |

### Implementation

- **`AckToken::nats_stream_position()`** extracts `(stream_sequence, published_unix_timestamp)` from JetStream message metadata before acking.
- **`SourcePosition`** struct stored as `source_sequence` / `source_timestamp` INTEGER columns in SQLite (auto-migrated from old schema via `PRAGMA table_info` check).
- **`StateRestoreMode`** enum (`Auto` / `ForceClear` / `ForceKeep`) replaces the old `clear_correlation_state: bool` on `DaemonConfig`.
- **`decide_state_restore()`** encapsulates the full decision tree, testable in isolation.
- **High-water mark** tracked via `AtomicU64` / `AtomicI64` in the ack task, read by the periodic and shutdown state savers.
- **`--timestamp-fallback`** wired through `build_correlation_config` to set `TimestampFallback::Skip` on the `CorrelationConfig`.

## Test plan

- [x] 5 unit tests for `SqliteStateStore` (round-trip with/without position, position updates, old schema migration, empty DB)
- [x] 10 unit tests for `decide_state_restore` (ForceClear, ForceKeep, Resume, Latest, forward/backward/equal sequence, forward/backward time, no stored position)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (without NATS feature)
- [x] Existing NATS integration + E2E tests still pass
- [x] Manual: daemon with `--state-db`, shut down, restart with `--replay-from-sequence` above stored position, verify state restored
- [x] Manual: same with sequence below stored position, verify state cleared