### PR TITLE
feat(eval): lower haystack once for case-insensitive matcher groups

### DIFF
--- a/crates/rsigma-eval/src/compiler/optimizer.rs
+++ b/crates/rsigma-eval/src/compiler/optimizer.rs
@@ -1,27 +1,34 @@
 //! Optimization passes over compiled matcher trees.
 //!
-//! The optimizer rewrites `CompiledMatcher::AnyOf(...)` groups into more
+//! The optimizer rewrites composite `CompiledMatcher` groups into more
 //! efficient equivalents:
 //!
-//! - **Phase 1**: Plain `Contains` matchers in groups of `AHO_CORASICK_THRESHOLD`
-//!   or more are batched into `AhoCorasickSet`, replacing a sequential
+//! - Plain `Contains` matchers in groups of `AHO_CORASICK_THRESHOLD` or more
+//!   are batched into `AhoCorasickSet`, replacing a sequential
 //!   O(N * haystack_len) scan with a single linear pass over the haystack.
+//! - When every child of the resulting group is case-insensitive and
+//!   pre-lowerable, the entire group is wrapped in `CaseInsensitiveGroup`,
+//!   which lowers the haystack once via `ascii_lowercase_cow` and dispatches
+//!   to children via `matches_pre_lowered`. This eliminates the redundant
+//!   `to_lowercase()` allocation that each CI matcher would otherwise do.
 //!
-//! Future extensions may add RegexSet batching for `Regex` groups, and
-//! a case-insensitive group wrapper that lowers the haystack once before
-//! dispatching to children.
+//! Future extensions may add RegexSet batching for `Regex` groups.
 //!
 //! # Invariants
 //!
-//! - Only invoked from `AnyOf` (OR) construction sites. **Never** called on
-//!   `AllOf` (`|all` modifier) groups: doing so would silently flip the
-//!   semantics from "all patterns must match" to "any pattern matches".
+//! - The Aho-Corasick collapse is only invoked from `AnyOf` (OR) construction
+//!   sites. **Never** called on `AllOf` (`|all` modifier) groups: doing so
+//!   would silently flip the semantics from "all patterns must match" to "any
+//!   pattern matches".
+//! - The `CaseInsensitiveGroup` wrapper requires every child to satisfy
+//!   `is_pre_lowerable`. This is enforced at construction time. The hot path
+//!   `matches_pre_lowered` `debug_assert!`s on violation.
 //! - Pure rewrite. Same input event yields the same `bool` from the optimized
 //!   tree as from the unoptimized tree.
 
 use aho_corasick::AhoCorasick;
 
-use crate::matcher::CompiledMatcher;
+use crate::matcher::{CompiledMatcher, GroupMode};
 
 /// Minimum number of patterns in an `AnyOf(Contains)` group required before
 /// the optimizer collapses it into an `AhoCorasickSet`.
@@ -32,16 +39,27 @@ use crate::matcher::CompiledMatcher;
 /// empirical sweep benchmark refines it for the typical Sigma workload.
 pub const AHO_CORASICK_THRESHOLD: usize = 8;
 
+/// Minimum number of pre-lowerable children to justify wrapping in a
+/// `CaseInsensitiveGroup`.
+///
+/// Below this count, the per-child `to_lowercase` cost is dominated by other
+/// work and the wrapper provides no measurable benefit.
+pub(crate) const CI_GROUP_THRESHOLD: usize = 2;
+
 /// Optimize an `AnyOf` group of compiled matchers.
 ///
 /// Input is the raw vector of children that would otherwise be wrapped in
 /// `CompiledMatcher::AnyOf(matchers)`. Output is a possibly-rewritten matcher
 /// with the same matching semantics.
 ///
