### PR TITLE
feat: add `rsigma fields` subcommand for field catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A complete Rust toolkit for the [Sigma](https://github.com/SigmaHQ/sigma) detect
 | [`rsigma-eval`](crates/rsigma-eval/) | Compile and evaluate rules against JSON events |
 | [`rsigma-convert`](crates/rsigma-convert/) | Transform rules into backend-native query strings |
 | [`rsigma-runtime`](crates/rsigma-runtime/) | Streaming runtime with input adapters, log processor, and hot-reload |
-| [`rsigma`](crates/rsigma-cli/) | CLI for parsing, validating, linting, evaluating, converting rules, and running a detection daemon |
+| [`rsigma`](crates/rsigma-cli/) | CLI for parsing, validating, linting, evaluating, converting rules, field catalog, and running a detection daemon |
 | [`rsigma-lsp`](crates/rsigma-lsp/) | Language Server Protocol (LSP) server for IDE support |
 
 > [!TIP]
@@ -176,6 +176,12 @@ rsigma convert rules/ -t postgres -O table=okta_events -O json_field=data -O tim
 
 # LynxDB search queries
 rsigma convert rules/ -t lynxdb
+
+# List all fields referenced by a ruleset
+rsigma fields -r rules/
+
+# Show fields after pipeline mapping
+rsigma fields -r rules/ -p ecs.yml --json
 
 # List available backends and formats
 rsigma list-targets

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/rsigma/actions/workflows/ci.yml)
 
