### PR TITLE
feat: embed builtin pipelines (ecs_windows, sysmon)

### DIFF
--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -22,10 +22,13 @@ rsigma eval -r path/to/rules/ -e '{"CommandLine": "cmd /c whoami"}'
 cat events.ndjson | rsigma eval -r path/to/rules/
 
 # Long-running daemon with hot-reload, health checks, and Prometheus metrics
-hel run | rsigma daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
+hel run | rsigma daemon -r rules/ -p ecs_windows --api-addr 0.0.0.0:9090
 
-# With a processing pipeline for field mapping
-rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
+# With a builtin pipeline (no external file needed)
+rsigma eval -r rules/ -p ecs_windows -e '{"process.command_line": "whoami"}'
+
+# Or use a custom pipeline YAML file
+rsigma eval -r rules/ -p pipelines/custom.yml -e '{"src_ip": "10.0.0.1"}'
 
 # Convert rules to backend-native queries
 rsigma convert -r rules/ -t test
@@ -34,7 +37,7 @@ rsigma convert -r rules/ -t test
 rsigma convert -r rules/ -t postgres
 
 # List all fields referenced by rules (with optional pipeline mapping)
-rsigma fields -r rules/ -p pipelines/ecs.yml
+rsigma fields -r rules/ -p ecs_windows
 
 # List available conversion backends
 rsigma list-targets
@@ -691,10 +694,13 @@ The `event` field is present only when `--include-event` is set.
 
 ## Pipeline Loading
 
-- Each `-p PATH` loads one pipeline file.
+- Each `-p NAME_OR_PATH` loads one pipeline. The argument is first checked against builtin names; if no builtin matches, it is treated as a file path.
+- **Builtin pipelines** (no external file needed):
+  - `ecs_windows` -- maps Sigma/Sysmon field names to Elastic Common Schema (ECS) fields (e.g. `CommandLine` becomes `process.command_line`). Use with Winlogbeat/Elastic Agent output.
+  - `sysmon` -- adds Sysmon `EventID` conditions for logsource routing. Use when evaluating against raw Sysmon JSON that includes `EventID`.
 - Pipelines are sorted by `priority` (ascending); lower priority runs first.
 - All pipelines are applied in sequence to each rule before compilation.
-- In daemon mode, pipeline files are watched for changes and re-read on reload (alongside rules). If a pipeline file becomes invalid, the reload fails and the previous configuration stays active.
+- In daemon mode, pipeline files are watched for changes and re-read on reload (alongside rules). Builtin pipelines are embedded at compile time and are not file-watched. If a pipeline file becomes invalid, the reload fails and the previous configuration stays active.
 - `merge_pipelines` is not used by the CLI; each pipeline remains separate with its own state.
 
 ## Environment Variables

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand};
 use jaq_interpret::{Ctx, FilterT, ParseCtx, RcIter, Val};
 use rsigma_eval::{
     CorrelationAction, CorrelationConfig, CorrelationEventMode, Pipeline, parse_pipeline_file,
+    resolve_builtin_pipeline,
 };
 use rsigma_parser::{SigmaCollection, parse_sigma_directory, parse_sigma_file};
 use serde_json_path::JsonPath;
@@ -46,7 +47,7 @@ enum Commands {
         #[arg(short, long)]
         verbose: bool,
 
-        /// Processing pipeline YAML file(s) to apply (can be specified multiple times)
+        /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
         #[arg(short = 'p', long = "pipeline")]
         pipelines: Vec<PathBuf>,
     },
