### PR TITLE
feat: add structured exit codes for CI/CD scripting

### DIFF
--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -87,6 +87,7 @@ Run 66 built-in lint rules with optional JSON schema validation.
 | `--config` | path | none | Explicit path to `.rsigma-lint.yml` (otherwise auto-discovered by walking ancestor directories) |
 | `--exclude` | string | none | Glob pattern for paths to skip (repeatable, relative to lint root) |
 | `--fix` | flag | `false` | Automatically apply safe fixes (lowercase keys, correct typos, remove duplicates, etc.) |
+| `--fail-level` | string | `"error"` | Minimum severity for non-zero exit: `error` (default), `warning`, or `info` |
 
 ```bash
 rsigma lint path/to/rules/                     # lint all rules
@@ -99,6 +100,8 @@ rsigma lint rules/ --config my-lint.yml        # explicit config file
 rsigma lint rules/ --exclude "config/**"       # skip non-rule files
 rsigma lint rules/ --exclude "config/**" --exclude "**/unsupported/**"  # multiple patterns
 rsigma lint rules/ --fix                       # auto-fix safe issues
+rsigma lint rules/ --fail-level warning        # CI: fail on warnings too
+rsigma lint rules/ --fail-level info           # CI: fail on any finding
 ```
 
 **Lint output summary format:**
@@ -352,6 +355,7 @@ Evaluate JSON events against Sigma detection and correlation rules.
 | `--timestamp-field` | repeatable | `[]` | Event field(s) for timestamp extraction (prepended to the default list) |
 | `--input-format` | string | `"auto"` | Input log format: `auto`, `json`, `syslog`, `plain`, `logfmt`\*, `cef`\* |
 | `--syslog-tz` | string | `"+00:00"` | Default timezone for RFC 3164 syslog (e.g. `+05:00`, `-08:00`) |
+| `--fail-on-detection` | flag | `false` | Exit with code 1 when any detection or correlation fires. Useful for CI/CD pipelines |
 
 \* Feature-gated: `logfmt` requires the `logfmt` feature, `cef` requires the `cef` feature.
 
@@ -728,8 +732,27 @@ cargo build --release --no-default-features
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success (no errors found for lint; matches may or may not exist for eval) |
-| `1` | Error: parse failure, validation error, lint errors found, missing required argument, invalid argument value |
+| `0` | Success. For `eval`: events processed (detections may or may not have fired, unless `--fail-on-detection` is set). For `lint`: no findings at the configured `--fail-level`. For `validate`: all rules parsed and compiled. |
+| `1` | Findings. For `eval --fail-on-detection`: at least one detection or correlation fired. For `lint`: at least one finding at or above `--fail-level` severity. |
+| `2` | Rule error. A Sigma rule could not be parsed, compiled, or converted. |
+| `3` | Configuration error. A pipeline file could not be loaded, a CLI argument was invalid, or the tool was otherwise misconfigured. |
+
+### CI/CD flags
+
+Use `--fail-on-detection` with `eval` to fail a CI pipeline when a detection rule matches:
+
+```bash
+rsigma eval -r rules/ --fail-on-detection -e @test-events.ndjson
+echo $?  # 0 = no detections, 1 = detections fired, 2 = rule error, 3 = config error
+```
+
+Use `--fail-level` with `lint` to control the minimum severity that triggers a non-zero exit:
+
+```bash
+rsigma lint rules/ --fail-level warning   # exit 1 on warnings or errors
+rsigma lint rules/ --fail-level info      # exit 1 on any finding
+rsigma lint rules/                        # default: exit 1 only on errors
+```
 
 ## License
 

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -19,7 +19,7 @@ fn get_backend(
         _ => {
             eprintln!("Unknown target: {target}");
             eprintln!("Available targets: postgres, lynxdb, test");
-            process::exit(1);
+            process::exit(crate::exit_code::CONFIG_ERROR);
         }
     }
 }
@@ -52,7 +52,7 @@ pub(crate) fn cmd_convert(
             "Backend '{}' requires a pipeline. Use -p or --without-pipeline.",
             target
         );
