### PR TITLE
test: add runtime integration tests and parser AST snapshot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,5 +163,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
     continue-on-error: true

--- a/crates/rsigma-convert/src/error.rs
+++ b/crates/rsigma-convert/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ConvertError {
     #[error("backend does not support modifier: {0}")]
     UnsupportedModifier(String),

--- a/crates/rsigma-parser/src/error.rs
+++ b/crates/rsigma-parser/src/error.rs
@@ -20,6 +20,7 @@ impl fmt::Display for SourceLocation {
 
 /// Errors that can occur during Sigma rule parsing.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SigmaParserError {
     #[error("YAML parsing error: {0}")]
     Yaml(#[from] serde_yaml::Error),

--- a/crates/rsigma-parser/tests/ast_snapshots.rs
+++ b/crates/rsigma-parser/tests/ast_snapshots.rs
@@ -1,0 +1,120 @@
+use rsigma_parser::parse_sigma_yaml;
+
+#[test]
+fn simple_detection_rule() {
+    let yaml = r#"
+title: Simple Detection
+id: 12345678-1234-1234-1234-123456789012
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: "powershell"
+    condition: selection
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(collection.rules.len(), 1);
+    insta::assert_debug_snapshot!("simple_detection", &collection.rules[0]);
+}
+
+#[test]
+fn complex_condition_with_or_and_not() {
+    let yaml = r#"
+title: Complex Condition
+status: test
+logsource:
+    category: test
+detection:
+    sel1:
+        FieldA: "alpha"
+    sel2:
+        FieldB: "beta"
+    filter:
+        FieldC: "gamma"
+    condition: (sel1 or sel2) and not filter
+level: medium
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(collection.rules.len(), 1);
+    let rule = &collection.rules[0];
+    assert_eq!(rule.detection.named.len(), 3);
+    insta::assert_debug_snapshot!("complex_condition", &rule.detection.conditions);
+}
+
+#[test]
+fn correlation_event_count() {
+    let yaml = r#"
+title: Base Rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection
+---
+title: Brute Force Correlation
+name: brute_force
+status: experimental
+correlation:
+    type: event_count
+    rules:
+        - Base Rule
+    group-by:
+        - SourceIP
+    timespan: 5m
+    condition:
+        gte: 10
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(collection.rules.len(), 1);
+    assert_eq!(collection.correlations.len(), 1);
+    insta::assert_debug_snapshot!("correlation_event_count", &collection.correlations[0]);
+}
+
+#[test]
+fn filter_rule() {
+    let yaml = r#"
+title: Exclude Known Good
+filter:
+    rules:
+        - 12345678-1234-1234-1234-123456789012
+    selection:
+        CommandLine|contains: "expected_tool.exe"
+    condition: not selection
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(collection.filters.len(), 1);
+    insta::assert_debug_snapshot!("filter_rule", &collection.filters[0]);
+}
+
+#[test]
+fn detection_with_multiple_values_and_modifiers() {
+    let yaml = r#"
+title: Multi-value Detection
+status: test
+logsource:
+    category: proxy
+    product: generic
+detection:
+    selection:
+        c-uri|contains|all:
+            - "/api/admin"
+            - "token="
+        cs-method:
+            - POST
+            - PUT
+    condition: selection
+level: critical
+tags:
+    - attack.initial_access
+    - attack.t1190
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(collection.rules.len(), 1);
+    insta::assert_debug_snapshot!("multi_value_modifiers", &collection.rules[0]);
+}

--- a/crates/rsigma-parser/tests/snapshots/ast_snapshots__complex_condition.snap
+++ b/crates/rsigma-parser/tests/snapshots/ast_snapshots__complex_condition.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rsigma-parser/tests/ast_snapshots.rs
+expression: "&rule.detection.conditions"
+---
+[
+    And(
+        [
+            Or(
+                [
+                    Identifier(
+                        "sel1",
+                    ),
+                    Identifier(
+                        "sel2",
+                    ),
+                ],
+            ),
+            Not(
+                Identifier(
+                    "filter",
+                ),
+            ),
+        ],
+    ),
+]

--- a/crates/rsigma-parser/tests/snapshots/ast_snapshots__correlation_event_count.snap
+++ b/crates/rsigma-parser/tests/snapshots/ast_snapshots__correlation_event_count.snap
@@ -1,0 +1,55 @@
+---
+source: crates/rsigma-parser/tests/ast_snapshots.rs
+expression: "&collection.correlations[0]"
+---
+CorrelationRule {
+    title: "Brute Force Correlation",
+    id: None,
+    name: Some(
+        "brute_force",
+    ),
+    status: Some(
+        Experimental,
+    ),
+    description: None,
+    author: None,
+    date: None,
+    modified: None,
+    related: [],
+    references: [],
+    taxonomy: None,
+    license: None,
+    tags: [],
+    fields: [],
+    falsepositives: [],
+    level: Some(
+        High,
+    ),
+    scope: [],
+    correlation_type: EventCount,
+    rules: [
+        "Base Rule",
+    ],
+    group_by: [
+        "SourceIP",
+    ],
+    timespan: Timespan {
+        count: 5,
+        unit: Minute,
+        seconds: 300,
+        original: "5m",
+    },
+    condition: Threshold {
+        predicates: [
+            (
+                Gte,
+                10,
+            ),
+        ],
+        field: None,
+        percentile: None,
+    },
+    aliases: [],
+    generate: false,
+    custom_attributes: {},
+}

--- a/crates/rsigma-parser/tests/snapshots/ast_snapshots__filter_rule.snap
+++ b/crates/rsigma-parser/tests/snapshots/ast_snapshots__filter_rule.snap
@@ -1,0 +1,71 @@
+---
+source: crates/rsigma-parser/tests/ast_snapshots.rs
+expression: "&collection.filters[0]"
+---
+FilterRule {
+    title: "Exclude Known Good",
+    id: None,
+    name: None,
+    taxonomy: None,
+    status: None,
+    description: None,
+    author: None,
+    date: None,
+    modified: None,
+    related: [],
+    license: None,
+    references: [],
+    tags: [],
+    fields: [],
+    falsepositives: [],
+    level: None,
+    scope: [],
+    logsource: None,
+    rules: Specific(
+        [
+            "12345678-1234-1234-1234-123456789012",
+        ],
+    ),
+    detection: Detections {
+        named: {
+            "selection": AllOf(
+                [
+                    DetectionItem {
+                        field: FieldSpec {
+                            name: Some(
+                                "CommandLine",
+                            ),
+                            modifiers: [
+                                Contains,
+                            ],
+                        },
+                        values: [
+                            String(
+                                SigmaString {
+                                    parts: [
+                                        Plain(
+                                            "expected_tool.exe",
+                                        ),
+                                    ],
+                                    original: "expected_tool.exe",
+                                },
+                            ),
+                        ],
+                    },
+                ],
+            ),
+        },
+        conditions: [
+            Not(
+                Identifier(
+                    "selection",
+                ),
+            ),
+        ],
+        condition_strings: [
+            "not selection",
+        ],
+        timeframe: None,
+    },
+    custom_attributes: {},
+}

--- a/crates/rsigma-parser/tests/snapshots/ast_snapshots__multi_value_modifiers.snap
+++ b/crates/rsigma-parser/tests/snapshots/ast_snapshots__multi_value_modifiers.snap
@@ -1,0 +1,122 @@
+---
+source: crates/rsigma-parser/tests/ast_snapshots.rs
+expression: "&collection.rules[0]"
+---
+SigmaRule {
+    title: "Multi-value Detection",
+    logsource: LogSource {
+        category: Some(
+            "proxy",
+        ),
+        product: Some(
+            "generic",
+        ),
+        service: None,
+        definition: None,
+        custom: {},
+    },
+    detection: Detections {
+        named: {
+            "selection": AllOf(
+                [
+                    DetectionItem {
+                        field: FieldSpec {
+                            name: Some(
+                                "c-uri",
+                            ),
+                            modifiers: [
+                                Contains,
+                                All,
+                            ],
+                        },
+                        values: [
+                            String(
+                                SigmaString {
+                                    parts: [
+                                        Plain(
+                                            "/api/admin",
+                                        ),
+                                    ],
+                                    original: "/api/admin",
+                                },
+                            ),
+                            String(
+                                SigmaString {
+                                    parts: [
+                                        Plain(
+                                            "token=",
+                                        ),
+                                    ],
+                                    original: "token=",
+                                },
+                            ),
+                        ],
+                    },
+                    DetectionItem {
+                        field: FieldSpec {
+                            name: Some(
+                                "cs-method",
+                            ),
+                            modifiers: [],
+                        },
+                        values: [
+                            String(
+                                SigmaString {
+                                    parts: [
+                                        Plain(
+                                            "POST",
+                                        ),
+                                    ],
+                                    original: "POST",
+                                },
+                            ),
+                            String(
+                                SigmaString {
+                                    parts: [
+                                        Plain(
+                                            "PUT",
+                                        ),
+                                    ],
+                                    original: "PUT",
+                                },
+                            ),
+                        ],
+                    },
+                ],
+            ),
+        },
+        conditions: [
+            Identifier(
+                "selection",
+            ),
+        ],
+        condition_strings: [
+            "selection",
+        ],
+        timeframe: None,
+    },
+    id: None,
+    name: None,
+    related: [],
+    taxonomy: None,
+    status: Some(
+        Test,
+    ),
+    description: None,
+    license: None,
+    author: None,
+    references: [],
+    date: None,
+    modified: None,
+    fields: [],
+    falsepositives: [],
+    level: Some(
+        Critical,
+    ),
+    tags: [
+        "attack.initial_access",
+        "attack.t1190",
+    ],
+    scope: [],
+    custom_attributes: {},
+}

--- a/crates/rsigma-parser/tests/snapshots/ast_snapshots__simple_detection.snap
+++ b/crates/rsigma-parser/tests/snapshots/ast_snapshots__simple_detection.snap
@@ -1,0 +1,80 @@
+---
+source: crates/rsigma-parser/tests/ast_snapshots.rs
+expression: "&collection.rules[0]"
+---
+SigmaRule {
+    title: "Simple Detection",
+    logsource: LogSource {
+        category: Some(
+            "process_creation",
+        ),
+        product: Some(
+            "windows",
+        ),
+        service: None,
+        definition: None,
+        custom: {},
+    },
+    detection: Detections {
+        named: {
+            "selection": AllOf(
+                [
+                    DetectionItem {
+                        field: FieldSpec {
+                            name: Some(
+                                "CommandLine",
+                            ),
+                            modifiers: [
+                                Contains,
+                            ],
+                        },
+                        values: [
+                            String(
+                                SigmaString {
+                                    parts: [
+                                        Plain(
+                                            "powershell",
+                                        ),
+                                    ],
+                                    original: "powershell",
+                                },
+                            ),
+                        ],
+                    },
+                ],
+            ),
+        },
+        conditions: [
+            Identifier(
+                "selection",
+            ),
+        ],
+        condition_strings: [
+            "selection",
+        ],
+        timeframe: None,
+    },
+    id: Some(
+        "12345678-1234-1234-1234-123456789012",
+    ),
+    name: None,
+    related: [],
+    taxonomy: None,
+    status: Some(
+        Test,
+    ),
+    description: None,
+    license: None,
+    author: None,
+    references: [],
+    date: None,
+    modified: None,
+    fields: [],
+    falsepositives: [],
+    level: Some(
+        High,
+    ),
+    tags: [],
+    scope: [],
+    custom_attributes: {},
+}

--- a/crates/rsigma-runtime/tests/integration.rs
+++ b/crates/rsigma-runtime/tests/integration.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use rsigma_eval::CorrelationConfig;
+use rsigma_runtime::{LogProcessor, NoopMetrics, RuntimeEngine};
+
+fn build_processor(rules_yaml: &str) -> (LogProcessor, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let rule_path = dir.path().join("test.yml");
+    std::fs::write(&rule_path, rules_yaml).unwrap();
+
+    let mut engine = RuntimeEngine::new(rule_path, vec![], CorrelationConfig::default(), false);
+    engine.load_rules().unwrap();
+    let proc = LogProcessor::new(engine, Arc::new(NoopMetrics));
+    (proc, dir)
+}
+
+fn identity_filter(v: &serde_json::Value) -> Vec<serde_json::Value> {
+    vec![v.clone()]
+}
+
+#[test]
+fn happy_path_single_detection() {
+    let (proc, _dir) = build_processor(
+        r#"
+title: Suspicious Process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: "powershell"
+    condition: selection
+level: high
+"#,
+    );
+
+    let batch = vec![
+        r#"{"CommandLine": "powershell -enc ABC", "Image": "cmd.exe"}"#.to_string(),
+        r#"{"CommandLine": "notepad.exe", "Image": "explorer.exe"}"#.to_string(),
+    ];
+    let results = proc.process_batch_lines(&batch, &identity_filter);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results[0].detections.len(),
+        1,
+        "powershell line should match"
+    );
+    assert_eq!(
+        results[0].detections[0].rule_title, "Suspicious Process",
+        "detection should carry the rule title"
+    );
+    assert!(
+        results[1].detections.is_empty(),
+        "notepad line should not match"
+    );
+}
+
+#[test]
+fn no_match_yields_empty_detections() {
+    let (proc, _dir) = build_processor(
+        r#"
+title: Never Matches
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 99999
+    condition: selection
+"#,
+    );
+
+    let batch = vec![r#"{"EventID": 1}"#.to_string()];
+    let results = proc.process_batch_lines(&batch, &identity_filter);
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].detections.is_empty());
+}
+
+#[test]
+fn reload_picks_up_new_rules() {
+    let dir = tempfile::tempdir().unwrap();
+    let rule_path = dir.path().join("rule.yml");
+    std::fs::write(
+        &rule_path,
+        r#"
+title: Original
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 1
+    condition: selection
+"#,
+    )
+    .unwrap();
+
+    let mut engine = RuntimeEngine::new(
+        rule_path.clone(),
+        vec![],
+        CorrelationConfig::default(),
+        false,
+    );
+    engine.load_rules().unwrap();
+    let proc = LogProcessor::new(engine, Arc::new(NoopMetrics));
+
+    let batch = vec![r#"{"EventID": 42}"#.to_string()];
+    let results = proc.process_batch_lines(&batch, &identity_filter);
+    assert!(
+        results[0].detections.is_empty(),
+        "should not match EventID=42 yet"
+    );
+
+    std::fs::write(
+        &rule_path,
+        r#"
+title: Updated
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        EventID: 42
+    condition: selection
+"#,
+    )
+    .unwrap();
+
+    proc.reload_rules().expect("reload should succeed");
+
+    let results = proc.process_batch_lines(&batch, &identity_filter);
+    assert_eq!(results[0].detections.len(), 1, "reloaded rule should match");
+    assert_eq!(results[0].detections[0].rule_title, "Updated");
+}


### PR DESCRIPTION
## Summary

Depends on #71.

- Add `crates/rsigma-runtime/tests/integration.rs` with three happy-path tests (single detection, no match, reload picks up new rules) exercising `LogProcessor` without Docker or feature flags
- Add `crates/rsigma-parser/tests/ast_snapshots.rs` with five `insta` debug snapshot tests covering simple detection, complex condition, event count correlation, filter rule, and multi-value modifier rules

## Test plan

- [x] All 3 runtime integration tests pass
- [x] All 5 parser snapshot tests pass and are stable across repeated runs
- [x] Snapshots committed under `tests/snapshots/`