-/// - `matchers.len() == 0` produces an empty `AnyOf` (always-false).
-/// - `matchers.len() == 1` unwraps the singleton matcher (no AnyOf wrapper).
-/// - Otherwise, partitions children into buckets and tries to build an
-///   `AhoCorasickSet` for `Contains` buckets exceeding the threshold.
+/// Pipeline:
+/// 1. Trivial cases: empty input, singleton, sub-threshold counts pass through.
+/// 2. Partition into `Contains` (by case sensitivity) and `others`.
+/// 3. Each `Contains` bucket of size >= `AHO_CORASICK_THRESHOLD` becomes one
+///    `AhoCorasickSet`; the rest stay as individual `Contains`.
+/// 4. If all surviving children are pre-lowerable and there are >=
+///    `CI_GROUP_THRESHOLD` of them, wrap the whole group in
+///    `CaseInsensitiveGroup` (Any mode) to lower the haystack once.
 pub(crate) fn optimize_any_of(matchers: Vec<CompiledMatcher>) -> CompiledMatcher {
     match matchers.len() {
         0 => return CompiledMatcher::AnyOf(Vec::new()),
@@ -52,10 +70,12 @@ pub(crate) fn optimize_any_of(matchers: Vec<CompiledMatcher>) -> CompiledMatcher
                 .next()
                 .expect("len == 1 was just checked");
         }
-        n if n < AHO_CORASICK_THRESHOLD => {
-            return CompiledMatcher::AnyOf(matchers);
-        }
         _ => {}
+    }
+
+    // Below the AC threshold we still want to consider CI grouping.
+    if matchers.len() < AHO_CORASICK_THRESHOLD {
+        return wrap_ci_group_or_anyof(matchers);
     }
 
     let mut contains_ci: Vec<String> = Vec::new();
@@ -87,8 +107,99 @@ pub(crate) fn optimize_any_of(matchers: Vec<CompiledMatcher>) -> CompiledMatcher
             .into_iter()
             .next()
             .expect("len == 1 was just checked"),
-        _ => CompiledMatcher::AnyOf(result),
+        _ => wrap_ci_group_or_anyof(result),
     }