-        process::exit(1);
+        process::exit(crate::exit_code::CONFIG_ERROR);
     }
 
     if !backend.formats().iter().any(|(f, _)| *f == format) {
@@ -66,7 +66,7 @@ pub(crate) fn cmd_convert(
                 .collect::<Vec<_>>()
                 .join(", ")
         );
-        process::exit(1);
+        process::exit(crate::exit_code::CONFIG_ERROR);
     }
 
     let result =
@@ -81,7 +81,7 @@ pub(crate) fn cmd_convert(
                 }
             }
             if !skip_unsupported && !output_data.errors.is_empty() {
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             }
             let all_queries: Vec<&str> = output_data
                 .queries
@@ -93,7 +93,7 @@ pub(crate) fn cmd_convert(
         }
         Err(e) => {
             eprintln!("Conversion failed: {e}");
-            process::exit(1);
+            process::exit(crate::exit_code::RULE_ERROR);
         }
     }
 }
@@ -125,7 +125,7 @@ fn load_collection_multi(paths: &[PathBuf]) -> SigmaCollection {
                 }
                 Err(e) => {
                     eprintln!("Error parsing directory {}: {e}", path.display());
-                    process::exit(1);
+                    process::exit(crate::exit_code::RULE_ERROR);
                 }
             }
         } else if path.is_file() {
@@ -137,17 +137,17 @@ fn load_collection_multi(paths: &[PathBuf]) -> SigmaCollection {
                 }
                 Err(e) => {
                     eprintln!("Error parsing {}: {e}", path.display());
-                    process::exit(1);
+                    process::exit(crate::exit_code::RULE_ERROR);
                 }
             }
         } else {
             eprintln!("Path not found: {}", path.display());
-            process::exit(1);
+            process::exit(crate::exit_code::RULE_ERROR);
         }
     }
     if collection.rules.is_empty() && collection.correlations.is_empty() {
         eprintln!("No rules found in specified path(s)");
-        process::exit(1);
+        process::exit(crate::exit_code::RULE_ERROR);
     }
     collection
 }
@@ -157,7 +157,7 @@ fn write_output(content: &str, output: Option<&std::path::Path>) {
         Some(path) => {
             if let Err(e) = std::fs::write(path, content) {
                 eprintln!("Error writing to {}: {e}", path.display());
-                process::exit(1);
+                process::exit(crate::exit_code::CONFIG_ERROR);
             }
         }
         None => println!("{content}"),

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -26,7 +26,7 @@ fn resolve_event_source(event_json: Option<String>) -> EventSource {
             let path = PathBuf::from(&s[1..]);
             if !path.exists() {
                 eprintln!("Event file not found: {}", path.display());
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             }
             EventSource::NdjsonFile(path)
         }
@@ -35,6 +35,7 @@ fn resolve_event_source(event_json: Option<String>) -> EventSource {
     }
 }
 
+/// Returns `true` if any detection or correlation matched.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn cmd_eval(
     rules_path: PathBuf,
@@ -52,7 +53,7 @@ pub(crate) fn cmd_eval(
     timestamp_fields: Vec<String>,
     input_format: String,
     syslog_tz: String,
-) {
+) -> bool {
     let collection = crate::load_collection(&rules_path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
     let has_correlations = !collection.correlations.is_empty();
@@ -83,7 +84,7 @@ pub(crate) fn cmd_eval(
             include_event,
             &input_format,
             &syslog_tz,
-        );
+        )
     } else {
         cmd_eval_detection_only(
             collection,
@@ -95,11 +96,11 @@ pub(crate) fn cmd_eval(
             include_event,
             &input_format,
             &syslog_tz,
-        );
+        )
     }
 }
 
