### PR TITLE
docs: document dynamic pipelines across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For rule quality and editor integration, a built-in linter validates rules again
 * Compile and evaluate rules against JSON events in real time with stateless detection and stateful correlation (sliding windows, group-by, chaining, suppression)
 * Accept JSON, syslog (RFC 3164/5424), logfmt, CEF, EVTX (Windows Event Log), plain text, and OTLP logs with format auto-detection
 * pySigma-compatible processing pipelines for field mapping, transformations, conditions, and finalizers
+* Dynamic pipelines: populate any pipeline value from external sources (HTTP, files, commands, NATS) with template expansion, auto-refresh, and data extraction via jq, JSONPath, or CEL
 * Convert rules into backend-native query strings via a pluggable backend trait (PostgreSQL/TimescaleDB SQL, LynxDB)
 * Run as a streaming detection daemon with hot-reload, Prometheus metrics, and HTTP/NATS/OTLP input
 * NATS JetStream support with authentication (credentials, mTLS), replay, consumer groups, and dead-letter queues
@@ -188,6 +189,51 @@ rsigma eval -r rules/ --input-format cef < arcsight.log
 rsigma eval -r rules/ -e @security.evtx
 ```
 
+### Dynamic Pipelines
+
+Standard Sigma pipelines are static: every value is hardcoded in YAML. RSigma extends this with dynamic pipelines where external data sources feed into any part of a pipeline via `${source.*}` template references. This means field mappings, condition values, and even entire transformation blocks can be populated from live APIs, configuration files, commands, or NATS subjects.
+
+```yaml
+# pipeline.yml with dynamic sources
+name: dynamic_example
+sources:
+  - id: threat_intel
+    type: http
+    url: https://intel.example.com/v1/iocs
+    format: json
+    extract: ".indicators[].ip"
+    refresh: 300s
+    timeout: 10s
+    on_error: use_cached
+
+  - id: field_map
+    type: file
+    path: /etc/rsigma/fields.json
+    format: json
+    refresh: watch
+
+transformations:
+  - id: map_fields
+    type: field_name_mapping
+    mapping: ${source.field_map}
+
+  - id: block_known_bad
+    type: add_condition
+    conditions:
+      - field: DestinationIp
+        value: ${source.threat_intel}
+```
+
+```bash
+# Test source resolution offline
+rsigma resolve -p pipeline.yml --pretty
+
+# Run the daemon with a dynamic pipeline
+rsigma daemon -r rules/ -p pipeline.yml
+```
+
+Sources support four types (file, HTTP, command, NATS), multiple data formats (JSON, YAML, lines, CSV), three extraction languages (jq, JSONPath, CEL), configurable refresh policies, error handling with caching, and include directives for injecting entire transformation blocks. See the [CLI README](crates/rsigma-cli/README.md#dynamic-pipelines) for the full reference and the [runtime README](crates/rsigma-runtime/README.md) for the library API.
+
 ### Rule Conversion
 
 Convert Sigma rules into backend-native queries for historical threat hunting.
@@ -301,7 +347,7 @@ Everything starts with a Sigma rule in YAML format:
 
 From there, the AST can go in three directions depending on what you need:
 
-- **Evaluation:** `rsigma-eval` compiles rules into optimized matchers (`compiler.rs`), runs stateless detection through `Engine`, and tracks stateful correlation (`correlation.rs`: sliding windows, group-by, chaining, suppression) across events. Processing pipelines handle field mapping, transformations, conditions, and finalizers before compilation. Events are accessed through a trait with implementations for JSON, key-value, and plain text.
+- **Evaluation:** `rsigma-eval` compiles rules into optimized matchers (`compiler.rs`), runs stateless detection through `Engine`, and tracks stateful correlation (`correlation.rs`: sliding windows, group-by, chaining, suppression) across events. Processing pipelines handle field mapping, transformations, conditions, and finalizers before compilation. Dynamic pipelines extend this with `${source.*}` template references that are resolved at runtime from external data sources. Events are accessed through a trait with implementations for JSON, key-value, and plain text.
 
 - **Conversion:** `rsigma-convert` transforms rules into backend-native query strings through a pluggable `Backend` trait. A condition walker traverses the AST and delegates to the backend for each node. `TextQueryConfig` exposes ~90 configuration fields for text-based backends. Concrete implementations include PostgreSQL/TimescaleDB (SQL for historical threat hunting) and LynxDB (SPL2-compatible search queries for log analytics).
 
@@ -310,6 +356,7 @@ From there, the AST can go in three directions depending on what you need:
 When running as a streaming detection engine, `rsigma-eval` feeds into `rsigma-runtime`:
 
 - **Input:** Format adapters parse raw log lines (JSON, syslog, logfmt\*, CEF\*, plain text, with auto-detection) into `EventInputDecoded`. EVTX\* files are parsed directly from binary via `EvtxFileReader`. Sources include stdin, HTTP POST, NATS JetStream, and OTLP\* (HTTP protobuf/JSON and gRPC).
+- **Dynamic sources:** `SourceResolver` fetches data from files, commands, HTTP APIs, and NATS subjects. Resolved values are injected into pipelines via `TemplateExpander`. A `SourceCache` (in-memory + optional SQLite) provides fallback data. `RefreshScheduler` manages auto-refresh (interval, file watch, NATS push, on-demand). Extraction supports jq, JSONPath, and CEL.
 - **Processing:** `LogProcessor` runs batch evaluation with parallel detection and sequential correlation. `RuntimeEngine` wraps `Engine` and `CorrelationEngine` with rule loading and `ArcSwap` hot-reload.
 - **Output:** Sinks write detection results to stdout, files, or NATS. Multiple sinks can run in fan-out. The output is `MatchResult` and `CorrelationResult`, containing rule title, id, level, tags, matched selections, field matches, aggregated values, and optionally the triggering events.
 

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -70,10 +70,12 @@ Parse and compile all rules in a directory, reporting errors.
 | `path` | positional | required | Path to a directory of Sigma YAML files |
 | `--verbose` / `-v` | flag | `false` | Show details for each file (parse errors, compile errors) |
 | `--pipeline` / `-p` | repeatable | `[]` | Processing pipeline YAML file(s) to apply before compilation |
+| `--resolve-sources` | flag | `false` | Also resolve dynamic pipeline sources during validation. Sources must be reachable (file/command/HTTP) for validation to pass |
 
 ```bash
 rsigma validate path/to/rules/ -v              # verbose output
 rsigma validate rules/ -p pipelines/ecs.yml    # validate with pipeline
