### PR TITLE
feat: hot-reload pipeline files alongside rules

### DIFF
--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -116,7 +116,7 @@ Checked N file(s): X passed, Y failed (A error(s), B warning(s), C info(s))
 
 Run rsigma as a long-running daemon that continuously reads NDJSON from stdin, evaluates against rules, writes matches to stdout, and exposes health/metrics/management APIs over HTTP.
 
-Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-reload: adding, modifying, or removing `.yml`/`.yaml` files in the rules directory triggers an automatic reload. SIGHUP and the `/api/v1/reload` endpoint also trigger reloads. The daemon is designed for production deployment behind a log collector (e.g. `hel run | rsigma daemon ...`) or an event bus.
+Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-reload: adding, modifying, or removing `.yml`/`.yaml` files in the rules directory or any pipeline file passed via `-p` triggers an automatic reload (rules and pipelines are re-read together). SIGHUP and the `/api/v1/reload` endpoint also trigger reloads. The daemon is designed for production deployment behind a log collector (e.g. `hel run | rsigma daemon ...`) or an event bus.
 
 > [!TIP]
 > Correlation rules also work in `eval` mode within a single run (via stdin or `@file`), but daemon mode is recommended for continuous stateful tracking with hot-reload and state persistence.
@@ -694,6 +694,7 @@ The `event` field is present only when `--include-event` is set.
 - Each `-p PATH` loads one pipeline file.
 - Pipelines are sorted by `priority` (ascending); lower priority runs first.
 - All pipelines are applied in sequence to each rule before compilation.
+- In daemon mode, pipeline files are watched for changes and re-read on reload (alongside rules). If a pipeline file becomes invalid, the reload fails and the previous configuration stays active.
 - `merge_pipelines` is not used by the CLI; each pipeline remains separate with its own state.
 
 ## Environment Variables

--- a/crates/rsigma-cli/src/daemon/reload.rs
+++ b/crates/rsigma-cli/src/daemon/reload.rs
@@ -4,8 +4,12 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 
 /// Watches a path for file changes and sends reload signals via a channel.