-/// Evaluation with correlations (stateful).
+/// Evaluation with correlations (stateful). Returns `true` if any match fired.
 #[allow(clippy::too_many_arguments)]
 fn cmd_eval_with_correlations(
     collection: SigmaCollection,
@@ -112,7 +113,7 @@ fn cmd_eval_with_correlations(
     include_event: bool,
     input_format_str: &str,
     syslog_tz_str: &str,
-) {
+) -> bool {
     let mut engine = CorrelationEngine::new(config);
     engine.set_include_event(include_event);
     for p in pipelines {
@@ -120,7 +121,7 @@ fn cmd_eval_with_correlations(
     }
     if let Err(e) = engine.add_collection(&collection) {
         eprintln!("Error compiling rules: {e}");
-        process::exit(1);
+        process::exit(crate::exit_code::RULE_ERROR);
     }
 
     eprintln!(
@@ -136,10 +137,11 @@ fn cmd_eval_with_correlations(
                 Ok(v) => v,
                 Err(e) => {
                     eprintln!("Invalid JSON event: {e}");
-                    process::exit(1);
+                    process::exit(crate::exit_code::RULE_ERROR);
                 }
             };
 
+            let mut had_matches = false;
             for payload in crate::apply_event_filter(&value, event_filter) {
                 let event = JsonEvent::borrow(&payload);
                 let result = engine.process_event(&event);
@@ -148,6 +150,7 @@ fn cmd_eval_with_correlations(
                 if total == 0 {
                     eprintln!("No matches.");
                 } else {
+                    had_matches = true;
                     for m in &result.detections {
                         crate::print_json(m, pretty);
                     }
@@ -156,11 +159,12 @@ fn cmd_eval_with_correlations(
                     }
                 }
             }
+            had_matches
         }
         EventSource::NdjsonFile(path) => {
             let file = File::open(&path).unwrap_or_else(|e| {
                 eprintln!("Error opening event file '{}': {e}", path.display());
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             });
             let reader = BufReader::new(file);
             let (det_count, corr_count, line_num) = eval_stream_corr(
@@ -174,6 +178,7 @@ fn cmd_eval_with_correlations(
             eprintln!(
                 "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
             );
+            det_count > 0 || corr_count > 0
         }
         EventSource::Stdin => {
             let stdin = io::stdin();
@@ -188,6 +193,7 @@ fn cmd_eval_with_correlations(
             eprintln!(
                 "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
             );
+            det_count > 0 || corr_count > 0
         }
     }
 }
@@ -331,7 +337,7 @@ fn eval_line_corr_json(
     }
 }
 
-/// Evaluation without correlations (stateless, original behavior).
+/// Evaluation without correlations (stateless). Returns `true` if any match fired.
 #[allow(clippy::too_many_arguments)]
 fn cmd_eval_detection_only(
     collection: SigmaCollection,
@@ -343,7 +349,7 @@ fn cmd_eval_detection_only(
     include_event: bool,
     input_format_str: &str,
     syslog_tz_str: &str,
-) {
+) -> bool {
     let mut engine = Engine::new();
     engine.set_include_event(include_event);
     for p in pipelines {
@@ -351,7 +357,7 @@ fn cmd_eval_detection_only(
     }
     if let Err(e) = engine.add_collection(&collection) {
         eprintln!("Error compiling rules: {e}");
-        process::exit(1);
+        process::exit(crate::exit_code::RULE_ERROR);
     }
 
     eprintln!(
@@ -366,10 +372,11 @@ fn cmd_eval_detection_only(
                 Ok(v) => v,
                 Err(e) => {
                     eprintln!("Invalid JSON event: {e}");
-                    process::exit(1);
+                    process::exit(crate::exit_code::RULE_ERROR);
                 }
             };
 
+            let mut had_matches = false;
             let payloads = crate::apply_event_filter(&value, event_filter);
             if payloads.is_empty() {
                 eprintln!("No matches.");
@@ -381,17 +388,19 @@ fn cmd_eval_detection_only(
                     if matches.is_empty() {
                         eprintln!("No matches.");
                     } else {
+                        had_matches = true;
                         for m in &matches {
                             crate::print_json(m, pretty);
                         }
                     }
                 }
             }
+            had_matches
         }
         EventSource::NdjsonFile(path) => {
             let file = File::open(&path).unwrap_or_else(|e| {
                 eprintln!("Error opening event file '{}': {e}", path.display());
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             });
             let reader = BufReader::new(file);
             let (match_count, line_num) = eval_stream_detect(
@@ -403,6 +412,7 @@ fn cmd_eval_detection_only(
                 syslog_tz_str,
             );
             eprintln!("Processed {line_num} events, {match_count} matches.");
+            match_count > 0
         }
         EventSource::Stdin => {
             let stdin = io::stdin();
@@ -415,6 +425,7 @@ fn cmd_eval_detection_only(
                 syslog_tz_str,
             );
             eprintln!("Processed {line_num} events, {match_count} matches.");
+            match_count > 0
         }
     }
 }

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -6,6 +6,13 @@ use std::time::SystemTime;
 use rsigma_parser::lint::{self, FileLintResult, LintConfig};
 use serde::Deserialize;
 
+/// Counts returned by `cmd_lint` so the caller can decide the exit code.
+pub(crate) struct LintCounts {
+    pub errors: usize,
+    pub warnings: usize,
+    pub infos: usize,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn cmd_lint(
     path: PathBuf,
@@ -16,7 +23,7 @@ pub(crate) fn cmd_lint(
     lint_config_path: Option<PathBuf>,
     exclude: Vec<String>,
     apply_fix: bool,
-) {
+) -> LintCounts {
     let p = Painter::new(color);
 
     // 0. Build lint config from file + CLI flags
@@ -28,7 +35,7 @@ pub(crate) fn cmd_lint(
             Ok(r) => r,
             Err(e) => {
                 eprintln!("Error: {e}");
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             }
         }
     } else {
@@ -36,7 +43,7 @@ pub(crate) fn cmd_lint(
             Ok(r) => vec![r],
             Err(e) => {
                 eprintln!("Error: {e}");
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             }
         }
     };
@@ -181,8 +188,10 @@ pub(crate) fn cmd_lint(
         }
     }
 
-    if total_errors > 0 {
-        process::exit(1);
+    LintCounts {
+        errors: total_errors,
+        warnings: total_warnings,
+        infos: total_infos,
     }
 }
 
@@ -224,7 +233,7 @@ fn resolve_schema(schema_arg: &str) -> String {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("Error reading schema file '{schema_arg}': {e}");
-                process::exit(1);
+                process::exit(crate::exit_code::CONFIG_ERROR);
             }
         }
     }
@@ -257,7 +266,7 @@ fn resolve_default_schema() -> String {
         Ok(response) => {
             let body = response.into_body().read_to_string().unwrap_or_else(|e| {
                 eprintln!("Error reading schema response: {e}");
-                process::exit(1);
+                process::exit(crate::exit_code::CONFIG_ERROR);
             });
 
             // Cache it
@@ -278,7 +287,7 @@ fn resolve_default_schema() -> String {
                 content
             } else {
                 eprintln!("Error downloading schema: {e}");
-                process::exit(1);
+                process::exit(crate::exit_code::CONFIG_ERROR);
             }
         }
     }
@@ -291,13 +300,13 @@ fn run_schema_validation(path: &std::path::Path, schema_arg: &str) -> Vec<FileLi
         Ok(v) => v,
         Err(e) => {
             eprintln!("Error parsing schema JSON: {e}");
-            process::exit(1);
+            process::exit(crate::exit_code::CONFIG_ERROR);
         }
     };
 
     let validator = jsonschema::validator_for(&schema_value).unwrap_or_else(|e| {
         eprintln!("Error compiling JSON schema: {e}");
-        process::exit(1);
+        process::exit(crate::exit_code::CONFIG_ERROR);
     });
 
     let mut results = Vec::new();
@@ -444,7 +453,7 @@ fn build_lint_config(
             }
             Err(e) => {
                 eprintln!("Error loading lint config '{}': {e}", explicit.display());
-                process::exit(1);
+                process::exit(crate::exit_code::CONFIG_ERROR);
             }
         }
     } else if let Some(found) = LintConfig::find_in_ancestors(path) {

--- a/crates/rsigma-cli/src/commands/parse.rs
+++ b/crates/rsigma-cli/src/commands/parse.rs
@@ -12,7 +12,7 @@ pub(crate) fn cmd_parse(path: PathBuf, pretty: bool) {
         }
         Err(e) => {
             eprintln!("Error parsing {}: {e}", path.display());
-            process::exit(1);
+            process::exit(crate::exit_code::RULE_ERROR);
         }
     }
 }
@@ -22,7 +22,7 @@ pub(crate) fn cmd_condition(expr: String) {
         Ok(ast) => crate::print_json(&ast, true),
         Err(e) => {
             eprintln!("Condition parse error: {e}");
-            process::exit(1);
+            process::exit(crate::exit_code::RULE_ERROR);
         }
     }
 }