@@ -128,7 +129,7 @@ enum Commands {
         #[arg(short, long)]
         rules: PathBuf,
 
-        /// Processing pipeline YAML file(s) to apply (can be specified multiple times)
+        /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
         #[arg(short = 'p', long = "pipeline")]
         pipelines: Vec<PathBuf>,
 
@@ -329,7 +330,7 @@ enum Commands {
         #[arg(long)]
         pretty: bool,
 
-        /// Processing pipeline YAML file(s) to apply (can be specified multiple times)
+        /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
         #[arg(short = 'p', long = "pipeline")]
         pipelines: Vec<PathBuf>,
 
@@ -417,7 +418,7 @@ enum Commands {
         #[arg(short, long, default_value = "default")]
         format: String,
 
-        /// Processing pipeline YAML file(s) (repeatable)
+        /// Processing pipeline(s) (repeatable). Accepts builtin names (ecs_windows, sysmon) or YAML file paths
         #[arg(short = 'p', long = "pipeline")]
         pipeline: Vec<PathBuf>,
 
@@ -457,7 +458,7 @@ enum Commands {
         #[arg(short, long)]
         rules: PathBuf,
 
-        /// Processing pipeline YAML file(s) to apply (can be specified multiple times).
+        /// Processing pipeline(s) to apply (repeatable). Accepts builtin names (ecs_windows, sysmon) or YAML file paths.
         /// When provided, fields are shown after pipeline transformations.
         #[arg(short = 'p', long = "pipeline")]
         pipelines: Vec<PathBuf>,
@@ -796,10 +797,15 @@ fn cmd_daemon(
         ..Default::default()
     };
 
+    let file_pipeline_paths: Vec<PathBuf> = pipeline_paths
+        .into_iter()
+        .filter(|p| resolve_builtin_pipeline(p.to_str().unwrap_or("")).is_none())
+        .collect();
+
     let config = daemon::server::DaemonConfig {
         rules_path,
         pipelines,
-        pipeline_paths,
+        pipeline_paths: file_pipeline_paths,
         corr_config,
         include_event,
         pretty,
@@ -841,14 +847,31 @@ fn cmd_daemon(
 pub(crate) fn load_pipelines(paths: &[PathBuf]) -> Vec<Pipeline> {
     let mut pipelines = Vec::new();
     for path in paths {
-        match parse_pipeline_file(path) {
-            Ok(p) => {
-                eprintln!("Loaded pipeline: {} (priority {})", p.name, p.priority);
-                pipelines.push(p);
+        let name = path.to_str().unwrap_or("");
+        if let Some(result) = resolve_builtin_pipeline(name) {
+            match result {
+                Ok(p) => {
+                    eprintln!(
+                        "Loaded builtin pipeline: {} (priority {})",
+                        p.name, p.priority
+                    );
+                    pipelines.push(p);
+                }
+                Err(e) => {
+                    eprintln!("Error parsing builtin pipeline '{name}': {e}");
+                    process::exit(exit_code::CONFIG_ERROR);
+                }
             }
-            Err(e) => {
-                eprintln!("Error loading pipeline {}: {e}", path.display());
-                process::exit(exit_code::CONFIG_ERROR);
+        } else {
+            match parse_pipeline_file(path) {
+                Ok(p) => {
+                    eprintln!("Loaded pipeline: {} (priority {})", p.name, p.priority);
+                    pipelines.push(p);
+                }
+                Err(e) => {
+                    eprintln!("Error loading pipeline {}: {e}", path.display());
+                    process::exit(exit_code::CONFIG_ERROR);
+                }
             }
         }
     }

--- a/crates/rsigma-eval/pipelines/ecs_windows.yml
+++ b/crates/rsigma-eval/pipelines/ecs_windows.yml
@@ -1,0 +1,174 @@
+# ECS (Elastic Common Schema) field mapping for Windows log sources.
+#
+# Maps generic Sigma / Sysmon field names to ECS field names as produced by
+# Winlogbeat >= 7 and Elastic Agent. Use this pipeline when evaluating Sigma
+# rules against ECS-formatted Windows events.
+#
+# Derived from pySigma-backend-elasticsearch ecs_windows pipeline.
+#
+# Usage:
+#   rsigma eval -r rules/ -p ecs_windows -e '{"process.command_line": "whoami"}'
+#   rsigma daemon -r rules/ -p ecs_windows
+
+name: ecs_windows
+priority: 20
+
+transformations:
+  # -- Process creation (Sysmon EventID 1) --
+  - id: ecs_process_creation_fields
+    type: field_name_mapping
+    mapping:
+      CommandLine: process.command_line
+      Image: process.executable
+      OriginalFileName: process.pe.original_file_name
+      CurrentDirectory: process.working_directory
+      ProcessGuid: process.entity_id
+      ProcessId: process.pid
+      ParentProcessGuid: process.parent.entity_id
+      ParentProcessId: process.parent.pid
+      ParentImage: process.parent.executable
+      ParentCommandLine: process.parent.command_line
+      User: user.name
+      IntegrityLevel: winlog.event_data.IntegrityLevel
+      Hashes: winlog.event_data.Hashes
+      Company: process.pe.company
+      Description: process.pe.description
+      Product: process.pe.product
+      FileVersion: process.pe.file_version
+    rule_conditions:
+      - type: logsource
+        category: process_creation
+
+  # -- Network connection (Sysmon EventID 3) --
+  - id: ecs_network_connection_fields
+    type: field_name_mapping
+    mapping:
+      SourceIp: source.ip
+      SourceHostname: source.domain
+      SourcePort: source.port
+      DestinationIp: destination.ip
+      DestinationHostname: destination.domain
+      DestinationPort: destination.port
+      DestinationPortName: network.protocol
+      Protocol: network.transport
+      Image: process.executable
+      User: user.name
+      ProcessId: process.pid
+    rule_conditions:
+      - type: logsource
+        category: network_connection
+
+  # -- Image/DLL load (Sysmon EventID 7) --
+  - id: ecs_image_load_fields
+    type: field_name_mapping
+    mapping:
+      ImageLoaded: file.path
+      Image: process.executable
+      Signed: file.code_signature.signed
+      SignatureStatus: file.code_signature.status
+      Signature: file.code_signature.subject_name
+      Imphash: file.pe.imphash
+      Company: file.pe.company
+      Description: file.pe.description
+      Product: file.pe.product
+      FileVersion: file.pe.file_version
+      OriginalFileName: file.pe.original_file_name
+    rule_conditions:
+      - type: logsource
+        category: image_load
+
+  # -- File events (Sysmon EventID 11) --
+  - id: ecs_file_event_fields
+    type: field_name_mapping
+    mapping:
+      TargetFilename: file.path
+      Image: process.executable
+      User: user.name
+    rule_conditions:
+      - type: logsource
+        category: file_event
+
+  # -- Registry events (Sysmon EventID 12/13/14) --
+  - id: ecs_registry_event_fields
+    type: field_name_mapping
+    mapping:
+      TargetObject: registry.path
+      Details: winlog.event_data.Details
+      Image: process.executable
+      EventType: winlog.event_data.EventType
+    rule_conditions:
+      - type: logsource
+        category: registry_event
+
+  # -- DNS query (Sysmon EventID 22) --
+  - id: ecs_dns_query_fields
+    type: field_name_mapping
+    mapping:
+      QueryName: dns.question.name
+      QueryStatus: sysmon.dns.status
+      Image: process.executable
+    rule_conditions:
+      - type: logsource
+        category: dns_query
+
+  # -- Pipe created (Sysmon EventID 17/18) --
+  - id: ecs_pipe_created_fields
+    type: field_name_mapping
+    mapping:
+      PipeName: file.name
+      Image: process.executable
+    rule_conditions:
+      - type: logsource
+        category: pipe_created
+
+  # -- Driver load (Sysmon EventID 6) --
+  - id: ecs_driver_load_fields
+    type: field_name_mapping
+    mapping:
+      ImageLoaded: file.path
+      Signed: file.code_signature.signed
+      SignatureStatus: file.code_signature.status
+      Signature: file.code_signature.subject_name
+      Imphash: file.pe.imphash
+    rule_conditions:
+      - type: logsource
+        category: driver_load
+
+  # -- Create remote thread (Sysmon EventID 8) --
+  - id: ecs_create_remote_thread_fields
+    type: field_name_mapping
+    mapping:
+      SourceImage: process.executable
+      SourceProcessId: process.pid
+      TargetImage: winlog.event_data.TargetImage
+      TargetProcessId: winlog.event_data.TargetProcessId
+      StartFunction: winlog.event_data.StartFunction
+    rule_conditions:
+      - type: logsource
+        category: create_remote_thread
+
+  # -- Process access (Sysmon EventID 10) --
+  - id: ecs_process_access_fields
+    type: field_name_mapping
+    mapping:
+      SourceImage: process.executable
+      SourceProcessId: process.pid
+      TargetImage: winlog.event_data.TargetImage
+      TargetProcessId: winlog.event_data.TargetProcessId
+      GrantedAccess: winlog.event_data.GrantedAccess
+      CallTrace: winlog.event_data.CallTrace
+    rule_conditions:
+      - type: logsource
+        category: process_access
+
+  # -- Global Windows field mappings (apply to all Windows rules) --
+  - id: ecs_windows_global_fields
+    type: field_name_mapping
+    mapping:
+      EventID: event.code
+      Channel: winlog.channel
+      Provider_Name: winlog.provider_name
+      ComputerName: winlog.computer_name
+    rule_conditions:
+      - type: logsource
+        product: windows

--- a/crates/rsigma-eval/pipelines/sysmon.yml
+++ b/crates/rsigma-eval/pipelines/sysmon.yml
@@ -1,0 +1,236 @@
+# Sysmon logsource routing pipeline.
+#
+# Maps generic Sigma log source categories (process_creation, network_connection,
+# etc.) to Sysmon EventIDs by adding EventID conditions. Use this pipeline when
+# evaluating Sigma rules against raw Sysmon JSON events that include the EventID
+# field but do not have pre-routed logsource metadata.
+#
+# This pipeline does NOT rename fields (Sigma Windows rules already use Sysmon
+# field names). It only adds EventID conditions so that logsource-scoped rules
+# match the correct event types.
+#
+# Derived from pySigma-pipeline-sysmon.
+#
+# Usage:
+#   rsigma eval -r rules/ -p sysmon -e '{"EventID": 1, "Image": "cmd.exe", ...}'
+#   rsigma daemon -r rules/ -p sysmon
+
+name: sysmon
+priority: 10
+
+transformations:
+  - id: sysmon_process_creation
+    type: add_condition
+    conditions:
+      EventID: 1
+    rule_conditions:
+      - type: logsource
+        category: process_creation
+        product: windows
+
+  - id: sysmon_file_change
+    type: add_condition
+    conditions:
+      EventID: 2
+    rule_conditions:
+      - type: logsource
+        category: file_change
+        product: windows
+
+  - id: sysmon_network_connection
+    type: add_condition
+    conditions:
+      EventID: 3
+    rule_conditions:
+      - type: logsource
+        category: network_connection
+        product: windows
+
+  - id: sysmon_process_termination
+    type: add_condition
+    conditions:
+      EventID: 5
+    rule_conditions:
+      - type: logsource
+        category: process_termination
+        product: windows
+
+  - id: sysmon_driver_load
+    type: add_condition
+    conditions:
+      EventID: 6
+    rule_conditions:
+      - type: logsource
+        category: driver_load
+        product: windows
+
+  - id: sysmon_image_load
+    type: add_condition
+    conditions:
+      EventID: 7
+    rule_conditions:
+      - type: logsource
+        category: image_load
+        product: windows
+
+  - id: sysmon_create_remote_thread
+    type: add_condition
+    conditions:
+      EventID: 8
+    rule_conditions:
+      - type: logsource
+        category: create_remote_thread
+        product: windows
+
+  - id: sysmon_raw_access_thread
+    type: add_condition
+    conditions:
+      EventID: 9
+    rule_conditions:
+      - type: logsource
+        category: raw_access_thread
+        product: windows
+
+  - id: sysmon_process_access
+    type: add_condition
+    conditions:
+      EventID: 10
+    rule_conditions:
+      - type: logsource
+        category: process_access
+        product: windows
+
+  - id: sysmon_file_event
+    type: add_condition
+    conditions:
+      EventID: 11
+    rule_conditions:
+      - type: logsource
+        category: file_event
+        product: windows
+
+  - id: sysmon_registry_add
+    type: add_condition
+    conditions:
+      EventID: 12
+    rule_conditions:
+      - type: logsource
+        category: registry_add
+        product: windows
+
+  - id: sysmon_registry_delete
+    type: add_condition
+    conditions:
+      EventID: 12
+    rule_conditions:
+      - type: logsource
+        category: registry_delete
+        product: windows
+
+  - id: sysmon_registry_set
+    type: add_condition
+    conditions:
+      EventID: 13
+    rule_conditions:
+      - type: logsource
+        category: registry_set
+        product: windows
+
+  - id: sysmon_registry_rename
+    type: add_condition
+    conditions:
+      EventID: 14
+    rule_conditions:
+      - type: logsource
+        category: registry_rename
+        product: windows
+
+  - id: sysmon_create_stream_hash
+    type: add_condition
+    conditions:
+      EventID: 15
+    rule_conditions:
+      - type: logsource
+        category: create_stream_hash
+        product: windows
+
+  - id: sysmon_pipe_created
+    type: add_condition
+    conditions:
+      EventID: 17
+    rule_conditions:
+      - type: logsource
+        category: pipe_created
+        product: windows
+
+  - id: sysmon_dns_query
+    type: add_condition
+    conditions:
+      EventID: 22
+    rule_conditions:
+      - type: logsource
+        category: dns_query
+        product: windows
+
+  - id: sysmon_file_delete
+    type: add_condition
+    conditions:
+      EventID: 23
+    rule_conditions:
+      - type: logsource
+        category: file_delete
+        product: windows
+
+  - id: sysmon_clipboard_capture
+    type: add_condition
+    conditions:
+      EventID: 24
+    rule_conditions:
+      - type: logsource
+        category: clipboard_capture
+        product: windows
+
+  - id: sysmon_process_tampering
+    type: add_condition
+    conditions:
+      EventID: 25
+    rule_conditions:
+      - type: logsource
+        category: process_tampering
+        product: windows
+
+  - id: sysmon_file_delete_detected
+    type: add_condition
+    conditions:
+      EventID: 26
+    rule_conditions:
+      - type: logsource
+        category: file_delete_detected
+        product: windows
+
+  - id: sysmon_file_block_executable
+    type: add_condition
+    conditions:
+      EventID: 27
+    rule_conditions:
+      - type: logsource
+        category: file_block_executable
+        product: windows
+
+  - id: sysmon_file_executable_detected
+    type: add_condition
+    conditions:
+      EventID: 29
+    rule_conditions:
+      - type: logsource
+        category: file_executable_detected
+        product: windows
+
+  # Change logsource to sysmon service for all matched categories
+  - id: sysmon_logsource
+    type: change_logsource
+    product: windows
+    service: sysmon
+    rule_conditions:
+      - type: logsource
+        product: windows

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -117,7 +117,10 @@ pub use error::{EvalError, Result};
 pub use event::{Event, EventValue, JsonEvent, KvEvent, MapEvent, PlainEvent};
 pub use matcher::CompiledMatcher;
 pub use pipeline::{
-    Pipeline, apply_pipelines, apply_pipelines_with_state, merge_pipelines, parse_pipeline,
-    parse_pipeline_file,
+    Pipeline, apply_pipelines, apply_pipelines_with_state,
+    builtin::{
+        builtin_names as builtin_pipeline_names, resolve_builtin as resolve_builtin_pipeline,
+    },
+    merge_pipelines, parse_pipeline, parse_pipeline_file,
 };
 pub use result::{FieldMatch, MatchResult};

--- a/crates/rsigma-eval/src/pipeline/builtin.rs
+++ b/crates/rsigma-eval/src/pipeline/builtin.rs
@@ -1,0 +1,59 @@
+use super::Pipeline;
+use super::parsing::parse_pipeline;
+use crate::error::Result;
+
+const ECS_WINDOWS_YAML: &str = include_str!("../../pipelines/ecs_windows.yml");
+const SYSMON_YAML: &str = include_str!("../../pipelines/sysmon.yml");
+
+/// Builtin pipeline entries: (name, yaml_content).
+const BUILTIN_PIPELINES: &[(&str, &str)] =
+    &[("ecs_windows", ECS_WINDOWS_YAML), ("sysmon", SYSMON_YAML)];
+
+/// Resolve a pipeline name to a parsed `Pipeline`.
+///
+/// Returns `Some(pipeline)` if the name matches a builtin pipeline,
+/// `None` if the name is not a known builtin (caller should try as a file path).
+pub fn resolve_builtin(name: &str) -> Option<Result<Pipeline>> {
+    BUILTIN_PIPELINES
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, yaml)| parse_pipeline(yaml))
+}
+
+/// Return the list of available builtin pipeline names.
+pub fn builtin_names() -> &'static [&'static str] {
+    &["ecs_windows", "sysmon"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ecs_windows_parses_successfully() {
+        let pipeline = resolve_builtin("ecs_windows").unwrap().unwrap();
+        assert_eq!(pipeline.name, "ecs_windows");
+        assert_eq!(pipeline.priority, 20);
+        assert!(!pipeline.transformations.is_empty());
+    }
+
+    #[test]
+    fn sysmon_parses_successfully() {
+        let pipeline = resolve_builtin("sysmon").unwrap().unwrap();
+        assert_eq!(pipeline.name, "sysmon");
+        assert_eq!(pipeline.priority, 10);
+        assert!(!pipeline.transformations.is_empty());
+    }
+
+    #[test]
+    fn unknown_name_returns_none() {
+        assert!(resolve_builtin("nonexistent").is_none());
+    }
+
+    #[test]
+    fn builtin_names_lists_all() {
+        let names = builtin_names();
+        assert!(names.contains(&"ecs_windows"));
+        assert!(names.contains(&"sysmon"));
+    }
+}

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -35,6 +35,7 @@
 //! assert_eq!(pipeline.name, "Sysmon Field Mapping");
 //! ```
 
+pub mod builtin;
 pub mod conditions;
 pub mod finalizers;
 mod parsing;


### PR DESCRIPTION
## Summary

- Embed two common processing pipelines (`ecs_windows`, `sysmon`) at compile time via `include_str!()` so that `rsigma eval -p ecs_windows` works without external YAML files.
- `ecs_windows` maps Sigma/Sysmon Windows fields to Elastic Common Schema (process creation, network, image load, file, registry, DNS, pipes, drivers, remote thread, process access).
- `sysmon` adds EventID conditions for logsource routing against raw Sysmon JSON.
- CLI resolves builtin names before falling back to file paths; builtin names are excluded from daemon file-watcher paths.

## Test plan

- [x] `cargo test --workspace --all-features` passes (includes 4 new builtin unit tests)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] Manual smoke test: `rsigma eval -r /tmp/rule.yml -p ecs_windows -e '{"process.command_line":"whoami"}'` matches
- [x] Manual smoke test: `rsigma eval -r /tmp/rule.yml -p sysmon -e '{"EventID":1,"CommandLine":"whoami"}'` matches
- [ ] CI green