### PR TITLE
fix: replace stale Phase 1 warning for dynamic pipelines

### DIFF
--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -38,6 +38,14 @@ pub(crate) fn cmd_convert(
     let collection = load_collection_multi(&rules);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
+    if pipelines.iter().any(|p| p.is_dynamic()) {
+        eprintln!(
+            "  note: dynamic sources are not resolved by `rsigma convert`. \
+             Use `rsigma resolve` to inspect sources or `rsigma daemon` to evaluate \
+             events with dynamic pipelines."
+        );
+    }
+
     let options: std::collections::HashMap<String, String> = backend_options
         .iter()
         .filter_map(|opt| {

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -67,6 +67,15 @@ pub(crate) fn cmd_eval(
 ) -> bool {
     let collection = crate::load_collection(&rules_path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
+
+    if pipelines.iter().any(|p| p.is_dynamic()) {
+        eprintln!(
+            "  note: dynamic sources are not resolved by `rsigma eval`. \
+             Use `rsigma resolve` to inspect sources or `rsigma daemon` to evaluate \
+             events with dynamic pipelines."
+        );
+    }
+
     let has_correlations = !collection.correlations.is_empty();
 
     let event_filter = crate::build_event_filter(jq, jsonpath);

--- a/crates/rsigma-cli/src/commands/fields.rs
+++ b/crates/rsigma-cli/src/commands/fields.rs
@@ -21,6 +21,14 @@ pub(crate) fn cmd_fields(
     let collection = crate::load_collection(&path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
+    if pipelines.iter().any(|p| p.is_dynamic()) {
+        eprintln!(
+            "  note: dynamic sources are not resolved by `rsigma fields`. \
+             Use `rsigma resolve` to inspect sources or `rsigma daemon` to evaluate \
+             events with dynamic pipelines."
+        );
+    }
+
     let report = build_report(&collection, &pipelines, no_filters);
 
     if json {

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -917,13 +917,7 @@ pub(crate) fn load_pipelines(paths: &[PathBuf]) -> Vec<Pipeline> {
                     if p.is_dynamic() {
                         let source_ids: Vec<&str> =
                             p.sources.iter().map(|s| s.id.as_str()).collect();
-                        eprintln!(
-                            "  warn: pipeline '{}' has {} dynamic source(s) ({}) \
-                             -- source resolution not yet supported",
-                            p.name,
-                            p.sources.len(),
-                            source_ids.join(", ")
-                        );
+                        eprintln!("  dynamic source(s): {}", source_ids.join(", "));
                     }
                     pipelines.push(p);
                 }


### PR DESCRIPTION
## Summary

- The `load_pipelines()` warning "source resolution not yet supported" was added during Phase 1 (PR #86) when source resolution did not exist. Phases 2-3 (PRs #87-#88) added full resolution in `rsigma-runtime` and the daemon, but the shared warning in `load_pipelines()` was never updated. The daemon resolves sources correctly after `load_pipelines()` runs, making the old warning misleading.
- Replace the blanket warning with a neutral `dynamic source(s): ...` info line in `load_pipelines()`, and add targeted notes in `eval`, `convert`, and `fields` commands explaining that these sync-only commands do not resolve dynamic sources and directing users to `rsigma resolve` or `rsigma daemon`.

## Changes

- `main.rs` (`load_pipelines`): Replace misleading "source resolution not yet supported" with `dynamic source(s): <ids>`
- `commands/eval.rs`: Add note that `rsigma eval` does not resolve dynamic sources
- `commands/convert.rs`: Add note that `rsigma convert` does not resolve dynamic sources
- `commands/fields.rs`: Add note that `rsigma fields` does not resolve dynamic sources

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual: `rsigma eval` with dynamic pipeline shows the new note instead of the old warning
- [x] Manual: `rsigma resolve` still resolves sources correctly (no change to resolve path)