@@ -31,7 +31,7 @@ pub(crate) fn cmd_stdin(pretty: bool) {
     let mut input = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut input) {
         eprintln!("Error reading stdin: {e}");
-        process::exit(1);
+        process::exit(crate::exit_code::RULE_ERROR);
     }
 
     match parse_sigma_yaml(&input) {
@@ -41,7 +41,7 @@ pub(crate) fn cmd_stdin(pretty: bool) {
         }
         Err(e) => {
             eprintln!("Parse error: {e}");
-            process::exit(1);
+            process::exit(crate::exit_code::RULE_ERROR);
         }
     }
 }

--- a/crates/rsigma-cli/src/commands/validate.rs
+++ b/crates/rsigma-cli/src/commands/validate.rs
@@ -60,12 +60,12 @@ pub(crate) fn cmd_validate(path: PathBuf, verbose: bool, pipeline_paths: Vec<Pat
             }
 
             if parse_errors > 0 || !compile_errors.is_empty() {
-                process::exit(1);
+                process::exit(crate::exit_code::RULE_ERROR);
             }
         }
         Err(e) => {
             eprintln!("Error: {e}");
-            process::exit(1);
+            process::exit(crate::exit_code::RULE_ERROR);
         }
     }
 }

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -93,7 +93,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     let state_store = config.state_db.as_ref().map(|path| {
         let store = SqliteStateStore::open(path).unwrap_or_else(|e| {
             tracing::error!(error = %e, path = %path.display(), "Failed to open state database");
-            std::process::exit(1);
+            std::process::exit(crate::exit_code::CONFIG_ERROR);
         });
         tracing::info!(path = %path.display(), "State database opened");
         Arc::new(store)
@@ -126,7 +126,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
         Err(e) => {
             tracing::error!(error = %e, "Failed to load initial rules");
-            std::process::exit(1);
+            std::process::exit(crate::exit_code::RULE_ERROR);
         }
     }
 
@@ -230,7 +230,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         .await
         .unwrap_or_else(|e| {
             tracing::error!(addr = %config.api_addr, error = %e, "Failed to bind API server");
-            std::process::exit(1);
+            std::process::exit(crate::exit_code::CONFIG_ERROR);
         });
     let actual_addr = listener.local_addr().unwrap_or(config.api_addr);
 
@@ -368,7 +368,7 @@ pub async fn run_daemon(config: DaemonConfig) {
                 }
                 Err(e) => {
                     tracing::error!(error = %e, url = url, "Failed to connect NATS source");
-                    std::process::exit(1);
+                    std::process::exit(crate::exit_code::CONFIG_ERROR);
                 }
             }
         }