+}
+
+/// Wrap `children` in `CaseInsensitiveGroup { mode: Any }` when every child is
+/// pre-lowerable and the count meets `CI_GROUP_THRESHOLD`. Otherwise return
+/// `AnyOf(children)` unchanged.
+fn wrap_ci_group_or_anyof(children: Vec<CompiledMatcher>) -> CompiledMatcher {
+    if children.len() >= CI_GROUP_THRESHOLD && children.iter().all(is_pre_lowerable) {
+        CompiledMatcher::CaseInsensitiveGroup {
+            children,
+            mode: GroupMode::Any,
+        }
+    } else {
+        CompiledMatcher::AnyOf(children)
+    }
+}
+
+/// Returns true when this matcher can be evaluated against a pre-lowered
+/// haystack via [`CompiledMatcher::matches_pre_lowered`].
+///
+/// The set is conservative: anything that is not provably equivalent under
+/// pre-lowering returns false (and the caller falls back to `matches`).
+pub(crate) fn is_pre_lowerable(m: &CompiledMatcher) -> bool {
+    match m {
+        // CI string leaves: stored value is already lowered, so a lowered
+        // haystack matches iff the original CI-aware matcher would.
+        CompiledMatcher::Contains {
+            case_insensitive: true,
+            ..
+        }
+        | CompiledMatcher::StartsWith {
+            case_insensitive: true,
+            ..
+        }
+        | CompiledMatcher::EndsWith {
+            case_insensitive: true,
+            ..
+        }
+        | CompiledMatcher::Exact {
+            case_insensitive: true,
+            ..
+        }
+        | CompiledMatcher::AhoCorasickSet {
+            case_insensitive: true,
+            ..
+        } => true,
+
+        // A regex is pre-lowerable iff its pattern carries the case-insensitive
+        // flag. Inline `(?i)` and `(?...i...)` flag groups both qualify; we
+        // detect them by scanning the leading flag region.
+        CompiledMatcher::Regex(re) => regex_is_case_insensitive(re.as_str()),
+
+        // Compositions are pre-lowerable iff every leaf is.
+        CompiledMatcher::Not(inner) => is_pre_lowerable(inner),
+        CompiledMatcher::AnyOf(children) | CompiledMatcher::AllOf(children) => {
+            children.iter().all(is_pre_lowerable)
+        }
+        CompiledMatcher::CaseInsensitiveGroup { children, .. } => {
+            children.iter().all(is_pre_lowerable)
+        }
+
+        // Everything else: case-sensitive string matchers, numeric, CIDR,
+        // FieldRef, Null, BoolEq, Expand, TimestampPart, etc. — not
+        // pre-lowerable.
+        _ => false,
+    }
+}
+
+/// Best-effort detector for an inline `i` flag in a regex pattern string.
+///
+/// Recognizes `(?i)` and `(?...i...)` flag groups at the start of the pattern.
+/// A negated form like `(?-i)` is rejected. False negatives are safe (the
+/// regex stays out of the CI group); false positives would be a correctness
+/// bug.
+fn regex_is_case_insensitive(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    if bytes.len() < 4 || bytes[0] != b'(' || bytes[1] != b'?' {
+        return false;
+    }
+    // Walk the flag set until the first character that ends the group:
+    // ')', ':', or '-' (negation onset).
+    let mut i = 2;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'i' => return true,
+            b')' | b':' | b'-' => return false,
+            b'a'..=b'z' | b'A'..=b'Z' => {}
+            _ => return false,
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Consume a bucket of `Contains` needles, building an `AhoCorasickSet`
@@ -157,19 +268,36 @@ mod tests {
     }
 
     #[test]
-    fn below_threshold_keeps_anyof() {
+    fn below_ac_threshold_wraps_ci_group_when_all_pre_lowerable() {
         let needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD - 1)
             .map(|i| ci_contains(&format!("p{i}")))
             .collect();
         let m = optimize_any_of(needles);
         match m {
-            CompiledMatcher::AnyOf(v) => assert_eq!(v.len(), AHO_CORASICK_THRESHOLD - 1),
-            _ => panic!("expected AnyOf below threshold"),
+            CompiledMatcher::CaseInsensitiveGroup {
+                children,
+                mode: GroupMode::Any,
+            } => assert_eq!(children.len(), AHO_CORASICK_THRESHOLD - 1),
+            other => panic!("expected CaseInsensitiveGroup, got {other:?}"),
         }
     }
 
     #[test]
+    fn below_ac_threshold_keeps_anyof_when_mixed_case() {
+        // Mixing CI and CS Contains makes the group non-pre-lowerable: the CS
+        // Contains has its needle in original case and would not match a
+        // pre-lowered haystack.
+        let needles: Vec<CompiledMatcher> = vec![ci_contains("foo"), cs_contains("BAR")];
+        let m = optimize_any_of(needles);
+        assert!(matches!(m, CompiledMatcher::AnyOf(ref v) if v.len() == 2));
+    }
+
+    #[test]
     fn at_threshold_builds_aho_corasick() {
+        // At threshold all needles collapse into a single AhoCorasickSet.
+        // After CI grouping the singleton bypasses CaseInsensitiveGroup
+        // wrapping (since CI_GROUP_THRESHOLD requires >= 2 children) and the
+        // top-level result is the bare AhoCorasickSet.
         let needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD)
             .map(|i| ci_contains(&format!("p{i}")))
             .collect();
@@ -215,7 +343,10 @@ mod tests {
     }
 
     #[test]
-    fn mixed_with_other_matchers_preserves_them() {
+    fn mixed_pre_lowerable_children_are_wrapped_in_ci_group() {
+        // AhoCorasickSet{ci=true} + CI StartsWith + CI EndsWith are all
+        // pre-lowerable, so the optimizer should wrap them in a
+        // CaseInsensitiveGroup to lower the haystack once for all three.
         let mut needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD)
             .map(|i| ci_contains(&format!("p{i}")))
             .collect();
@@ -230,8 +361,11 @@ mod tests {
 
         let m = optimize_any_of(needles);
         let children = match m {
-            CompiledMatcher::AnyOf(v) => v,
-            _ => panic!("expected AnyOf wrapping AC + StartsWith + EndsWith"),
+            CompiledMatcher::CaseInsensitiveGroup {
+                children,
+                mode: GroupMode::Any,
+            } => children,
+            other => panic!("expected CaseInsensitiveGroup, got {other:?}"),
         };
         assert_eq!(children.len(), 3);
         assert!(matches!(
@@ -240,6 +374,130 @@ mod tests {
         ));
         assert!(matches!(children[1], CompiledMatcher::StartsWith { .. }));
         assert!(matches!(children[2], CompiledMatcher::EndsWith { .. }));
+    }
+
+    #[test]
+    fn ci_group_skipped_when_a_child_is_case_sensitive() {
+        // One CS Contains poisons the group: it must NOT see a pre-lowered
+        // haystack, so the optimizer must keep AnyOf as-is.
+        let mut needles: Vec<_> = (0..AHO_CORASICK_THRESHOLD)
+            .map(|i| ci_contains(&format!("p{i}")))
+            .collect();
+        needles.push(cs_contains("EXACT"));
+
+        let m = optimize_any_of(needles);
+        assert!(matches!(m, CompiledMatcher::AnyOf(ref v) if v.len() == 2));
+    }
+
+    #[test]
+    fn is_pre_lowerable_classifies_correctly() {
+        use regex::Regex;
+
+        // Pre-lowerable cases.
+        assert!(is_pre_lowerable(&ci_contains("foo")));
+        assert!(is_pre_lowerable(&CompiledMatcher::StartsWith {
+            value: "x".into(),
+            case_insensitive: true,
+        }));
+        assert!(is_pre_lowerable(&CompiledMatcher::EndsWith {
+            value: "x".into(),
+            case_insensitive: true,
+        }));
+        assert!(is_pre_lowerable(&CompiledMatcher::Exact {
+            value: "x".into(),
+            case_insensitive: true,
+        }));
+        assert!(is_pre_lowerable(&CompiledMatcher::Regex(
+            Regex::new(r"(?i)foo.*bar").unwrap()
+        )));
+        assert!(is_pre_lowerable(&CompiledMatcher::Regex(
+            Regex::new(r"(?ims)foo").unwrap()
+        )));
+
+        // Not pre-lowerable.
+        assert!(!is_pre_lowerable(&cs_contains("foo")));
+        assert!(!is_pre_lowerable(&CompiledMatcher::Exact {
+            value: "X".into(),
+            case_insensitive: false,
+        }));
+        // Regex without the i flag: case-sensitive, must not appear in CI group.
+        assert!(!is_pre_lowerable(&CompiledMatcher::Regex(
+            Regex::new(r"^foo").unwrap()
+        )));
+        // Numeric and CIDR are never pre-lowerable.
+        assert!(!is_pre_lowerable(&CompiledMatcher::NumericEq(42.0)));
+        assert!(!is_pre_lowerable(&CompiledMatcher::Cidr(
+            "10.0.0.0/8".parse().unwrap()
+        )));
+    }
+
+    #[test]
+    fn regex_is_case_insensitive_recognizer() {
+        assert!(regex_is_case_insensitive("(?i)foo"));
+        assert!(regex_is_case_insensitive("(?im)foo"));
+        assert!(regex_is_case_insensitive("(?si)foo"));
+        // No flags.
+        assert!(!regex_is_case_insensitive("foo"));
+        // Other flags only.
+        assert!(!regex_is_case_insensitive("(?m)foo"));
+        // Empty / malformed.
+        assert!(!regex_is_case_insensitive(""));
+        assert!(!regex_is_case_insensitive("(?"));
+        // Negated flag (not yet trusted to keep things simple).
+        assert!(!regex_is_case_insensitive("(?-i)foo"));
+        // Group with subpattern (we conservatively bail at ':').
+        assert!(!regex_is_case_insensitive("(?:foo)"));
+    }
+
+    #[test]
+    fn ci_group_matches_same_haystacks_as_anyof() {
+        let event_json = json!({});
+        let event = JsonEvent::borrow(&event_json);
+
+        let make_children = || -> Vec<CompiledMatcher> {
+            vec![
+                ci_contains("powershell"),
+                CompiledMatcher::StartsWith {
+                    value: "cmd".to_lowercase(),
+                    case_insensitive: true,
+                },
+                CompiledMatcher::EndsWith {
+                    value: ".exe".to_lowercase(),
+                    case_insensitive: true,
+                },
+                CompiledMatcher::Exact {
+                    value: "whoami".to_lowercase(),
+                    case_insensitive: true,
+                },
+            ]
+        };
+        let optimized = optimize_any_of(make_children());
+        let unoptimized = CompiledMatcher::AnyOf(make_children());
+
+        // Optimizer must have wrapped in CaseInsensitiveGroup.
+        assert!(matches!(
+            optimized,
+            CompiledMatcher::CaseInsensitiveGroup {
+                mode: GroupMode::Any,
+                ..
+            }
+        ));
+
+        for s in [
+            "PowerShell.exe -enc XYZ",
+            "CMD.exe /c whoami",
+            "C:/Windows/System32/notepad.exe",
+            "WHOAMI",
+            "no match",
+            "",
+        ] {
+            let v = EventValue::Str(s.into());
+            assert_eq!(
+                optimized.matches(&v, &event),
+                unoptimized.matches(&v, &event),
+                "CI group disagrees with AnyOf on {s:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rsigma-eval/src/matcher/matching.rs
+++ b/crates/rsigma-eval/src/matcher/matching.rs
@@ -1,8 +1,8 @@
-use super::CompiledMatcher;
 use super::helpers::{
     ascii_lowercase_cow, expand_template, extract_timestamp_part, match_cidr, match_numeric_value,
     match_str_value,
 };
+use super::{CompiledMatcher, GroupMode};
 use crate::event::{Event, EventValue};
 
 impl CompiledMatcher {
@@ -150,6 +150,77 @@ impl CompiledMatcher {
             // -- Composite --
             CompiledMatcher::AnyOf(matchers) => matchers.iter().any(|m| m.matches(value, event)),
             CompiledMatcher::AllOf(matchers) => matchers.iter().all(|m| m.matches(value, event)),
+
+            CompiledMatcher::CaseInsensitiveGroup { children, mode } => {
+                match_str_value(value, |s| {
+                    let lowered = ascii_lowercase_cow(s);
+                    match mode {
+                        GroupMode::Any => children
+                            .iter()
+                            .any(|c| c.matches_pre_lowered(lowered.as_ref())),
+                        GroupMode::All => children
+                            .iter()
+                            .all(|c| c.matches_pre_lowered(lowered.as_ref())),
+                    }
+                })
+            }
+        }
+    }
+
+    /// Match a haystack that has already been Unicode-lowercased.
+    ///
+    /// **Precondition**: `lowered_str` was produced by `ascii_lowercase_cow`
+    /// (or an equivalent full-Unicode lowercaser) AND every child of the
+    /// surrounding [`CompiledMatcher::CaseInsensitiveGroup`] is pre-lowerable
+    /// (see `compiler::optimizer::is_pre_lowerable`).
+    ///
+    /// This method is internal to the crate. Optimizer bugs that violate the
+    /// precondition trip a `debug_assert!`; in release the conservative
+    /// fallback (`false`) avoids producing a false positive but may miss a
+    /// match.
+    ///
+    /// No `event` parameter: pre-lowerable matchers are pure string predicates
+    /// that never reference cross-event state. If a future event-aware matcher
+    /// becomes pre-lowerable, the signature gains `event` then.
+    pub(crate) fn matches_pre_lowered(&self, lowered_str: &str) -> bool {
+        match self {
+            CompiledMatcher::Contains {
+                value,
+                case_insensitive: true,
+            } => lowered_str.contains(value.as_str()),
+            CompiledMatcher::StartsWith {
+                value,
+                case_insensitive: true,
+            } => lowered_str.starts_with(value.as_str()),
+            CompiledMatcher::EndsWith {
+                value,
+                case_insensitive: true,
+            } => lowered_str.ends_with(value.as_str()),
+            CompiledMatcher::Exact {
+                value,
+                case_insensitive: true,
+            } => lowered_str == value,
+            CompiledMatcher::Regex(re) => re.is_match(lowered_str),
+            CompiledMatcher::AhoCorasickSet {
+                automaton,
+                case_insensitive: true,
+            } => automaton.is_match(lowered_str),
+
+            CompiledMatcher::Not(inner) => !inner.matches_pre_lowered(lowered_str),
+            CompiledMatcher::AnyOf(ms) => ms.iter().any(|m| m.matches_pre_lowered(lowered_str)),
+            CompiledMatcher::AllOf(ms) => ms.iter().all(|m| m.matches_pre_lowered(lowered_str)),
+            CompiledMatcher::CaseInsensitiveGroup { children, mode } => match mode {
+                GroupMode::Any => children.iter().any(|c| c.matches_pre_lowered(lowered_str)),
+                GroupMode::All => children.iter().all(|c| c.matches_pre_lowered(lowered_str)),
+            },
+
+            other => {
+                debug_assert!(
+                    false,
+                    "matches_pre_lowered called with non-pre-lowerable matcher: {other:?}"
+                );
+                false
+            }
         }
     }
 
@@ -214,6 +285,17 @@ impl CompiledMatcher {
             CompiledMatcher::Not(inner) => !inner.matches_str(s),
             CompiledMatcher::AnyOf(matchers) => matchers.iter().any(|m| m.matches_str(s)),
             CompiledMatcher::AllOf(matchers) => matchers.iter().all(|m| m.matches_str(s)),
+            CompiledMatcher::CaseInsensitiveGroup { children, mode } => {
+                let lowered = ascii_lowercase_cow(s);
+                match mode {
+                    GroupMode::Any => children
+                        .iter()
+                        .any(|c| c.matches_pre_lowered(lowered.as_ref())),
+                    GroupMode::All => children
+                        .iter()
+                        .all(|c| c.matches_pre_lowered(lowered.as_ref())),
+                }
+            }
             _ => false,
         }
     }

--- a/crates/rsigma-eval/src/matcher/mod.rs
+++ b/crates/rsigma-eval/src/matcher/mod.rs
@@ -118,6 +118,41 @@ pub enum CompiledMatcher {
     AnyOf(Vec<CompiledMatcher>),
     /// Match if ALL children match (AND).
     AllOf(Vec<CompiledMatcher>),
+
+    /// A composite of case-insensitive string matchers that lowers the haystack
+    /// once before dispatching to children.
+    ///
+    /// Built by the optimizer when an `AnyOf` or `AllOf` group is composed
+    /// entirely of case-insensitive string matchers (`Contains`, `StartsWith`,
+    /// `EndsWith`, `Exact`, `AhoCorasickSet`, plus regexes that carry the
+    /// `(?i)` flag, plus `Not` / nested `AnyOf` / `AllOf` whose every leaf
+    /// satisfies these rules).
+    ///
+    /// **Invariant**: every child must be pre-lowerable. The optimizer's
+    /// `is_pre_lowerable` validator enforces this; `matches_pre_lowered`
+    /// `debug_assert!`s on violation.
+    ///
+    /// **Why this exists**: a mixed `AnyOf([Contains, StartsWith, EndsWith])`
+    /// previously called `s.to_lowercase()` once per child. Pre-lowering the
+    /// haystack a single time and dispatching to a CI-aware match path
+    /// eliminates the redundant allocations.
+    CaseInsensitiveGroup {
+        children: Vec<CompiledMatcher>,
+        mode: GroupMode,
+    },
+}
+
+/// Reduction mode for composite matchers.
+///
+/// `Any` corresponds to OR semantics; `All` to AND. Used by
+/// `CaseInsensitiveGroup` to encode whether a single match suffices or every
+/// child must match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupMode {
+    /// At least one child must match (`AnyOf` semantics).
+    Any,
+    /// Every child must match (`AllOf` semantics).
+    All,
 }
 
 /// A part of an expand template.

--- a/crates/rsigma-eval/src/rule_index.rs
+++ b/crates/rsigma-eval/src/rule_index.rs
@@ -176,12 +176,12 @@ fn extract_from_matcher(matcher: &CompiledMatcher, field: &str, out: &mut Vec<(S
         CompiledMatcher::Exact { value, .. } => {
             out.push((field.to_string(), value.to_lowercase()));
         }
-        CompiledMatcher::AnyOf(children) => {
+        CompiledMatcher::AnyOf(children) | CompiledMatcher::AllOf(children) => {
             for child in children {
                 extract_from_matcher(child, field, out);
             }
         }
-        CompiledMatcher::AllOf(children) => {
+        CompiledMatcher::CaseInsensitiveGroup { children, .. } => {
             for child in children {
                 extract_from_matcher(child, field, out);
             }


### PR DESCRIPTION
## Summary

When a group of matchers is composed entirely of case-insensitive string predicates, this PR makes the eval engine lower the haystack once and reuse it across all children. Previously, each `Contains`, `StartsWith`, `EndsWith`, `Exact` matcher with `case_insensitive: true` allocated its own lowered `String` per call, scaling allocations with the child count.

A new `CompiledMatcher::CaseInsensitiveGroup { children, mode }` variant encodes the optimization in the type system. The optimizer wraps an `AnyOf` into a `CaseInsensitiveGroup` when every child is **pre-lowerable**: CI `Contains` / `StartsWith` / `EndsWith` / `Exact` / `AhoCorasickSet`, regexes carrying the `(?i)` flag, and recursively pre-lowerable composites.

## Hot path

The new `matches_pre_lowered(&str)` method assumes the haystack is already Unicode-lowercased and dispatches to children as pure string predicates. Optimizer bugs that feed it a non-pre-lowerable matcher trip a `debug_assert!`; in release the conservative fallback (`false`) avoids producing a false positive.

## Changes

- New `GroupMode { Any, All }` enum.
- New `CompiledMatcher::CaseInsensitiveGroup` variant.
- New `is_pre_lowerable` validator + `regex_is_case_insensitive` flag inspector in `compiler/optimizer.rs`.
- `optimize_any_of` extended with `wrap_ci_group_or_anyof` post-pass.
- `rule_index.rs` learned to descend into `CaseInsensitiveGroup` so detection items with multiple values keep their exact-match indexing.

## Tests

- 4 new unit tests for CI grouping: below-threshold wrap, mixed-case bypass, mixed pre-lowerable children wrapping, CS child poisoning the wrap.
- `is_pre_lowerable_classifies_correctly` covering all relevant variants.
- `regex_is_case_insensitive_recognizer` covering `(?i)`, `(?im)`, `(?si)`, no-flags, other-flags-only, malformed, negated, and subpattern groups.
- `ci_group_matches_same_haystacks_as_anyof` equivalence test on six hand-picked haystacks.

All 471 workspace tests pass; `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean.

## Benchmarks (`eval_contains_heavy`, 1 rule × 1000 events)

| Pattern count | Phase 1 baseline | After CI grouping | Δ throughput |
|---|---|---|---|
| 5 | ~232 µs (4.3 Melem/s) | 121 µs (8.2 Melem/s) | **+90%** |
| 20 | ~125 µs (8.0 Melem/s) | 98 µs (10.2 Melem/s) | **+28%** |
| 50 | 99 µs | 100 µs | no change |
| 100 | 99 µs | 99 µs | no change |

The biggest wins land below the Aho-Corasick threshold where multiple individual matchers stay live in the group. Once AC consumes the bucket, only one matcher remains so the CI wrapper provides no further benefit.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (471 tests pass, 0 failures)
- [x] Criterion benchmarks before/after on `eval_contains_heavy`
- [ ] SigmaHQ corpus regression (run after merge)