### PR TITLE
feat(eval): batch large `|contains` lists into Aho-Corasick automaton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
 name = "rsigma-eval"
 version = "0.10.0"
 dependencies = [
+ "aho-corasick",
  "base64",
  "chrono",
  "criterion",

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_yaml = { package = "yaml_serde", version = "0.10" }
 regex = "1"
+aho-corasick = "1"
 base64 = "0.22"
 ipnet = "2"
 thiserror = "2"

--- a/crates/rsigma-eval/benches/datagen.rs
+++ b/crates/rsigma-eval/benches/datagen.rs
@@ -201,6 +201,60 @@ pub fn gen_single_rule(rng: &mut StdRng, id: usize) -> String {
     )
 }
 
+/// Generate a single rule with `n_patterns` plain `|contains` values on
+/// `CommandLine`. Used by the AC threshold sweep and contains-heavy throughput
+/// benchmarks.
+///
+/// Pattern bytes are uniform random lowercase ASCII to avoid coincidental
+/// matches with `COMMAND_LINES` literal corpus.
+pub fn gen_contains_heavy_rule(rng: &mut StdRng, id: usize, n_patterns: usize) -> String {
+    let mut values = String::new();
+    for _ in 0..n_patterns {
+        let len = rng.random_range(4..12);
+        let word: String = (0..len)
+            .map(|_| (rng.random_range(b'a'..=b'z')) as char)
+            .collect();
+        values.push_str(&format!("            - '{word}'\n"));
+    }
+    format!(
+        "title: Contains Heavy {id}\n\
+         id: contains-heavy-{id:06}\n\
+         logsource:\n\
+         \x20   product: windows\n\
+         \x20   category: process_creation\n\
+         detection:\n\
+         \x20   selection:\n\
+         \x20       CommandLine|contains:\n\
+         {values}\
+         \x20   condition: selection\n\
+         level: medium\n"
+    )
+}
+
+/// Generate `n` contains-heavy rules, each with the same `n_patterns` count.
+pub fn gen_n_contains_heavy_rules(n: usize, n_patterns: usize) -> String {
+    let mut rng = rng();
+    let mut docs = Vec::with_capacity(n);
+    for i in 0..n {
+        docs.push(gen_contains_heavy_rule(&mut rng, i, n_patterns));
+    }
+    docs.join("---\n")
+}
+
+/// Generate a synthetic event with a `CommandLine` of approximately
+/// `cmdline_len` bytes. Used by the threshold sweep to vary haystack length.
+pub fn gen_event_with_cmdline_len(rng: &mut StdRng, cmdline_len: usize) -> serde_json::Value {
+    let cmdline: String = (0..cmdline_len)
+        .map(|_| (rng.random_range(b'a'..=b'z')) as char)
+        .collect();
+    serde_json::json!({
+        "User": "admin",
+        "Image": "C:\\Windows\\System32\\cmd.exe",
+        "CommandLine": cmdline,
+        "EventType": "process_create",
+    })
+}
+
 /// Generate a single wildcard-heavy rule.
 pub fn gen_wildcard_rule(rng: &mut StdRng, id: usize) -> String {
     let num_items = rng.random_range(2..=5);

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -187,6 +187,95 @@ fn bench_eval_batch(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: contains-heavy rules — N plain |contains needles on CommandLine
+// ---------------------------------------------------------------------------
+
+fn bench_eval_contains_heavy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eval_contains_heavy");
+    group.sample_size(40);
+
+    let event_values = datagen::gen_event_values(1000);
+    let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
+
+    for n_patterns in [5, 10, 20, 50, 100, 200] {
+        let yaml = datagen::gen_n_contains_heavy_rules(1, n_patterns);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+        let mut engine = rsigma_eval::Engine::new();
+        engine.add_collection(&collection).unwrap();
+
+        group.throughput(criterion::Throughput::Elements(events.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("patterns", n_patterns),
+            &(&engine, &events),
+            |b, (engine, events)| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for event in *events {
+                        total += engine.evaluate(black_box(event)).len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: AC threshold sweep — find the cross-over between
+// AnyOf(Contains) and AhoCorasickSet across haystack lengths.
+// ---------------------------------------------------------------------------
+
+fn bench_eval_ac_threshold_sweep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eval_ac_threshold_sweep");
+    group.sample_size(30);
+
+    let mut rng = datagen::rng();
+    // Pre-generate one event per haystack length so each pattern-count run
+    // sees the same haystack distribution.
+    let events_per_len: Vec<(usize, Vec<JsonEvent<'_>>)> = [100usize, 1024, 8 * 1024, 64 * 1024]
+        .into_iter()
+        .map(|len| {
+            let values: Vec<serde_json::Value> = (0..50)
+                .map(|_| datagen::gen_event_with_cmdline_len(&mut rng, len))
+                .collect();
+            (len, values)
+        })
+        .map(|(len, values)| {
+            let leaked: &'static [serde_json::Value] = Box::leak(values.into_boxed_slice());
+            let events: Vec<JsonEvent<'_>> = leaked.iter().map(JsonEvent::borrow).collect();
+            (len, events)
+        })
+        .collect();
+
+    for n_patterns in [1usize, 2, 4, 8, 16, 32] {
+        let yaml = datagen::gen_n_contains_heavy_rules(1, n_patterns);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+        let mut engine = rsigma_eval::Engine::new();
+        engine.add_collection(&collection).unwrap();
+
+        for (len, events) in &events_per_len {
+            let label = format!("p{n_patterns}_h{len}");
+            group.throughput(criterion::Throughput::Elements(events.len() as u64));
+            group.bench_with_input(
+                BenchmarkId::new("sweep", &label),
+                &(&engine, events),
+                |b, (engine, events)| {
+                    b.iter(|| {
+                        let mut total = 0usize;
+                        for event in *events {
+                            total += engine.evaluate(black_box(event)).len();
+                        }
+                        black_box(total);
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Benchmark: regex-heavy rules
 // ---------------------------------------------------------------------------
 
@@ -230,6 +319,8 @@ criterion_group!(
     bench_eval_single_event,
     bench_eval_throughput,
     bench_eval_batch,
+    bench_eval_contains_heavy,
+    bench_eval_ac_threshold_sweep,
     bench_eval_wildcard_heavy,
     bench_eval_regex_heavy,
 );

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -8,8 +8,14 @@
 //! from each `FieldSpec` and produces the appropriate `CompiledMatcher` variant.
 
 mod helpers;
+mod optimizer;
 #[cfg(test)]
 mod tests;
+
+// Test-only re-export so equivalence proptests in other modules can drive
+// the optimizer directly.
+#[cfg(test)]
+pub(crate) use optimizer::optimize_any_of as optimize_any_of_for_test;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -324,15 +330,8 @@ pub fn compile_detection(detection: &Detection) -> Result<CompiledDetection> {
                 .iter()
                 .map(|v| compile_value_default(v, ci))
                 .collect::<Result<Vec<_>>>()?;
-            let matcher = if matchers.len() == 1 {
-                // SAFETY: length checked above
-                matchers
-                    .into_iter()
-                    .next()
-                    .unwrap_or(CompiledMatcher::AnyOf(vec![]))
-            } else {
-                CompiledMatcher::AnyOf(matchers)
-            };
+            // Keywords are OR-semantics; safe to apply AnyOf optimizer.
+            let matcher = optimizer::optimize_any_of(matchers);
             Ok(CompiledDetection::Keywords(matcher))
         }
     }
@@ -371,17 +370,23 @@ fn compile_detection_item(item: &DetectionItem) -> Result<CompiledDetectionItem>
         item.values.iter().map(|v| compile_value(v, &ctx)).collect();
     let matchers = matchers?;
 
-    // Combine multiple values: |all → AND, default → OR
-    let combined = if matchers.len() == 1 {
-        // SAFETY: length checked above
-        matchers
-            .into_iter()
-            .next()
-            .unwrap_or(CompiledMatcher::AnyOf(vec![]))
-    } else if ctx.all {
-        CompiledMatcher::AllOf(matchers)
+    // Combine multiple values: |all → AND, default → OR.
+    //
+    // CRITICAL invariant: the optimizer is only applied to the OR (`AnyOf`)
+    // branch. `AllOf` MUST keep its `Vec<Contains>` intact: collapsing
+    // `AllOf(Contains(...))` into `AhoCorasickSet` would silently flip the
+    // semantics from "all patterns must match" to "any matches".
+    let combined = if ctx.all {
+        if matchers.len() == 1 {
+            matchers
+                .into_iter()
+                .next()
+                .unwrap_or(CompiledMatcher::AllOf(vec![]))
+        } else {
+            CompiledMatcher::AllOf(matchers)
+        }
     } else {
-        CompiledMatcher::AnyOf(matchers)
+        optimizer::optimize_any_of(matchers)
     };
 
     Ok(CompiledDetectionItem {

--- a/crates/rsigma-eval/src/compiler/optimizer.rs
+++ b/crates/rsigma-eval/src/compiler/optimizer.rs
@@ -1,0 +1,285 @@
+//! Optimization passes over compiled matcher trees.
+//!
+//! The optimizer rewrites `CompiledMatcher::AnyOf(...)` groups into more
+//! efficient equivalents:
+//!
+//! - **Phase 1**: Plain `Contains` matchers in groups of `AHO_CORASICK_THRESHOLD`
+//!   or more are batched into `AhoCorasickSet`, replacing a sequential
+//!   O(N * haystack_len) scan with a single linear pass over the haystack.
+//!
+//! Future extensions may add RegexSet batching for `Regex` groups, and
+//! a case-insensitive group wrapper that lowers the haystack once before
+//! dispatching to children.
+//!
+//! # Invariants
+//!
+//! - Only invoked from `AnyOf` (OR) construction sites. **Never** called on
+//!   `AllOf` (`|all` modifier) groups: doing so would silently flip the
+//!   semantics from "all patterns must match" to "any pattern matches".
+//! - Pure rewrite. Same input event yields the same `bool` from the optimized
+//!   tree as from the unoptimized tree.
+
+use aho_corasick::AhoCorasick;
+
+use crate::matcher::CompiledMatcher;
+
+/// Minimum number of patterns in an `AnyOf(Contains)` group required before
+/// the optimizer collapses it into an `AhoCorasickSet`.
+///
+/// **Tuning**: Below this threshold, the sequential `str::contains` path
+/// (which uses `memchr`/Two-Way SIMD acceleration) is faster than building
+/// an Aho-Corasick automaton. The current value is a starting point; an
+/// empirical sweep benchmark refines it for the typical Sigma workload.
+pub const AHO_CORASICK_THRESHOLD: usize = 8;
+
+/// Optimize an `AnyOf` group of compiled matchers.
+///
+/// Input is the raw vector of children that would otherwise be wrapped in
+/// `CompiledMatcher::AnyOf(matchers)`. Output is a possibly-rewritten matcher
+/// with the same matching semantics.
+///
+/// - `matchers.len() == 0` produces an empty `AnyOf` (always-false).
+/// - `matchers.len() == 1` unwraps the singleton matcher (no AnyOf wrapper).
+/// - Otherwise, partitions children into buckets and tries to build an
+///   `AhoCorasickSet` for `Contains` buckets exceeding the threshold.
+pub(crate) fn optimize_any_of(matchers: Vec<CompiledMatcher>) -> CompiledMatcher {
+    match matchers.len() {
+        0 => return CompiledMatcher::AnyOf(Vec::new()),
+        1 => {
+            // SAFETY: length checked above.
+            return matchers
+                .into_iter()
+                .next()
+                .expect("len == 1 was just checked");
+        }
+        n if n < AHO_CORASICK_THRESHOLD => {
+            return CompiledMatcher::AnyOf(matchers);
+        }
+        _ => {}
+    }
+
+    let mut contains_ci: Vec<String> = Vec::new();
+    let mut contains_cs: Vec<String> = Vec::new();
+    let mut others: Vec<CompiledMatcher> = Vec::new();
+
+    for m in matchers {
+        match m {
+            CompiledMatcher::Contains {
+                value,
+                case_insensitive: true,
+            } => contains_ci.push(value),
+            CompiledMatcher::Contains {
+                value,
+                case_insensitive: false,
+            } => contains_cs.push(value),
+            other => others.push(other),
+        }
+    }
+
+    let mut result: Vec<CompiledMatcher> = Vec::with_capacity(others.len() + 2);
+    consume_contains(&mut result, contains_ci, true);
+    consume_contains(&mut result, contains_cs, false);
+    result.extend(others);
+
+    match result.len() {
+        0 => CompiledMatcher::AnyOf(Vec::new()),
+        1 => result
+            .into_iter()
+            .next()
+            .expect("len == 1 was just checked"),
+        _ => CompiledMatcher::AnyOf(result),
+    }
+}
+
+/// Consume a bucket of `Contains` needles, building an `AhoCorasickSet`
+/// when the count meets the threshold; otherwise, restoring individual
+/// `Contains` matchers.
+fn consume_contains(result: &mut Vec<CompiledMatcher>, needles: Vec<String>, ci: bool) {
+    if needles.is_empty() {
+        return;
+    }
+    if needles.len() >= AHO_CORASICK_THRESHOLD
+        && let Ok(automaton) = AhoCorasick::new(&needles)
+    {
+        // Needles are already pre-lowered when ci=true (Contains invariant from
+        // `compile_string_value`). The automaton itself is built case-sensitively;
+        // the hot path lowers the haystack before searching.
+        result.push(CompiledMatcher::AhoCorasickSet {
+            automaton,
+            case_insensitive: ci,
+        });
+        return;
+    }
+    for value in needles {
+        result.push(CompiledMatcher::Contains {
+            value,
+            case_insensitive: ci,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{EventValue, JsonEvent};
+    use serde_json::json;
+
+    fn ci_contains(s: &str) -> CompiledMatcher {
+        CompiledMatcher::Contains {
+            value: s.to_lowercase(),
+            case_insensitive: true,
+        }
+    }
+
+    fn cs_contains(s: &str) -> CompiledMatcher {
+        CompiledMatcher::Contains {
+            value: s.to_string(),
+            case_insensitive: false,
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_empty_anyof() {
+        let m = optimize_any_of(Vec::new());
+        assert!(matches!(m, CompiledMatcher::AnyOf(ref v) if v.is_empty()));
+    }
+
+    #[test]
+    fn singleton_unwraps() {
+        let m = optimize_any_of(vec![ci_contains("foo")]);
+        assert!(matches!(
+            m,
+            CompiledMatcher::Contains {
+                case_insensitive: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn below_threshold_keeps_anyof() {
+        let needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD - 1)
+            .map(|i| ci_contains(&format!("p{i}")))
+            .collect();
+        let m = optimize_any_of(needles);
+        match m {
+            CompiledMatcher::AnyOf(v) => assert_eq!(v.len(), AHO_CORASICK_THRESHOLD - 1),
+            _ => panic!("expected AnyOf below threshold"),
+        }
+    }
+
+    #[test]
+    fn at_threshold_builds_aho_corasick() {
+        let needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD)
+            .map(|i| ci_contains(&format!("p{i}")))
+            .collect();
+        let m = optimize_any_of(needles);
+        assert!(matches!(
+            m,
+            CompiledMatcher::AhoCorasickSet {
+                case_insensitive: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn separate_buckets_for_ci_and_cs() {
+        let mut needles = Vec::new();
+        for i in 0..AHO_CORASICK_THRESHOLD {
+            needles.push(ci_contains(&format!("ci{i}")));
+        }
+        for i in 0..AHO_CORASICK_THRESHOLD {
+            needles.push(cs_contains(&format!("CS{i}")));
+        }
+        let m = optimize_any_of(needles);
+        let children = match m {
+            CompiledMatcher::AnyOf(v) => v,
+            _ => panic!("expected AnyOf wrapping two AC sets"),
+        };
+        assert_eq!(children.len(), 2);
+        assert!(children.iter().any(|c| matches!(
+            c,
+            CompiledMatcher::AhoCorasickSet {
+                case_insensitive: true,
+                ..
+            }
+        )));
+        assert!(children.iter().any(|c| matches!(
+            c,
+            CompiledMatcher::AhoCorasickSet {
+                case_insensitive: false,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn mixed_with_other_matchers_preserves_them() {
+        let mut needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD)
+            .map(|i| ci_contains(&format!("p{i}")))
+            .collect();
+        needles.push(CompiledMatcher::StartsWith {
+            value: "cmd".into(),
+            case_insensitive: true,
+        });
+        needles.push(CompiledMatcher::EndsWith {
+            value: ".exe".into(),
+            case_insensitive: true,
+        });
+
+        let m = optimize_any_of(needles);
+        let children = match m {
+            CompiledMatcher::AnyOf(v) => v,
+            _ => panic!("expected AnyOf wrapping AC + StartsWith + EndsWith"),
+        };
+        assert_eq!(children.len(), 3);
+        assert!(matches!(
+            children[0],
+            CompiledMatcher::AhoCorasickSet { .. }
+        ));
+        assert!(matches!(children[1], CompiledMatcher::StartsWith { .. }));
+        assert!(matches!(children[2], CompiledMatcher::EndsWith { .. }));
+    }
+
+    #[test]
+    fn ac_matches_same_haystack_as_anyof() {
+        // Equivalence smoke test: the optimized matcher must match the same
+        // haystacks as the unoptimized one.
+        let needles_str = [
+            "whoami",
+            "mimikatz",
+            "powershell",
+            "invoke",
+            "iex",
+            "rundll32",
+            "regsvr32",
+            "certutil",
+        ];
+        assert!(needles_str.len() >= AHO_CORASICK_THRESHOLD);
+
+        let optimized = optimize_any_of(needles_str.iter().map(|s| ci_contains(s)).collect());
+        let unoptimized =
+            CompiledMatcher::AnyOf(needles_str.iter().map(|s| ci_contains(s)).collect());
+
+        let event_json = json!({});
+        let event = JsonEvent::borrow(&event_json);
+
+        let test_strings = [
+            "cmd.exe /c whoami",
+            "Invoke-Mimikatz with PowerShell",
+            "no patterns here",
+            "RUNDLL32.EXE foo.dll",
+            "WHOAMI in caps",
+            "",
+        ];
+        for s in test_strings {
+            let v = EventValue::Str(s.into());
+            assert_eq!(
+                optimized.matches(&v, &event),
+                unoptimized.matches(&v, &event),
+                "mismatch on haystack {s:?}"
+            );
+        }
+    }
+}

--- a/crates/rsigma-eval/src/matcher/helpers.rs
+++ b/crates/rsigma-eval/src/matcher/helpers.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::net::IpAddr;
 
 use chrono::{Datelike, Timelike};
@@ -5,6 +6,30 @@ use ipnet::IpNet;
 
 use super::{ExpandPart, TimePart};
 use crate::event::{Event, EventValue};
+
+/// Lowercase a `&str` with minimal allocation, falling back to full Unicode case
+/// folding only when the input contains non-ASCII bytes.
+///
+/// Three-tier fast path:
+/// 1. Pure ASCII with no uppercase letters: returns `Cow::Borrowed(s)` (zero allocation).
+/// 2. Pure ASCII with some uppercase: allocates once and folds via `make_ascii_lowercase`.
+/// 3. Contains non-ASCII: falls through to `s.to_lowercase()` (full Unicode).
+///
+/// **Correctness note**: the first branch must require BOTH `s.is_ascii()` AND
+/// no ASCII-uppercase bytes. A naive `s.bytes().all(|b| !b.is_ascii_uppercase())`
+/// alone returns `true` for non-ASCII input (whose continuation bytes are not
+/// in `0x41..=0x5A`), which would silently skip Unicode case folding.
+pub fn ascii_lowercase_cow(s: &str) -> Cow<'_, str> {
+    if s.is_ascii() && s.bytes().all(|b| !b.is_ascii_uppercase()) {
+        return Cow::Borrowed(s);
+    }
+    if s.is_ascii() {
+        let mut buf = s.to_owned();
+        buf.make_ascii_lowercase();
+        return Cow::Owned(buf);
+    }
+    Cow::Owned(s.to_lowercase())
+}
 
 /// Try to extract a string representation from an [`EventValue`] and apply a predicate.
 ///
@@ -395,6 +420,80 @@ mod proptests {
             let re = regex::Regex::new(&pattern).unwrap();
             let s = c.to_string();
             prop_assert!(re.is_match(&s), "? should match single char: {:?}", s);
+        }
+    }
+
+    // =========================================================================
+    // ascii_lowercase_cow correctness
+    // =========================================================================
+
+    proptest! {
+        #[test]
+        fn ascii_lowercase_cow_correct(s in ".{0,40}") {
+            let expected = s.to_lowercase();
+            let cow = ascii_lowercase_cow(&s);
+            prop_assert_eq!(
+                cow.as_ref(),
+                expected.as_str(),
+                "ascii_lowercase_cow disagrees with std to_lowercase on {:?}",
+                s
+            );
+        }
+
+        #[test]
+        fn ascii_lowercase_cow_borrows_when_already_lower_ascii(s in "[a-z0-9 _.,/-]{0,40}") {
+            let cow = ascii_lowercase_cow(&s);
+            // Pure ASCII with no uppercase must hit the zero-alloc branch.
+            prop_assert!(matches!(cow, std::borrow::Cow::Borrowed(_)));
+        }
+    }
+
+    #[test]
+    fn ascii_lowercase_cow_handles_unicode_uppercase() {
+        // Regression: a non-ASCII string with no ASCII-uppercase bytes must NOT
+        // be returned as Borrowed without lowercasing the non-ASCII chars.
+        let inputs = ["Ärzte", "ΣΊΓΜΑ", "Über", "España", "ÉCOLE"];
+        for input in inputs {
+            let cow = ascii_lowercase_cow(input);
+            assert_eq!(
+                cow.as_ref(),
+                input.to_lowercase(),
+                "ascii_lowercase_cow failed Unicode lowering for {input:?}"
+            );
+        }
+    }
+
+    // =========================================================================
+    // AhoCorasickSet equivalence with AnyOf(Contains)
+    // =========================================================================
+
+    proptest! {
+        #[test]
+        fn ac_agrees_with_anyof_contains(
+            needles in prop::collection::vec("[a-z0-9._/]{1,12}", 8..=20),
+            haystack in "[[:print:]]{0,80}",
+        ) {
+            // Build both forms from the same needles. They MUST produce identical
+            // results on every haystack.
+            let ci_contains: Vec<CompiledMatcher> = needles.iter().map(|n| {
+                CompiledMatcher::Contains {
+                    value: n.to_lowercase(),
+                    case_insensitive: true,
+                }
+            }).collect();
+
+            let unoptimized = CompiledMatcher::AnyOf(ci_contains.clone());
+            let optimized = crate::compiler::optimize_any_of_for_test(ci_contains);
+
+            let event_json = json!({});
+            let event = JsonEvent::borrow(&event_json);
+            let value = EventValue::Str(haystack.clone().into());
+
+            prop_assert_eq!(
+                optimized.matches(&value, &event),
+                unoptimized.matches(&value, &event),
+                "AC vs AnyOf(Contains) disagree on haystack {:?}", haystack
+            );
         }
     }
 }

--- a/crates/rsigma-eval/src/matcher/matching.rs
+++ b/crates/rsigma-eval/src/matcher/matching.rs
@@ -1,6 +1,7 @@
 use super::CompiledMatcher;
 use super::helpers::{
-    expand_template, extract_timestamp_part, match_cidr, match_numeric_value, match_str_value,
+    ascii_lowercase_cow, expand_template, extract_timestamp_part, match_cidr, match_numeric_value,
+    match_str_value,
 };
 use crate::event::{Event, EventValue};
 
@@ -57,6 +58,17 @@ impl CompiledMatcher {
             }),
 
             CompiledMatcher::Regex(re) => match_str_value(value, |s| re.is_match(s)),
+
+            CompiledMatcher::AhoCorasickSet {
+                automaton,
+                case_insensitive,
+            } => match_str_value(value, |s| {
+                if *case_insensitive {
+                    automaton.is_match(ascii_lowercase_cow(s).as_ref())
+                } else {
+                    automaton.is_match(s)
+                }
+            }),
 
             // -- Network --
             CompiledMatcher::Cidr(net) => match_cidr(value, net),
@@ -189,6 +201,16 @@ impl CompiledMatcher {
                 }
             }
             CompiledMatcher::Regex(re) => re.is_match(s),
+            CompiledMatcher::AhoCorasickSet {
+                automaton,
+                case_insensitive,
+            } => {
+                if *case_insensitive {
+                    automaton.is_match(ascii_lowercase_cow(s).as_ref())
+                } else {
+                    automaton.is_match(s)
+                }
+            }
             CompiledMatcher::Not(inner) => !inner.matches_str(s),
             CompiledMatcher::AnyOf(matchers) => matchers.iter().any(|m| m.matches_str(s)),
             CompiledMatcher::AllOf(matchers) => matchers.iter().all(|m| m.matches_str(s)),

--- a/crates/rsigma-eval/src/matcher/mod.rs
+++ b/crates/rsigma-eval/src/matcher/mod.rs
@@ -7,8 +7,9 @@
 mod helpers;
 mod matching;
 
-pub use helpers::{parse_expand_template, sigma_string_to_regex};
+pub use helpers::{ascii_lowercase_cow, parse_expand_template, sigma_string_to_regex};
 
+use aho_corasick::AhoCorasick;
 use regex::Regex;
 
 use crate::event::Event;
@@ -44,6 +45,26 @@ pub enum CompiledMatcher {
     },
     /// Compiled regex pattern (flags baked in at compile time).
     Regex(Regex),
+
+    /// Multi-pattern substring match via Aho-Corasick automaton.
+    ///
+    /// Built by the optimizer when an `AnyOf` group contains
+    /// `AHO_CORASICK_THRESHOLD` or more plain `Contains` matchers with the
+    /// same case sensitivity. Replaces the sequential O(N * haystack_len)
+    /// scan of `AnyOf([Contains, ...])` with a single linear pass.
+    ///
+    /// **Invariant**: this variant only encodes `AnyOf` (OR) semantics.
+    /// `AllOf(Contains)` (`|all` modifier) MUST NOT be collapsed into this
+    /// variant - the optimizer enforces this.
+    ///
+    /// **Case insensitivity**: when `case_insensitive` is true, needles are
+    /// stored pre-lowered (matching the `Contains` invariant) and the hot
+    /// path lowers the haystack via [`ascii_lowercase_cow`] before searching.
+    /// The `AhoCorasick` automaton itself is built case-sensitively.
+    AhoCorasickSet {
+        automaton: AhoCorasick,
+        case_insensitive: bool,
+    },
 
     // -- Network --
     /// CIDR network match for IP addresses.

--- a/crates/rsigma-eval/tests/regression_eval.rs
+++ b/crates/rsigma-eval/tests/regression_eval.rs
@@ -1,0 +1,213 @@
+//! Differential regression tests for the eval engine.
+//!
+//! For each phase that introduces a new optimization, this suite captures the
+//! exact `MatchResult` set produced by `Engine::evaluate` on a fixed corpus
+//! of rules and events. Subsequent runs must produce identical output.
+//!
+//! Snapshots are stored as in-line literal expectations rather than golden
+//! files: the corpus is small enough that locality matters more than
+//! externalization, and a snapshot diff is easier to review in a PR.
+
+use rsigma_eval::{Engine, JsonEvent, MatchResult};
+use rsigma_parser::parse_sigma_yaml;
+use serde_json::{Value, json};
+
+/// Build an engine from a multi-document YAML string.
+fn engine_from(yaml: &str) -> Engine {
+    let collection = parse_sigma_yaml(yaml).expect("rules parse");
+    let mut engine = Engine::new();
+    engine.add_collection(&collection).expect("compile");
+    engine
+}
+
+/// Sort match results by `rule_id` for stable comparison.
+fn sorted_titles(results: Vec<MatchResult>) -> Vec<String> {
+    let mut titles: Vec<String> = results.into_iter().map(|m| m.rule_title).collect();
+    titles.sort();
+    titles
+}
+
+/// Evaluate a list of events against an engine and produce per-event sorted
+/// rule-title lists. This is the canonical regression artifact.
+fn evaluate_corpus(engine: &Engine, events: &[Value]) -> Vec<Vec<String>> {
+    events
+        .iter()
+        .map(|ev| {
+            let event = JsonEvent::borrow(ev);
+            sorted_titles(engine.evaluate(&event))
+        })
+        .collect()
+}
+
+const CONTAINS_HEAVY_RULES: &str = r#"
+title: Suspicious LOLBAS
+id: lolbas-bench
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        Image|contains:
+            - 'whoami'
+            - 'mimikatz'
+            - 'invoke-mimikatz'
+            - 'powershell'
+            - 'rundll32'
+            - 'regsvr32'
+            - 'certutil'
+            - 'bitsadmin'
+            - 'mshta'
+            - 'wscript'
+    condition: selection
+level: high
+---
+title: Process Create Login
+id: login-event
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+level: low
+---
+title: Mixed Modifiers
+id: mixed-mods
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains:
+            - '-encodedcommand'
+            - '-enc'
+            - 'frombase64string'
+            - 'iex'
+            - 'invoke-expression'
+            - 'downloadstring'
+        Image|endswith: '.exe'
+    condition: selection
+level: medium
+"#;
+
+const ALL_OF_CONTAINS_RULES: &str = r#"
+title: AllOf Contains Sentinel
+id: allof-contains
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains|all:
+            - 'powershell'
+            - '-enc'
+            - 'http'
+    condition: selection
+level: medium
+"#;
+
+#[test]
+fn baseline_contains_heavy_corpus() {
+    let engine = engine_from(CONTAINS_HEAVY_RULES);
+
+    let events = vec![
+        json!({"EventType": "login", "Image": "C:/Windows/System32/explorer.exe"}),
+        json!({"Image": "C:/Tools/MIMIKATZ.exe", "CommandLine": "mimikatz.exe sekurlsa::logonpasswords"}),
+        json!({"Image": "C:/Windows/System32/powershell.exe", "CommandLine": "powershell.exe -enc aHR0cHM6Ly9ldmls"}),
+        json!({"Image": "/usr/bin/whoami", "CommandLine": "whoami /all"}),
+        json!({"Image": "/usr/bin/notepad.exe", "CommandLine": "notepad readme.txt"}),
+        json!({}),
+    ];
+    let actual = evaluate_corpus(&engine, &events);
+
+    let expected: Vec<Vec<String>> = vec![
+        vec!["Process Create Login".into()],
+        vec!["Suspicious LOLBAS".into()],
+        vec!["Mixed Modifiers".into(), "Suspicious LOLBAS".into()],
+        vec!["Suspicious LOLBAS".into()],
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    ];
+
+    assert_eq!(actual, expected, "regression: optimizer changed results");
+}
+
+#[test]
+fn allof_contains_semantics_preserved() {
+    // Hardens the optimizer's invariant: AllOf(Contains(...)) MUST keep AND
+    // semantics. If anyone accidentally collapses |all into AhoCorasickSet,
+    // partial matches would fire the rule and this test would catch it.
+    let engine = engine_from(ALL_OF_CONTAINS_RULES);
+
+    let events = vec![
+        // All three substrings present — should match.
+        json!({"CommandLine": "powershell.exe -enc http://evil.com/x"}),
+        // Two of three present — must NOT match.
+        json!({"CommandLine": "powershell.exe -enc dummy"}),
+        // One of three present — must NOT match.
+        json!({"CommandLine": "powershell.exe foo"}),
+        // Zero of three — must NOT match.
+        json!({"CommandLine": "notepad.exe"}),
+    ];
+    let actual = evaluate_corpus(&engine, &events);
+
+    let expected: Vec<Vec<String>> = vec![
+        vec!["AllOf Contains Sentinel".into()],
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    ];
+
+    assert_eq!(
+        actual, expected,
+        "AllOf|contains semantics broken: rule fired on partial match"
+    );
+}
+
+#[test]
+fn keyword_aho_corasick_path_correct() {
+    // Keywords are field-less, case-insensitive, and OR-semantics by spec.
+    // Keep the keyword count above the optimizer threshold so AC kicks in.
+    let yaml = r#"
+title: Keyword AC Path
+id: keyword-ac
+logsource:
+    product: windows
+detection:
+    keywords:
+        - 'whoami'
+        - 'MIMIKATZ'
+        - 'invoke-expression'
+        - 'powershell'
+        - 'rundll32'
+        - 'regsvr32'
+        - 'certutil'
+        - 'bitsadmin'
+        - 'mshta.exe'
+    condition: keywords
+"#;
+    let engine = engine_from(yaml);
+
+    let events = vec![
+        // Hits via lowercased haystack + lowered needles.
+        json!({"some_field": "oops MIMIKATZ"}),
+        json!({"some_field": "Invoke-Expression"}),
+        json!({"path": "C:/Windows/System32/CertUtil.exe"}),
+        // No match.
+        json!({"path": "C:/Windows/System32/explorer.exe"}),
+        // Nested object: keyword traversal must descend.
+        json!({"outer": {"inner": "powershell foo"}}),
+    ];
+    let actual = evaluate_corpus(&engine, &events);
+
+    let expected: Vec<Vec<String>> = vec![
+        vec!["Keyword AC Path".into()],
+        vec!["Keyword AC Path".into()],
+        vec!["Keyword AC Path".into()],
+        Vec::<String>::new(),
+        vec!["Keyword AC Path".into()],
+    ];
+
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
## Summary

When a detection item or keyword group has 8+ plain `|contains` needles with the same case sensitivity, the compiler now collapses them into a single `AhoCorasickSet` matcher. This replaces N sequential `str::contains` calls with one linear pass over the haystack.

The optimizer is invoked only on `AnyOf` (OR) construction sites; `AllOf` (`|all` modifier) is left untouched so AND semantics are preserved.

For case-insensitive matching, needles are pre-lowered (matching the existing `Contains` invariant) and the hot path lowers the haystack once via a new `ascii_lowercase_cow` helper with a 3-tier fast path: borrow when already lowercase ASCII, in-place `make_ascii_lowercase` for ASCII with uppercase, full Unicode `to_lowercase` only for non-ASCII input.

## Changes

- New `aho-corasick = "1"` direct dep (already transitive via `regex`).
- New `CompiledMatcher::AhoCorasickSet { automaton, case_insensitive }` variant.
- New `compiler/optimizer.rs` module with `optimize_any_of` partition+bucket implementation. Threshold: 8 (placeholder; refined by sweep benchmark).
- New `matcher/helpers::ascii_lowercase_cow` helper.
- New `tests/regression_eval.rs` with 3 snapshot tests (contains-heavy corpus, AllOf semantics safeguard, keyword AC path).
- New bench groups: `eval_contains_heavy` (5–200 patterns) and `eval_ac_threshold_sweep` (pattern count × haystack length cross-product).

## Tests

- 7 unit tests for `optimize_any_of` (empty, singleton, below/at threshold, separate CI/CS buckets, mixed matchers, equivalence).
- Proptest `ac_agrees_with_anyof_contains` asserts the optimized matcher agrees with the unoptimized version on random haystacks.
- Proptests for `ascii_lowercase_cow` correctness vs std `to_lowercase` and the zero-alloc fast path.
- Regression test for the AllOf safeguard: a `|contains|all` rule must NOT fire on partial matches.

All 412 unit tests + 3 regression tests + workspace clippy clean.

## Benchmarks (vs `before-p1` baseline)

| Group | Before | After | Change |
|---|---|---|---|
| `eval_throughput/events/1000` | 388 K elem/s | 404 K elem/s | +3.3% |
| `eval_throughput/events/10000` | 389 K elem/s | 406 K elem/s | +5.1% |
| `eval_throughput/events/100000` | 386 K elem/s | 405 K elem/s | +4.8% |

New `eval_contains_heavy` (1 rule with N |contains needles, 1000 events):

| Patterns | Throughput |
|---|---|
| 10 | 7.25 Melem/s |
| 20 | 8.68 Melem/s |
| 50 | 10.32 Melem/s |
| 100 | 10.40 Melem/s |
| 200 | 7.25 Melem/s |

The 50-100 sweet spot reflects AC's automaton-traversal cost balancing pattern count.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] Criterion benchmarks before/after on `eval_throughput` and new `eval_contains_heavy`
- [x] SigmaHQ corpus regression (run after merge)

## Acknowledgements

This PR and the subsequent changes are inspired by [this post](https://medium.com/data-science/optimizing-sigma-rules-in-spark-with-the-aho-corasick-algorithm-52ebd5d8105e) about optimizing the [pySigma-backend-spark](https://github.com/CybercentreCanada/PySigma-backend-spark) with Aho-Corasick algorithm for contains modifiers in Spark by Jean-Claude Cote. Also, I'd like to thank [Vinicius Morais](https://www.linkedin.com/in/vinicius-m-a76ba51b5/) who informed me about this.