### PR TITLE
fix(quality): add KEY_CACHE completeness test, replace partial_cmp with total_cmp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,5 +163,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
     continue-on-error: true

--- a/crates/rsigma-convert/src/error.rs
+++ b/crates/rsigma-convert/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ConvertError {
     #[error("backend does not support modifier: {0}")]
     UnsupportedModifier(String),

--- a/crates/rsigma-eval/src/correlation/window.rs
+++ b/crates/rsigma-eval/src/correlation/window.rs
@@ -226,7 +226,7 @@ impl WindowState {
                 if values.is_empty() {
                     return None;
                 }
-                values.sort_by(|a, b| a.partial_cmp(b).expect("NaN filtered"));
+                values.sort_by(|a, b| a.total_cmp(b));
                 let percentile_rank = condition.percentile.map(|p| p as f64).unwrap_or(50.0);
                 let pval = percentile_linear_interp(&values, percentile_rank);
                 return Some(pval);
@@ -243,7 +243,7 @@ impl WindowState {
                     if values.is_empty() {
                         return None;
                     }
-                    values.sort_by(|a, b| a.partial_cmp(b).expect("NaN filtered"));
+                    values.sort_by(|a, b| a.total_cmp(b));
                     let mid = values.len() / 2;
                     if values.len().is_multiple_of(2) && values.len() >= 2 {
                         (values[mid - 1] + values[mid]) / 2.0

--- a/crates/rsigma-parser/src/error.rs
+++ b/crates/rsigma-parser/src/error.rs
@@ -20,6 +20,7 @@ impl fmt::Display for SourceLocation {
 
 /// Errors that can occur during Sigma rule parsing.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SigmaParserError {
     #[error("YAML parsing error: {0}")]
     Yaml(#[from] serde_yaml::Error),

--- a/crates/rsigma-parser/src/lint/mod.rs
+++ b/crates/rsigma-parser/src/lint/mod.rs
@@ -1681,4 +1681,38 @@ EventID: 4624
             .collect();
         assert_eq!(rule_results.len(), 1);
     }
+
+    #[test]
+    fn all_lint_keys_are_cached() {
+        const ALL_LINT_KEYS: &[&str] = &[
+            "action",
+            "author",
+            "condition",
+            "correlation",
+            "date",
+            "description",
+            "detection",
+            "field",
+            "filter",
+            "generate",
+            "group-by",
+            "id",
+            "level",
+            "logsource",
+            "modified",
+            "name",
+            "rules",
+            "selection",
+            "status",
+            "tags",
+            "taxonomy",
+            "timeframe",
+            "timespan",
+            "title",
+            "type",
+        ];
+        for key_str in ALL_LINT_KEYS {
+            assert!(KEY_CACHE.contains_key(key_str), "key not cached: {key_str}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Depends on #71.

- Add exhaustive test that verifies all lint key strings are present in `KEY_CACHE`, turning a runtime panic into a test-time failure
- Replace `partial_cmp().expect("NaN filtered")` with `f64::total_cmp()` in `window.rs` percentile/median calculations, eliminating potential panic on NaN

## Test plan

- [x] `all_lint_keys_are_cached` test passes
- [x] All existing eval tests pass with `total_cmp`