### PR TITLE
security: harden dynamic pipeline source resolvers

### DIFF
--- a/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
+++ b/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
@@ -65,6 +65,7 @@ impl SourceResolver for InstrumentedResolver {
                     rsigma_runtime::SourceErrorKind::Parse(_) => "Parse",
                     rsigma_runtime::SourceErrorKind::Extract(_) => "Extract",
                     rsigma_runtime::SourceErrorKind::Timeout => "Timeout",
+                    rsigma_runtime::SourceErrorKind::ResourceLimit(_) => "ResourceLimit",
                 };
                 self.metrics
                     .source_resolve_errors

--- a/crates/rsigma-runtime/src/sources/command.rs
+++ b/crates/rsigma-runtime/src/sources/command.rs
@@ -28,8 +28,8 @@ pub async fn resolve_command(
     .await
 }
 
-/// Inner implementation with configurable limits (for testing).
-pub(crate) async fn resolve_command_with_limit(
+/// Same as [`resolve_command`] but with a configurable stdout size limit.
+pub async fn resolve_command_with_limit(
     command: &[String],
     format: DataFormat,
     extract_expr: Option<&ExtractExpr>,

--- a/crates/rsigma-runtime/src/sources/command.rs
+++ b/crates/rsigma-runtime/src/sources/command.rs
@@ -1,18 +1,40 @@
 //! Command source resolver: runs a local command and captures stdout.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use rsigma_eval::pipeline::sources::{DataFormat, ExtractExpr};
+use tokio::io::AsyncReadExt;
 
 use super::extract::apply_extract;
 use super::file::parse_data;
-use super::{ResolvedValue, SourceError, SourceErrorKind};
+use super::{MAX_SOURCE_RESPONSE_BYTES, ResolvedValue, SourceError, SourceErrorKind};
+
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Resolve a command source by executing it and parsing stdout.
 pub async fn resolve_command(
     command: &[String],
     format: DataFormat,
     extract_expr: Option<&ExtractExpr>,
+    timeout: Option<Duration>,
+) -> Result<ResolvedValue, SourceError> {
+    resolve_command_with_limit(
+        command,
+        format,
+        extract_expr,
+        timeout,
+        MAX_SOURCE_RESPONSE_BYTES,
+    )
+    .await
+}
+
+/// Inner implementation with configurable limits (for testing).
+pub(crate) async fn resolve_command_with_limit(
+    command: &[String],
+    format: DataFormat,
+    extract_expr: Option<&ExtractExpr>,
+    timeout: Option<Duration>,
+    max_stdout_bytes: usize,
 ) -> Result<ResolvedValue, SourceError> {
     if command.is_empty() {
         return Err(SourceError {
@@ -21,7 +43,7 @@ pub async fn resolve_command(
         });
     }
 
-    let output = tokio::process::Command::new(&command[0])
+    let mut child = tokio::process::Command::new(&command[0])
         .args(&command[1..])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -29,27 +51,86 @@ pub async fn resolve_command(
         .map_err(|e| SourceError {
             source_id: String::new(),
             kind: SourceErrorKind::Fetch(format!("failed to spawn '{}': {e}", command[0])),
-        })?
-        .wait_with_output()
-        .await
-        .map_err(|e| SourceError {
+        })?;
+
+    let deadline = timeout.unwrap_or(DEFAULT_COMMAND_TIMEOUT);
+
+    let result = tokio::time::timeout(deadline, async {
+        let mut stdout_buf = Vec::new();
+        let mut stderr_buf = Vec::new();
+
+        if let Some(mut stdout) = child.stdout.take() {
+            let mut tmp = vec![0u8; 8192];
+            loop {
+                let n = stdout.read(&mut tmp).await.map_err(|e| SourceError {
+                    source_id: String::new(),
+                    kind: SourceErrorKind::Fetch(format!("failed to read stdout: {e}")),
+                })?;
+                if n == 0 {
+                    break;
+                }
+                if stdout_buf.len() + n > max_stdout_bytes {
+                    let _ = child.kill().await;
+                    return Err(SourceError {
+                        source_id: String::new(),
+                        kind: SourceErrorKind::ResourceLimit(format!(
+                            "command stdout exceeds {} byte limit",
+                            max_stdout_bytes
+                        )),
+                    });
+                }
+                stdout_buf.extend_from_slice(&tmp[..n]);
+            }
+        }
+
+        if let Some(mut stderr) = child.stderr.take() {
+            let cap = 64 * 1024; // 64 KB for error messages
+            let mut tmp = vec![0u8; 4096];
+            loop {
+                let n = stderr.read(&mut tmp).await.unwrap_or(0);
+                if n == 0 {
+                    break;
+                }
+                if stderr_buf.len() + n > cap {
+                    break;
+                }
+                stderr_buf.extend_from_slice(&tmp[..n]);
+            }
+        }
+
+        let status = child.wait().await.map_err(|e| SourceError {
             source_id: String::new(),
             kind: SourceErrorKind::Fetch(format!("command execution failed: {e}")),
         })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        Ok((status, stdout_buf, stderr_buf))
+    })
+    .await;
+
+    let (status, stdout_bytes, stderr_bytes) = match result {
+        Ok(inner) => inner?,
+        Err(_) => {
+            let _ = child.kill().await;
+            return Err(SourceError {
+                source_id: String::new(),
+                kind: SourceErrorKind::Timeout,
+            });
+        }
+    };
+
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr_bytes);
         return Err(SourceError {
             source_id: String::new(),
             kind: SourceErrorKind::Fetch(format!(
                 "command exited with {}: {}",
-                output.status,
+                status,
                 stderr.trim()
             )),
         });
     }
 
-    let stdout = String::from_utf8(output.stdout).map_err(|e| SourceError {
+    let stdout = String::from_utf8(stdout_bytes).map_err(|e| SourceError {
         source_id: String::new(),
         kind: SourceErrorKind::Parse(format!("command output is not valid UTF-8: {e}")),
     })?;

--- a/crates/rsigma-runtime/src/sources/http.rs
+++ b/crates/rsigma-runtime/src/sources/http.rs
@@ -7,7 +7,7 @@ use rsigma_eval::pipeline::sources::{DataFormat, ExtractExpr};
 
 use super::extract::apply_extract;
 use super::file::parse_data;
-use super::{ResolvedValue, SourceError, SourceErrorKind};
+use super::{MAX_SOURCE_RESPONSE_BYTES, ResolvedValue, SourceError, SourceErrorKind};
 
 /// Resolve an HTTP source by fetching the URL and parsing the response.
 pub async fn resolve_http(
@@ -17,6 +17,28 @@ pub async fn resolve_http(
     format: DataFormat,
     extract_expr: Option<&ExtractExpr>,
     timeout: Option<Duration>,
+) -> Result<ResolvedValue, SourceError> {
+    resolve_http_with_limit(
+        url,
+        method,
+        headers,
+        format,
+        extract_expr,
+        timeout,
+        MAX_SOURCE_RESPONSE_BYTES,
+    )
+    .await
+}
+
+/// Inner implementation with a configurable size limit (for testing).
+pub(crate) async fn resolve_http_with_limit(
+    url: &str,
+    method: Option<&str>,
+    headers: &HashMap<String, String>,
+    format: DataFormat,
+    extract_expr: Option<&ExtractExpr>,
+    timeout: Option<Duration>,
+    max_bytes: usize,
 ) -> Result<ResolvedValue, SourceError> {
     let client = reqwest::Client::builder()
         .timeout(timeout.unwrap_or(Duration::from_secs(30)))
@@ -57,17 +79,28 @@ pub async fn resolve_http(
 
     let status = response.status();
     if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
+        let body = read_body_capped(response, max_bytes)
+            .await
+            .unwrap_or_default();
         return Err(SourceError {
             source_id: String::new(),
             kind: SourceErrorKind::Fetch(format!("HTTP {status}: {}", body.trim())),
         });
     }
 
-    let body = response.text().await.map_err(|e| SourceError {
-        source_id: String::new(),
-        kind: SourceErrorKind::Fetch(format!("failed to read response body: {e}")),
-    })?;
+    if let Some(content_length) = response.content_length()
+        && content_length as usize > max_bytes
+    {
+        return Err(SourceError {
+            source_id: String::new(),
+            kind: SourceErrorKind::ResourceLimit(format!(
+                "HTTP response Content-Length ({content_length} bytes) exceeds {} byte limit",
+                max_bytes
+            )),
+        });
+    }
+
+    let body = read_body_capped(response, max_bytes).await?;
 
     let parsed = parse_data(&body, format)?;
 
@@ -81,6 +114,33 @@ pub async fn resolve_http(
         data,
         resolved_at: Instant::now(),
         from_cache: false,
+    })
+}
+
+/// Read a response body in chunks, enforcing a maximum byte cap.
+async fn read_body_capped(
+    mut response: reqwest::Response,
+    max_bytes: usize,
+) -> Result<String, SourceError> {
+    let mut buf = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| SourceError {
+        source_id: String::new(),
+        kind: SourceErrorKind::Fetch(format!("failed to read response chunk: {e}")),
+    })? {
+        if buf.len() + chunk.len() > max_bytes {
+            return Err(SourceError {
+                source_id: String::new(),
+                kind: SourceErrorKind::ResourceLimit(format!(
+                    "HTTP response body exceeds {} byte limit",
+                    max_bytes
+                )),
+            });
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    String::from_utf8(buf).map_err(|e| SourceError {
+        source_id: String::new(),
+        kind: SourceErrorKind::Parse(format!("response body is not valid UTF-8: {e}")),
     })
 }
 

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -136,7 +136,7 @@ impl SourceResolver for DefaultSourceResolver {
                 command,
                 format,
                 extract,
-            } => command::resolve_command(command, *format, extract.as_ref()).await,
+            } => command::resolve_command(command, *format, extract.as_ref(), source.timeout).await,
             SourceType::Http {
                 url,
                 method,

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -15,9 +15,15 @@ pub mod nats;
 pub mod refresh;
 pub mod template;
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use rsigma_eval::pipeline::sources::{DynamicSource, ErrorPolicy, SourceType};
+
+/// Maximum size of a source response body (HTTP, command stdout, NATS payload).
+pub const MAX_SOURCE_RESPONSE_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+
+/// Minimum allowed refresh interval to prevent hot CPU loops.
+pub const MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 pub use cache::SourceCache;
 pub use template::TemplateExpander;
@@ -61,6 +67,8 @@ pub enum SourceErrorKind {
     Extract(String),
     /// The fetch exceeded the configured timeout.
     Timeout,
+    /// The response exceeded the maximum allowed size.
+    ResourceLimit(String),
 }
 
 impl std::fmt::Display for SourceErrorKind {
@@ -70,6 +78,7 @@ impl std::fmt::Display for SourceErrorKind {
             Self::Parse(msg) => write!(f, "parse failed: {msg}"),
             Self::Extract(msg) => write!(f, "extract failed: {msg}"),
             Self::Timeout => write!(f, "timed out"),
+            Self::ResourceLimit(msg) => write!(f, "resource limit exceeded: {msg}"),
         }
     }
 }

--- a/crates/rsigma-runtime/src/sources/nats.rs
+++ b/crates/rsigma-runtime/src/sources/nats.rs
@@ -6,7 +6,22 @@ use rsigma_eval::pipeline::sources::{DataFormat, ExtractExpr};
 
 use super::extract::apply_extract;
 use super::file::parse_data;
-use super::{ResolvedValue, SourceError, SourceErrorKind};
+use super::{MAX_SOURCE_RESPONSE_BYTES, ResolvedValue, SourceError, SourceErrorKind};
+
+/// Check that a NATS payload does not exceed the size limit.
+fn check_payload_size(payload: &[u8], max_bytes: usize) -> Result<(), SourceError> {
+    if payload.len() > max_bytes {
+        return Err(SourceError {
+            source_id: String::new(),
+            kind: SourceErrorKind::ResourceLimit(format!(
+                "NATS message payload ({} bytes) exceeds {} byte limit",
+                payload.len(),
+                max_bytes
+            )),
+        });
+    }
+    Ok(())
+}
 
 /// Resolve a NATS source by connecting and fetching the latest message.
 ///
@@ -36,9 +51,9 @@ pub async fn resolve_nats_initial(
             kind: SourceErrorKind::Fetch(format!("failed to subscribe to '{subject}': {e}")),
         })?;
 
-    // Wait up to 1 second for an initial message
     let data = match tokio::time::timeout(std::time::Duration::from_secs(1), sub.next()).await {
         Ok(Some(msg)) => {
+            check_payload_size(&msg.payload, MAX_SOURCE_RESPONSE_BYTES)?;
             let raw = std::str::from_utf8(&msg.payload).map_err(|e| SourceError {
                 source_id: String::new(),
                 kind: SourceErrorKind::Parse(format!("NATS message is not valid UTF-8: {e}")),
@@ -61,12 +76,15 @@ pub async fn resolve_nats_initial(
 }
 
 /// Parse a raw NATS message payload into a resolved value.
+///
+/// Rejects payloads exceeding `MAX_SOURCE_RESPONSE_BYTES`.
 #[cfg(feature = "nats")]
 pub fn parse_nats_message(
     payload: &[u8],
     format: DataFormat,
     extract_expr: Option<&ExtractExpr>,
 ) -> Result<serde_json::Value, SourceError> {
+    check_payload_size(payload, MAX_SOURCE_RESPONSE_BYTES)?;
     let raw = std::str::from_utf8(payload).map_err(|e| SourceError {
         source_id: String::new(),
         kind: SourceErrorKind::Parse(format!("NATS message is not valid UTF-8: {e}")),

--- a/crates/rsigma-runtime/src/sources/refresh.rs
+++ b/crates/rsigma-runtime/src/sources/refresh.rs
@@ -115,7 +115,17 @@ impl RefreshScheduler {
             if let RefreshPolicy::Interval(duration) = &source.refresh {
                 let tx = trigger_tx.clone();
                 let id = source.id.clone();
-                let interval = *duration;
+                let interval = if *duration < super::MIN_REFRESH_INTERVAL {
+                    tracing::warn!(
+                        source_id = %id,
+                        configured = ?duration,
+                        clamped_to = ?super::MIN_REFRESH_INTERVAL,
+                        "Refresh interval below minimum, clamping to floor"
+                    );
+                    super::MIN_REFRESH_INTERVAL
+                } else {
+                    *duration
+                };
                 tokio::spawn(async move {
                     let mut timer = tokio::time::interval(interval);
                     timer.tick().await; // skip immediate first tick

--- a/crates/rsigma-runtime/tests/sources_integration.rs
+++ b/crates/rsigma-runtime/tests/sources_integration.rs
@@ -206,9 +206,10 @@ async fn command_source_echo_json() {
         format!("type {}", path.to_str().unwrap()),
     ];
 
-    let result = rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Json, None)
-        .await
-        .unwrap();
+    let result =
+        rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Json, None, None)
+            .await
+            .unwrap();
 
     let expected = serde_json::json!({"status": "ok", "count": 42});
     assert_eq!(result.data, expected);
@@ -230,10 +231,14 @@ async fn command_source_with_extract() {
     ];
 
     let extract = ExtractExpr::Jq(".items[]".to_string());
-    let result =
-        rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Json, Some(&extract))
-            .await
-            .unwrap();
+    let result = rsigma_runtime::sources::command::resolve_command(
+        &cmd,
+        DataFormat::Json,
+        Some(&extract),
+        None,
+    )
+    .await
+    .unwrap();
 
     let expected = serde_json::json!([1, 2, 3]);
     assert_eq!(result.data, expected);
@@ -241,7 +246,6 @@ async fn command_source_with_extract() {
 
 #[tokio::test]
 async fn command_source_lines() {
-    // Use a cross-platform approach: write to a temp file and cat it
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("lines.txt");
     std::fs::write(&path, "line1\nline2\nline3\n").unwrap();
@@ -255,9 +259,10 @@ async fn command_source_lines() {
         format!("type {}", path.to_str().unwrap()),
     ];
 
-    let result = rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Lines, None)
-        .await
-        .unwrap();
+    let result =
+        rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Lines, None, None)
+            .await
+            .unwrap();
 
     let expected = serde_json::json!(["line1", "line2", "line3"]);
     assert_eq!(result.data, expected);
@@ -271,7 +276,7 @@ async fn command_source_failing_command() {
     let cmd = vec!["cmd".to_string(), "/C".to_string(), "exit 1".to_string()];
 
     let result =
-        rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Json, None).await;
+        rsigma_runtime::sources::command::resolve_command(&cmd, DataFormat::Json, None, None).await;
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -284,7 +289,7 @@ async fn command_source_failing_command() {
 #[tokio::test]
 async fn command_source_empty_command() {
     let result =
-        rsigma_runtime::sources::command::resolve_command(&[], DataFormat::Json, None).await;
+        rsigma_runtime::sources::command::resolve_command(&[], DataFormat::Json, None, None).await;
 
     assert!(result.is_err());
 }

--- a/crates/rsigma-runtime/tests/sources_integration.rs
+++ b/crates/rsigma-runtime/tests/sources_integration.rs
@@ -615,3 +615,81 @@ fn cache_no_ttl_never_expires() {
     assert_eq!(cache.ttl(), None);
     assert_eq!(cache.get("src1").unwrap(), serde_json::json!("persistent"));
 }
+
+// =============================================================================
+// Security hardening tests
+// =============================================================================
+
+#[tokio::test]
+async fn command_source_timeout_kills_child() {
+    #[cfg(unix)]
+    let cmd = vec!["sleep".to_string(), "60".to_string()];
+    #[cfg(windows)]
+    let cmd = vec![
+        "cmd".to_string(),
+        "/C".to_string(),
+        "timeout /T 60 /NOBREAK".to_string(),
+    ];
+
+    let result = rsigma_runtime::sources::command::resolve_command(
+        &cmd,
+        DataFormat::Json,
+        None,
+        Some(std::time::Duration::from_millis(100)),
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err().kind,
+        rsigma_runtime::SourceErrorKind::Timeout
+    ));
+}
+
+#[tokio::test]
+async fn command_source_stdout_size_limit() {
+    #[cfg(unix)]
+    {
+        // Generate more than 100 bytes of stdout with a tiny limit
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "yes | head -n 200".to_string(),
+        ];
+        let result = rsigma_runtime::sources::command::resolve_command_with_limit(
+            &cmd,
+            DataFormat::Lines,
+            None,
+            Some(std::time::Duration::from_secs(5)),
+            100, // 100 byte cap
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err().kind,
+            rsigma_runtime::SourceErrorKind::ResourceLimit(_)
+        ));
+    }
+}
+
+#[cfg(feature = "nats")]
+#[test]
+fn nats_payload_size_rejected() {
+    let oversized = vec![b'x'; 11 * 1024 * 1024]; // 11 MB
+    let result =
+        rsigma_runtime::sources::nats::parse_nats_message(&oversized, DataFormat::Json, None);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err().kind,
+        rsigma_runtime::SourceErrorKind::ResourceLimit(_)
+    ));
+}
+
+#[cfg(feature = "nats")]
+#[test]
+fn nats_payload_within_limit_accepted() {
+    let small = br#"{"key": "value"}"#;
+    let result = rsigma_runtime::sources::nats::parse_nats_message(small, DataFormat::Json, None);
+    assert!(result.is_ok());
+}

--- a/crates/rsigma-runtime/tests/sources_integration.rs
+++ b/crates/rsigma-runtime/tests/sources_integration.rs
@@ -626,9 +626,9 @@ async fn command_source_timeout_kills_child() {
     let cmd = vec!["sleep".to_string(), "60".to_string()];
     #[cfg(windows)]
     let cmd = vec![
-        "cmd".to_string(),
-        "/C".to_string(),
-        "timeout /T 60 /NOBREAK".to_string(),
+        "powershell".to_string(),
+        "-Command".to_string(),
+        "Start-Sleep -Seconds 60".to_string(),
     ];
 
     let result = rsigma_runtime::sources::command::resolve_command(


### PR DESCRIPTION
## Summary

- Add 10 MB response body size limit to HTTP source resolver via chunked reads with early Content-Length rejection
- Add execution timeout (default 30s, configurable via `DynamicSource.timeout`) and 10 MB stdout cap to command source resolver, killing the child on overflow
- Add 10 MB payload size check to NATS source in both initial subscription and push message paths
- Clamp refresh interval to a 1-second floor to prevent hot CPU loops, with a warning log when clamped
- Add `ResourceLimit` error variant to `SourceErrorKind` and handle it in the instrumented resolver metrics

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New test: command timeout kills child process within 100ms
- [x] New test: command stdout cap rejects output exceeding 100-byte limit
- [x] New test: NATS payload over 10 MB rejected with ResourceLimit
- [x] New test: NATS payload under 10 MB accepted
- [x] Existing integration tests updated for new `timeout` parameter
- [x] CI passes on all platforms