+///
+/// In addition to the rules path, optionally watches pipeline file paths.
+/// Any YAML change in watched paths triggers a reload signal.
 pub fn spawn_file_watcher(
     rules_path: &Path,
+    pipeline_paths: &[&Path],
     reload_tx: mpsc::Sender<()>,
 ) -> Option<RecommendedWatcher> {
     let tx = reload_tx.clone();
@@ -40,6 +44,19 @@ pub fn spawn_file_watcher(
     }
 
     tracing::info!(path = %rules_path.display(), "Watching rules directory for changes");
+
+    for path in pipeline_paths {
+        if let Err(e) = watcher.watch(path, RecursiveMode::NonRecursive) {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "Could not watch pipeline file"
+            );
+        } else {
+            tracing::info!(path = %path.display(), "Watching pipeline file for changes");
+        }
+    }
+
     Some(watcher)
 }
 

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -62,6 +62,7 @@ struct AppState {
 pub struct DaemonConfig {
     pub rules_path: PathBuf,
     pub pipelines: Vec<Pipeline>,
+    pub pipeline_paths: Vec<PathBuf>,
     pub corr_config: CorrelationConfig,
     pub include_event: bool,
     pub pretty: bool,
@@ -99,12 +100,13 @@ pub async fn run_daemon(config: DaemonConfig) {
         Arc::new(store)
     });
 
-    let engine = RuntimeEngine::new(
+    let mut engine = RuntimeEngine::new(
         config.rules_path.clone(),
         config.pipelines.clone(),
         config.corr_config.clone(),
         config.include_event,
     );
+    engine.set_pipeline_paths(config.pipeline_paths.clone());
     let processor = Arc::new(LogProcessor::new(engine, metrics.clone()));
 
     // Initial rule load
@@ -176,12 +178,15 @@ pub async fn run_daemon(config: DaemonConfig) {
 
     let (reload_tx, mut reload_rx) = mpsc::channel::<()>(4);
 
-    // File watcher for hot-reload
+    // File watcher for hot-reload (rules + pipeline files)
+    let pipeline_watch_paths: Vec<&std::path::Path> =
+        config.pipeline_paths.iter().map(|p| p.as_path()).collect();
     let _watcher = if config.rules_path.is_dir() {
-        reload::spawn_file_watcher(&config.rules_path, reload_tx.clone())
+        reload::spawn_file_watcher(&config.rules_path, &pipeline_watch_paths, reload_tx.clone())
     } else {
         reload::spawn_file_watcher(
             config.rules_path.parent().unwrap_or(&config.rules_path),
+            &pipeline_watch_paths,
             reload_tx.clone(),
         )
     };
@@ -267,7 +272,7 @@ pub async fn run_daemon(config: DaemonConfig) {
             while reload_rx.try_recv().is_ok() {}
 
             reload_metrics.reloads_total.inc();
-            tracing::info!("Reloading rules...");
+            tracing::info!("Reloading rules and pipelines...");
 
             match reload_processor.reload_rules() {
                 Ok(stats) => {
@@ -275,7 +280,7 @@ pub async fn run_daemon(config: DaemonConfig) {
                         detection_rules = stats.detection_rules,
                         correlation_rules = stats.correlation_rules,
                         path = %reload_processor.rules_path().display(),
-                        "Rules reloaded"
+                        "Rules and pipelines reloaded"
                     );
                     reload_metrics
                         .detection_rules_loaded

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -799,6 +799,7 @@ fn cmd_daemon(
     let config = daemon::server::DaemonConfig {
         rules_path,
         pipelines,
+        pipeline_paths,
         corr_config,
         include_event,
         pretty,

--- a/crates/rsigma-runtime/src/engine.rs
+++ b/crates/rsigma-runtime/src/engine.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rsigma_eval::event::Event;
 use rsigma_eval::{
     CorrelationConfig, CorrelationEngine, CorrelationSnapshot, Engine, Pipeline, ProcessResult,
+    parse_pipeline_file,
 };
 use rsigma_parser::SigmaCollection;
 
@@ -11,6 +12,7 @@ use rsigma_parser::SigmaCollection;
 pub struct RuntimeEngine {
     engine: EngineVariant,
     pipelines: Vec<Pipeline>,
+    pipeline_paths: Vec<PathBuf>,
     rules_path: std::path::PathBuf,
     corr_config: CorrelationConfig,
     include_event: bool,
@@ -38,10 +40,25 @@ impl RuntimeEngine {
         RuntimeEngine {
             engine: EngineVariant::DetectionOnly(Engine::new()),
             pipelines,
+            pipeline_paths: Vec::new(),
             rules_path,
             corr_config,
             include_event,
         }
+    }
+
+    /// Set the pipeline file paths used for hot-reload.
+    ///
+    /// When paths are set, `load_rules()` re-reads pipeline YAML from disk
+    /// before rebuilding the engine. This enables pipeline hot-reload
+    /// alongside rule hot-reload.
+    pub fn set_pipeline_paths(&mut self, paths: Vec<PathBuf>) {
+        self.pipeline_paths = paths;
+    }
+
+    /// Return the pipeline file paths (used by the daemon to set up watchers).
+    pub fn pipeline_paths(&self) -> &[PathBuf] {
+        &self.pipeline_paths
     }
 
     /// Load (or reload) rules from the configured path.
@@ -49,7 +66,16 @@ impl RuntimeEngine {
     /// On reload, correlation state is exported before replacing the engine
     /// and re-imported after, so in-flight windows and suppression state
     /// survive rule changes (entries for removed correlations are dropped).
+    ///
+    /// If pipeline paths are set (via [`set_pipeline_paths`](Self::set_pipeline_paths)),
+    /// pipelines are re-read from disk before rebuilding the engine. If any
+    /// pipeline file fails to parse, the entire reload is aborted and the
+    /// old engine remains active.
     pub fn load_rules(&mut self) -> Result<EngineStats, String> {
+        if !self.pipeline_paths.is_empty() {
+            self.pipelines = reload_pipelines(&self.pipeline_paths)?;
+        }
+
         let previous_state = self.export_state();
         let collection = load_collection(&self.rules_path)?;
         let has_correlations = !collection.correlations.is_empty();
@@ -189,4 +215,16 @@ fn load_collection(path: &Path) -> Result<SigmaCollection, String> {
     }
 
     Ok(collection)
+}
+
+/// Re-read and parse all pipeline files from disk, sorted by priority.
+fn reload_pipelines(paths: &[PathBuf]) -> Result<Vec<Pipeline>, String> {
+    let mut pipelines = Vec::with_capacity(paths.len());
+    for path in paths {
+        let pipeline = parse_pipeline_file(path)
+            .map_err(|e| format!("Error reloading pipeline {}: {e}", path.display()))?;
+        pipelines.push(pipeline);
+    }
+    pipelines.sort_by_key(|p| p.priority);
+    Ok(pipelines)
 }

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -244,26 +244,31 @@ impl LogProcessor {
         line_results
     }
 
-    /// Reload rules without blocking in-flight event processing.
+    /// Reload rules (and pipelines) without blocking in-flight event processing.
     ///
     /// Builds a fresh `RuntimeEngine` with the same configuration as the
-    /// current one, loads rules into it, imports the old engine's correlation
-    /// state, and atomically swaps. In-flight batches that already hold an
-    /// `Arc` to the old engine finish undisturbed.
+    /// current one, re-reads pipeline files from disk (if paths are set),
+    /// loads rules into it, imports the old engine's correlation state, and
+    /// atomically swaps. In-flight batches that already hold an `Arc` to
+    /// the old engine finish undisturbed.
+    ///
+    /// If pipeline or rule loading fails, the old engine remains active.
     pub fn reload_rules(&self) -> Result<crate::engine::EngineStats, String> {
-        let (old_state, rules_path, pipelines, corr_config, include_event) = {
+        let (old_state, rules_path, pipelines, pipeline_paths, corr_config, include_event) = {
             let snapshot = self.engine.load();
             let old = snapshot.lock().unwrap();
             (
                 old.export_state(),
                 old.rules_path().to_path_buf(),
                 old.pipelines().to_vec(),
+                old.pipeline_paths().to_vec(),
                 old.corr_config().clone(),
                 old.include_event(),
             )
         };
 
         let mut new_engine = RuntimeEngine::new(rules_path, pipelines, corr_config, include_event);
+        new_engine.set_pipeline_paths(pipeline_paths);
         let stats = new_engine.load_rules()?;
 
         if let Some(state) = old_state
@@ -538,6 +543,172 @@ detection:
             !proc.process_batch_lines(&batch2, &identity_filter)[0]
                 .detections
                 .is_empty()
+        );
+
+        std::mem::forget(dir);
+    }
+
+    #[test]
+    fn reload_re_reads_pipelines_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Rule uses the generic Sigma field name "SourceIP".
+        // The pipeline maps it to what the events actually contain.
+        let rule_path = dir.path().join("test.yml");
+        std::fs::write(
+            &rule_path,
+            r#"
+title: Rule A
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        SourceIP: "10.0.0.1"
+    condition: selection
+"#,
+        )
+        .unwrap();
+
+        // Pipeline maps the rule's SourceIP field to "src_ip" (event field)
+        let pipeline_path = dir.path().join("pipeline.yml");
+        std::fs::write(
+            &pipeline_path,
+            r#"
+name: Initial Pipeline
+priority: 10
+transformations:
+  - id: rename_field
+    type: field_name_mapping
+    mapping:
+      SourceIP: src_ip
+"#,
+        )
+        .unwrap();
+
+        let pipelines = vec![rsigma_eval::parse_pipeline_file(&pipeline_path).unwrap()];
+        let mut engine = RuntimeEngine::new(
+            rule_path.clone(),
+            pipelines,
+            CorrelationConfig::default(),
+            false,
+        );
+        engine.set_pipeline_paths(vec![pipeline_path.clone()]);
+        engine.load_rules().unwrap();
+        let proc = LogProcessor::new(engine, Arc::new(NoopMetrics));
+
+        // Event uses "src_ip" which the pipeline mapped from SourceIP
+        let batch = vec![r#"{"src_ip": "10.0.0.1"}"#.to_string()];
+        assert!(
+            !proc.process_batch_lines(&batch, &identity_filter)[0]
+                .detections
+                .is_empty(),
+            "src_ip should match because pipeline mapped SourceIP -> src_ip"
+        );
+
+        // Update pipeline to map SourceIP to a different event field name
+        std::fs::write(
+            &pipeline_path,
+            r#"
+name: Updated Pipeline
+priority: 10
+transformations:
+  - id: rename_field
+    type: field_name_mapping
+    mapping:
+      SourceIP: source.ip
+"#,
+        )
+        .unwrap();
+
+        proc.reload_rules().unwrap();
+
+        // src_ip no longer the target, should not match
+        assert!(
+            proc.process_batch_lines(&batch, &identity_filter)[0]
+                .detections
+                .is_empty(),
+            "after pipeline reload, src_ip should no longer match"
+        );
+
+        // source.ip is now the mapped name, should match
+        let batch2 = vec![r#"{"source.ip": "10.0.0.1"}"#.to_string()];
+        assert!(
+            !proc.process_batch_lines(&batch2, &identity_filter)[0]
+                .detections
+                .is_empty(),
+            "after pipeline reload, source.ip should match"
+        );
+
+        std::mem::forget(dir);
+    }
+
+    #[test]
+    fn reload_with_broken_pipeline_keeps_old_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let rule_path = dir.path().join("test.yml");
+        std::fs::write(
+            &rule_path,
+            r#"
+title: Rule A
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        SourceIP: "10.0.0.1"
+    condition: selection
+"#,
+        )
+        .unwrap();
+
+        let pipeline_path = dir.path().join("pipeline.yml");
+        std::fs::write(
+            &pipeline_path,
+            r#"
+name: Working Pipeline
+priority: 10
+transformations:
+  - id: rename_field
+    type: field_name_mapping
+    mapping:
+      SourceIP: src_ip
+"#,
+        )
+        .unwrap();
+
+        let pipelines = vec![rsigma_eval::parse_pipeline_file(&pipeline_path).unwrap()];
+        let mut engine = RuntimeEngine::new(
+            rule_path.clone(),
+            pipelines,
+            CorrelationConfig::default(),
+            false,
+        );
+        engine.set_pipeline_paths(vec![pipeline_path.clone()]);
+        engine.load_rules().unwrap();
+        let proc = LogProcessor::new(engine, Arc::new(NoopMetrics));
+
+        // Verify initial state works (SourceIP mapped to src_ip)
+        let batch = vec![r#"{"src_ip": "10.0.0.1"}"#.to_string()];
+        assert!(
+            !proc.process_batch_lines(&batch, &identity_filter)[0]
+                .detections
+                .is_empty()
+        );
+
+        // Write broken YAML to the pipeline file
+        std::fs::write(&pipeline_path, "{{{{ invalid yaml !!!!").unwrap();
+
+        // Reload should fail
+        let result = proc.reload_rules();
+        assert!(result.is_err(), "reload with broken pipeline should fail");
+
+        // Old engine should still be active and working
+        assert!(
+            !proc.process_batch_lines(&batch, &identity_filter)[0]
+                .detections
+                .is_empty(),
+            "old engine should still work after failed reload"
         );
 
         std::mem::forget(dir);


### PR DESCRIPTION
## Summary

- Store pipeline file paths in `RuntimeEngine` so that `load_rules()` re-reads pipeline YAML from disk before rebuilding the engine, instead of carrying over stale in-memory pipelines.
- Extend the `notify` file watcher to also watch individual pipeline files (in addition to the rules directory). Any YAML change triggers the same debounced reload signal.
- If any pipeline file fails to parse during reload, the entire reload aborts and the old engine stays active (same fail-safe pattern as rule reload errors).

## Changes

| File | What |
|------|------|
| `rsigma-runtime/src/engine.rs` | `pipeline_paths` field, `set_pipeline_paths()`, `pipeline_paths()`, `reload_pipelines()` helper |
| `rsigma-runtime/src/processor.rs` | `reload_rules()` carries `pipeline_paths` through to the new engine; 2 new tests |
| `rsigma-cli/src/daemon/reload.rs` | `spawn_file_watcher()` accepts and watches additional pipeline file paths |
| `rsigma-cli/src/daemon/server.rs` | `DaemonConfig.pipeline_paths`, engine setup, watcher setup, updated log messages |
| `rsigma-cli/src/main.rs` | Pass `pipeline_paths` into `DaemonConfig` |

## Test plan

- [x] `reload_re_reads_pipelines_from_disk`: verifies field mapping changes take effect after reload
- [x] `reload_with_broken_pipeline_keeps_old_engine`: verifies failed reload leaves old engine active
- [x] Existing `reload_rules_preserves_engine` still passes
- [x] Full workspace test suite passes (`cargo test --workspace`, zero failures)
- [x] `cargo clippy --workspace --all-features -- -D warnings` clean