### PR TITLE
fix(security): prevent SQL injection, unbounded recursion, and condition DoS

### DIFF
--- a/crates/rsigma-convert/src/backends/postgres/correlation.rs
+++ b/crates/rsigma-convert/src/backends/postgres/correlation.rs
@@ -12,22 +12,22 @@ impl super::PostgresBackend {
     /// - Expressions containing parentheses (function calls) pass through unchanged
     /// - `field as alias` is split and both sides are quoted independently
     /// - Plain field names are quoted via `field_expr`
-    pub(super) fn format_select_field(&self, field: &str) -> String {
+    pub(super) fn format_select_field(&self, field: &str) -> Result<String> {
         if field == "*" {
-            return "*".to_string();
+            return Ok("*".to_string());
         }
         if field.contains('(') && field.contains(')') {
-            return field.to_string();
+            return Ok(field.to_string());
         }
         if let Some((expr, alias)) = field.split_once(" as ") {
-            let quoted_expr = self.field_expr(expr.trim());
-            let quoted_alias = self.field_expr(alias.trim());
-            return format!("{quoted_expr} AS {quoted_alias}");
+            let quoted_expr = self.field_expr(expr.trim())?;
+            let quoted_alias = self.field_expr(alias.trim())?;
+            return Ok(format!("{quoted_expr} AS {quoted_alias}"));
         }
         if let Some((expr, alias)) = field.split_once(" AS ") {
-            let quoted_expr = self.field_expr(expr.trim());
-            let quoted_alias = self.field_expr(alias.trim());
-            return format!("{quoted_expr} AS {quoted_alias}");
+            let quoted_expr = self.field_expr(expr.trim())?;
+            let quoted_alias = self.field_expr(alias.trim())?;
+            return Ok(format!("{quoted_expr} AS {quoted_alias}"));
         }
         self.field_expr(field)
     }
@@ -98,7 +98,10 @@ impl super::PostgresBackend {
         let partition_clause = if group_by.is_empty() {
             String::new()
         } else {
-            let cols: Vec<String> = group_by.iter().map(|g| self.field_expr(g)).collect();
+            let cols: Vec<String> = group_by
+                .iter()
+                .map(|g| self.field_expr(g))
+                .collect::<Result<_>>()?;
             format!("PARTITION BY {} ", cols.join(", "))
         };
 
@@ -238,7 +241,7 @@ impl super::PostgresBackend {
             let raw_table = rule_tables.get(rule_ref).map(|s| s.as_str());
             let per_rule_schema = rule_schemas.get(rule_ref).map(|s| s.as_str());
             let qualified = match raw_table {
-                Some(t) => self.qualify_table_name(t, &pipeline_state.state, per_rule_schema),
+                Some(t) => self.qualify_table_name(t, &pipeline_state.state, per_rule_schema)?,
                 None => default_table.to_string(),
             };
             table_to_rules

--- a/crates/rsigma-convert/src/backends/postgres/mod.rs
+++ b/crates/rsigma-convert/src/backends/postgres/mod.rs
@@ -11,7 +11,9 @@ mod correlation;
 mod tests;
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
+use regex::Regex;
 use rsigma_eval::pipeline::state::PipelineState;
 use rsigma_parser::*;
 
@@ -20,6 +22,16 @@ use crate::condition::convert_condition_expr;
 use crate::convert::{default_convert_detection, default_convert_detection_item};
 use crate::error::{ConvertError, Result};
 use crate::state::{ConversionState, ConvertResult};
+
+fn validate_sql_identifier(s: &str) -> Result<()> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_$]*$").unwrap());
+    if RE.is_match(s) {
+        Ok(())
+    } else {
+        Err(ConvertError::InvalidIdentifier(s.to_string()))
+    }
+}
 
 // =============================================================================
 // PostgreSQL TextQueryConfig
@@ -188,12 +200,13 @@ impl PostgresBackend {
         &self,
         custom_attrs: &HashMap<String, serde_yaml::Value>,
         state: &HashMap<String, serde_json::Value>,
-    ) -> String {
+    ) -> Result<String> {
         let table = custom_attrs
             .get("postgres.table")
             .and_then(|v| v.as_str())
             .or(state.get("table").and_then(|v| v.as_str()))
             .unwrap_or(&self.table);
+        validate_sql_identifier(table)?;
 
         let schema = custom_attrs
             .get("postgres.schema")
@@ -202,9 +215,11 @@ impl PostgresBackend {
             .or(self.schema.as_deref())
             .filter(|s| !s.is_empty());
 
-        match schema {
-            Some(s) => format!("{s}.{table}"),
-            None => table.to_string(),
+        if let Some(s) = schema {
+            validate_sql_identifier(s)?;
+            Ok(format!("{s}.{table}"))
+        } else {
+            Ok(table.to_string())
         }
     }
 
@@ -215,35 +230,45 @@ impl PostgresBackend {
         table: &str,
         state: &HashMap<String, serde_json::Value>,
         per_rule_schema: Option<&str>,
-    ) -> String {
+    ) -> Result<String> {
+        validate_sql_identifier(table)?;
+
         let schema = per_rule_schema
             .or(state.get("schema").and_then(|v| v.as_str()))
             .or(self.schema.as_deref())
             .filter(|s| !s.is_empty());
 
-        match schema {
-            Some(s) => format!("{s}.{table}"),
-            None => table.to_string(),
+        if let Some(s) = schema {
+            validate_sql_identifier(s)?;
+            Ok(format!("{s}.{table}"))
+        } else {
+            Ok(table.to_string())
         }
     }
 
-    fn field_expr(&self, field: &str) -> String {
+    fn field_expr(&self, field: &str) -> Result<String> {
         match &self.json_field {
             Some(json_col) if field.contains('.') => {
                 let parts: Vec<&str> = field.split('.').collect();
                 let last = parts.len() - 1;
                 let mut expr = json_col.clone();
                 for (i, part) in parts.iter().enumerate() {
+                    validate_sql_identifier(part)?;
+                    let escaped = part.replace('\'', "''");
                     if i == last {
-                        expr.push_str(&format!("->>'{part}'"));
+                        expr.push_str(&format!("->>'{escaped}'"));
                     } else {
-                        expr.push_str(&format!("->'{part}'"));
+                        expr.push_str(&format!("->'{escaped}'"));
                     }
                 }
-                expr
+                Ok(expr)
             }
-            Some(json_col) => format!("{json_col}->>'{field}'"),
-            None => text_escape_and_quote_field(self.config, field),
+            Some(json_col) => {
+                validate_sql_identifier(field)?;
+                let escaped = field.replace('\'', "''");
+                Ok(format!("{json_col}->>'{escaped}'"))
+            }
+            None => Ok(text_escape_and_quote_field(self.config, field)),
         }
     }
 
@@ -405,6 +430,7 @@ impl Backend for PostgresBackend {
 
     fn escape_and_quote_field(&self, field: &str) -> String {
         self.field_expr(field)
+            .unwrap_or_else(|_| text_escape_and_quote_field(self.config, field))
     }
 
     fn convert_value_str(&self, value: &SigmaString, _state: &ConversionState) -> String {
@@ -424,7 +450,7 @@ impl Backend for PostgresBackend {
         modifiers: &[Modifier],
         _state: &mut ConversionState,
     ) -> Result<ConvertResult> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         let is_cased = modifiers.contains(&Modifier::Cased);
         let is_contains = modifiers.contains(&Modifier::Contains);
         let is_startswith = modifiers.contains(&Modifier::StartsWith);
@@ -463,7 +489,7 @@ impl Backend for PostgresBackend {
         value: f64,
         _state: &mut ConversionState,
     ) -> Result<String> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         if value.fract() == 0.0 && (i64::MIN as f64..=i64::MAX as f64).contains(&value) {
             Ok(format!("{f} = {}", value as i64))
         } else {
@@ -477,7 +503,7 @@ impl Backend for PostgresBackend {
         value: bool,
         _state: &mut ConversionState,
     ) -> Result<String> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         let v = if value {
             self.config.bool_true
         } else {
@@ -487,7 +513,7 @@ impl Backend for PostgresBackend {
     }
 
     fn convert_field_eq_null(&self, field: &str, _state: &mut ConversionState) -> Result<String> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         Ok(format!("{f} IS NULL"))
     }
 
@@ -498,7 +524,7 @@ impl Backend for PostgresBackend {
         flags: &[Modifier],
         _state: &mut ConversionState,
     ) -> Result<ConvertResult> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         let escaped_pattern = self.escape_sql_str(pattern);
         let is_cased = flags.contains(&Modifier::Cased) || self.case_sensitive_re;
         let op = if is_cased { "~" } else { "~*" };
@@ -513,7 +539,7 @@ impl Backend for PostgresBackend {
         cidr: &str,
         _state: &mut ConversionState,
     ) -> Result<ConvertResult> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         Ok(ConvertResult::Query(format!(
             "({f})::inet <<= '{cidr}'::cidr"
         )))
@@ -526,7 +552,7 @@ impl Backend for PostgresBackend {
         value: f64,
         _state: &mut ConversionState,
     ) -> Result<String> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         let op_token = match op {
             Modifier::Lt => "<",
             Modifier::Lte => "<=",
@@ -553,7 +579,7 @@ impl Backend for PostgresBackend {
         exists: bool,
         _state: &mut ConversionState,
     ) -> Result<String> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         if exists {
             Ok(format!("{f} IS NOT NULL"))
         } else {
@@ -568,7 +594,7 @@ impl Backend for PostgresBackend {
         _id: &str,
         _state: &mut ConversionState,
     ) -> Result<String> {
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         let resolved = expr.replace("{field}", &f);
         Ok(resolved)
     }
@@ -579,8 +605,8 @@ impl Backend for PostgresBackend {
         field2: &str,
         _state: &mut ConversionState,
     ) -> Result<ConvertResult> {
-        let f1 = self.field_expr(field1);
-        let f2 = self.field_expr(field2);
+        let f1 = self.field_expr(field1)?;
+        let f2 = self.field_expr(field2)?;
         Ok(ConvertResult::Query(format!("{f1} = {f2}")))
     }
 
@@ -622,7 +648,7 @@ impl Backend for PostgresBackend {
                 "AND IN-list not supported for PostgreSQL".into(),
             ));
         }
-        let f = self.field_expr(field);
+        let f = self.field_expr(field)?;
         let items: Vec<String> = values
             .iter()
             .map(|v| match v {
@@ -644,7 +670,7 @@ impl Backend for PostgresBackend {
         query: String,
         state: &ConversionState,
     ) -> Result<String> {
-        let qualified = self.resolve_table(&rule.custom_attributes, &state.processing_state);
+        let qualified = self.resolve_table(&rule.custom_attributes, &state.processing_state)?;
 
         let is_timescaledb = state
             .get_state_str("_output_format")
@@ -656,7 +682,7 @@ impl Backend for PostgresBackend {
             rule.fields
                 .iter()
                 .map(|f| self.format_select_field(f))
-                .collect::<Vec<_>>()
+                .collect::<Result<Vec<_>>>()?
                 .join(", ")
         };
 
@@ -745,13 +771,16 @@ impl Backend for PostgresBackend {
         output_format: &str,
         pipeline_state: &PipelineState,
     ) -> Result<Vec<String>> {
-        let table = self.resolve_table(&rule.custom_attributes, &pipeline_state.state);
+        let table = self.resolve_table(&rule.custom_attributes, &pipeline_state.state)?;
         let ts = &self.timestamp_field;
         let use_time_bucket =
             output_format == "timescaledb" || output_format == "continuous_aggregate";
 
-        let mut group_by_cols: Vec<String> =
-            rule.group_by.iter().map(|g| self.field_expr(g)).collect();
+        let mut group_by_cols: Vec<String> = rule
+            .group_by
+            .iter()
+            .map(|g| self.field_expr(g))
+            .collect::<Result<_>>()?;
         if use_time_bucket {
             group_by_cols.insert(0, format!("time_bucket('1 hour', {ts})"));
         }
@@ -820,9 +849,10 @@ impl Backend for PostgresBackend {
                 )
             }
             CorrelationType::ValueCount => {
-                let field = value_field
-                    .map(|f| self.field_expr(f))
-                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let field = match value_field {
+                    Some(f) => self.field_expr(f)?,
+                    None => "'unknown_field'".to_string(),
+                };
                 let agg = format!("COUNT(DISTINCT {field})");
                 format!(
                     "{cte_prefix}SELECT {group_by_select}{agg} AS value_count \
@@ -846,9 +876,10 @@ impl Backend for PostgresBackend {
                     pipeline_state,
                 )?,
             CorrelationType::ValueSum => {
-                let field = value_field
-                    .map(|f| self.field_expr(f))
-                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let field = match value_field {
+                    Some(f) => self.field_expr(f)?,
+                    None => "'unknown_field'".to_string(),
+                };
                 let agg = format!("SUM({field})");
                 format!(
                     "{cte_prefix}SELECT {group_by_select}{agg} AS value_sum \
@@ -860,9 +891,10 @@ impl Backend for PostgresBackend {
                 )
             }
             CorrelationType::ValueAvg => {
-                let field = value_field
-                    .map(|f| self.field_expr(f))
-                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let field = match value_field {
+                    Some(f) => self.field_expr(f)?,
+                    None => "'unknown_field'".to_string(),
+                };
                 let agg = format!("AVG({field})");
                 format!(
                     "{cte_prefix}SELECT {group_by_select}{agg} AS value_avg \
@@ -874,9 +906,10 @@ impl Backend for PostgresBackend {
                 )
             }
             CorrelationType::ValuePercentile | CorrelationType::ValueMedian => {
-                let field = value_field
-                    .map(|f| self.field_expr(f))
-                    .unwrap_or_else(|| "'unknown_field'".to_string());
+                let field = match value_field {
+                    Some(f) => self.field_expr(f)?,
+                    None => "'unknown_field'".to_string(),
+                };
                 let percentile = if rule.correlation_type == CorrelationType::ValueMedian {
                     0.5
                 } else {

--- a/crates/rsigma-convert/src/backends/postgres/tests.rs
+++ b/crates/rsigma-convert/src/backends/postgres/tests.rs
@@ -898,7 +898,10 @@ fn test_resolve_table_defaults() {
     let backend = PostgresBackend::new();
     let attrs = HashMap::new();
     let state = HashMap::new();
-    assert_eq!(backend.resolve_table(&attrs, &state), "security_events");
+    assert_eq!(
+        backend.resolve_table(&attrs, &state).unwrap(),
+        "security_events"
+    );
 }
 
 #[test]
@@ -908,7 +911,7 @@ fn test_resolve_table_backend_schema() {
     let attrs = HashMap::new();
     let state = HashMap::new();
     assert_eq!(
-        backend.resolve_table(&attrs, &state),
+        backend.resolve_table(&attrs, &state).unwrap(),
         "audit.security_events"
     );
 }
@@ -919,7 +922,10 @@ fn test_resolve_table_state_overrides_default() {
     let attrs = HashMap::new();
     let mut state = HashMap::new();
     state.insert("table".to_string(), serde_json::json!("process_events"));
-    assert_eq!(backend.resolve_table(&attrs, &state), "process_events");
+    assert_eq!(
+        backend.resolve_table(&attrs, &state).unwrap(),
+        "process_events"
+    );
 }
 
 #[test]
@@ -930,7 +936,7 @@ fn test_resolve_table_state_with_backend_schema() {
     let mut state = HashMap::new();
     state.insert("table".to_string(), serde_json::json!("process_events"));
     assert_eq!(
-        backend.resolve_table(&attrs, &state),
+        backend.resolve_table(&attrs, &state).unwrap(),
         "audit.process_events"
     );
 }
@@ -943,7 +949,10 @@ fn test_resolve_table_state_schema_overrides_backend() {
     let mut state = HashMap::new();
     state.insert("table".to_string(), serde_json::json!("process_events"));
     state.insert("schema".to_string(), serde_json::json!("siem"));
-    assert_eq!(backend.resolve_table(&attrs, &state), "siem.process_events");
+    assert_eq!(
+        backend.resolve_table(&attrs, &state).unwrap(),
+        "siem.process_events"
+    );
 }
 
 #[test]
@@ -962,7 +971,10 @@ fn test_resolve_table_custom_attrs_override_all() {
     let mut state = HashMap::new();
     state.insert("table".to_string(), serde_json::json!("pipeline_events"));
     state.insert("schema".to_string(), serde_json::json!("siem"));
-    assert_eq!(backend.resolve_table(&attrs, &state), "custom.my_events");
+    assert_eq!(
+        backend.resolve_table(&attrs, &state).unwrap(),
+        "custom.my_events"
+    );
 }
 
 #[test]
@@ -974,7 +986,7 @@ fn test_resolve_table_custom_table_only() {
         serde_yaml::Value::String("my_events".to_string()),
     );
     let state = HashMap::new();
-    assert_eq!(backend.resolve_table(&attrs, &state), "my_events");
+    assert_eq!(backend.resolve_table(&attrs, &state).unwrap(), "my_events");
 }
 
 #[test]
@@ -988,7 +1000,10 @@ fn test_resolve_table_empty_schema_treated_as_none() {
     );
     let state = HashMap::new();
     // Empty schema in custom_attrs removes the schema prefix
-    assert_eq!(backend.resolve_table(&attrs, &state), "security_events");
+    assert_eq!(
+        backend.resolve_table(&attrs, &state).unwrap(),
+        "security_events"
+    );
 }
 
 // --- Backend options (from_options) ---
@@ -1969,4 +1984,68 @@ correlation:
         q.contains("FROM security_events"),
         "event_count uses default table: {q}"
     );
+}
+
+// --- SQL injection prevention ---
+
+#[test]
+fn field_expr_rejects_quote_in_field_name() {
+    let mut backend = PostgresBackend::new();
+    backend.json_field = Some("metadata".to_string());
+    let result = backend.field_expr("field'; DROP TABLE users --");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("invalid SQL identifier"));
+}
+
+#[test]
+fn field_expr_rejects_quote_in_dotted_path() {
+    let mut backend = PostgresBackend::new();
+    backend.json_field = Some("metadata".to_string());
+    let result = backend.field_expr("process.name'; DROP TABLE x --");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("invalid SQL identifier"));
+}
+
+#[test]
+fn resolve_table_rejects_quote_in_table_name() {
+    let backend = PostgresBackend::new();
+    let custom_attrs = HashMap::new();
+    let mut state = HashMap::new();
+    state.insert(
+        "table".to_string(),
+        serde_json::Value::String("events'; DROP TABLE x --".into()),
+    );
+    let result = backend.resolve_table(&custom_attrs, &state);
+    assert!(result.is_err());
+}
+
+#[test]
+fn resolve_table_rejects_quote_in_schema_name() {
+    let backend = PostgresBackend::new();
+    let custom_attrs = HashMap::new();
+    let mut state = HashMap::new();
+    state.insert(
+        "schema".to_string(),
+        serde_json::Value::String("public'; DROP TABLE x --".into()),
+    );
+    let result = backend.resolve_table(&custom_attrs, &state);
+    assert!(result.is_err());
+}
+
+#[test]
+fn legitimate_dotted_json_path_still_works() {
+    let mut backend = PostgresBackend::new();
+    backend.json_field = Some("metadata".to_string());
+    let result = backend.field_expr("process.name").unwrap();
+    assert_eq!(result, "metadata->'process'->>'name'");
+}
+
+#[test]
+fn legitimate_dotted_json_path_three_levels() {
+    let mut backend = PostgresBackend::new();
+    backend.json_field = Some("data".to_string());
+    let result = backend.field_expr("a.b.c").unwrap();
+    assert_eq!(result, "data->'a'->'b'->>'c'");
 }

--- a/crates/rsigma-convert/src/error.rs
+++ b/crates/rsigma-convert/src/error.rs
@@ -29,6 +29,9 @@ pub enum ConvertError {
     #[error("rule conversion failed: {0}")]
     RuleConversion(String),
 
+    #[error("invalid SQL identifier: {0}")]
+    InvalidIdentifier(String),
+
     #[error("pipeline error: {0}")]
     Pipeline(#[from] rsigma_eval::error::EvalError),
 }

--- a/crates/rsigma-parser/src/condition.rs
+++ b/crates/rsigma-parser/src/condition.rs
@@ -28,6 +28,9 @@ struct SigmaConditionParser;
 // Public API
 // ---------------------------------------------------------------------------
 
+const MAX_CONDITION_LEN: usize = 64 * 1024;
+const MAX_CONDITION_DEPTH: usize = 64;
+
 /// Parse a Sigma condition expression string into an AST.
 ///
 /// # Examples
@@ -39,6 +42,13 @@ struct SigmaConditionParser;
 /// println!("{expr}");
 /// ```
 pub fn parse_condition(input: &str) -> Result<ConditionExpr> {
+    if input.len() > MAX_CONDITION_LEN {
+        return Err(SigmaParserError::ConditionTooLong(
+            input.len(),
+            MAX_CONDITION_LEN,
+        ));
+    }
+
     let pairs = SigmaConditionParser::parse(Rule::condition, input).map_err(|e| {
         let loc = extract_pest_location(&e);
         SigmaParserError::Condition(e.to_string(), loc)
@@ -59,7 +69,8 @@ pub fn parse_condition(input: &str) -> Result<ConditionExpr> {
         .find(|p| p.as_rule() == Rule::expr)
         .ok_or_else(|| SigmaParserError::Condition("missing expr in condition".into(), None))?;
 
-    parse_expr(expr_pair, &pratt)
+    let depth = std::cell::Cell::new(0usize);
+    parse_expr(expr_pair, &pratt, &depth)
 }
 
 fn extract_pest_location(err: &pest::error::Error<Rule>) -> Option<SourceLocation> {
@@ -93,7 +104,20 @@ fn location_from_pair(pair: &Pair<'_, Rule>) -> Option<SourceLocation> {
     })
 }
 
-fn parse_expr(pair: Pair<'_, Rule>, pratt: &PrattParser<Rule>) -> Result<ConditionExpr> {
+fn parse_expr(
+    pair: Pair<'_, Rule>,
+    pratt: &PrattParser<Rule>,
+    depth: &std::cell::Cell<usize>,
+) -> Result<ConditionExpr> {
+    let current = depth.get();
+    if current > MAX_CONDITION_DEPTH {
+        return Err(SigmaParserError::Condition(
+            format!("condition nesting exceeds maximum depth ({MAX_CONDITION_DEPTH})"),
+            None,
+        ));
+    }
+    depth.set(current + 1);
+
     // The Pratt parser closures cannot return Result, so we collect all
     // errors in a shared RefCell and report them after parsing completes.
     let errors: std::cell::RefCell<Vec<PrattError>> = std::cell::RefCell::new(Vec::new());
@@ -110,7 +134,7 @@ fn parse_expr(pair: Pair<'_, Rule>, pratt: &PrattParser<Rule>) -> Result<Conditi
                     });
                     ConditionExpr::Identifier(String::new())
                 }),
-                Rule::expr => parse_expr(primary, pratt).unwrap_or_else(|e| {
+                Rule::expr => parse_expr(primary, pratt, depth).unwrap_or_else(|e| {
                     errors.borrow_mut().push(PrattError {
                         message: e.to_string(),
                         location: e.location().or(loc),
@@ -154,6 +178,8 @@ fn parse_expr(pair: Pair<'_, Rule>, pratt: &PrattParser<Rule>) -> Result<Conditi
             }
         })
         .parse(pair.into_inner());
+
+    depth.set(depth.get().saturating_sub(1));
 
     let collected = errors.into_inner();
     if !collected.is_empty() {
@@ -729,5 +755,24 @@ mod tests {
     fn test_nested_empty_parens_fails() {
         let err = parse_condition("selection and ()").unwrap_err();
         assert!(matches!(err, SigmaParserError::Condition(_, _)));
+    }
+
+    #[test]
+    fn condition_too_long_returns_error() {
+        let big = "a".repeat(MAX_CONDITION_LEN + 1);
+        let err = parse_condition(&big).unwrap_err();
+        assert!(
+            matches!(err, SigmaParserError::ConditionTooLong(_, _)),
+            "expected ConditionTooLong, got: {err}"
+        );
+    }
+
+    #[test]
+    fn moderate_condition_still_parses() {
+        let expr = parse_condition("((((((((((a and b))))))))))").unwrap();
+        match expr {
+            ConditionExpr::And(children) => assert_eq!(children.len(), 2),
+            other => panic!("expected And, got {other:?}"),
+        }
     }
 }

--- a/crates/rsigma-parser/src/error.rs
+++ b/crates/rsigma-parser/src/error.rs
@@ -56,6 +56,12 @@ pub enum SigmaParserError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("YAML merge exceeds maximum depth ({0})")]
+    MergeTooDeep(usize),
+
+    #[error("Condition string too long ({0} bytes, max {1})")]
+    ConditionTooLong(usize, usize),
 }
 
 impl SigmaParserError {

--- a/crates/rsigma-parser/src/parser/mod.rs
+++ b/crates/rsigma-parser/src/parser/mod.rs
@@ -89,11 +89,11 @@ pub fn parse_sigma_yaml(yaml: &str) -> Result<SigmaCollection> {
                         if let Some(m) = repeat_val.as_mapping_mut() {
                             m.remove(Value::String("action".to_string()));
                         }
-                        let merged_repeat = deep_merge(prev.clone(), repeat_val);
+                        let merged_repeat = deep_merge(prev.clone(), repeat_val)?;
 
                         // Apply global template if present
                         let final_val = if let Some(ref global_val) = global {
-                            deep_merge(global_val.clone(), merged_repeat)
+                            deep_merge(global_val.clone(), merged_repeat)?
                         } else {
                             merged_repeat
                         };
@@ -130,7 +130,7 @@ pub fn parse_sigma_yaml(yaml: &str) -> Result<SigmaCollection> {
 
         // Merge with global template if present
         let merged = if let Some(ref global_val) = global {
-            deep_merge(global_val.clone(), value)
+            deep_merge(global_val.clone(), value)?
         } else {
             value
         };
@@ -326,20 +326,44 @@ pub(super) fn get_str_list(m: &serde_yaml::Mapping, key: &str) -> Vec<String> {
 
 /// Deep-merge two YAML values (src overrides dest, recursively for mappings).
 ///
+/// Uses an explicit work-stack to avoid unbounded recursion from crafted input.
+/// Returns `MergeTooDeep` if nesting exceeds `MAX_DEPTH`.
+///
 /// Reference: pySigma collection.py deep_dict_update
-fn deep_merge(dest: Value, src: Value) -> Value {
-    match (dest, src) {
-        (Value::Mapping(mut dest_map), Value::Mapping(src_map)) => {
-            for (k, v) in src_map {
-                let merged = if let Some(existing) = dest_map.remove(&k) {
-                    deep_merge(existing, v)
-                } else {
-                    v
-                };
-                dest_map.insert(k, merged);
-            }
-            Value::Mapping(dest_map)
+fn deep_merge(dest: Value, src: Value) -> crate::error::Result<Value> {
+    const MAX_DEPTH: usize = 64;
+
+    let (mut root_dest, root_src) = match (dest, src) {
+        (Value::Mapping(d), Value::Mapping(s)) => (d, s),
+        (_, src) => return Ok(src),
+    };
+
+    fn merge_level(
+        dest: &mut serde_yaml::Mapping,
+        src: serde_yaml::Mapping,
+        depth: usize,
+    ) -> crate::error::Result<()> {
+        if depth > MAX_DEPTH {
+            return Err(crate::error::SigmaParserError::MergeTooDeep(MAX_DEPTH));
         }
-        (_, src) => src, // non-mapping: source wins
+        for (k, v) in src {
+            if let Some(existing) = dest.remove(&k) {
+                match (existing, v) {
+                    (Value::Mapping(mut d), Value::Mapping(s)) => {
+                        merge_level(&mut d, s, depth + 1)?;
+                        dest.insert(k, Value::Mapping(d));
+                    }
+                    (_, src_val) => {
+                        dest.insert(k, src_val);
+                    }
+                }
+            } else {
+                dest.insert(k, v);
+            }
+        }
+        Ok(())
     }
+
+    merge_level(&mut root_dest, root_src, 0)?;
+    Ok(Value::Mapping(root_dest))
 }

--- a/crates/rsigma-parser/src/parser/tests.rs
+++ b/crates/rsigma-parser/src/parser/tests.rs
@@ -1329,3 +1329,44 @@ correlation:
     let collection = parse_sigma_yaml(yaml).unwrap();
     assert!(collection.correlations[0].generate);
 }
+
+#[test]
+fn deep_merge_handles_deeply_nested_global() {
+    use serde_yaml::Value;
+
+    fn nested_map(depth: usize) -> Value {
+        let mut v = Value::String("leaf".into());
+        for i in (0..depth).rev() {
+            let mut map = serde_yaml::Mapping::new();
+            map.insert(Value::String(format!("k{i}")), v);
+            v = Value::Mapping(map);
+        }
+        v
+    }
+
+    let result = super::deep_merge(nested_map(200), nested_map(200));
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("maximum depth"),
+        "expected MergeTooDeep, got: {err}"
+    );
+}
+
+#[test]
+fn deep_merge_succeeds_at_reasonable_depth() {
+    use serde_yaml::Value;
+
+    fn nested_map(depth: usize) -> Value {
+        let mut v = Value::String("leaf".into());
+        for i in (0..depth).rev() {
+            let mut map = serde_yaml::Mapping::new();
+            map.insert(Value::String(format!("k{i}")), v);
+            v = Value::Mapping(map);
+        }
+        v
+    }
+
+    let result = super::deep_merge(nested_map(10), nested_map(10));
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

- Validate SQL identifiers in the PostgreSQL backend with a regex allowlist, returning `InvalidIdentifier` errors instead of interpolating untrusted strings into queries
- Convert `deep_merge` to an iterative implementation with `MAX_DEPTH=64`, returning `MergeTooDeep` on crafted YAML
- Add length cap (64 KB) and recursion depth counter (64) to the condition parser, returning `ConditionTooLong` on oversized input

## Test plan

- [x] New unit tests for SQL identifier rejection (`field_expr_rejects_quote_in_field_name`, `resolve_table_rejects_quote_in_schema_name`, etc.)
- [x] New test for legitimate dotted JSON paths still working
- [x] `deep_merge_handles_deeply_nested_global` verifies depth limit triggers
- [x] `deep_merge_succeeds_at_reasonable_depth` verifies normal operation
- [x] `condition_too_long_returns_error` and `moderate_condition_still_parses`
- [x] All existing tests pass