-`rsigma` is a command-line interface for parsing, validating, linting, evaluating, converting, and running [Sigma](https://github.com/SigmaHQ/sigma) detection rules as a long-running daemon.
+`rsigma` is a command-line interface for parsing, validating, linting, evaluating, converting, inspecting field usage, and running [Sigma](https://github.com/SigmaHQ/sigma) detection rules as a long-running daemon.
 
 This binary is part of the [rsigma workspace].
 
@@ -32,6 +32,9 @@ rsigma convert -r rules/ -t test
 
 # Convert to PostgreSQL SQL
 rsigma convert -r rules/ -t postgres
+
+# List all fields referenced by rules (with optional pipeline mapping)
+rsigma fields -r rules/ -p pipelines/ecs.yml
 
 # List available conversion backends
 rsigma list-targets
@@ -543,6 +546,49 @@ rsigma list-formats postgres
 #   continuous_aggregate CREATE MATERIALIZED VIEW ... WITH (timescaledb.continuous)
 #   sliding_window       Correlation queries using window functions for per-row sliding detection
 ```
+
+### `fields`: List all fields referenced by Sigma rules
+
+Extract and display every field name referenced across detection rules, correlation rules, filter rules, and rule metadata. Useful for building a field catalog, auditing pipeline coverage, or understanding which fields a ruleset depends on.
+
+When pipelines are provided, fields are shown after pipeline transformations (field name mappings, prefixes, suffixes), so you can verify that your pipeline maps every field your rules need.
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `--rules` / `-r` | path | required | Path to a Sigma rule file or directory |
+| `--pipeline` / `-p` | repeatable | `[]` | Processing pipeline YAML file(s). When provided, fields are shown after transformations |
+| `--no-filters` | flag | `false` | Exclude fields contributed by filter rules |
+| `--json` | flag | `false` | Output as JSON instead of a table |
+
+**Field sources:** each field is annotated with where it was found:
+
+| Source | Description |
+|--------|-------------|
+| `detection` | Field names from detection block items (`selection`, `filter`, etc.) |
+| `correlation` | `group-by` fields, `condition.field`, and alias mapping values |
+| `filter` | Fields from filter rule detection blocks |
+| `metadata` | Fields listed in the rule's `fields:` metadata section |
+
+```bash
+# List all fields in a ruleset
+rsigma fields -r rules/
+
+# Show fields after ECS pipeline mapping
+rsigma fields -r rules/ -p pipelines/ecs.yml
+
+# Exclude filter-contributed fields
+rsigma fields -r rules/ --no-filters
+
+# JSON output for scripting
+rsigma fields -r rules/ --json
+
+# Pipe JSON to jq for further analysis
+rsigma fields -r rules/ --json | jq '.fields[] | select(.sources[] == "detection") | .field'
+```
+
+**Table output** writes field data to stdout and a summary line to stderr, so you can pipe the table or redirect it without mixing in summary text.
+
+**JSON output** includes a `summary` object (rule/correlation/filter counts, unique fields, pipelines applied), a `fields` array, and when pipelines are applied, a `pipeline_mappings` array showing each field name transformation.
 
 ### `condition`: Parse a condition expression
 

--- a/crates/rsigma-cli/src/commands/fields.rs
+++ b/crates/rsigma-cli/src/commands/fields.rs
@@ -1,0 +1,386 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use rsigma_eval::{Pipeline, apply_pipelines};
+use rsigma_parser::{
+    CorrelationCondition, CorrelationRule, Detection, DetectionItem, Detections, FilterRule,
+    SigmaCollection, SigmaRule,
+};
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+pub(crate) fn cmd_fields(
+    path: PathBuf,
+    pipeline_paths: Vec<PathBuf>,
+    no_filters: bool,
+    json: bool,
+) {
+    let collection = crate::load_collection(&path);
+    let pipelines = crate::load_pipelines(&pipeline_paths);
+
+    let report = build_report(&collection, &pipelines, no_filters);
+
+    if json {
+        crate::print_json(&report, true);
+    } else {
+        print_table(&report);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Report types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+struct FieldsReport {
+    summary: Summary,
+    fields: Vec<FieldEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pipeline_mappings: Vec<PipelineMapping>,
+}
+
+#[derive(Debug, Serialize)]
+struct Summary {
+    total_rules: usize,
+    total_correlations: usize,
+    total_filters: usize,
+    unique_fields: usize,
+    pipelines_applied: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct FieldEntry {
+    field: String,
+    rule_count: usize,
+    sources: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PipelineMapping {
+    original: String,
+    mapped_to: Vec<String>,
+    pipeline: String,
+}
+
+// ---------------------------------------------------------------------------
+// Field collection
+// ---------------------------------------------------------------------------
+
+/// Tracks where a field was seen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum FieldSource {
+    Detection,
+    Correlation,
+    Filter,
+    Metadata,
+}
+
+impl FieldSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            FieldSource::Detection => "detection",
+            FieldSource::Correlation => "correlation",
+            FieldSource::Filter => "filter",
+            FieldSource::Metadata => "metadata",
+        }
+    }
+}
+
+struct FieldCollector {
+    /// field_name -> (set of rule titles that reference it, set of source types)
+    fields: BTreeMap<String, (BTreeSet<String>, BTreeSet<FieldSource>)>,
+}
+
+impl FieldCollector {
+    fn new() -> Self {
+        Self {
+            fields: BTreeMap::new(),
+        }
+    }
+
+    fn add(&mut self, field: &str, rule_title: &str, source: FieldSource) {
+        let entry = self
+            .fields
+            .entry(field.to_string())
+            .or_insert_with(|| (BTreeSet::new(), BTreeSet::new()));
+        entry.0.insert(rule_title.to_string());
+        entry.1.insert(source);
+    }
+
+    fn collect_detection_items(
+        &mut self,
+        detection: &Detection,
+        rule_title: &str,
+        source: FieldSource,
+    ) {
+        match detection {
+            Detection::AllOf(items) => {
+                for item in items {
+                    self.collect_item(item, rule_title, source);
+                }
+            }
+            Detection::AnyOf(subs) => {
+                for sub in subs {
+                    self.collect_detection_items(sub, rule_title, source);
+                }
+            }
+            Detection::Keywords(_) => {}
+        }
+    }
+
+    fn collect_item(&mut self, item: &DetectionItem, rule_title: &str, source: FieldSource) {
+        if let Some(ref name) = item.field.name {
+            self.add(name, rule_title, source);
+        }
+    }
+
+    fn collect_detections(
+        &mut self,
+        detections: &Detections,
+        rule_title: &str,
+        source: FieldSource,
+    ) {
+        for det in detections.named.values() {
+            self.collect_detection_items(det, rule_title, source);
+        }
+    }
+
+    fn collect_rule(&mut self, rule: &SigmaRule) {
+        self.collect_detections(&rule.detection, &rule.title, FieldSource::Detection);
+        for f in &rule.fields {
+            self.add(f, &rule.title, FieldSource::Metadata);
+        }
+    }
+
+    fn collect_correlation(&mut self, corr: &CorrelationRule) {
+        for f in &corr.group_by {
+            self.add(f, &corr.title, FieldSource::Correlation);
+        }
+        if let CorrelationCondition::Threshold {
+            field: Some(ref fields),
+            ..
+        } = corr.condition
+        {
+            for f in fields {
+                self.add(f, &corr.title, FieldSource::Correlation);
+            }
+        }
+        for alias in &corr.aliases {
+            for mapped_field in alias.mapping.values() {
+                self.add(mapped_field, &corr.title, FieldSource::Correlation);
+            }
+        }
+        for f in &corr.fields {
+            self.add(f, &corr.title, FieldSource::Metadata);
+        }
+    }
+
+    fn collect_filter(&mut self, filter: &FilterRule) {
+        self.collect_detections(&filter.detection, &filter.title, FieldSource::Filter);
+        for f in &filter.fields {
+            self.add(f, &filter.title, FieldSource::Metadata);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline mapping extraction
+// ---------------------------------------------------------------------------
+
+fn extract_pipeline_mappings(pipelines: &[Pipeline]) -> Vec<PipelineMapping> {
+    use rsigma_eval::pipeline::transformations::Transformation;
+
+    let mut mappings = Vec::new();
+    for pipeline in pipelines {
+        for item in &pipeline.transformations {
+            match &item.transformation {
+                Transformation::FieldNameMapping { mapping } => {
+                    for (from, to) in mapping {
+                        mappings.push(PipelineMapping {
+                            original: from.clone(),
+                            mapped_to: to.clone(),
+                            pipeline: pipeline.name.clone(),
+                        });
+                    }
+                }
+                Transformation::FieldNamePrefixMapping { mapping } => {
+                    for (prefix, replacement) in mapping {
+                        mappings.push(PipelineMapping {
+                            original: format!("{prefix}*"),
+                            mapped_to: vec![format!("{replacement}*")],
+                            pipeline: pipeline.name.clone(),
+                        });
+                    }
+                }
+                Transformation::FieldNamePrefix { prefix } => {
+                    mappings.push(PipelineMapping {
+                        original: "*".to_string(),
+                        mapped_to: vec![format!("{prefix}*")],
+                        pipeline: pipeline.name.clone(),
+                    });
+                }
+                Transformation::FieldNameSuffix { suffix } => {
+                    mappings.push(PipelineMapping {
+                        original: "*".to_string(),
+                        mapped_to: vec![format!("*{suffix}")],
+                        pipeline: pipeline.name.clone(),
+                    });
+                }
+                Transformation::FieldNameTransform { mapping, .. } => {
+                    for (from, to) in mapping {
+                        mappings.push(PipelineMapping {
+                            original: from.clone(),
+                            mapped_to: vec![to.clone()],
+                            pipeline: pipeline.name.clone(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    mappings
+}
+
+// ---------------------------------------------------------------------------
+// Report building
+// ---------------------------------------------------------------------------
+
+fn build_report(
+    collection: &SigmaCollection,
+    pipelines: &[Pipeline],
+    no_filters: bool,
+) -> FieldsReport {
+    let mut collector = FieldCollector::new();
+
+    if pipelines.is_empty() {
+        for rule in &collection.rules {
+            collector.collect_rule(rule);
+        }
+        for corr in &collection.correlations {
+            collector.collect_correlation(corr);
+        }
+    } else {
+        for rule in &collection.rules {
+            let mut transformed = rule.clone();
+            if let Err(e) = apply_pipelines(pipelines, &mut transformed) {
+                eprintln!("Warning: pipeline error for '{}': {e}", rule.title);
+                collector.collect_rule(rule);
+                continue;
+            }
+            collector.collect_rule(&transformed);
+        }
+        for corr in &collection.correlations {
+            collector.collect_correlation(corr);
+        }
+    }
+
+    if !no_filters {
+        for filter in &collection.filters {
+            collector.collect_filter(filter);
+        }
+    }
+
+    let pipeline_mappings = extract_pipeline_mappings(pipelines);
+
+    let fields: Vec<FieldEntry> = collector
+        .fields
+        .into_iter()
+        .map(|(name, (rules, sources))| FieldEntry {
+            field: name,
+            rule_count: rules.len(),
+            sources: sources.iter().map(|s| s.as_str().to_string()).collect(),
+        })
+        .collect();
+
+    let unique_fields = fields.len();
+
+    FieldsReport {
+        summary: Summary {
+            total_rules: collection.rules.len(),
+            total_correlations: collection.correlations.len(),
+            total_filters: collection.filters.len(),
+            unique_fields,
+            pipelines_applied: pipelines.len(),
+        },
+        fields,
+        pipeline_mappings,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Table output
+// ---------------------------------------------------------------------------
+
+fn print_table(report: &FieldsReport) {
+    let s = &report.summary;
+    eprintln!(
+        "Rules: {} detection, {} correlation, {} filter | Pipelines: {} | Unique fields: {}",
+        s.total_rules, s.total_correlations, s.total_filters, s.pipelines_applied, s.unique_fields
+    );
+
+    if report.fields.is_empty() {
+        eprintln!("No fields found.");
+        return;
+    }
+
+    let max_field = report
+        .fields
+        .iter()
+        .map(|f| f.field.len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let max_sources = report
+        .fields
+        .iter()
+        .map(|f| f.sources.join(", ").len())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+
+    eprintln!();
+    println!(
+        "{:<width_f$}  {:>5}  {:<width_s$}",
+        "FIELD",
+        "RULES",
+        "SOURCES",
+        width_f = max_field,
+        width_s = max_sources,
+    );
+    println!(
+        "{:<width_f$}  {:>5}  {:<width_s$}",
+        "-".repeat(max_field),
+        "-----",
+        "-".repeat(max_sources),
+        width_f = max_field,
+        width_s = max_sources,
+    );
+
+    for entry in &report.fields {
+        println!(
+            "{:<width_f$}  {:>5}  {:<width_s$}",
+            entry.field,
+            entry.rule_count,
+            entry.sources.join(", "),
+            width_f = max_field,
+            width_s = max_sources,
+        );
+    }
+
+    if !report.pipeline_mappings.is_empty() {
+        eprintln!();
+        eprintln!("Pipeline field mappings:");
+        for m in &report.pipeline_mappings {
+            eprintln!(
+                "  {} -> {} ({})",
+                m.original,
+                m.mapped_to.join(" | "),
+                m.pipeline
+            );
+        }
+    }
+}

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -1,11 +1,13 @@
 mod convert;
 mod eval;
+mod fields;
 mod lint;
 mod parse;
 mod validate;
 
 pub(crate) use convert::{cmd_convert, cmd_list_formats, cmd_list_targets};
 pub(crate) use eval::cmd_eval;
+pub(crate) use fields::cmd_fields;
 pub(crate) use lint::cmd_lint;
 pub(crate) use parse::{cmd_condition, cmd_parse, cmd_stdin};
 pub(crate) use validate::cmd_validate;

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -432,6 +432,30 @@ enum Commands {
         /// Target backend name
         target: String,
     },
+
+    /// List all fields referenced by Sigma rules
+    ///
+    /// Extracts field names from detection blocks, correlation group-by/condition
+    /// fields, filter detections, and rule metadata. Optionally applies pipelines
+    /// to show post-mapping field names.
+    Fields {
+        /// Path to a Sigma rule file or directory of rules
+        #[arg(short, long)]
+        rules: PathBuf,
+
+        /// Processing pipeline YAML file(s) to apply (can be specified multiple times).
+        /// When provided, fields are shown after pipeline transformations.
+        #[arg(short = 'p', long = "pipeline")]
+        pipelines: Vec<PathBuf>,
+
+        /// Exclude fields from filter rules
+        #[arg(long)]
+        no_filters: bool,
+
+        /// Output as JSON instead of a table
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 fn main() {
@@ -642,6 +666,12 @@ fn main() {
         ),
         Commands::ListTargets => commands::cmd_list_targets(),
         Commands::ListFormats { target } => commands::cmd_list_formats(target),
+        Commands::Fields {
+            rules,
+            pipelines,
+            no_filters,
+            json,
+        } => commands::cmd_fields(rules, pipelines, no_filters, json),
     }
 }
 

--- a/crates/rsigma-cli/tests/cli_fields.rs
+++ b/crates/rsigma-cli/tests/cli_fields.rs
@@ -456,7 +456,10 @@ fn fields_json_with_filter() {
     assert_eq!(json["summary"]["total_filters"], 1);
 
     let fields = json["fields"].as_array().unwrap();
-    let target_user = fields.iter().find(|f| f["field"] == "TargetUserName").unwrap();
+    let target_user = fields
+        .iter()
+        .find(|f| f["field"] == "TargetUserName")
+        .unwrap();
     assert_eq!(target_user["rule_count"], 3);
     let sources = target_user["sources"].as_array().unwrap();
     assert!(sources.iter().any(|s| s == "filter"));

--- a/crates/rsigma-cli/tests/cli_fields.rs
+++ b/crates/rsigma-cli/tests/cli_fields.rs
@@ -1,0 +1,566 @@
+//! Integration tests for the `fields` subcommand.
+//!
+//! Uses insta inline snapshot testing for stdout/stderr output verification.
+
+mod common;
+
+use common::{rsigma, temp_file};
+use insta::assert_snapshot;
+use tempfile::TempDir;
+
+const SIMPLE_DETECTION: &str = r#"
+title: Detect Whoami
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\cmd.exe'
+        CommandLine|contains:
+            - '/c'
+            - '/k'
+    condition: selection
+level: medium
+"#;
+
+const RULE_WITH_FIELDS_METADATA: &str = r#"
+title: Failed Login
+id: failed-login
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4625
+        TargetUserName|endswith: '@company.com'
+    condition: selection
+fields:
+    - SourceIP
+    - LogonType
+level: medium
+"#;
+
+const CORRELATION_RULES: &str = r#"
+title: Failed Login
+id: failed-login
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4625
+        TargetUserName|endswith: '@company.com'
+    condition: selection
+fields:
+    - SourceIP
+    - LogonType
+level: medium
+---
+title: Brute Force
+correlation:
+    type: event_count
+    rules:
+        - failed-login
+    group-by:
+        - TargetUserName
+        - SourceIP
+    timespan: 5m
+    condition:
+        gte: 10
+level: high
+"#;
+
+const WITH_FILTER: &str = r#"
+title: Failed Login
+id: failed-login
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4625
+        TargetUserName|endswith: '@company.com'
+    condition: selection
+fields:
+    - SourceIP
+    - LogonType
+level: medium
+---
+title: Brute Force
+correlation:
+    type: event_count
+    rules:
+        - failed-login
+    group-by:
+        - TargetUserName
+        - SourceIP
+    timespan: 5m
+    condition:
+        gte: 10
+level: high
+---
+title: Exclude Service Accounts
+logsource:
+    product: windows
+    service: security
+filter:
+    rules:
+        - failed-login
+    selection:
+        TargetUserName|startswith: 'svc_'
+    condition: selection
+"#;
+
+const VALUE_COUNT_CORRELATION: &str = r#"
+title: DNS Query
+id: dns-query
+logsource:
+    category: dns
+detection:
+    selection:
+        QueryType: A
+    condition: selection
+---
+title: Too Many Unique Domains
+correlation:
+    type: value_count
+    rules:
+        - dns-query
+    group-by:
+        - SourceIP
+    timespan: 10m
+    condition:
+        field: QueryName
+        gte: 50
+level: high
+"#;
+
+const FIELD_ALIAS_CORRELATION: &str = r#"
+title: Login Attempt
+id: login-attempt
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: login
+    condition: selection
+---
+title: SSH Login
+id: ssh-login
+logsource:
+    category: ssh
+detection:
+    selection:
+        action: login
+    condition: selection
+---
+title: Cross-Source Login Correlation
+correlation:
+    type: temporal
+    rules:
+        - login-attempt
+        - ssh-login
+    group-by:
+        - user
+    timespan: 5m
+    condition:
+        gte: 1
+    aliases:
+        user:
+            login-attempt: UserName
+            ssh-login: ssh_user
+level: high
+"#;
+
+const PIPELINE_YAML: &str = r#"
+name: ecs-mapping
+priority: 10
+transformations:
+  - type: field_name_mapping
+    mapping:
+      CommandLine: process.command_line
+      Image: process.executable
+    rule_conditions:
+      - type: logsource
+        product: windows
+"#;
+
+const KEYWORDS_ONLY: &str = r#"
+title: Keyword Rule
+logsource:
+    category: test
+detection:
+    keywords:
+        - 'malware'
+        - 'virus'
+    condition: keywords
+level: high
+"#;
+
+// ---------------------------------------------------------------------------
+// Basic field extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fields_simple_detection() {
+    let rule = temp_file(".yml", SIMPLE_DETECTION);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD        RULES  SOURCES  
+    -----------  -----  ---------
+    CommandLine      1  detection
+    Image            1  detection
+    ");
+    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r"
+    Rules: 1 detection, 0 correlation, 0 filter | Pipelines: 0 | Unique fields: 2
+
+    ");
+}
+
+#[test]
+fn fields_with_metadata_fields() {
+    let rule = temp_file(".yml", RULE_WITH_FIELDS_METADATA);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD           RULES  SOURCES  
+    --------------  -----  ---------
+    EventID             1  detection
+    LogonType           1  metadata 
+    SourceIP            1  metadata 
+    TargetUserName      1  detection
+    ");
+}
+
+#[test]
+fn fields_correlation_adds_group_by() {
+    let rule = temp_file(".yml", CORRELATION_RULES);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD           RULES  SOURCES               
+    --------------  -----  ----------------------
+    EventID             1  detection             
+    LogonType           1  metadata              
+    SourceIP            2  correlation, metadata 
+    TargetUserName      2  detection, correlation
+    ");
+    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r"
+    Rules: 1 detection, 1 correlation, 0 filter | Pipelines: 0 | Unique fields: 4
+
+    ");
+}
+
+#[test]
+fn fields_value_count_condition_field() {
+    let rule = temp_file(".yml", VALUE_COUNT_CORRELATION);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD      RULES  SOURCES    
+    ---------  -----  -----------
+    QueryName      1  correlation
+    QueryType      1  detection  
+    SourceIP       1  correlation
+    ");
+}
+
+#[test]
+fn fields_alias_mapping_values() {
+    let rule = temp_file(".yml", FIELD_ALIAS_CORRELATION);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD      RULES  SOURCES    
+    ---------  -----  -----------
+    EventType      1  detection  
+    UserName       1  correlation
+    action         1  detection  
+    ssh_user       1  correlation
+    user           1  correlation
+    ");
+}
+
+#[test]
+fn fields_keywords_only_rule_has_no_fields() {
+    let rule = temp_file(".yml", KEYWORDS_ONLY);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unique fields: 0"));
+    assert!(stderr.contains("No fields found."));
+}
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fields_includes_filters_by_default() {
+    let rule = temp_file(".yml", WITH_FILTER);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD           RULES  SOURCES                       
+    --------------  -----  ------------------------------
+    EventID             1  detection                     
+    LogonType           1  metadata                      
+    SourceIP            2  correlation, metadata         
+    TargetUserName      3  detection, correlation, filter
+    ");
+    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r"
+    Rules: 1 detection, 1 correlation, 1 filter | Pipelines: 0 | Unique fields: 4
+
+    ");
+}
+
+#[test]
+fn fields_no_filters_excludes_filter_fields() {
+    let rule = temp_file(".yml", WITH_FILTER);
+    let output = rsigma()
+        .args([
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--no-filters",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD           RULES  SOURCES               
+    --------------  -----  ----------------------
+    EventID             1  detection             
+    LogonType           1  metadata              
+    SourceIP            2  correlation, metadata 
+    TargetUserName      2  detection, correlation
+    ");
+}
+
+// ---------------------------------------------------------------------------
+// Pipelines
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fields_with_pipeline_transforms_names() {
+    let rule = temp_file(".yml", SIMPLE_DETECTION);
+    let pipeline = temp_file(".yml", PIPELINE_YAML);
+    let output = rsigma()
+        .args([
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "-p",
+            pipeline.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD                 RULES  SOURCES  
+    --------------------  -----  ---------
+    process.command_line      1  detection
+    process.executable        1  detection
+    ");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Pipelines: 1"));
+    assert!(stderr.contains("Pipeline field mappings:"));
+    assert!(stderr.contains("CommandLine -> process.command_line"));
+    assert!(stderr.contains("Image -> process.executable"));
+}
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fields_json_output() {
+    let rule = temp_file(".yml", SIMPLE_DETECTION);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap(), "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(json["summary"]["total_rules"], 1);
+    assert_eq!(json["summary"]["unique_fields"], 2);
+    assert_eq!(json["summary"]["pipelines_applied"], 0);
+    let fields = json["fields"].as_array().unwrap();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0]["field"], "CommandLine");
+    assert_eq!(fields[1]["field"], "Image");
+}
+
+#[test]
+fn fields_json_with_pipeline_includes_mappings() {
+    let rule = temp_file(".yml", SIMPLE_DETECTION);
+    let pipeline = temp_file(".yml", PIPELINE_YAML);
+    let output = rsigma()
+        .args([
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "-p",
+            pipeline.path().to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(json["summary"]["pipelines_applied"], 1);
+    let mappings = json["pipeline_mappings"].as_array().unwrap();
+    assert!(mappings.len() >= 2);
+    let originals: Vec<&str> = mappings
+        .iter()
+        .map(|m| m["original"].as_str().unwrap())
+        .collect();
+    assert!(originals.contains(&"CommandLine"));
+    assert!(originals.contains(&"Image"));
+}
+
+#[test]
+fn fields_json_with_filter() {
+    let rule = temp_file(".yml", WITH_FILTER);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap(), "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(json["summary"]["total_filters"], 1);
+
+    let fields = json["fields"].as_array().unwrap();
+    let target_user = fields.iter().find(|f| f["field"] == "TargetUserName").unwrap();
+    assert_eq!(target_user["rule_count"], 3);
+    let sources = target_user["sources"].as_array().unwrap();
+    assert!(sources.iter().any(|s| s == "filter"));
+}
+
+#[test]
+fn fields_json_snapshot() {
+    let rule = temp_file(".yml", CORRELATION_RULES);
+    let output = rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap(), "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r#"
+    {
+      "summary": {
+        "total_rules": 1,
+        "total_correlations": 1,
+        "total_filters": 0,
+        "unique_fields": 4,
+        "pipelines_applied": 0
+      },
+      "fields": [
+        {
+          "field": "EventID",
+          "rule_count": 1,
+          "sources": [
+            "detection"
+          ]
+        },
+        {
+          "field": "LogonType",
+          "rule_count": 1,
+          "sources": [
+            "metadata"
+          ]
+        },
+        {
+          "field": "SourceIP",
+          "rule_count": 2,
+          "sources": [
+            "correlation",
+            "metadata"
+          ]
+        },
+        {
+          "field": "TargetUserName",
+          "rule_count": 2,
+          "sources": [
+            "detection",
+            "correlation"
+          ]
+        }
+      ]
+    }
+    "#);
+}
+
+// ---------------------------------------------------------------------------
+// Directory of rules
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fields_directory_of_rules() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("rule_a.yml"), SIMPLE_DETECTION).unwrap();
+    std::fs::write(dir.path().join("rule_b.yml"), RULE_WITH_FIELDS_METADATA).unwrap();
+
+    let output = rsigma()
+        .args(["fields", "-r", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r"
+    FIELD           RULES  SOURCES  
+    --------------  -----  ---------
+    CommandLine         1  detection
+    EventID             1  detection
+    Image               1  detection
+    LogonType           1  metadata 
+    SourceIP            1  metadata 
+    TargetUserName      1  detection
+    ");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Rules: 2 detection"));
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fields_nonexistent_path() {
+    rsigma()
+        .args(["fields", "-r", "/nonexistent/path"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn fields_missing_rules_arg() {
+    rsigma()
+        .args(["fields"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--rules"));
+}


### PR DESCRIPTION
## Summary

- Add `rsigma fields` subcommand that extracts and lists all field names referenced across detection rules, correlation rules (group-by, condition fields, alias mappings), filter rules, and rule metadata (`fields:` section).
- Supports pipeline application (`-p`) to show post-mapping field names, `--no-filters` to exclude filter-contributed fields, and `--json` for machine-readable output with summary stats and pipeline mapping details.
- 16 integration tests with insta inline snapshots covering all field source types, pipeline transforms, JSON output, directory loading, keyword-only rules, and error cases.
- Updated both READMEs with subcommand documentation, examples, and flag reference.

## Test plan

- [x] `cargo test -p rsigma --test cli_fields` passes all 16 tests
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] CI passes on all platforms (ubuntu, macos, windows)