@@ -377,7 +377,7 @@ pub async fn run_daemon(config: DaemonConfig) {
                 input = other,
                 "Unsupported input source (supported: stdin, http, nats://)"
             );
-            std::process::exit(1);
+            std::process::exit(crate::exit_code::CONFIG_ERROR);
         }
     };
 
@@ -719,7 +719,7 @@ async fn build_sink(
             }
             Err(e) => {
                 tracing::error!(path = %path.display(), error = %e, "Failed to open file sink");
-                std::process::exit(1);
+                std::process::exit(crate::exit_code::CONFIG_ERROR);
             }
         };
     }
@@ -736,7 +736,7 @@ async fn build_sink(
             }
             Err(e) => {
                 tracing::error!(error = %e, url = url, "Failed to connect NATS sink");
-                std::process::exit(1);
+                std::process::exit(crate::exit_code::CONFIG_ERROR);
             }
         };
     }
@@ -745,7 +745,7 @@ async fn build_sink(
         output = spec,
         "Unsupported output sink (supported: stdout, file://<path>, nats://)"
     );
-    std::process::exit(1);
+    std::process::exit(crate::exit_code::CONFIG_ERROR);
 }
 
 /// Parse a nats:// URL into (server_url, subject).

--- a/crates/rsigma-cli/src/exit_code.rs
+++ b/crates/rsigma-cli/src/exit_code.rs
@@ -1,0 +1,26 @@
+//! Structured exit codes for CI/CD scripting.
+//!
+//! These codes let callers distinguish between "the tool ran successfully but
+//! found something" (detections, lint findings) and "the tool could not run
+//! because of a configuration or rule error."
+
+/// Operation completed successfully.
+/// For `eval`: events were processed (detections may or may not have fired).
+/// For `lint`: no findings at the configured severity threshold.
+/// For `validate`: all rules parsed and compiled.
+#[allow(dead_code)]
+pub const SUCCESS: i32 = 0;
+
+/// Findings were produced.
+/// For `eval --fail-on-detection`: at least one detection or correlation fired.
+/// For `lint --fail-level`: at least one finding at or above the threshold.
+pub const FINDINGS: i32 = 1;
+
+/// Rule syntax, parse, or compilation error.
+/// The input rules could not be loaded or compiled.
+pub const RULE_ERROR: i32 = 2;
+
+/// Pipeline, configuration, or invalid argument error.
+/// A pipeline file could not be loaded, a CLI argument was invalid,
+/// or the tool was misconfigured.
+pub const CONFIG_ERROR: i32 = 3;

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 #[cfg(feature = "daemon")]
 mod daemon;
