### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to rsigma
+
+Thank you for considering a contribution to rsigma! This document covers the basics of setting up a development environment, running tests, and submitting changes.
+
+## Getting Started
+
+### Prerequisites
+
+- Rust toolchain (MSRV: 1.88.0). Install via [rustup](https://rustup.rs/).
+- Docker (optional, required for integration tests that use testcontainers).
+
+### Building
+
+```bash
+cargo build --workspace
+```
+
+### Running Tests
+
+```bash
+# Unit and integration tests
+cargo test --workspace
+
+# Clippy lints (must pass with zero warnings)
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# Formatting check
+cargo fmt --all -- --check
+
+# Dependency audit
+cargo deny check
+```
+
+## Development Workflow
+
+### Branching
+
+- Feature branches: `feat/<name>`
+- Fix branches: `fix/<name>`
+- Target `main` for all PRs.
+
+### Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) style:
+
+- `feat(parser): add support for temporal_ordered correlation`
+- `fix(convert): prevent SQL injection in identifier interpolation`
+- `test: add snapshot tests for parser AST`
+- `ci: add cargo-deny job to audit workflow`
+
+### Pull Requests
+
+- Keep PRs focused on a single concern.
+- Reference any related issue numbers.
+- Ensure CI is green before requesting review.
+- New public API surface should include rustdoc with examples.
+- New features should include tests. Prefer integration tests for cross-crate behavior and unit tests for isolated logic.
+
+## Code Quality
+
+- `cargo fmt` and `cargo clippy` must pass with zero warnings.
+- `cargo deny check` must pass (licenses, advisories, bans, sources).
+- Do not add `unsafe` code without justification and a safety comment.
+- Avoid `.unwrap()` in library crates. Use `?` or return descriptive errors. `.unwrap()` is acceptable in tests.
+
+## Testing
+
+- **Unit tests** live in `#[cfg(test)]` modules alongside the code they test.
+- **Integration tests** go under `crates/<crate>/tests/`.
+- **Snapshot tests** use [insta](https://insta.rs/). Run `cargo insta review` after updating snapshots.
+- **Fuzz targets** live in `fuzz/fuzz_targets/`. Add a fuzz target for any new untrusted input surface.
+- **Benchmarks** use Criterion and live in `benches/`.
+
+## Architecture
+
+rsigma is a Cargo workspace with the following crates:
+
+| Crate | Purpose |
+| ----- | ------- |
+| `rsigma-parser` | YAML parsing, AST, linting, auto-fix |
+| `rsigma-eval` | Rule compilation, matching engine, correlation |
+| `rsigma-convert` | Backend conversion (PostgreSQL, Splunk, etc.) |
+| `rsigma-runtime` | Streaming I/O, daemon engine, input adapters |
+| `rsigma-cli` | CLI binary (validate, lint, convert, daemon) |
+| `rsigma-lsp` | Language Server Protocol implementation |
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported with security updates. We recommend always running the most recent version.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+| < latest | No       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in rsigma, please report it responsibly. **Do not open a public GitHub issue.**
+
+Instead, use [GitHub Security Advisories](https://github.com/timescale/rsigma/security/advisories/new) to report the vulnerability privately. This allows us to assess the issue, develop a fix, and coordinate disclosure before the details become public.
+
+You can expect an initial response within 72 hours. We will work with you to understand the scope and impact, and will credit reporters in the release notes unless anonymity is requested.
+
+## Scope
+
+The following areas are in scope for security reports:
+
+- SQL injection or query manipulation in conversion backends
+- Denial of service via crafted Sigma rules or events (unbounded recursion, memory exhaustion, regex catastrophic backtracking)
+- Path traversal or arbitrary file access in rule loading
+- Authentication or authorization bypass in the daemon HTTP API
+- Supply chain issues (compromised dependencies, unsigned artifacts)
+- Container escape or privilege escalation in the Docker image
+
+## Security Hardening
+
+rsigma ships with several built-in protections:
+
+- **Input validation**: SQL identifiers are validated against an allowlist pattern before interpolation into queries.
+- **Recursion limits**: YAML deep-merge and condition parsing enforce depth and length caps.
+- **Event size caps**: The daemon rejects individual event lines exceeding 1 MB.
+- **Dependency auditing**: `cargo-deny` and `cargo audit` run in CI on every push. Dependabot monitors for known vulnerabilities weekly.
+- **Container image signing**: Docker images are signed with keyless cosign (Sigstore/Fulcio OIDC) and include SBOM and SLSA Build L3 provenance attestations.
+- **Binary provenance**: Release binaries are built with SLSA Build L3 provenance via `actions/attest-build-provenance`.
+
+When running the daemon in production, we recommend the following Docker flags:
+
+```bash
+docker run --read-only --cap-drop=ALL --security-opt=no-new-privileges \
+  ghcr.io/timescale/rsigma:latest daemon ...
+```


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with vulnerability reporting via GitHub Security Advisories, supported versions, scope, and hardening recommendations
- Add `CONTRIBUTING.md` with development setup, testing, branching, commit conventions, code quality expectations, and crate architecture overview

## Test plan

- [x] No code changes, documentation only