### PR TITLE
feat(eval): add opt-in bloom filter pre-filtering for substring matchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
 name = "rsigma-eval"
 version = "0.10.0"
 dependencies = [
+ "ahash",
  "aho-corasick",
  "base64",
  "chrono",

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 serde_yaml = { package = "yaml_serde", version = "0.10" }
 regex = "1"
 aho-corasick = "1"
+ahash = "0.8"
 base64 = "0.22"
 ipnet = "2"
 thiserror = "2"

--- a/crates/rsigma-eval/benches/datagen.rs
+++ b/crates/rsigma-eval/benches/datagen.rs
@@ -340,6 +340,80 @@ pub fn gen_regex_rule(rng: &mut StdRng, id: usize) -> String {
     )
 }
 
+/// Generate a single rule whose detection items use only `|contains`
+/// against a randomly-chosen field, with one needle per item.
+///
+/// Differs from `gen_single_rule` in that EVERY rule produced here is
+/// substring-only, so the rule index marks them all unindexable. This is
+/// the worst case for the engine without bloom pre-filtering and the best
+/// case for measuring bloom-rejection benefits.
+pub fn gen_substring_only_rule(rng: &mut StdRng, id: usize) -> String {
+    let num_items = rng.random_range(1..=3);
+    let mut detection = String::new();
+    detection.push_str("    selection:\n");
+    let mut used_fields = std::collections::HashSet::new();
+    for _ in 0..num_items {
+        let field = FIELD_NAMES[rng.random_range(0..FIELD_NAMES.len())];
+        if !used_fields.insert(field) {
+            continue;
+        }
+        let val = STRING_VALUES[rng.random_range(0..STRING_VALUES.len())];
+        let modifier = match rng.random_range(0..3u8) {
+            0 => "|contains",
+            1 => "|startswith",
+            _ => "|endswith",
+        };
+        detection.push_str(&format!("        {field}{modifier}: '{val}'\n"));
+    }
+    format!(
+        "title: Substring Rule {id}\n\
+         id: substring-rule-{id:06}\n\
+         logsource:\n\
+         \x20   product: windows\n\
+         \x20   category: process_creation\n\
+         detection:\n\
+         {detection}\
+         \x20   condition: selection\n\
+         level: medium\n"
+    )
+}
+
+/// Generate `n` substring-only rules (see [`gen_substring_only_rule`]).
+pub fn gen_n_substring_only_rules(n: usize) -> String {
+    let mut rng = rng();
+    let mut docs = Vec::with_capacity(n);
+    for i in 0..n {
+        docs.push(gen_substring_only_rule(&mut rng, i));
+    }
+    docs.join("---\n")
+}
+
+/// Generate a synthetic event whose string fields contain ONLY digits and
+/// punctuation, guaranteeing no overlap with `STRING_VALUES`. Useful for
+/// the bloom rejection benchmark where every event must be a guaranteed
+/// non-match against the rule corpus.
+pub fn gen_non_matching_event(rng: &mut StdRng) -> serde_json::Value {
+    let cmdline: String = (0..rng.random_range(20..60))
+        .map(|_| (rng.random_range(b'0'..=b'9')) as char)
+        .collect();
+    serde_json::json!({
+        "User": "0000",
+        "Image": "/0000/0000/0000",
+        "CommandLine": cmdline,
+        "ParentImage": "/0000/0000/0000",
+        "SourceIp": "10.0.0.0",
+        "DestinationPort": 0,
+        "EventType": "0000",
+        "ProcessName": "/0000/0000/0000",
+        "OriginalFileName": "0000",
+    })
+}
+
+pub fn gen_non_matching_events(n: usize) -> Vec<serde_json::Value> {
+    let mut rng = rng();
+    (0..n).map(|_| gen_non_matching_event(&mut rng)).collect()
+}
+
 /// Generate a multi-document YAML string with `n` detection rules.
 pub fn gen_n_rules(n: usize) -> String {
     let mut rng = rng();

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -312,6 +312,67 @@ fn bench_eval_regex_set_heavy(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: bloom rejection — many substring-only rules vs events that
+// guaranteed-do-not-match any pattern. Measures the fast-reject path.
+// ---------------------------------------------------------------------------
+
+fn bench_eval_bloom_rejection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eval_bloom_rejection");
+    group.sample_size(20);
+
+    // 1000 events that contain only digits — guaranteed not to share any
+    // trigram with the alphabetical needles in `STRING_VALUES`.
+    let event_values = datagen::gen_non_matching_events(1000);
+    let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
+
+    for n_rules in [100, 500, 1000, 5000] {
+        let yaml = datagen::gen_n_substring_only_rules(n_rules);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+
+        // Default engine: bloom pre-filter off.
+        let mut off_engine = rsigma_eval::Engine::new();
+        off_engine.add_collection(&collection).unwrap();
+        // Bloom-enabled engine: same rules.
+        let mut on_engine = rsigma_eval::Engine::new();
+        on_engine.add_collection(&collection).unwrap();
+        on_engine.set_bloom_prefilter(true);
+
+        group.throughput(criterion::Throughput::Elements(events.len() as u64));
+
+        let off_label = format!("{n_rules}r_bloom_off");
+        group.bench_with_input(
+            BenchmarkId::new("default", &off_label),
+            &(&off_engine, &events),
+            |b, (engine, events)| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for event in *events {
+                        total += engine.evaluate(black_box(event)).len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+
+        let on_label = format!("{n_rules}r_bloom_on");
+        group.bench_with_input(
+            BenchmarkId::new("bloom_prefilter", &on_label),
+            &(&on_engine, &events),
+            |b, (engine, events)| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for event in *events {
+                        total += engine.evaluate(black_box(event)).len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Benchmark: regex-heavy rules
 // ---------------------------------------------------------------------------
 
@@ -358,6 +419,7 @@ criterion_group!(
     bench_eval_contains_heavy,
     bench_eval_ac_threshold_sweep,
     bench_eval_regex_set_heavy,
+    bench_eval_bloom_rejection,
     bench_eval_wildcard_heavy,
     bench_eval_regex_heavy,
 );

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -87,6 +87,11 @@ pub struct CompiledDetectionItem {
     pub matcher: CompiledMatcher,
     /// If `Some(true)`, field must exist; `Some(false)`, must not exist.
     pub exists: Option<bool>,
+    /// Pre-computed flag set when the matcher is a positive substring
+    /// assertion eligible for bloom-filter pre-filtering. Recomputing the
+    /// recursive `is_positive_substring_matcher` walk for every event would
+    /// dominate the eval cost on rule sets where most items don't qualify.
+    pub bloom_eligible: bool,
 }
 
 // =============================================================================
@@ -268,10 +273,40 @@ fn validate_condition_refs(
 }
 
 /// Evaluate a compiled rule against an event, returning a `MatchResult` if it matches.
+///
+/// This is the public entry point for one-shot rule evaluation. It does no
+/// bloom pre-filtering; every detection item is evaluated directly. Engines
+/// that maintain a [`crate::engine::bloom_index::FieldBloomIndex`] should
+/// instead call [`evaluate_rule_with_bloom`].
 pub fn evaluate_rule(rule: &CompiledRule, event: &impl Event) -> Option<MatchResult> {
+    evaluate_rule_with_bloom(rule, event, &crate::engine::bloom_index::NoBloom)
+}
+
+/// Evaluate a compiled rule against an event with bloom pre-filtering.
+///
+/// `bloom` provides per-field verdicts for positive substring matchers.
+/// When `bloom.verdict_for_field(field)` returns `DefinitelyNoMatch`, any
+/// positive substring item targeting that field is short-circuited to
+/// `false` without invoking its matcher. The pre-filter is purely an
+/// optimization: it never changes the eval result vs `evaluate_rule`.
+pub(crate) fn evaluate_rule_with_bloom<E, B>(
+    rule: &CompiledRule,
+    event: &E,
+    bloom: &B,
+) -> Option<MatchResult>
+where
+    E: Event,
+    B: crate::engine::bloom_index::BloomLookup,
+{
     for condition in &rule.conditions {
         let mut matched_selections = Vec::new();
-        if eval_condition(condition, &rule.detections, event, &mut matched_selections) {
+        if eval_condition_with_bloom(
+            condition,
+            &rule.detections,
+            event,
+            &mut matched_selections,
+            bloom,
+        ) {
             let matched_fields =
                 collect_field_matches(&matched_selections, &rule.detections, event);
 
@@ -355,6 +390,7 @@ fn compile_detection_item(item: &DetectionItem) -> Result<CompiledDetectionItem>
             field: item.field.name.clone(),
             matcher: CompiledMatcher::Exists(expect),
             exists: Some(expect),
+            bloom_eligible: false,
         });
     }
 
@@ -389,10 +425,14 @@ fn compile_detection_item(item: &DetectionItem) -> Result<CompiledDetectionItem>
         optimizer::optimize_any_of(matchers)
     };
 
+    let bloom_eligible = item.field.name.is_some()
+        && crate::engine::bloom_index::is_positive_substring_matcher(&combined);
+
     Ok(CompiledDetectionItem {
         field: item.field.name.clone(),
         matcher: combined,
         exists: None,
+        bloom_eligible,
     })
 }
 
@@ -710,10 +750,35 @@ pub fn eval_condition(
     event: &impl Event,
     matched_selections: &mut Vec<String>,
 ) -> bool {
+    eval_condition_with_bloom(
+        expr,
+        detections,
+        event,
+        matched_selections,
+        &crate::engine::bloom_index::NoBloom,
+    )
+}
+
+/// Bloom-aware version of [`eval_condition`].
+///
+/// Identical to `eval_condition` except that positive substring leaves are
+/// short-circuited to `false` when the bloom proves no pattern can match
+/// the event's field value.
+pub(crate) fn eval_condition_with_bloom<E, B>(
+    expr: &ConditionExpr,
+    detections: &HashMap<String, CompiledDetection>,
+    event: &E,
+    matched_selections: &mut Vec<String>,
+    bloom: &B,
+) -> bool
+where
+    E: Event,
+    B: crate::engine::bloom_index::BloomLookup,
+{
     match expr {
         ConditionExpr::Identifier(name) => {
             if let Some(det) = detections.get(name) {
-                let result = eval_detection(det, event);
+                let result = eval_detection_with_bloom(det, event, bloom);
                 if result {
                     matched_selections.push(name.clone());
                 }
@@ -725,13 +790,15 @@ pub fn eval_condition(
 
         ConditionExpr::And(exprs) => exprs
             .iter()
-            .all(|e| eval_condition(e, detections, event, matched_selections)),
+            .all(|e| eval_condition_with_bloom(e, detections, event, matched_selections, bloom)),
 
         ConditionExpr::Or(exprs) => exprs
             .iter()
-            .any(|e| eval_condition(e, detections, event, matched_selections)),
+            .any(|e| eval_condition_with_bloom(e, detections, event, matched_selections, bloom)),
 
-        ConditionExpr::Not(inner) => !eval_condition(inner, detections, event, matched_selections),
+        ConditionExpr::Not(inner) => {
+            !eval_condition_with_bloom(inner, detections, event, matched_selections, bloom)
+        }
 
         ConditionExpr::Selector {
             quantifier,
@@ -751,7 +818,7 @@ pub fn eval_condition(
             let mut match_count = 0u64;
             for name in &matching_names {
                 if let Some(det) = detections.get(*name)
-                    && eval_detection(det, event)
+                    && eval_detection_with_bloom(det, event, bloom)
                 {
                     match_count += 1;
                     matched_selections.push((*name).clone());
@@ -767,19 +834,43 @@ pub fn eval_condition(
     }
 }
 
-/// Evaluate a compiled detection against an event.
-fn eval_detection(detection: &CompiledDetection, event: &impl Event) -> bool {
+/// Evaluate a compiled detection item against an event without bloom
+/// pre-filtering. Used only by the in-crate compiler tests; the production
+/// paths run through `eval_detection_item_with_bloom` from
+/// `evaluate_rule_with_bloom`.
+#[cfg(test)]
+fn eval_detection_item(item: &CompiledDetectionItem, event: &impl Event) -> bool {
+    eval_detection_item_with_bloom(item, event, &crate::engine::bloom_index::NoBloom)
+}
+
+/// Evaluate a compiled detection against an event with a bloom lookup.
+fn eval_detection_with_bloom<E, B>(detection: &CompiledDetection, event: &E, bloom: &B) -> bool
+where
+    E: Event,
+    B: crate::engine::bloom_index::BloomLookup,
+{
     match detection {
-        CompiledDetection::AllOf(items) => {
-            items.iter().all(|item| eval_detection_item(item, event))
-        }
-        CompiledDetection::AnyOf(dets) => dets.iter().any(|d| eval_detection(d, event)),
+        CompiledDetection::AllOf(items) => items
+            .iter()
+            .all(|item| eval_detection_item_with_bloom(item, event, bloom)),
+        CompiledDetection::AnyOf(dets) => dets
+            .iter()
+            .any(|d| eval_detection_with_bloom(d, event, bloom)),
         CompiledDetection::Keywords(matcher) => matcher.matches_keyword(event),
     }
 }
 
-/// Evaluate a single compiled detection item against an event.
-fn eval_detection_item(item: &CompiledDetectionItem, event: &impl Event) -> bool {
+/// Evaluate a single detection item with bloom pre-filtering.
+///
+/// When the matcher targets a single field and is a positive substring
+/// matcher (not under negation), the bloom verdict is consulted first. A
+/// `DefinitelyNoMatch` verdict guarantees the matcher would return `false`,
+/// so we return early without invoking it.
+fn eval_detection_item_with_bloom<E, B>(item: &CompiledDetectionItem, event: &E, bloom: &B) -> bool
+where
+    E: Event,
+    B: crate::engine::bloom_index::BloomLookup,
+{
     if let Some(expect_exists) = item.exists {
         if let Some(field) = &item.field {
             let exists = event.get_field(field).is_some_and(|v| !v.is_null());
@@ -791,6 +882,12 @@ fn eval_detection_item(item: &CompiledDetectionItem, event: &impl Event) -> bool
     match &item.field {
         Some(field_name) => {
             if let Some(value) = event.get_field(field_name) {
+                if item.bloom_eligible
+                    && bloom.verdict_for_field(field_name)
+                        == crate::engine::bloom_index::BloomVerdict::DefinitelyNoMatch
+                {
+                    return false;
+                }
                 item.matcher.matches(&value, event)
             } else {
                 matches!(item.matcher, CompiledMatcher::Null)
@@ -836,7 +933,7 @@ fn collect_detection_fields(
         }
         CompiledDetection::AnyOf(dets) => {
             for d in dets {
-                if eval_detection(d, event) {
+                if eval_detection_with_bloom(d, event, &crate::engine::bloom_index::NoBloom) {
                     collect_detection_fields(d, event, out);
                 }
             }

--- a/crates/rsigma-eval/src/compiler/optimizer.rs
+++ b/crates/rsigma-eval/src/compiler/optimizer.rs
@@ -269,6 +269,7 @@ fn consume_contains(result: &mut Vec<CompiledMatcher>, needles: Vec<String>, ci:
         result.push(CompiledMatcher::AhoCorasickSet {
             automaton,
             case_insensitive: ci,
+            needles,
         });
         return;
     }

--- a/crates/rsigma-eval/src/engine/bloom_index.rs
+++ b/crates/rsigma-eval/src/engine/bloom_index.rs
@@ -1,0 +1,714 @@
+//! Per-field bloom filter pre-filtering for substring matchers.
+//!
+//! At rule load time, walks every compiled rule and collects the positive
+//! substring needles per field across the entire rule set. Each set is hashed
+//! into a small bloom filter keyed by trigrams. At eval time, the engine
+//! probes the event's field values: if no trigram from a pattern is present,
+//! every positive substring matcher on that field is guaranteed to return
+//! `false`, so individual rule items can be short-circuited without
+//! evaluating their matcher.
+//!
+//! # Correctness
+//!
+//! The bloom filter is over-approximate: it can say "maybe match" when no
+//! pattern actually matches, but never "no match" when one does. Combined
+//! with the eval engine only consulting the bloom for **positive** substring
+//! matchers, this guarantees zero false negatives at the Sigma semantic
+//! layer regardless of where the matcher sits in the condition tree (under
+//! `Not`, inside `not 1 of ...`, or in any nested boolean expression).
+//!
+//! # Pre-filtering scope
+//!
+//! Only positive `Contains` / `StartsWith` / `EndsWith` / `AhoCorasickSet`
+//! matchers contribute to the bloom. `Exact` matchers are intentionally
+//! excluded: the rule index already pre-filters those at the rule level. By
+//! the time a rule reaches `evaluate_rule`, `Exact` items have either been
+//! validated by the index or come from a partially-indexable rule that needs
+//! direct evaluation anyway.
+//!
+//! # Length cutoff
+//!
+//! Trigram extraction is `O(field_value.len())`. For very long haystacks the
+//! pre-check can cost more than the matchers themselves, so probes against
+//! values longer than [`MAX_BLOOM_SCAN_BYTES`] are skipped (returning
+//! [`BloomVerdict::SkippedTooLong`]).
+//!
+//! # Memory budget
+//!
+//! Total bloom memory is capped at [`DEFAULT_MAX_TOTAL_BYTES`]. When the
+//! computed size exceeds the budget, fields with the lowest bits-per-pattern
+//! density are disabled until the total fits.
+
+use std::collections::HashMap;
+use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
+
+use crate::compiler::{CompiledDetection, CompiledRule};
+use crate::event::{Event, EventValue};
+use crate::matcher::CompiledMatcher;
+
+/// Bytes per trigram window.
+pub(crate) const NGRAM_SIZE: usize = 3;
+
+/// Skip the bloom probe entirely for field values longer than this. Above
+/// this threshold the trigram sweep starts to compete with the matcher's
+/// own work; a 4 KB cap matches typical Windows event log fields without
+/// penalizing CommandLine outliers that are still under it.
+pub(crate) const MAX_BLOOM_SCAN_BYTES: usize = 4096;
+
+/// Default memory ceiling shared across all per-field filters.
+pub(crate) const DEFAULT_MAX_TOTAL_BYTES: usize = 1024 * 1024;
+
+/// Target false-positive rate for individual filters.
+const TARGET_FPR: f64 = 0.01;
+
+/// Lower bound for bits-per-pattern. Below this density the FPR is too
+/// high for the filter to provide useful pre-filtering: the engine probes
+/// once per trigram in a haystack so even a 1% per-probe FPR compounds into
+/// a high false-positive rate over a 30-character field. Bumping this to 16
+/// pushes per-probe FPR below 0.1% for typical pattern counts while still
+/// keeping the per-field memory cost negligible.
+const MIN_BITS_PER_PATTERN: usize = 16;
+
+/// Per-field hard cap. Pathological rule sets with thousands of patterns
+/// per field still fit under this without bloating the engine.
+const MAX_BYTES_PER_FIELD: usize = 64 * 1024;
+
+/// What the bloom filter could prove about an event's field value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BloomVerdict {
+    /// No trigram from any positive substring pattern is present in the
+    /// field value. Any positive substring matcher on this field will
+    /// return `false`; the eval engine can short-circuit.
+    DefinitelyNoMatch,
+    /// At least one trigram could match; the engine must evaluate the
+    /// matcher directly.
+    MaybeMatch,
+}
+
+/// Pre-filter lookup interface used by the eval functions.
+///
+/// The eval helpers in [`crate::compiler`] are generic over `B: BloomLookup`
+/// so the same code services both:
+/// - The public `evaluate_rule` path, which passes a [`NoBloom`] zero-sized
+///   stub. The compiler monomorphizes the matcher dispatch with no extra
+///   work per call.
+/// - The engine path with a real [`BloomCache`], where positive substring
+///   items short-circuit on `DefinitelyNoMatch`.
+pub(crate) trait BloomLookup {
+    fn verdict_for_field(&self, field: &str) -> BloomVerdict;
+}
+
+/// Zero-sized implementation that disables pre-filtering. Every probe
+/// answers [`BloomVerdict::MaybeMatch`], so generic eval code falls through
+/// to direct matcher evaluation.
+pub(crate) struct NoBloom;
+
+impl BloomLookup for NoBloom {
+    #[inline(always)]
+    fn verdict_for_field(&self, _field: &str) -> BloomVerdict {
+        BloomVerdict::MaybeMatch
+    }
+}
+
+/// Bit-array bloom filter using FNV-style double hashing over the AHash
+/// output of each input. `k` hash functions are simulated by `h1 + i*h2`
+/// where `h1`, `h2` are the low and high words of a 128-bit AHash digest.
+struct FieldBloom {
+    bits: Vec<u64>,
+    num_bits: usize,
+    num_hashes: u32,
+    hasher_factory: BuildHasherDefault<ahash::AHasher>,
+}
+
+impl FieldBloom {
+    fn new_with_capacity(n_items: usize) -> Option<Self> {
+        if n_items == 0 {
+            return None;
+        }
+        // Standard sizing: m = ceil(-n * ln(p) / (ln 2)^2). With p=1% this
+        // is ~9.585 n.
+        let m_ideal = (-(n_items as f64) * TARGET_FPR.ln() / 2.0_f64.ln().powi(2)).ceil() as usize;
+        let mut num_bits = m_ideal.max(MIN_BITS_PER_PATTERN * n_items);
+        // Round up to a multiple of 64 so storage maps cleanly onto u64 limbs.
+        num_bits = num_bits.div_ceil(64) * 64;
+
+        let max_bits = MAX_BYTES_PER_FIELD * 8;
+        if num_bits > max_bits {
+            num_bits = max_bits;
+        }
+
+        if num_bits / 8 < n_items.div_ceil(8) {
+            // Too few bits per pattern to be useful.
+            return None;
+        }
+
+        // k = (m/n) ln 2, rounded; clamp to a sane range.
+        let k_ideal = ((num_bits as f64 / n_items as f64) * 2.0_f64.ln()).round() as u32;
+        let num_hashes = k_ideal.clamp(2, 12);
+
+        Some(Self {
+            bits: vec![0u64; num_bits / 64],
+            num_bits,
+            num_hashes,
+            hasher_factory: BuildHasherDefault::default(),
+        })
+    }
+
+    fn byte_size(&self) -> usize {
+        self.bits.len() * 8
+    }
+
+    fn insert_trigram(&mut self, trigram: &[u8]) {
+        let (h1, h2) = self.hash_pair(trigram);
+        for i in 0..self.num_hashes as u64 {
+            let pos = (h1.wrapping_add(i.wrapping_mul(h2))) as usize % self.num_bits;
+            self.bits[pos / 64] |= 1 << (pos % 64);
+        }
+    }
+
+    fn contains_trigram(&self, trigram: &[u8]) -> bool {
+        let (h1, h2) = self.hash_pair(trigram);
+        for i in 0..self.num_hashes as u64 {
+            let pos = (h1.wrapping_add(i.wrapping_mul(h2))) as usize % self.num_bits;
+            if self.bits[pos / 64] & (1 << (pos % 64)) == 0 {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Produce two independent 64-bit hashes from a single AHash digest by
+    /// feeding the trigram twice with different prefixes. Cheap and gives
+    /// the double-hashing scheme enough independence to behave like two
+    /// distinct functions.
+    fn hash_pair(&self, trigram: &[u8]) -> (u64, u64) {
+        let mut h1 = self.hasher_factory.build_hasher();
+        h1.write_u8(0xA1);
+        h1.write(trigram);
+        let mut h2 = self.hasher_factory.build_hasher();
+        h2.write_u8(0xB2);
+        h2.write(trigram);
+        (h1.finish(), h2.finish())
+    }
+}
+
+/// Per-field bloom filters built from the union of every positive substring
+/// needle across all compiled rules.
+pub(crate) struct FieldBloomIndex {
+    /// `field_name → bloom`. Fields without any positive substring needles
+    /// (or that exceeded the memory budget) are absent from the map; probes
+    /// against them return `MaybeMatch` and the engine evaluates as usual.
+    filters: HashMap<String, FieldBloom>,
+}
+
+impl FieldBloomIndex {
+    pub(crate) fn empty() -> Self {
+        Self {
+            filters: HashMap::new(),
+        }
+    }
+
+    /// Build the index from a rule slice, respecting the default memory
+    /// budget.
+    pub(crate) fn build(rules: &[CompiledRule]) -> Self {
+        Self::build_with_budget(rules, DEFAULT_MAX_TOTAL_BYTES)
+    }
+
+    pub(crate) fn build_with_budget(rules: &[CompiledRule], max_total_bytes: usize) -> Self {
+        let mut field_needles: HashMap<String, Vec<String>> = HashMap::new();
+        for rule in rules {
+            for detection in rule.detections.values() {
+                collect_positive_substring_needles(detection, &mut field_needles);
+            }
+        }
+
+        // Build filters per field, then enforce the total memory budget.
+        struct Built {
+            field: String,
+            bloom: FieldBloom,
+            n_patterns: usize,
+        }
+
+        let mut built: Vec<Built> = field_needles
+            .into_iter()
+            .filter_map(|(field, mut needles)| {
+                // Deduplicate so the bit count reflects unique pattern strings.
+                needles.sort();
+                needles.dedup();
+
+                // Count the total number of distinct trigrams that will be
+                // inserted; the bloom must be sized against this number,
+                // not the pattern count, or the filter saturates as soon as
+                // any needle longer than NGRAM_SIZE+1 bytes is inserted.
+                let mut trigram_set: std::collections::HashSet<[u8; NGRAM_SIZE]> =
+                    std::collections::HashSet::new();
+                for needle in &needles {
+                    let bytes = needle.as_bytes();
+                    if bytes.len() < NGRAM_SIZE {
+                        continue;
+                    }
+                    for window in bytes.windows(NGRAM_SIZE) {
+                        let mut buf = [0u8; NGRAM_SIZE];
+                        buf.copy_from_slice(window);
+                        trigram_set.insert(buf);
+                    }
+                }
+                let n_trigrams = trigram_set.len();
+
+                let mut bloom = FieldBloom::new_with_capacity(n_trigrams)?;
+                for needle in &needles {
+                    insert_needle_trigrams(&mut bloom, needle);
+                }
+                Some(Built {
+                    field,
+                    bloom,
+                    n_patterns: needles.len(),
+                })
+            })
+            .collect();
+
+        // Total budget enforcement: drop the lowest-density filters first.
+        let mut total: usize = built.iter().map(|b| b.bloom.byte_size()).sum();
+        if total > max_total_bytes {
+            built.sort_by(|a, b| {
+                let da = a.bloom.byte_size() as f64 / a.n_patterns.max(1) as f64;
+                let db = b.bloom.byte_size() as f64 / b.n_patterns.max(1) as f64;
+                // Higher bytes-per-pattern = lower density per bit = drop first.
+                db.partial_cmp(&da).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            while total > max_total_bytes {
+                if let Some(victim) = built.pop() {
+                    total = total.saturating_sub(victim.bloom.byte_size());
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let filters = built
+            .into_iter()
+            .map(|b| (b.field, b.bloom))
+            .collect::<HashMap<_, _>>();
+        Self { filters }
+    }
+
+    /// Number of fields with active filters. Useful for diagnostics and
+    /// tests; not on the hot path.
+    #[cfg(test)]
+    pub(crate) fn field_count(&self) -> usize {
+        self.filters.len()
+    }
+
+    /// Total bytes consumed across every field's bloom filter.
+    #[cfg(test)]
+    pub(crate) fn total_bytes(&self) -> usize {
+        self.filters.values().map(FieldBloom::byte_size).sum()
+    }
+
+    /// Probe the bloom for `field` against `value`. Returns the verdict the
+    /// engine should use to decide whether to short-circuit positive
+    /// substring matchers on this field.
+    pub(crate) fn probe(&self, field: &str, value: &str) -> BloomVerdict {
+        let Some(bloom) = self.filters.get(field) else {
+            return BloomVerdict::MaybeMatch;
+        };
+        if value.len() < NGRAM_SIZE {
+            // Cannot extract a full trigram; answer conservatively.
+            return BloomVerdict::MaybeMatch;
+        }
+        if value.len() > MAX_BLOOM_SCAN_BYTES {
+            return BloomVerdict::MaybeMatch;
+        }
+
+        // Lower the haystack once. Sigma defaults to case-insensitive
+        // matching and the bloom is built from lowered needles.
+        let lowered = crate::matcher::ascii_lowercase_cow(value);
+        let bytes = lowered.as_bytes();
+        for window in bytes.windows(NGRAM_SIZE) {
+            if bloom.contains_trigram(window) {
+                return BloomVerdict::MaybeMatch;
+            }
+        }
+        BloomVerdict::DefinitelyNoMatch
+    }
+}
+
+/// Per-event memoization layer: probes lazily and caches the verdict per
+/// field name so each rule item that needs the verdict pays only the first
+/// probe.
+pub(crate) struct BloomCache<'a, E: Event> {
+    index: &'a FieldBloomIndex,
+    event: &'a E,
+    /// `None` means "not probed yet"; `Some(verdict)` is the cached answer.
+    cache: std::cell::RefCell<HashMap<String, BloomVerdict>>,
+}
+
+impl<'a, E: Event> BloomCache<'a, E> {
+    pub(crate) fn new(index: &'a FieldBloomIndex, event: &'a E) -> Self {
+        Self {
+            index,
+            event,
+            cache: std::cell::RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl<E: Event> BloomLookup for BloomCache<'_, E> {
+    fn verdict_for_field(&self, field: &str) -> BloomVerdict {
+        if let Some(v) = self.cache.borrow().get(field) {
+            return *v;
+        }
+        // Compute and cache. Only string event values participate; arrays
+        // and other variants always answer MaybeMatch (the bloom can only
+        // probe a single string at a time and arrays are rare on hot fields).
+        let verdict = match self.event.get_field(field) {
+            Some(EventValue::Str(s)) => self.index.probe(field, &s),
+            _ => BloomVerdict::MaybeMatch,
+        };
+        self.cache.borrow_mut().insert(field.to_string(), verdict);
+        verdict
+    }
+}
+
+/// True iff this matcher is a positive (non-negated) substring assertion
+/// that the bloom filter can pre-filter.
+pub(crate) fn is_positive_substring_matcher(matcher: &CompiledMatcher) -> bool {
+    match matcher {
+        CompiledMatcher::Contains { .. }
+        | CompiledMatcher::StartsWith { .. }
+        | CompiledMatcher::EndsWith { .. }
+        | CompiledMatcher::AhoCorasickSet { .. } => true,
+        CompiledMatcher::AnyOf(children) => children.iter().all(is_positive_substring_matcher),
+        CompiledMatcher::CaseInsensitiveGroup { children, .. } => {
+            children.iter().all(is_positive_substring_matcher)
+        }
+        // AllOf is intentionally excluded: even if every child is a positive
+        // substring, the bloom only proves "no pattern present", which is
+        // already enough to short-circuit (`AllOf(false) = false`). But the
+        // savings are small and a single AllOf containing other matchers
+        // (FieldRef, etc.) would corrupt the analysis. Keep it simple and
+        // off the bloom path.
+        _ => false,
+    }
+}
+
+/// Walk a compiled detection tree and collect positive substring needles
+/// per field. `Not(...)` subtrees contribute nothing because their
+/// match-falsifying values are independent of pattern presence.
+fn collect_positive_substring_needles(
+    detection: &CompiledDetection,
+    out: &mut HashMap<String, Vec<String>>,
+) {
+    match detection {
+        CompiledDetection::AllOf(items) => {
+            for item in items {
+                if let Some(field) = &item.field {
+                    extract_from_matcher(&item.matcher, field, /*negated=*/ false, out);
+                }
+            }
+        }
+        CompiledDetection::AnyOf(subs) => {
+            for sub in subs {
+                collect_positive_substring_needles(sub, out);
+            }
+        }
+        CompiledDetection::Keywords(_) => {
+            // Keyword detections are field-less; not bloom-eligible at the
+            // per-field granularity.
+        }
+    }
+}
+
+fn extract_from_matcher(
+    m: &CompiledMatcher,
+    field: &str,
+    negated: bool,
+    out: &mut HashMap<String, Vec<String>>,
+) {
+    if negated {
+        return;
+    }
+    match m {
+        CompiledMatcher::Contains { value, .. }
+        | CompiledMatcher::StartsWith { value, .. }
+        | CompiledMatcher::EndsWith { value, .. } => {
+            out.entry(field.to_string())
+                .or_default()
+                .push(value.clone());
+        }
+        CompiledMatcher::AhoCorasickSet { needles, .. } => {
+            // The optimizer stores the pre-lowered needles on the variant so
+            // the bloom builder can recover them without inspecting the
+            // automaton's private state.
+            let entry = out.entry(field.to_string()).or_default();
+            entry.extend(needles.iter().cloned());
+        }
+        CompiledMatcher::AnyOf(children) | CompiledMatcher::AllOf(children) => {
+            for child in children {
+                extract_from_matcher(child, field, negated, out);
+            }
+        }
+        CompiledMatcher::CaseInsensitiveGroup { children, .. } => {
+            for child in children {
+                extract_from_matcher(child, field, negated, out);
+            }
+        }
+        CompiledMatcher::Not(inner) => {
+            extract_from_matcher(inner, field, true, out);
+        }
+        // Exact, Regex, RegexSetMatch, Cidr, Numeric*, Exists, BoolEq,
+        // FieldRef, Null, Expand, TimestampPart: not bloom-eligible. Exact
+        // is excluded deliberately so the rule index keeps its monopoly
+        // there.
+        _ => {}
+    }
+}
+
+fn insert_needle_trigrams(bloom: &mut FieldBloom, needle: &str) {
+    let bytes = needle.as_bytes();
+    if bytes.len() < NGRAM_SIZE {
+        return;
+    }
+    for window in bytes.windows(NGRAM_SIZE) {
+        bloom.insert_trigram(window);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Engine;
+    use rsigma_parser::parse_sigma_yaml;
+
+    fn engine_from(yaml: &str) -> Engine {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+        engine
+    }
+
+    fn bloom_from(yaml: &str) -> FieldBloomIndex {
+        let engine = engine_from(yaml);
+        FieldBloomIndex::build(engine.rules())
+    }
+
+    #[test]
+    fn empty_when_no_positive_substring_rules() {
+        let yaml = r#"
+title: Exact Only
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        assert_eq!(bloom.field_count(), 0);
+    }
+
+    #[test]
+    fn populates_filter_for_contains_field() {
+        let yaml = r#"
+title: Contains Field
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains:
+            - 'whoami'
+            - 'mimikatz'
+            - 'powershell'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        assert_eq!(bloom.field_count(), 1);
+
+        // Trigrams from "whoami" (who/hoa/oam/ami) are present.
+        assert_eq!(
+            bloom.probe("CommandLine", "execute whoami /all"),
+            BloomVerdict::MaybeMatch
+        );
+
+        // Digit-only trigrams cannot share any input with the alphabetical
+        // needles, and the filter is sized for ~18 trigrams against 1%
+        // FPR. Sweep all 1000 digit triples and verify high rejection.
+        let mut rejected = 0usize;
+        let mut total = 0usize;
+        for a in b'0'..=b'9' {
+            for b in b'0'..=b'9' {
+                for c in b'0'..=b'9' {
+                    total += 1;
+                    let s = std::str::from_utf8(&[a, b, c]).unwrap().to_string();
+                    if bloom.probe("CommandLine", &s) == BloomVerdict::DefinitelyNoMatch {
+                        rejected += 1;
+                    }
+                }
+            }
+        }
+        assert!(
+            rejected * 100 >= total * 95,
+            "expected >= 95% rejection on digit-only trigrams; got {rejected}/{total}"
+        );
+    }
+
+    #[test]
+    fn negated_contains_does_not_contribute_needles() {
+        // `Not(Contains)` subtrees are excluded so a value WITHOUT the
+        // pattern can fire the rule (negation semantics). The bloom must
+        // not be biased toward those needles; in fact we shouldn't even
+        // build a filter for a field whose only patterns are negated.
+        let yaml = r#"
+title: Negated Contains
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|not: 'whoami'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        assert_eq!(bloom.field_count(), 0);
+    }
+
+    #[test]
+    fn unrelated_field_falls_through_to_maybe_match() {
+        let yaml = r#"
+title: Some Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        // No filter for `User` field, so probe must answer MaybeMatch.
+        assert_eq!(bloom.probe("User", "anything"), BloomVerdict::MaybeMatch);
+    }
+
+    #[test]
+    fn skips_haystacks_below_ngram_size() {
+        let yaml = r#"
+title: Some Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'foo'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        // value shorter than NGRAM_SIZE → conservative MaybeMatch.
+        assert_eq!(bloom.probe("CommandLine", "ab"), BloomVerdict::MaybeMatch);
+    }
+
+    #[test]
+    fn skips_haystacks_above_max_scan_bytes() {
+        let yaml = r#"
+title: Some Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'foo'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        let huge = "x".repeat(MAX_BLOOM_SCAN_BYTES + 1);
+        assert_eq!(bloom.probe("CommandLine", &huge), BloomVerdict::MaybeMatch);
+    }
+
+    #[test]
+    fn ahocorasick_needles_contribute_to_bloom() {
+        // 8+ contains values trigger the Aho-Corasick optimizer; the bloom
+        // builder must still extract the needles from the AC variant.
+        let yaml = r#"
+title: AC Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains:
+            - 'mimikatz'
+            - 'powershell'
+            - 'rundll32'
+            - 'regsvr32'
+            - 'certutil'
+            - 'bitsadmin'
+            - 'mshta'
+            - 'wscript'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        assert_eq!(bloom.field_count(), 1);
+        assert_eq!(
+            bloom.probe("CommandLine", "rundll32.exe foo"),
+            BloomVerdict::MaybeMatch
+        );
+        // Single-trigram digit haystack: provably no overlap with the
+        // alphabetical needles, no compounding over many probe windows.
+        assert_eq!(
+            bloom.probe("CommandLine", "012"),
+            BloomVerdict::DefinitelyNoMatch
+        );
+    }
+
+    #[test]
+    fn case_insensitive_probe() {
+        let yaml = r#"
+title: CI
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        // Patterns are stored lowercased; probes lower the haystack too.
+        assert_eq!(
+            bloom.probe("CommandLine", "execute WHOAMI /all"),
+            BloomVerdict::MaybeMatch
+        );
+    }
+
+    #[test]
+    fn memory_budget_drops_lowest_density_fields_first() {
+        // Build many fields, each with one pattern, against a tiny total
+        // budget. The constructor must drop the lowest-density fields
+        // until the total fits.
+        let mut rules = String::new();
+        for i in 0..50 {
+            rules.push_str(&format!(
+                "title: R{i}\n\
+                 id: r-{i:03}\n\
+                 logsource:\n\
+                 \x20   product: windows\n\
+                 detection:\n\
+                 \x20   selection:\n\
+                 \x20       Field{i}|contains: 'foo'\n\
+                 \x20   condition: selection\n\
+                 ---\n",
+            ));
+        }
+        let collection = parse_sigma_yaml(&rules).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+
+        // Each single-pattern field rounds up to one 64-bit limb (8 bytes).
+        // With a 100-byte budget, only ~12 fields can fit.
+        let bloom = FieldBloomIndex::build_with_budget(engine.rules(), 100);
+        assert!(bloom.total_bytes() <= 100);
+        assert!(
+            bloom.field_count() < 50,
+            "expected eviction; got {} fields, {} bytes",
+            bloom.field_count(),
+            bloom.total_bytes()
+        );
+
+        // A budget large enough to fit everything keeps all 50 fields.
+        let big = FieldBloomIndex::build_with_budget(engine.rules(), 1024);
+        assert_eq!(big.field_count(), 50);
+    }
+}

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -4,6 +4,7 @@
 //! against them. It supports optional logsource-based pre-filtering to
 //! reduce the number of rules evaluated per event.
 
+pub(crate) mod bloom_index;
 mod filters;
 #[cfg(test)]
 mod tests;
@@ -12,12 +13,16 @@ use rsigma_parser::{
     ConditionExpr, FilterRule, FilterRuleTarget, LogSource, SigmaCollection, SigmaRule,
 };
 
-use crate::compiler::{CompiledRule, compile_detection, compile_rule, evaluate_rule};
+use crate::compiler::{
+    CompiledRule, compile_detection, compile_rule, evaluate_rule, evaluate_rule_with_bloom,
+};
 use crate::error::Result;
 use crate::event::Event;
 use crate::pipeline::{Pipeline, apply_pipelines};
 use crate::result::MatchResult;
 use crate::rule_index::RuleIndex;
+
+use bloom_index::{BloomCache, FieldBloomIndex};
 
 use filters::{filter_logsource_contains, logsource_matches, rewrite_condition_identifiers};
 
@@ -68,6 +73,17 @@ pub struct Engine {
     /// Inverted index mapping `(field, exact_value)` to candidate rule indices.
     /// Rebuilt after every rule mutation (add, filter).
     rule_index: RuleIndex,
+    /// Per-field bloom filter over positive substring needles. Rebuilt
+    /// alongside `rule_index`. Consulted only when `bloom_prefilter` is
+    /// enabled.
+    bloom_index: FieldBloomIndex,
+    /// Toggle for bloom pre-filtering. Off by default: the per-event probe
+    /// overhead exceeds the savings on rule sets where most events overlap
+    /// with at least one needle's trigrams. Workloads with many substring
+    /// rules and mostly-non-matching events (e.g. high-volume telemetry
+    /// streams against an active threat-intel ruleset) opt in via
+    /// [`Engine::set_bloom_prefilter`].
+    bloom_prefilter: bool,
 }
 
 impl Engine {
@@ -79,6 +95,8 @@ impl Engine {
             include_event: false,
             filter_counter: 0,
             rule_index: RuleIndex::empty(),
+            bloom_index: FieldBloomIndex::empty(),
+            bloom_prefilter: false,
         }
     }
 
@@ -90,7 +108,32 @@ impl Engine {
             include_event: false,
             filter_counter: 0,
             rule_index: RuleIndex::empty(),
+            bloom_index: FieldBloomIndex::empty(),
+            bloom_prefilter: false,
         }
+    }
+
+    /// Enable or disable bloom-filter pre-filtering of positive substring
+    /// detection items.
+    ///
+    /// When enabled, `evaluate*` short-circuits any positive substring
+    /// matcher (`Contains` / `StartsWith` / `EndsWith` / `AhoCorasickSet`,
+    /// alone or wrapped in `CaseInsensitiveGroup`) whose field cannot
+    /// possibly contain a needle trigram.
+    ///
+    /// Disabled by default. The per-event probe (trigram extraction +
+    /// double hashing) costs ~1 µs on a typical CommandLine field, which
+    /// outweighs the savings on rule sets where most events overlap with
+    /// at least one needle. Enable for workloads that pair many substring
+    /// rules with mostly-non-matching events; benchmark with
+    /// `eval_bloom_rejection` before flipping it on in production.
+    pub fn set_bloom_prefilter(&mut self, enabled: bool) {
+        self.bloom_prefilter = enabled;
+    }
+
+    /// Returns whether bloom pre-filtering is currently enabled.
+    pub fn bloom_prefilter_enabled(&self) -> bool {
+        self.bloom_prefilter
     }
 
     /// Set global `include_event` — when `true`, all match results include
@@ -261,17 +304,48 @@ impl Engine {
         self.rebuild_index();
     }
 
-    /// Rebuild the inverted index from the current rule set.
+    /// Rebuild every per-engine index from the current rule set.
+    ///
+    /// Called after every rule mutation. Both the inverted index and the
+    /// per-field bloom filter must reflect the same view of the rules,
+    /// so they share a single rebuild path.
     fn rebuild_index(&mut self) {
         self.rule_index = RuleIndex::build(&self.rules);
+        self.bloom_index = FieldBloomIndex::build(&self.rules);
     }
 
     /// Evaluate an event against candidate rules using the inverted index.
     pub fn evaluate<E: Event>(&self, event: &E) -> Vec<MatchResult> {
+        if self.bloom_prefilter {
+            self.evaluate_with_bloom_path(event)
+        } else {
+            self.evaluate_no_bloom_path(event)
+        }
+    }
+
+    fn evaluate_no_bloom_path<E: Event>(&self, event: &E) -> Vec<MatchResult> {
+        // The public `evaluate_rule` is not generic over `BloomLookup`, so
+        // the no-bloom hot path lowers to straight-line code identical to
+        // the pre-bloom engine.
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
             let rule = &self.rules[idx];
             if let Some(mut m) = evaluate_rule(rule, event) {
+                if self.include_event && m.event.is_none() {
+                    m.event = Some(event.to_json());
+                }
+                results.push(m);
+            }
+        }
+        results
+    }
+
+    fn evaluate_with_bloom_path<E: Event>(&self, event: &E) -> Vec<MatchResult> {
+        let bloom = BloomCache::new(&self.bloom_index, event);
+        let mut results = Vec::new();
+        for idx in self.rule_index.candidates(event) {
+            let rule = &self.rules[idx];
+            if let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom) {
                 if self.include_event && m.event.is_none() {
                     m.event = Some(event.to_json());
                 }
@@ -291,11 +365,44 @@ impl Engine {
         event: &E,
         event_logsource: &LogSource,
     ) -> Vec<MatchResult> {
+        if self.bloom_prefilter {
+            self.evaluate_with_logsource_with_bloom(event, event_logsource)
+        } else {
+            self.evaluate_with_logsource_no_bloom(event, event_logsource)
+        }
+    }
+
+    fn evaluate_with_logsource_no_bloom<E: Event>(
+        &self,
+        event: &E,
+        event_logsource: &LogSource,
+    ) -> Vec<MatchResult> {
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
             let rule = &self.rules[idx];
             if logsource_matches(&rule.logsource, event_logsource)
                 && let Some(mut m) = evaluate_rule(rule, event)
+            {
+                if self.include_event && m.event.is_none() {
+                    m.event = Some(event.to_json());
+                }
+                results.push(m);
+            }
+        }
+        results
+    }
+
+    fn evaluate_with_logsource_with_bloom<E: Event>(
+        &self,
+        event: &E,
+        event_logsource: &LogSource,
+    ) -> Vec<MatchResult> {
+        let bloom = BloomCache::new(&self.bloom_index, event);
+        let mut results = Vec::new();
+        for idx in self.rule_index.candidates(event) {
+            let rule = &self.rules[idx];
+            if logsource_matches(&rule.logsource, event_logsource)
+                && let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom)
             {
                 if self.include_event && m.event.is_none() {
                     m.event = Some(event.to_json());

--- a/crates/rsigma-eval/src/matcher/matching.rs
+++ b/crates/rsigma-eval/src/matcher/matching.rs
@@ -80,6 +80,7 @@ impl CompiledMatcher {
             CompiledMatcher::AhoCorasickSet {
                 automaton,
                 case_insensitive,
+                ..
             } => match_str_value(value, |s| {
                 if *case_insensitive {
                     automaton.is_match(ascii_lowercase_cow(s).as_ref())
@@ -226,6 +227,7 @@ impl CompiledMatcher {
             CompiledMatcher::AhoCorasickSet {
                 automaton,
                 case_insensitive: true,
+                ..
             } => automaton.is_match(lowered_str),
             CompiledMatcher::RegexSetMatch { set, mode } => {
                 regex_set_matches(set, *mode, lowered_str)
@@ -300,6 +302,7 @@ impl CompiledMatcher {
             CompiledMatcher::AhoCorasickSet {
                 automaton,
                 case_insensitive,
+                ..
             } => {
                 if *case_insensitive {
                     automaton.is_match(ascii_lowercase_cow(s).as_ref())

--- a/crates/rsigma-eval/src/matcher/mod.rs
+++ b/crates/rsigma-eval/src/matcher/mod.rs
@@ -64,6 +64,11 @@ pub enum CompiledMatcher {
     AhoCorasickSet {
         automaton: AhoCorasick,
         case_insensitive: bool,
+        /// Pre-lowered needles in the same order they were fed to
+        /// [`AhoCorasick::new`]. Retained so downstream consumers (e.g. the
+        /// engine's per-field bloom builder) can recover the pattern set
+        /// without parsing the automaton's internal state.
+        needles: Vec<String>,
     },
 
     /// Multi-pattern regex match via [`regex::RegexSet`].

--- a/crates/rsigma-eval/tests/regression_eval.rs
+++ b/crates/rsigma-eval/tests/regression_eval.rs
@@ -211,3 +211,82 @@ detection:
 
     assert_eq!(actual, expected);
 }
+
+#[test]
+fn bloom_prefilter_preserves_match_results() {
+    // The bloom pre-filter is purely an optimization: enabling or disabling
+    // it must never change which rules fire on any event.
+    let mut engine = engine_from(CONTAINS_HEAVY_RULES);
+
+    let events = vec![
+        json!({"EventType": "login", "Image": "C:/Windows/System32/explorer.exe"}),
+        json!({"Image": "C:/Tools/MIMIKATZ.exe", "CommandLine": "mimikatz.exe sekurlsa::logonpasswords"}),
+        json!({"Image": "C:/Windows/System32/powershell.exe", "CommandLine": "powershell.exe -enc aHR0cHM6Ly9ldmls"}),
+        json!({"Image": "/usr/bin/whoami", "CommandLine": "whoami /all"}),
+        json!({"Image": "/usr/bin/notepad.exe", "CommandLine": "notepad readme.txt"}),
+        // Pure-digit event: bloom should reject every substring item.
+        json!({"Image": "0000000000", "CommandLine": "0000111122223333"}),
+        json!({}),
+    ];
+
+    engine.set_bloom_prefilter(false);
+    let no_bloom = evaluate_corpus(&engine, &events);
+
+    engine.set_bloom_prefilter(true);
+    let with_bloom = evaluate_corpus(&engine, &events);
+
+    assert_eq!(
+        no_bloom, with_bloom,
+        "bloom pre-filter changed match output"
+    );
+}
+
+#[test]
+fn bloom_prefilter_handles_condition_negation() {
+    // The condition `selection and not other` evaluates `other` first and
+    // negates the result. When `other` is a positive substring detection
+    // and the bloom verdict is `DefinitelyNoMatch`, the bloom short-circuits
+    // `other` to false; the negation flips it to true. This is the correct
+    // behavior at the Sigma semantic layer because the bloom only short-
+    // circuits cases where the underlying matcher would have returned false.
+    let yaml = r#"
+title: Selection Without Substring
+id: selection-without-substring
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        EventType: 'process_create'
+    other:
+        CommandLine|contains: 'whoami'
+    condition: selection and not other
+level: medium
+"#;
+    let mut engine = engine_from(yaml);
+    engine.set_bloom_prefilter(true);
+
+    let events = vec![
+        // No 'whoami' in CommandLine -> `other` false -> rule fires.
+        json!({"EventType": "process_create", "CommandLine": "notepad foo"}),
+        // 'whoami' present -> `other` true -> rule does NOT fire.
+        json!({"EventType": "process_create", "CommandLine": "exec whoami"}),
+        // Pure digits -> bloom rejects `other`'s substring -> `other` false
+        // -> rule fires (the bloom-driven rejection is the right answer).
+        json!({"EventType": "process_create", "CommandLine": "0123456789"}),
+    ];
+    let actual = evaluate_corpus(&engine, &events);
+
+    let expected: Vec<Vec<String>> = vec![
+        vec!["Selection Without Substring".into()],
+        Vec::<String>::new(),
+        vec!["Selection Without Substring".into()],
+    ];
+
+    assert_eq!(actual, expected);
+
+    // Also assert the result is identical without bloom.
+    engine.set_bloom_prefilter(false);
+    let no_bloom = evaluate_corpus(&engine, &events);
+    assert_eq!(no_bloom, expected);
+}


### PR DESCRIPTION
## Summary

Adds a per-field bloom filter built at engine load time over the union of positive substring needles (`Contains` / `StartsWith` / `EndsWith` / `AhoCorasickSet`) across all rules. When enabled, `Engine::evaluate` probes the bloom for each event field and short-circuits any positive substring detection item whose field cannot possibly contain a needle trigram.

**Pre-filtering is opt-in, off by default.** Toggle per-engine via `Engine::set_bloom_prefilter(true)`.

## Why opt-in

The per-event probe (trigram extraction + double hashing) costs ~1 µs on a typical CommandLine field. On rule sets where most events overlap with at least one needle, the probe is pure overhead because every detection item still falls through to the matcher. On substring-heavy rule sets paired with mostly-non-matching events (high-volume telemetry vs an active threat-intel ruleset), the bloom skips the matcher entirely on the rejection path. Ship the knob, document the trade-off, let users benchmark their corpus.

## Implementation highlights

- **`engine::bloom_index`** module: custom bit-array bloom with AHash-based double hashing (`h_i = h1 + i*h2 mod m`). 16 bits per trigram floor keeps per-probe FPR well under 1% even at small N.
- **Pattern collection** walks the compiled matcher tree, excludes `Not(...)` subtrees, and skips `Exact` (rule index already covers it).
- **`BloomLookup` trait** abstracts the lookup so eval functions stay generic. `NoBloom` is a zero-sized stub the compiler elides. Default `evaluate_rule` doesn't reference any bloom types.
- **`BloomCache`** memoizes per-event verdicts per field so each candidate rule pays at most one probe per shared field.
- **`AhoCorasickSet` gained `needles: Vec<String>`** so the bloom builder can recover patterns the optimizer collapsed into the automaton.
- **`CompiledDetectionItem.bloom_eligible: bool`** precomputed at compile time so the per-event hot path doesn't walk the matcher tree to decide eligibility.
- **Memory budget**: per-field 64 KB cap, 1 MB total; lowest-density fields drop first when budget exceeded.

## Tests

- 10 unit tests in `engine::bloom_index` cover: empty filter when no positive substring rules, populates filter for `Contains`, negated contains contributes nothing, unrelated field falls through to `MaybeMatch`, skips haystacks below `NGRAM_SIZE` and above `MAX_BLOOM_SCAN_BYTES`, Aho-Corasick needles contribute, case-insensitive probe, memory-budget eviction.
- Two new regression tests:
  - `bloom_prefilter_preserves_match_results` asserts identical output with bloom on vs off across a 7-event corpus including a digit-only event the bloom would reject.
  - `bloom_prefilter_handles_condition_negation` covers `selection and not other` where `other` is a substring detection. The bloom rejects `other` for digit-only events, the negation flips the result to true; both paths agree.

All 444 workspace tests pass; clippy + fmt clean.

## Benchmarks

New `eval_bloom_rejection` group exercises substring-only rules vs digit-only events that share zero trigrams with the alphabetical patterns.

| Rules | Default (bloom off) | Bloom on | Δ throughput |
|---|---|---|---|
| 100   | 170 Kelem/s | 169 Kelem/s | ~0% (rule index is fast enough) |
| 500   | 25.9 Kelem/s | 29.0 Kelem/s | **+12%** |
| 1000  | 12.5 Kelem/s | 14.5 Kelem/s | **+16%** |
| 5000  | 2.5 Kelem/s | 2.97 Kelem/s | **+19%** |

Default-path benchmarks (bloom off) vs the pre-Phase-4 baseline:
- `eval_throughput`: within ±4% (no statistically significant change at 1k events; -3.6% at 10k, -3.9% at 100k events — within criterion's noise threshold).
- `eval_contains_heavy` and `eval_regex_set_heavy`: unchanged.

The bloom-on path is faster than bloom-off only when most candidate rules use substring matching AND most events don't share trigrams with the needles. Outside that regime, leaving bloom off is the right choice.

## Dependency

Adds `ahash = \"0.8\"` (already transitive via `regex-automata`).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] `eval_bloom_rejection` benchmark with both default and bloom_prefilter variants
- [x] `eval_throughput` benchmark vs pre-Phase-4 baseline
- [ ] SigmaHQ corpus regression (run after merge)