### PR TITLE
fix(hardening): add SIGTERM handler, parking_lot mutex, event size cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,5 +163,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
     continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,6 +3648,7 @@ dependencies = [
  "criterion",
  "evtx",
  "opentelemetry-proto",
+ "parking_lot",
  "prost",
  "rand 0.9.4",
  "rsigma-eval",

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -176,6 +176,10 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
     }
 
+    // Bounded channel acts as backpressure for reload requests. Capacity 4
+    // allows the file watcher, SIGHUP handler, and HTTP endpoint to queue
+    // reloads without blocking, while the consumer debounces with a 500ms
+    // sleep + try_recv drain, collapsing bursts into a single reload.
     let (reload_tx, mut reload_rx) = mpsc::channel::<()>(4);
 
     // File watcher for hot-reload (rules + pipeline files)
@@ -628,10 +632,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         tokio::spawn(async move {
             if let Err(e) = tonic::transport::Server::builder()
                 .accept_http1(true)
-                .serve_with_incoming_shutdown(otlp_routes, incoming, async {
-                    tokio::signal::ctrl_c().await.ok();
-                    tracing::info!("Shutdown signal received");
-                })
+                .serve_with_incoming_shutdown(otlp_routes, incoming, shutdown_signal())
                 .await
             {
                 tracing::error!(error = %e, "server error");
@@ -641,10 +642,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     #[cfg(not(feature = "daemon-otlp"))]
     let mut serve_handle = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app)
-            .with_graceful_shutdown(async {
-                tokio::signal::ctrl_c().await.ok();
-                tracing::info!("Shutdown signal received");
-            })
+            .with_graceful_shutdown(shutdown_signal())
             .await
         {
             tracing::error!(error = %e, "server error");
@@ -703,6 +701,26 @@ pub async fn run_daemon(config: DaemonConfig) {
             Err(e) => tracing::error!(error = %e, "Failed to save state on shutdown"),
         }
     }
+}
+
+/// Wait for either SIGINT (Ctrl+C) or SIGTERM, then log and return.
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+
+    #[cfg(unix)]
+    {
+        let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = term.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    ctrl_c.await.ok();
+
+    tracing::info!("Shutdown signal received");
 }
 
 /// Build a single Sink from an output spec string.
@@ -983,10 +1001,22 @@ async fn ingest_events(State(state): State<AppState>, body: String) -> Response 
         }
     };
 
+    const MAX_LINE_BYTES: usize = 1_048_576; // 1 MB
+
     let mut accepted = 0u64;
     for line in body.lines() {
         if line.trim().is_empty() {
             continue;
+        }
+        if line.len() > MAX_LINE_BYTES {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(serde_json::json!({
+                    "error": "line exceeds maximum size",
+                    "max_bytes": MAX_LINE_BYTES,
+                })),
+            )
+                .into_response();
         }
         let raw_event = RawEvent {
             payload: line.to_string(),

--- a/crates/rsigma-convert/src/error.rs
+++ b/crates/rsigma-convert/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ConvertError {
     #[error("backend does not support modifier: {0}")]
     UnsupportedModifier(String),

--- a/crates/rsigma-parser/src/error.rs
+++ b/crates/rsigma-parser/src/error.rs
@@ -20,6 +20,7 @@ impl fmt::Display for SourceLocation {
 
 /// Errors that can occur during Sigma rule parsing.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SigmaParserError {
     #[error("YAML parsing error: {0}")]
     Yaml(#[from] serde_yaml::Error),

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
 arc-swap = "1"
+parking_lot = "0.12"
 syslog_loose = "0.23"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
@@ -67,7 +69,7 @@ impl LogProcessor {
         event_filter: &EventFilter,
     ) -> Vec<ProcessResult> {
         let engine_guard = self.engine.load();
-        let mut engine = engine_guard.lock().unwrap();
+        let mut engine = engine_guard.lock();
 
         // Phase 1: Parse JSON and apply event filters, tracking line origin.
         let mut parsed: Vec<(usize, Vec<serde_json::Value>)> = Vec::with_capacity(batch.len());
@@ -162,7 +164,7 @@ impl LogProcessor {
         event_filter: Option<&EventFilter>,
     ) -> Vec<ProcessResult> {
         let engine_guard = self.engine.load();
-        let mut engine = engine_guard.lock().unwrap();
+        let mut engine = engine_guard.lock();
 
         // Phase 1: Parse each line into decoded events, tracking line origin.
         // For JSON with an event_filter, one line can produce multiple events.
@@ -256,7 +258,7 @@ impl LogProcessor {
     pub fn reload_rules(&self) -> Result<crate::engine::EngineStats, String> {
         let (old_state, rules_path, pipelines, pipeline_paths, corr_config, include_event) = {
             let snapshot = self.engine.load();
-            let old = snapshot.lock().unwrap();
+            let old = snapshot.lock();
             (
                 old.export_state(),
                 old.rules_path().to_path_buf(),
@@ -286,7 +288,7 @@ impl LogProcessor {
     /// Return the rules path from the current engine.
     pub fn rules_path(&self) -> std::path::PathBuf {
         let snapshot = self.engine.load();
-        let engine = snapshot.lock().unwrap();
+        let engine = snapshot.lock();
         engine.rules_path().to_path_buf()
     }
 
@@ -298,21 +300,21 @@ impl LogProcessor {
     /// Export correlation state from the current engine.
     pub fn export_state(&self) -> Option<rsigma_eval::CorrelationSnapshot> {
         let snapshot = self.engine.load();
-        let engine = snapshot.lock().unwrap();
+        let engine = snapshot.lock();
         engine.export_state()
     }
 
     /// Import correlation state into the current engine.
     pub fn import_state(&self, snapshot: &rsigma_eval::CorrelationSnapshot) -> bool {
         let guard = self.engine.load();
-        let mut engine = guard.lock().unwrap();
+        let mut engine = guard.lock();
         engine.import_state(snapshot)
     }
 
     /// Return summary statistics about the current engine.
     pub fn stats(&self) -> crate::engine::EngineStats {
         let snapshot = self.engine.load();
-        let engine = snapshot.lock().unwrap();
+        let engine = snapshot.lock();
         engine.stats()
     }
 }


### PR DESCRIPTION
## Summary

Depends on #71.

- Add SIGTERM handler alongside ctrl_c for graceful daemon shutdown
- Replace `std::sync::Mutex` with `parking_lot::Mutex` in `processor.rs`, eliminating 7 `.lock().unwrap()` call sites
- Add per-line size cap (1 MB) to `/api/v1/events` handler, returning 413 Payload Too Large
- Document the reload channel backpressure design (capacity 4, debounce, try_recv drain)

## Test plan

- [x] `cargo check` passes with `parking_lot::Mutex`
- [x] All existing processor tests pass
- [x] Manual verification of SIGTERM behavior documented