### PR TITLE
fix(parser): reject `|not` modifier with guidance toward condition negation

### DIFF
--- a/crates/rsigma-parser/src/error.rs
+++ b/crates/rsigma-parser/src/error.rs
@@ -31,6 +31,17 @@ pub enum SigmaParserError {
     #[error("Unknown modifier '{0}'")]
     UnknownModifier(String),
 
+    /// Reserved when a user writes `field|not: value` or
+    /// `field|contains|not: value` as if `not` were a value modifier.
+    /// Sigma does not support a `|not` modifier; negation is expressed at
+    /// the condition level (`not selection` or `selection and not filter`).
+    #[error(
+        "`not` is not a value modifier in Sigma; express negation in the \
+         condition (e.g. `not selection`) or move the inverted check into a \
+         separate detection used as a filter (e.g. `selection and not other`)"
+    )]
+    NotIsNotAModifier,
+
     #[error("Invalid field specification: {0}")]
     InvalidFieldSpec(String),
 

--- a/crates/rsigma-parser/src/parser/detection.rs
+++ b/crates/rsigma-parser/src/parser/detection.rs
@@ -250,6 +250,12 @@ pub fn parse_field_spec(key: &str) -> Result<FieldSpec> {
 
     let mut modifiers = Vec::new();
     for &mod_str in &parts[1..] {
+        // Sigma reserves `not` for condition expressions; it is not a value
+        // modifier. Catch this idiom up front so the diagnostic explains
+        // the workaround instead of just saying "unknown modifier".
+        if mod_str == "not" {
+            return Err(SigmaParserError::NotIsNotAModifier);
+        }
         let m = mod_str
             .parse::<Modifier>()
             .map_err(|_| SigmaParserError::UnknownModifier(mod_str.to_string()))?;

--- a/crates/rsigma-parser/src/parser/tests.rs
+++ b/crates/rsigma-parser/src/parser/tests.rs
@@ -302,6 +302,30 @@ fn test_unknown_modifier_error() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_not_modifier_is_rejected_with_guidance() {
+    // `field|not: value` is a common mistranslation of pySigma's
+    // `not selection` condition idiom. The parser must reject it with a
+    // dedicated error pointing the user at the correct workaround.
+    let leaf = parse_field_spec("field|not");
+    assert!(matches!(
+        leaf,
+        Err(crate::error::SigmaParserError::NotIsNotAModifier)
+    ));
+
+    // Also rejected when `not` is composed after another modifier.
+    let composed = parse_field_spec("CommandLine|contains|not");
+    assert!(matches!(
+        composed,
+        Err(crate::error::SigmaParserError::NotIsNotAModifier)
+    ));
+
+    // The error message names both alternatives so users can act on it.
+    let msg = format!("{}", composed.unwrap_err());
+    assert!(msg.contains("not selection"), "msg was: {msg}");
+    assert!(msg.contains("filter"), "msg was: {msg}");
+}
+
 // ── Field modifier edge cases ────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

A common mistranslation from pySigma's docs lands as `field|not: value` or `field|contains|not: value` in YAML, and the parser would previously surface it as the generic `Unknown modifier 'not'` error. Sigma reserves `not` exclusively for condition expressions; there is no value modifier of that name in pySigma either.

This PR adds a dedicated `SigmaParserError::NotIsNotAModifier` variant whose message points users at the two correct alternatives:

- `condition: not selection` for whole-detection negation.
- `selection and not filter` with the inverted predicate moved into a separate detection used as a filter.

The parser short-circuits on `mod_str == "not"` inside `parse_field_spec` before falling through to the unknown-modifier path.

## Tests

- `test_not_modifier_is_rejected_with_guidance` covers both `field|not` and `field|contains|not`, asserts the dedicated error variant, and pins the error message wording so the guidance text doesn't drift.

All workspace tests pass; clippy + fmt clean.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`