+pub(crate) mod exit_code;
 mod fix;
 
 use std::path::PathBuf;
@@ -106,6 +107,14 @@ enum Commands {
         /// Applies format-preserving fixes to files on disk.
         #[arg(long)]
         fix: bool,
+
+        /// Minimum severity that causes a non-zero exit code.
+        /// 'error' (default): exit 1 only when errors are found.
+        /// 'warning': exit 1 when warnings or errors are found.
+        /// 'info': exit 1 when any findings (info, warning, error) are found.
+        #[arg(long = "fail-level", default_value = "error",
+               value_parser = ["error", "warning", "info"])]
+        fail_level: String,
     },
 
     /// Run as a long-running daemon with hot-reload, health checks, and metrics
@@ -388,6 +397,11 @@ enum Commands {
         /// Only used when --input-format is syslog or auto. Defaults to UTC.
         #[arg(long = "syslog-tz", default_value = "+00:00")]
         syslog_tz: String,
+
+        /// Exit with code 1 when any detection or correlation fires.
+        /// Useful in CI/CD pipelines to fail a build on detection.
+        #[arg(long = "fail-on-detection")]
+        fail_on_detection: bool,
     },
 
     /// Convert Sigma rules to backend-native queries
@@ -534,7 +548,7 @@ fn main() {
                     time::OffsetDateTime::parse(ts, &time::format_description::well_known::Rfc3339)
                         .unwrap_or_else(|e| {
                             eprintln!("Invalid --replay-from-time '{ts}': {e}");
-                            process::exit(1);
+                            process::exit(exit_code::CONFIG_ERROR);
                         });
                 rsigma_runtime::ReplayPolicy::FromTime(t)
             } else if replay_from_latest {
@@ -600,16 +614,27 @@ fn main() {
             lint_config,
             exclude,
             fix: apply_fix,
-        } => commands::cmd_lint(
-            path,
-            schema,
-            verbose,
-            &color,
-            disable,
-            lint_config,
-            exclude,
-            apply_fix,
-        ),
+            fail_level,
+        } => {
+            let counts = commands::cmd_lint(
+                path,
+                schema,
+                verbose,
+                &color,
+                disable,
+                lint_config,
+                exclude,
+                apply_fix,
+            );
+            let should_fail = match fail_level.as_str() {
+                "info" => counts.errors > 0 || counts.warnings > 0 || counts.infos > 0,
+                "warning" => counts.errors > 0 || counts.warnings > 0,
+                _ => counts.errors > 0,
+            };
+            if should_fail {
+                process::exit(exit_code::FINDINGS);
+            }
+        }
         Commands::Condition { expr } => commands::cmd_condition(expr),
         Commands::Stdin { pretty } => commands::cmd_stdin(pretty),
         Commands::Eval {
@@ -628,23 +653,29 @@ fn main() {
             timestamp_fields,
             input_format,
             syslog_tz,
-        } => commands::cmd_eval(
-            rules,
-            event,
-            pretty,
-            pipelines,
-            jq,
-            jsonpath,
-            suppress,
-            action,
-            no_detections,
-            include_event,
-            correlation_event_mode,
-            max_correlation_events,
-            timestamp_fields,
-            input_format,
-            syslog_tz,
-        ),
+            fail_on_detection,
+        } => {
+            let had_matches = commands::cmd_eval(
+                rules,
+                event,
+                pretty,
+                pipelines,
+                jq,
+                jsonpath,
+                suppress,
+                action,
+                no_detections,
+                include_event,
+                correlation_event_mode,
+                max_correlation_events,
+                timestamp_fields,
+                input_format,
+                syslog_tz,
+            );
+            if fail_on_detection && had_matches {
+                process::exit(exit_code::FINDINGS);
+            }
+        }
         Commands::Convert {
             rules,
             target,
@@ -749,7 +780,7 @@ fn cmd_daemon(
 
     let addr: std::net::SocketAddr = api_addr.parse().unwrap_or_else(|e| {
         eprintln!("Invalid API address '{api_addr}': {e}");
-        process::exit(1);
+        process::exit(exit_code::CONFIG_ERROR);
     });
 
     #[cfg(feature = "daemon-nats")]
@@ -796,7 +827,7 @@ fn cmd_daemon(
         .build()
         .unwrap_or_else(|e| {
             eprintln!("Failed to create Tokio runtime: {e}");
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         });
 
     rt.block_on(daemon::run_daemon(config));
@@ -816,7 +847,7 @@ pub(crate) fn load_pipelines(paths: &[PathBuf]) -> Vec<Pipeline> {
             }
             Err(e) => {
                 eprintln!("Error loading pipeline {}: {e}", path.display());
-                process::exit(1);
+                process::exit(exit_code::CONFIG_ERROR);
             }
         }
     }
@@ -830,7 +861,7 @@ pub(crate) fn load_collection(path: &std::path::Path) -> SigmaCollection {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("Error loading rules from {}: {e}", path.display());
-                process::exit(1);
+                process::exit(exit_code::RULE_ERROR);
             }
         }
     } else {
@@ -838,7 +869,7 @@ pub(crate) fn load_collection(path: &std::path::Path) -> SigmaCollection {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("Error loading rule {}: {e}", path.display());
-                process::exit(1);
+                process::exit(exit_code::RULE_ERROR);
             }
         }
     };
