### PR TITLE
feat: add per-rule labels to Prometheus metrics

### DIFF
--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -252,20 +252,29 @@ rsigma daemon \
 
 **Prometheus metrics:**
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `rsigma_events_processed_total` | counter | Total events processed |
-| `rsigma_detection_matches_total` | counter | Total detection matches |
-| `rsigma_correlation_matches_total` | counter | Total correlation matches |
-| `rsigma_events_parse_errors_total` | counter | JSON parse errors on input |
-| `rsigma_detection_rules_loaded` | gauge | Number of detection rules loaded |
-| `rsigma_correlation_rules_loaded` | gauge | Number of correlation rules loaded |
-| `rsigma_correlation_state_entries` | gauge | Active correlation state entries |
-| `rsigma_reloads_total` | counter | Total rule reload attempts |
-| `rsigma_reloads_failed_total` | counter | Failed rule reload attempts |
-| `rsigma_event_processing_seconds` | histogram | Per-event processing latency |
-| `rsigma_uptime_seconds` | gauge | Daemon uptime in seconds |
-| `rsigma_dlq_events_total` | counter | Events routed to the dead-letter queue |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `rsigma_events_processed_total` | counter | | Total events processed |
+| `rsigma_detection_matches_total` | counter | | Total detection matches (aggregate) |
+| `rsigma_detection_matches_by_rule_total` | counter | `rule_title`, `level` | Detection matches per rule |
+| `rsigma_correlation_matches_total` | counter | | Total correlation matches (aggregate) |
+| `rsigma_correlation_matches_by_rule_total` | counter | `rule_title`, `level`, `correlation_type` | Correlation matches per rule |
+| `rsigma_events_parse_errors_total` | counter | | JSON parse errors on input |
+| `rsigma_detection_rules_loaded` | gauge | | Number of detection rules loaded |
+| `rsigma_correlation_rules_loaded` | gauge | | Number of correlation rules loaded |
+| `rsigma_correlation_state_entries` | gauge | | Active correlation state entries |
+| `rsigma_reloads_total` | counter | | Total rule reload attempts |
+| `rsigma_reloads_failed_total` | counter | | Failed rule reload attempts |
+| `rsigma_event_processing_seconds` | histogram | | Per-event processing latency |
+| `rsigma_pipeline_latency_seconds` | histogram | | End-to-end latency from event dequeue to sink send |
+| `rsigma_batch_size` | histogram | | Number of events processed per batch |
+| `rsigma_input_queue_depth` | gauge | | Current events buffered in source-to-engine channel |
+| `rsigma_output_queue_depth` | gauge | | Current results buffered in engine-to-sink channel |
+| `rsigma_back_pressure_events_total` | counter | | Times a source was blocked on a full event channel |
+| `rsigma_uptime_seconds` | gauge | | Daemon uptime in seconds |
+| `rsigma_dlq_events_total` | counter | | Events routed to the dead-letter queue |
+
+The per-rule labeled counters (`_by_rule_total`) enable per-rule alerting in Grafana or other Prometheus-based tools. A single PromQL query like `increase(rsigma_detection_matches_by_rule_total[5m]) > 0` produces separate alert instances for each `{rule_title, level}` combination. The aggregate counters (`_total`) remain for lightweight total-throughput monitoring.
 
 **Logging:** structured JSON to stderr, configurable via `RUST_LOG` environment variable (default: `info`).
 

--- a/crates/rsigma-cli/src/daemon/metrics.rs
+++ b/crates/rsigma-cli/src/daemon/metrics.rs
@@ -1,5 +1,6 @@
 use prometheus::{
-    Gauge, Histogram, HistogramOpts, IntCounter, IntGauge, Opts, Registry, TextEncoder,
+    Gauge, Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, Opts, Registry,
+    TextEncoder,
 };
 use rsigma_runtime::MetricsHook;
 
@@ -23,6 +24,8 @@ pub struct Metrics {
     pub pipeline_latency: Histogram,
     pub batch_size_histogram: Histogram,
     pub dlq_events: IntCounter,
+    pub detection_matches_by_rule: IntCounterVec,
+    pub correlation_matches_by_rule: IntCounterVec,
 }
 
 impl Metrics {
@@ -126,6 +129,22 @@ impl Metrics {
             "Events routed to dead-letter queue",
         ))
         .unwrap();
+        let detection_matches_by_rule = IntCounterVec::new(
+            Opts::new(
+                "rsigma_detection_matches_by_rule_total",
+                "Detection matches per rule",
+            ),
+            &["rule_title", "level"],
+        )
+        .unwrap();
+        let correlation_matches_by_rule = IntCounterVec::new(
+            Opts::new(
+                "rsigma_correlation_matches_by_rule_total",
+                "Correlation matches per rule",
+            ),
+            &["rule_title", "level", "correlation_type"],
+        )
+        .unwrap();
 
         registry
             .register(Box::new(events_processed.clone()))
