### PR TITLE
fix(ci): add MSRV job, cargo-deny, semver-checks, --locked, dependabot, serde_yaml migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-updates:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,3 +33,14 @@ jobs:
           toolchain: stable
       - run: cargo install cargo-audit --locked
       - run: cargo audit
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repo
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,22 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo check --workspace --all-targets --all-features
+      - run: cargo check --workspace --all-targets --all-features --locked
+
+  msrv:
+    name: MSRV (1.88.0)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repo
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: "1.88.0"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo check --workspace --all-features --locked
 
   fmt:
     name: Format
@@ -73,7 +88,7 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   test:
     name: Test (${{ matrix.os }})
@@ -92,7 +107,7 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace --all-features --locked
 
   coverage:
     name: Coverage
@@ -113,7 +128,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Generate coverage
         run: |
-          cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+          cargo llvm-cov --workspace --all-features --locked --lcov --output-path lcov.info
           echo '## Coverage Report' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           cargo llvm-cov report --summary-only 2>&1 >> "$GITHUB_STEP_SUMMARY"
@@ -133,8 +148,20 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build rsigma
-        run: cargo build --release --all-features -p rsigma
+        run: cargo build --release --all-features --locked -p rsigma
       - name: Clone SigmaHQ rules
         run: git clone --depth 1 https://github.com/SigmaHQ/sigma.git /tmp/sigma
       - name: Validate and compile all Sigma rules
         run: ./target/release/rsigma validate /tmp/sigma/rules/ --verbose
+
+  semver:
+    name: Semver Checks (informational)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repo
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+    continue-on-error: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
 
       - name: Build release
-        run: cargo build --release --all-features --target "${TARGET}" -p rsigma -p rsigma-lsp
+        run: cargo build --release --all-features --locked --target "${TARGET}" -p rsigma -p rsigma-lsp
         env:
           TARGET: ${{ matrix.target }}
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "line-index"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +3561,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "yaml_serde",
  "yamlpatch",
  "yamlpath",
 ]
@@ -3571,12 +3578,12 @@ dependencies = [
  "rsigma-eval",
  "rsigma-parser",
  "serde_json",
- "serde_yaml",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -3596,8 +3603,8 @@ dependencies = [
  "rsigma-parser",
  "serde",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -3626,9 +3633,9 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
- "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -5738,6 +5745,19 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -26,7 +26,8 @@ rsigma-runtime = { path = "../rsigma-runtime", version = "0.9.0", optional = tru
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { package = "yaml_serde", version = "0.10" }
+yamlpatch_yaml = { package = "serde_yaml", version = "0.9" }
 jaq-interpret = "1.5.0"
 jaq-parse = "1.0.3"
 serde_json_path = "0.7.2"

--- a/crates/rsigma-cli/src/fix.rs
+++ b/crates/rsigma-cli/src/fix.rs
@@ -50,7 +50,7 @@ fn apply_single_fix_patch(
         FixPatch::ReplaceValue { path, new_value } => {
             let yp = yamlpatch::Patch {
                 route: json_pointer_to_route(path),
-                operation: yamlpatch::Op::Replace(serde_yaml::Value::String(new_value.clone())),
+                operation: yamlpatch::Op::Replace(yamlpatch_yaml::Value::String(new_value.clone())),
             };
             yamlpatch::apply_yaml_patches(doc, &[yp]).map_err(|e| e.to_string())
         }
@@ -229,7 +229,7 @@ mod tests {
         let route = json_pointer_to_route("/status");
         let patch = yamlpatch::Patch {
             route,
-            operation: yamlpatch::Op::Replace(serde_yaml::Value::String(
+            operation: yamlpatch::Op::Replace(yamlpatch_yaml::Value::String(
                 "experimental".to_string(),
             )),
         };

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -14,7 +14,7 @@ rsigma-parser = { path = "../rsigma-parser", version = "0.9.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.9.0" }
 thiserror = "2"
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { package = "yaml_serde", version = "0.10" }
 regex = "1"
 ipnet = "2"
 log = "0.4"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -16,7 +16,7 @@ parallel = ["rayon"]
 rsigma-parser = { path = "../rsigma-parser", version = "0.9.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml = { package = "yaml_serde", version = "0.10" }
 regex = "1"
 base64 = "0.22"
 ipnet = "2"

--- a/crates/rsigma-parser/Cargo.toml
+++ b/crates/rsigma-parser/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 pest = "2"
 pest_derive = "2"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
+serde_yaml = { package = "yaml_serde", version = "0.10" }
 serde_json = "1"
 thiserror = "2"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,31 @@
+[advisories]
+ignore = [
+    # encoding 0.2.33 (RUSTSEC-2021-0153) -- unmaintained, pulled transitively
+    # via evtx. No safe upgrade available; tracked for removal when evtx drops
+    # the encoding dependency.
+    "RUSTSEC-2021-0153",
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary

- Add MSRV CI job pinned to `rust-version` 1.88.0
- Add `cargo-deny` with license allowlist and advisory config (`deny.toml`)
- Add informational `cargo-semver-checks` job (continue-on-error for pre-1.0)
- Add `--locked` to all `cargo check`/`test`/`build`/`clippy` invocations in CI
- Add `.github/dependabot.yml` for weekly cargo and github-actions updates
- Migrate `serde_yaml` 0.9 to `yaml_serde` 0.10 via Cargo package renaming across all 4 crates, with `yamlpatch_yaml` compat shim in rsigma-cli

## Test plan

- [x] `cargo deny check` passes (advisories ok, bans ok, licenses ok, sources ok)
- [x] `cargo check --locked` passes
- [x] All existing tests pass with `yaml_serde` 0.10