@@ -872,7 +903,7 @@ pub(crate) fn print_json(value: &impl serde::Serialize, pretty: bool) {
         Ok(j) => println!("{j}"),
         Err(e) => {
             eprintln!("JSON serialization error: {e}");
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         }
     }
 }
@@ -908,7 +939,7 @@ pub(crate) fn parse_input_format(format_str: &str, syslog_tz: &str) -> rsigma_ru
             eprintln!("  (with logfmt feature): logfmt");
             #[cfg(feature = "cef")]
             eprintln!("  (with cef feature): cef");
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         }
     }
 }
@@ -927,22 +958,22 @@ fn parse_tz_offset(s: &str) -> i32 {
         (-1i32, rest)
     } else {
         eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
-        process::exit(1);
+        process::exit(exit_code::CONFIG_ERROR);
     };
 
     let parts: Vec<&str> = rest.split(':').collect();
     if parts.len() != 2 {
         eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
-        process::exit(1);
+        process::exit(exit_code::CONFIG_ERROR);
     }
 
     let hours: i32 = parts[0].parse().unwrap_or_else(|_| {
         eprintln!("Invalid timezone offset hours: '{}'", parts[0]);
-        process::exit(1);
+        process::exit(exit_code::CONFIG_ERROR);
     });
     let minutes: i32 = parts[1].parse().unwrap_or_else(|_| {
         eprintln!("Invalid timezone offset minutes: '{}'", parts[1]);
-        process::exit(1);
+        process::exit(exit_code::CONFIG_ERROR);
     });
 
     sign * (hours * 3600 + minutes * 60)