+rsigma validate rules/ -p dynamic.yml --resolve-sources  # validate + test source resolution
 ```
 
 ### `lint`: Lint rules against the Sigma specification
@@ -152,6 +154,7 @@ Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-r
 | `--clear-state` | flag | `false` | Clear correlation state on startup (conflicts with `--keep-state`) |
 | `--keep-state` | flag | `false` | Force restore correlation state on startup, even during replay (conflicts with `--clear-state`) |
 | `--timestamp-fallback` | string | `"wallclock"` | `wallclock` (substitute current time) or `skip` (omit from correlation) when events lack parseable timestamps |
+| `--allow-remote-include` | flag | `false` | Allow `include` directives in dynamic pipelines to reference remote (HTTP/NATS) sources. Local sources (file/command) are always permitted |
 
 **NATS flags** (require `daemon-nats` feature):
 
@@ -252,6 +255,9 @@ rsigma daemon \
 | `/api/v1/rules` | GET | Rule counts and rules path |
 | `/api/v1/reload` | POST | Trigger a manual rule reload |
 | `/api/v1/events` | POST | Ingest events (NDJSON body, one event per line). Only available with `--input http` |
+| `/api/v1/sources` | GET | List dynamic sources and their resolution status |
+| `/api/v1/sources/resolve` | POST | Trigger re-resolution of all dynamic sources (or specific ones via request body) |
+| `/api/v1/sources/cache/{source_id}` | DELETE | Invalidate the cached value for a specific source |
 | `/v1/logs` | POST | OTLP log ingestion (`application/x-protobuf` or `application/json`, gzip supported). Requires `daemon-otlp` feature |
 
 **OTLP log ingestion** (requires `daemon-otlp` feature):
@@ -286,8 +292,10 @@ curl -X POST http://localhost:9090/v1/logs \
 **Hot-reload triggers:**
 
 - File system changes to `.yml`/`.yaml` files in the rules directory (debounced 500ms)
-- `SIGHUP` signal (Unix only)
+- `SIGHUP` signal (Unix only) -- triggers both rule reload and dynamic source re-resolution
 - `POST /api/v1/reload`
+- `POST /api/v1/sources/resolve` -- re-resolves dynamic sources without reloading rules
+- NATS control subject `rsigma.control.resolve` (when using NATS sources) -- payload can be empty (resolve all) or `{"source_id": "..."}` (resolve one)
 
 **Prometheus metrics:**
 
@@ -312,6 +320,11 @@ curl -X POST http://localhost:9090/v1/logs \
 | `rsigma_back_pressure_events_total` | counter | | Times a source was blocked on a full event channel |
 | `rsigma_uptime_seconds` | gauge | | Daemon uptime in seconds |
 | `rsigma_dlq_events_total` | counter | | Events routed to the dead-letter queue |
+| `rsigma_source_resolves_total` | counter | `source_id` | Total dynamic source resolution attempts |
+| `rsigma_source_resolve_errors_total` | counter | `source_id` | Total dynamic source resolution failures |
+| `rsigma_source_resolve_latency_seconds` | histogram | | Source resolution latency |
+| `rsigma_source_cache_hits_total` | counter | | Times a cached value was served instead of fetching fresh |
+| `rsigma_source_last_resolved_timestamp` | gauge | `source_id` | Unix timestamp of last successful resolution per source |
 | `rsigma_otlp_requests_total` | counter | `transport`, `encoding` | OTLP export requests received (requires `daemon-otlp`) |
 | `rsigma_otlp_log_records_total` | counter | | Log records ingested via OTLP (requires `daemon-otlp`) |
 | `rsigma_otlp_errors_total` | counter | `transport`, `reason` | OTLP request errors (requires `daemon-otlp`) |
@@ -609,6 +622,54 @@ rsigma fields -r rules/ --json | jq '.fields[] | select(.sources[] == "detection
 
 **JSON output** includes a `summary` object (rule/correlation/filter counts, unique fields, pipelines applied), a `fields` array, and when pipelines are applied, a `pipeline_mappings` array showing each field name transformation.
 
+### `resolve`: Test dynamic source resolution
+
+Resolve all dynamic sources declared in the given pipeline(s) and print the resulting data as JSON. Useful for testing pipeline source configuration without running the daemon.
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `--pipeline` / `-p` | repeatable | required | Processing pipeline(s) containing dynamic sources |
+| `--source` / `-s` | string | none | Resolve only a specific source by ID |
+| `--pretty` | flag | `false` | Pretty-print JSON output |
+| `--dry-run` | flag | `false` | Show what would be resolved (source metadata) without performing resolution |
+
+```bash
+# Resolve all sources in a dynamic pipeline
+rsigma resolve -p pipelines/dynamic.yml --pretty
+
+# Resolve a specific source by ID
+rsigma resolve -p pipelines/dynamic.yml --source threat_intel
+
+# Dry-run: list sources and metadata without fetching
+rsigma resolve -p pipelines/dynamic.yml --dry-run
+
+# Test multiple pipelines at once
+rsigma resolve -p pipeline1.yml -p pipeline2.yml
+```
+
+**Output format (normal mode):**
+
+```json
+{
+  "pipeline": "dynamic_example",
+  "source_id": "field_map",
+  "status": "ok",
+  "data": { "CommandLine": "process.command_line", "User": "user.name" }
+}
+```
+
+**Output format (dry-run mode):**
+
+```json
+{
+  "pipeline": "dynamic_example",
+  "source_id": "field_map",
+  "source_type": "File",
+  "required": true,
+  "refresh": "Watch"
+}
+```
+
 ### `condition`: Parse a condition expression
 
 Parse a Sigma condition expression and output the AST as pretty-printed JSON. Output is always pretty-printed.
@@ -715,6 +776,134 @@ The `event` field is present only when `--include-event` is set.
 - All pipelines are applied in sequence to each rule before compilation.
 - In daemon mode, pipeline files are watched for changes and re-read on reload (alongside rules). Builtin pipelines are embedded at compile time and are not file-watched. If a pipeline file becomes invalid, the reload fails and the previous configuration stays active.
 - `merge_pipelines` is not used by the CLI; each pipeline remains separate with its own state.
+
+## Dynamic Pipelines
+
+Dynamic pipelines extend static Sigma pipelines with external data sources. Any string, list, or mapping value in the pipeline YAML can contain `${source.<id>}` template references that are resolved at runtime.
+
+### Source declaration
+
+Add a `sources` section to your pipeline YAML:
+
+```yaml
+name: dynamic_threat_intel
+sources:
+  - id: ip_blocklist
+    type: http
+    url: https://feeds.example.com/blocklist.json
+    format: json
+    extract: ".ips"
+    refresh: 300s
+    timeout: 10s
+    on_error: use_cached
+    required: true
+
+  - id: field_config
+    type: file
+    path: /etc/rsigma/fields.json
+    format: json
+    refresh: watch
+
+  - id: enrichment_rules
+    type: command
+    command: ["generate-transformations", "--format", "json"]
+    format: json
+    refresh: once
+
+transformations:
+  - id: map_fields
+    type: field_name_mapping
+    mapping: ${source.field_config}
+
+  - id: block_known_bad
+    type: add_condition
+    conditions:
+      - field: DestinationIp
+        value: ${source.ip_blocklist}
+
+  - include: ${source.enrichment_rules}
+```
+
+### Source types
+
+| Type | Description |
+|------|-------------|
+| `file` | Read from a local file. Supports `refresh: watch` for automatic reload on change |
+| `http` | Fetch from an HTTP endpoint. Supports `method`, `headers`, `timeout` |
+| `command` | Run a local command and capture stdout |
+| `nats` | Subscribe to a NATS subject for push-based updates (requires `daemon-nats` feature) |
+
+### Data formats
+
+| Format | Description |
+|--------|-------------|
+| `json` | Parsed with serde_json |
+| `yaml` | Parsed with serde_yaml |
+| `lines` | One value per line (produces a JSON array of strings) |
+| `csv` | Comma-separated values |
+
+### Extraction languages
+
+After parsing the source data, an optional `extract` expression selects a subset:
+
+```yaml
+# jq (default) -- plain string is always jq
+extract: ".indicators[].ip"
+
+# JSONPath -- structured syntax
+extract:
+  type: jsonpath
+  expr: "$.indicators[*].ip"
+
+# CEL (Common Expression Language) -- structured syntax
+extract:
+  type: cel
+  expr: "data.indicators.filter(i, i.severity > 7)"
+```
+
+| Language | Syntax | Library |
+|----------|--------|---------|
+| jq | Plain string or `{ type: jq, expr: "..." }` | jaq |
+| JSONPath | `{ type: jsonpath, expr: "..." }` | jsonpath-rust |
+| CEL | `{ type: cel, expr: "..." }` | cel-rust |
+
+### Refresh policies
+
+| Policy | Behavior |
+|--------|----------|
+| `once` | Fetch at startup only |
+| `<duration>` (e.g. `300s`, `5m`) | Re-fetch on a fixed interval |
+| `watch` | Watch the file for changes (file sources only) |
+| `push` | Updated on each incoming NATS message (NATS sources only) |
+| `on_demand` | Fetch at startup, then only when triggered via API or SIGHUP |
+
+### Error policies
+
+| Policy | Behavior |
+|--------|----------|
+| `use_cached` | Serve the last successfully fetched value on failure |
+| `fail` | For required sources: block startup. For optional sources: log and use null |
+| `use_default` | Fall back to the `default` value declared in the source config |
+
+### Include directives
+
+The `include` transformation type injects an entire block of transformations from a resolved source:
+
+```yaml
+transformations:
+  - include: ${source.dynamic_transforms}
+```
+
+The source must resolve to a JSON array of transformation objects. Nested includes are rejected (max depth 1). Remote sources (HTTP/NATS) require `--allow-remote-include` for security.
+
+### Startup behavior
+
+- **Required sources** (`required: true`, the default): the daemon blocks until resolution succeeds. If `on_error: fail`, it exits on failure.
+- **Optional sources** (`required: false`): if resolution fails at startup, the daemon starts with a null fallback and retries in the background.
+
+### Caching
+
+Resolved values are cached in memory (and optionally SQLite). The cache supports TTL-based expiration. The `use_cached` error policy serves stale data from the cache when a fresh fetch fails. Cache entries can be invalidated per-source via `DELETE /api/v1/sources/cache/{source_id}`.
 
 ## Environment Variables
 

--- a/crates/rsigma-runtime/README.md
+++ b/crates/rsigma-runtime/README.md
@@ -1,12 +1,13 @@
 # rsigma-runtime
 
-Streaming runtime for [rsigma](https://github.com/timescale/rsigma) — input format adapters, batch log processing, hot-reload, and pluggable metrics.
+Streaming runtime for [rsigma](https://github.com/timescale/rsigma) — input format adapters, batch log processing, hot-reload, dynamic source resolution, and pluggable metrics.
 
 ## Features
 
 - **Input adapters**: JSON/NDJSON, syslog (RFC 3164/5424), logfmt, CEF, EVTX (Windows Event Log), plain text, and auto-detect. Line-oriented adapters parse raw log lines into typed events implementing the `rsigma_eval::Event` trait. The EVTX adapter reads binary `.evtx` files directly via `EvtxFileReader` and yields `serde_json::Value` records.
 - **`LogProcessor`**: batch evaluation pipeline with atomic engine swap via `ArcSwap`, `MetricsHook` for pluggable metrics, and `EventFilter` for JSON payload extraction.
 - **`RuntimeEngine`**: wraps `Engine` and `CorrelationEngine` with rule loading, reload, and correlation state management.
+- **Dynamic source resolution**: `SourceResolver` trait with `DefaultSourceResolver` implementation fetching data from files, commands, HTTP APIs, and NATS subjects. Includes template expansion, extraction (jq/JSONPath/CEL), caching with TTL, and scheduled refresh.
 - **I/O**: `EventSource` trait (stdin, HTTP, NATS) and `Sink` enum (stdout, file, NATS) with fan-out support.
 - **OTLP**: `LogRecord`-to-JSON conversion for OpenTelemetry log ingestion (feature-gated under `otlp`). Resource and log attributes are flattened for direct Sigma rule matching.
 
@@ -37,6 +38,93 @@ let results = processor.process_batch_with_format(
 
 See the [examples](examples/) directory for complete working programs.
 
+## Dynamic Source Resolution
+
+The `sources` module provides the infrastructure for resolving external data at pipeline load time. This allows pipeline values to be populated from live data rather than hardcoded.
+
+### Core types
+
+```rust
+use rsigma_runtime::{DefaultSourceResolver, SourceResolver, SourceCache, ResolvedValue, SourceError};
+
+// Create a resolver with in-memory cache
+let resolver = DefaultSourceResolver::new();
+
+// Or with SQLite-backed persistence and TTL
+use std::time::Duration;
+let cache = SourceCache::with_sqlite_and_ttl(
+    std::path::Path::new("/tmp/rsigma-cache.db"),
+    Some(Duration::from_secs(3600)),
+).unwrap();
+let resolver = DefaultSourceResolver::with_cache(cache);
+```
+
+### Resolution flow
+
+1. **Fetch**: the source type (file, command, HTTP, NATS) determines how raw data is obtained.
+2. **Parse**: raw bytes are parsed according to the declared `DataFormat` (JSON, YAML, lines, CSV).
+3. **Extract**: an optional expression (jq, JSONPath, or CEL) selects a subset of the parsed data.
+4. **Cache**: successful results are stored for `use_cached` error policy fallback.
+5. **Template expansion**: `TemplateExpander` substitutes `${source.<id>}` references with resolved values.
+
+### Resolving all sources
+
+```rust
+use rsigma_runtime::sources::resolve_all;
+
+// sources: &[DynamicSource] from the parsed pipeline
+let resolved_map = resolve_all(&resolver, &pipeline.sources).await?;
+// resolved_map: HashMap<String, serde_json::Value>
+
+// Or with PipelineState tracking:
+use rsigma_runtime::sources::resolve_all_with_state;
+let resolved_map = resolve_all_with_state(&resolver, &pipeline.sources, Some(&mut state)).await?;
+```
+
+### Extraction languages
+
+The `extract` module supports three languages for selecting data from resolved sources:
+
+| Language | Use case | Example |
+|----------|----------|---------|
+| jq | Complex transformations, array iteration, filtering | `.indicators[].ip` |
+| JSONPath | Simple path queries into nested JSON | `$.data.items[*].value` |
+| CEL | Typed expressions with filtering and aggregation | `data.filter(x, x.score > 7)` |
+
+### Refresh scheduling
+
+The `refresh` module manages automatic re-resolution:
+
+- **Interval**: periodic timer fires resolution on a configurable cadence.
+- **Watch**: file system notifications (via `notify`) trigger re-resolution when a file source changes.
+- **Push**: NATS messages on the source subject trigger immediate updates.
+- **OnDemand**: resolution only happens when triggered via API, SIGHUP, or NATS control subject (`rsigma.control.resolve`).
+
+### Include expansion
+
+The `include` module splices transformation blocks from resolved sources into the pipeline:
+
+```rust
+use rsigma_runtime::sources::include::expand_includes;
+
+// Modifies pipeline.transformations in place, replacing Include directives
+// with the resolved transformation blocks.
+expand_includes(&mut pipeline, &resolved_map, allow_remote_include)?;
+```
+
+Recursive includes are rejected (max depth 1) to prevent cycles.
+
+### Template expansion
+
+The `template` module replaces `${source.<id>}` and `${source.<id>.<path>}` references in pipeline vars:
+
+```rust
+use rsigma_runtime::sources::TemplateExpander;
+
+// Returns a new pipeline with vars expanded using resolved source data.
+let expanded_pipeline = TemplateExpander::expand(&pipeline, &resolved_map);
+```
+
 ## Feature flags
 
 | Flag | Description |
@@ -44,7 +132,7 @@ See the [examples](examples/) directory for complete working programs.
 | `logfmt` | Enable logfmt input adapter |
 | `cef` | Enable CEF (ArcSight) input adapter |
 | `evtx` | Enable EVTX (Windows Event Log) input adapter. Provides `EvtxFileReader` for reading `.evtx` files and iterating records as `serde_json::Value` |
-| `nats` | Enable NATS JetStream source and sink |
+| `nats` | Enable NATS JetStream source and sink, NATS dynamic sources, and NATS control subject |
 | `otlp` | Enable OTLP log ingestion types and `LogRecord`-to-JSON conversion |
 
 ## License


### PR DESCRIPTION
## Summary

- Adds a brief dynamic pipelines section with YAML example to the root README, linking to the full reference
- Adds comprehensive documentation to the CLI README covering the `resolve` command, `validate --resolve-sources`, `--allow-remote-include`, source types, data formats, extraction languages (jq/JSONPath/CEL), refresh policies, error handling, caching, include directives, new API endpoints, and Prometheus metrics
- Adds dynamic source resolution documentation to the runtime README covering `SourceResolver` trait, `DefaultSourceResolver`, extraction, caching with TTL, refresh scheduling, template expansion, and include expansion

## Test plan

- [x] Verify all internal links resolve correctly
- [x] Confirm code examples are syntactically valid
- [x] Check markdown renders properly on GitHub