@@ -170,6 +189,12 @@ impl Metrics {
             .register(Box::new(batch_size_histogram.clone()))
             .unwrap();
         registry.register(Box::new(dlq_events.clone())).unwrap();
+        registry
+            .register(Box::new(detection_matches_by_rule.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(correlation_matches_by_rule.clone()))
+            .unwrap();
 
         Metrics {
             registry,
@@ -190,6 +215,8 @@ impl Metrics {
             pipeline_latency,
             batch_size_histogram,
             dlq_events,
+            detection_matches_by_rule,
+            correlation_matches_by_rule,
         }
     }
 
@@ -254,5 +281,79 @@ impl MetricsHook for Metrics {
 
     fn set_correlation_state_entries(&self, count: u64) {
         self.correlation_state_entries.set(count as i64);
+    }
+
+    fn on_detection_match_detail(&self, rule_title: &str, level: &str) {
+        self.detection_matches_by_rule
+            .with_label_values(&[rule_title, level])
+            .inc();
+    }
+
+    fn on_correlation_match_detail(&self, rule_title: &str, level: &str, correlation_type: &str) {
+        self.correlation_matches_by_rule
+            .with_label_values(&[rule_title, level, correlation_type])
+            .inc();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detection_matches_by_rule_labels() {
+        let m = Metrics::new();
+        m.on_detection_match_detail("Detect Whoami", "medium");
+        m.on_detection_match_detail("Detect Whoami", "medium");
+        m.on_detection_match_detail("Suspicious Login", "high");
+
+        assert_eq!(
+            m.detection_matches_by_rule
+                .with_label_values(&["Detect Whoami", "medium"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.detection_matches_by_rule
+                .with_label_values(&["Suspicious Login", "high"])
+                .get(),
+            1
+        );
+    }
+
+    #[test]
+    fn correlation_matches_by_rule_labels() {
+        let m = Metrics::new();
+        m.on_correlation_match_detail("Brute Force", "high", "event_count");
+        m.on_correlation_match_detail("Brute Force", "high", "event_count");
+        m.on_correlation_match_detail("Lateral Movement", "critical", "temporal");
+
+        assert_eq!(
+            m.correlation_matches_by_rule
+                .with_label_values(&["Brute Force", "high", "event_count"])
+                .get(),
+            2
+        );
+        assert_eq!(
+            m.correlation_matches_by_rule
+                .with_label_values(&["Lateral Movement", "critical", "temporal"])
+                .get(),
+            1
+        );
+    }
+
+    #[test]
+    fn labeled_counters_appear_in_encoded_output() {
+        let m = Metrics::new();
+        m.on_detection_match_detail("Test Rule", "high");
+        m.on_correlation_match_detail("Corr Rule", "medium", "event_count");
+
+        let output = m.encode();
+        assert!(output.contains("rsigma_detection_matches_by_rule_total"));
+        assert!(output.contains(r#"rule_title="Test Rule""#));
+        assert!(output.contains(r#"level="high""#));
+        assert!(output.contains("rsigma_correlation_matches_by_rule_total"));
+        assert!(output.contains(r#"rule_title="Corr Rule""#));
+        assert!(output.contains(r#"correlation_type="event_count""#));
     }
 }

--- a/crates/rsigma-cli/tests/cli_daemon_http.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_http.rs
@@ -260,3 +260,31 @@ fn ingest_updates_status_counters() {
         "detection_matches should be at least 1 for matching event"
     );
 }
+
+#[test]
+fn metrics_include_per_rule_labels_after_detection() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+
+    http_post(
+        &daemon.url("/api/v1/events"),
+        r#"{"CommandLine":"malware.exe"}"#,
+    );
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let (status, body) = http_get(&daemon.url("/metrics"));
+    assert_eq!(status, 200);
+    assert!(
+        body.contains("rsigma_detection_matches_by_rule_total"),
+        "metrics should contain per-rule detection counter"
+    );
+    assert!(
+        body.contains(r#"rule_title="Test Rule""#),
+        "metrics should contain rule_title label"
+    );
+    assert!(
+        body.contains(r#"level="high""#),
+        "metrics should contain level label"
+    );
+}

--- a/crates/rsigma-parser/src/ast.rs
+++ b/crates/rsigma-parser/src/ast.rs
@@ -54,6 +54,18 @@ pub enum Level {
     Critical,
 }
 
+impl Level {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Level::Informational => "informational",
+            Level::Low => "low",
+            Level::Medium => "medium",
+            Level::High => "high",
+            Level::Critical => "critical",
+        }
+    }
+}
+
 impl FromStr for Level {
     type Err = ();
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -467,6 +479,21 @@ pub enum CorrelationType {
     ValueAvg,
     ValuePercentile,
     ValueMedian,
+}
+
+impl CorrelationType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CorrelationType::EventCount => "event_count",
+            CorrelationType::ValueCount => "value_count",
+            CorrelationType::Temporal => "temporal",
+            CorrelationType::TemporalOrdered => "temporal_ordered",
+            CorrelationType::ValueSum => "value_sum",
+            CorrelationType::ValueAvg => "value_avg",
+            CorrelationType::ValuePercentile => "value_percentile",
+            CorrelationType::ValueMedian => "value_median",
+        }
+    }
 }
 
 impl FromStr for CorrelationType {

--- a/crates/rsigma-runtime/src/metrics.rs
+++ b/crates/rsigma-runtime/src/metrics.rs
@@ -24,6 +24,17 @@ pub trait MetricsHook: Send + Sync {
     fn observe_pipeline_latency(&self, seconds: f64);
     /// Report current correlation state entry count.
     fn set_correlation_state_entries(&self, count: u64);
+
+    /// A single detection rule matched. Labels enable per-rule Prometheus counters.
+    fn on_detection_match_detail(&self, _rule_title: &str, _level: &str) {}
+    /// A single correlation rule matched. Labels enable per-rule Prometheus counters.
+    fn on_correlation_match_detail(
+        &self,
+        _rule_title: &str,
+        _level: &str,
+        _correlation_type: &str,
+    ) {
+    }
 }
 
 /// No-op implementation for use when metrics are disabled (e.g., `rsigma run`).

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -123,6 +123,20 @@ impl LogProcessor {
             self.metrics
                 .on_correlation_matches(result.correlations.len() as u64);
 
+            for det in &result.detections {
+                let level_str = det.level.as_ref().map_or("unknown", |l| l.as_str());
+                self.metrics
+                    .on_detection_match_detail(&det.rule_title, level_str);
+            }
+            for cor in &result.correlations {
+                let level_str = cor.level.as_ref().map_or("unknown", |l| l.as_str());
+                self.metrics.on_correlation_match_detail(
+                    &cor.rule_title,
+                    level_str,
+                    cor.correlation_type.as_str(),
+                );
+            }
+
             line_results[*line_idx].detections.extend(result.detections);
             line_results[*line_idx]
                 .correlations
@@ -206,6 +220,20 @@ impl LogProcessor {
                 .on_detection_matches(result.detections.len() as u64);
             self.metrics
                 .on_correlation_matches(result.correlations.len() as u64);
+
+            for det in &result.detections {
+                let level_str = det.level.as_ref().map_or("unknown", |l| l.as_str());
+                self.metrics
+                    .on_detection_match_detail(&det.rule_title, level_str);
+            }
+            for cor in &result.correlations {
+                let level_str = cor.level.as_ref().map_or("unknown", |l| l.as_str());
+                self.metrics.on_correlation_match_detail(
+                    &cor.rule_title,
+                    level_str,
+                    cor.correlation_type.as_str(),
+                );
+            }
 
             line_results[*line_idx].detections.extend(result.detections);
             line_results[*line_idx]


### PR DESCRIPTION
## Summary

- Add `rsigma_detection_matches_by_rule_total{rule_title, level}` and `rsigma_correlation_matches_by_rule_total{rule_title, level, correlation_type}` as labeled `IntCounterVec` metrics alongside the existing aggregate counters.
- Extend the `MetricsHook` trait with two new default methods (`on_detection_match_detail`, `on_correlation_match_detail`) so `NoopMetrics` and external consumers remain backward-compatible.
- Add `Level::as_str()` and `CorrelationType::as_str()` to `rsigma-parser` for label string conversion.
- Update the README metrics table to include all 19 metrics with a Labels column.

## What this enables

A single PromQL query like `increase(rsigma_detection_matches_by_rule_total[5m]) > 0` produces separate alert instances for each `{rule_title, level}` combination, replacing the need for N individual alert rules. This is inspired by the Grafana Managed Alerting's [dynamic labels](https://grafana.com/docs/grafana/latest/alerting/examples/dynamic-labels/) feature.

## Test plan

- [x] 3 unit tests in `daemon/metrics.rs`: detection label values, correlation label values, encoded output contains new families
- [x] 1 E2E test in `cli_daemon_http.rs`: ingest event, verify `/metrics` contains `rsigma_detection_matches_by_rule_total` with correct labels
- [x] All existing tests pass (zero regressions across full workspace)
- [x] `cargo fmt` and `cargo clippy` clean