@@ -970,16 +1001,16 @@ pub(crate) fn build_event_filter(jq: Option<String>, jsonpath: Option<String>) -
         let (parsed, errs) = jaq_parse::parse(&jq_expr, jaq_parse::main());
         if !errs.is_empty() {
             eprintln!("Invalid jq filter: {:?}", errs);
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         }
         let Some(parsed) = parsed else {
             eprintln!("Invalid jq filter: failed to parse '{jq_expr}'");
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         };
         let filter = defs.compile(parsed);
         if !defs.errs.is_empty() {
             eprintln!("jq compilation errors ({} error(s))", defs.errs.len());
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         }
         EventFilter::Jq(filter)
     } else if let Some(jp_expr) = jsonpath {
@@ -988,7 +1019,7 @@ pub(crate) fn build_event_filter(jq: Option<String>, jsonpath: Option<String>) -
             Ok(path) => EventFilter::JsonPath(path),
             Err(e) => {
                 eprintln!("Invalid JSONPath: {e}");
-                process::exit(1);
+                process::exit(exit_code::CONFIG_ERROR);
             }
         }
     } else {
@@ -1010,7 +1041,7 @@ pub(crate) fn build_correlation_config(
         Ok(ts) => ts.seconds,
         Err(e) => {
             eprintln!("Invalid suppress duration '{s}': {e}");
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         }
     });
 
@@ -1018,7 +1049,7 @@ pub(crate) fn build_correlation_config(
         .map(|s| {
             s.parse::<CorrelationAction>().unwrap_or_else(|e| {
                 eprintln!("{e}");
-                process::exit(1);
+                process::exit(exit_code::CONFIG_ERROR);
             })
         })
         .unwrap_or_default();
@@ -1027,7 +1058,7 @@ pub(crate) fn build_correlation_config(
         .parse::<CorrelationEventMode>()
         .unwrap_or_else(|e| {
             eprintln!("{e}");
-            process::exit(1);
+            process::exit(exit_code::CONFIG_ERROR);
         });
 
     let ts_fallback = match timestamp_fallback {


### PR DESCRIPTION
## Summary

- Introduce categorized exit codes (0 SUCCESS, 1 FINDINGS, 2 RULE_ERROR, 3 CONFIG_ERROR) so CI/CD pipelines can distinguish "the tool found something" from "the tool broke."
- Add `eval --fail-on-detection` flag to exit 1 when any detection or correlation fires.
- Add `lint --fail-level <error|warning|info>` flag to control the severity threshold that triggers a non-zero exit.
- Replace all blanket `process::exit(1)` calls across every subcommand (`eval`, `lint`, `validate`, `convert`, `parse`) and the daemon with the appropriate categorized code.

## Test results

All tests verified manually on `feat/structured-exit-codes` @ 9453f86.

### Automated

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo test --workspace` -- all passing

### Manual: `eval --fail-on-detection`

| Test | Command | Expected | Actual |
|------|---------|----------|--------|
| Match + flag | `rsigma eval --fail-on-detection -r rule.yml -e '{"CommandLine":"mimikatz.exe …"}'` | exit 1 | **exit 1** |
| No match + flag | `rsigma eval --fail-on-detection -r rule.yml -e '{"CommandLine":"whoami"}'` | exit 0 | **exit 0** |
| Match, no flag | `rsigma eval -r rule.yml -e '{"CommandLine":"mimikatz.exe …"}'` | exit 0 | **exit 0** |
| Match + flag + @file | `rsigma eval --fail-on-detection -r rule.yml -e @match.json` | exit 1 | **exit 1** |

### Manual: `lint --fail-level`

| Test | Command | Expected | Actual |
|------|---------|----------|--------|
| Default (error) | `rsigma lint rule.yml` (has warnings + infos, no errors) | exit 0 | **exit 0** |
| `--fail-level warning` | `rsigma lint --fail-level warning rule.yml` | exit 1 | **exit 1** |
| `--fail-level info` | `rsigma lint --fail-level info rule.yml` | exit 1 | **exit 1** |

### Manual: categorized error codes

| Test | Command | Expected | Actual |
|------|---------|----------|--------|
| Bad rule syntax | `rsigma eval -r bad_syntax.yml -e '{…}'` | exit 2 (RULE_ERROR) | **exit 2** |
| Nonexistent pipeline | `rsigma eval -r rule.yml -p nonexistent.yml -e '{…}'` | exit 3 (CONFIG_ERROR) | **exit 3** |