### PR TITLE
feat(cli): expose bloom prefilter via `--bloom-prefilter` on eval and daemon

### DIFF
--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -145,6 +145,8 @@ Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-r
 | `--correlation-event-mode` | string | `"none"` | `none`, `full`, or `refs` |
 | `--max-correlation-events` | integer | **10** | Max events stored per correlation window |
 | `--timestamp-field` | repeatable | `[]` | Event field(s) for timestamp extraction |
+| `--bloom-prefilter` | flag | `false` | Enable bloom-filter pre-filtering of positive substring matchers (workload-dependent; see `crates/rsigma-eval/README.md`) |
+| `--bloom-max-bytes` | integer | **1048576** | Memory budget for the bloom index (no effect without `--bloom-prefilter`) |
 | `--buffer-size` | integer | **10000** | Bounded channel capacity for source-to-engine and engine-to-sink queues |
 | `--batch-size` | integer | **1** | Maximum events per engine lock acquisition (reduces mutex overhead under load) |
 | `--drain-timeout` | integer | **5** | Seconds to wait for in-flight events to drain on shutdown |
@@ -372,6 +374,8 @@ Evaluate JSON events against Sigma detection and correlation rules.
 | `--input-format` | string | `"auto"` | Input log format: `auto`, `json`, `syslog`, `plain`, `logfmt`\*, `cef`\* |
 | `--syslog-tz` | string | `"+00:00"` | Default timezone for RFC 3164 syslog (e.g. `+05:00`, `-08:00`) |
 | `--fail-on-detection` | flag | `false` | Exit with code 1 when any detection or correlation fires. Useful for CI/CD pipelines |
+| `--bloom-prefilter` | flag | `false` | Enable bloom-filter pre-filtering of positive substring matchers (see `crates/rsigma-eval/README.md` for the trade-off) |
+| `--bloom-max-bytes` | integer | **1048576** | Memory budget for the bloom index (no effect without `--bloom-prefilter`) |
 
 \* Feature-gated: `logfmt` requires the `logfmt` feature, `cef` requires the `cef` feature, `evtx` requires the `evtx` feature.
 

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -64,6 +64,8 @@ pub(crate) fn cmd_eval(
     timestamp_fields: Vec<String>,
     input_format: String,
     syslog_tz: String,
+    bloom_prefilter: bool,
+    bloom_max_bytes: Option<usize>,
 ) -> bool {
     let collection = crate::load_collection(&rules_path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
@@ -104,6 +106,8 @@ pub(crate) fn cmd_eval(
             include_event,
             &input_format,
             &syslog_tz,
+            bloom_prefilter,
+            bloom_max_bytes,
         )
     } else {
         cmd_eval_detection_only(
@@ -116,6 +120,8 @@ pub(crate) fn cmd_eval(
             include_event,
             &input_format,
             &syslog_tz,
+            bloom_prefilter,
+            bloom_max_bytes,
         )
     }
 }
@@ -133,9 +139,15 @@ fn cmd_eval_with_correlations(
     include_event: bool,
     input_format_str: &str,
     syslog_tz_str: &str,
+    bloom_prefilter: bool,
+    bloom_max_bytes: Option<usize>,
 ) -> bool {
     let mut engine = CorrelationEngine::new(config);
     engine.set_include_event(include_event);
+    if let Some(budget) = bloom_max_bytes {
+        engine.set_bloom_max_bytes(budget);
+    }
+    engine.set_bloom_prefilter(bloom_prefilter);
     for p in pipelines {
         engine.add_pipeline(p.clone());
     }
@@ -378,9 +390,15 @@ fn cmd_eval_detection_only(
     include_event: bool,
     input_format_str: &str,
     syslog_tz_str: &str,
+    bloom_prefilter: bool,
+    bloom_max_bytes: Option<usize>,
 ) -> bool {
     let mut engine = Engine::new();
     engine.set_include_event(include_event);
+    if let Some(budget) = bloom_max_bytes {
+        engine.set_bloom_max_bytes(budget);
+    }
+    engine.set_bloom_prefilter(bloom_prefilter);
     for p in pipelines {
         engine.add_pipeline(p.clone());
     }

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -89,6 +89,12 @@ pub struct DaemonConfig {
     pub drain_timeout: u64,
     pub input_format: InputFormat,
     pub allow_remote_include: bool,
+    /// Enable opt-in bloom-filter pre-filtering of positive substring
+    /// matchers. Off by default; benefit is workload-dependent.
+    pub bloom_prefilter: bool,
+    /// Optional override for the bloom memory budget (bytes). `None` means
+    /// the crate default (1 MB).
+    pub bloom_max_bytes: Option<usize>,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
@@ -113,6 +119,10 @@ pub async fn run_daemon(config: DaemonConfig) {
     );
     engine.set_pipeline_paths(config.pipeline_paths.clone());
     engine.set_allow_remote_include(config.allow_remote_include);
+    engine.set_bloom_prefilter(config.bloom_prefilter);
+    if let Some(budget) = config.bloom_max_bytes {
+        engine.set_bloom_max_bytes(budget);
+    }
 
     // Set up dynamic source resolver if any pipeline has dynamic sources
     let has_dynamic = config.pipelines.iter().any(|p| p.is_dynamic());

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -320,6 +320,28 @@ enum Commands {
         /// for security. Use this flag to opt in to remote include resolution.
         #[arg(long = "allow-remote-include")]
         allow_remote_include: bool,
+
+        /// Enable bloom-filter pre-filtering of positive substring matchers.
+        ///
+        /// Off by default. When enabled, the engine builds a per-field bloom
+        /// over every rule's `|contains` / `|startswith` / `|endswith`
+        /// needles and short-circuits items whose field value cannot
+        /// possibly contain a needle trigram. The probe costs ~1 µs per
+        /// event, so this only pays off on rule sets where most events do
+        /// NOT match any pattern (e.g. high-volume telemetry against
+        /// substring-heavy threat-intel rules). Run the
+        /// `eval_bloom_rejection` benchmark on representative data before
+        /// flipping this on in production.
+        #[arg(long = "bloom-prefilter")]
+        bloom_prefilter: bool,
+
+        /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB
+        /// (1048576). Lower the cap on memory-constrained deployments;
+        /// raise it for very large rule sets where the default starts
+        /// evicting useful filters. Has no effect unless
+        /// `--bloom-prefilter` is set.
+        #[arg(long = "bloom-max-bytes")]
+        bloom_max_bytes: Option<usize>,
     },
 
     /// Evaluate events against Sigma rules
@@ -417,6 +439,16 @@ enum Commands {
         /// Useful in CI/CD pipelines to fail a build on detection.
         #[arg(long = "fail-on-detection")]
         fail_on_detection: bool,
+
+        /// Enable bloom-filter pre-filtering of positive substring matchers.
+        /// See `rsigma daemon --help` for the trade-off.
+        #[arg(long = "bloom-prefilter")]
+        bloom_prefilter: bool,
+
+        /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB.
+        /// No effect unless `--bloom-prefilter` is set.
+        #[arg(long = "bloom-max-bytes")]
+        bloom_max_bytes: Option<usize>,
     },
 
     /// Convert Sigma rules to backend-native queries
@@ -567,6 +599,8 @@ fn main() {
             #[cfg(feature = "daemon-nats")]
             consumer_group,
             allow_remote_include,
+            bloom_prefilter,
+            bloom_max_bytes,
         } => {
             #[cfg(feature = "daemon-nats")]
             let nats_auth = NatsAuthArgs {
@@ -637,6 +671,8 @@ fn main() {
                 #[cfg(feature = "daemon-nats")]
                 consumer_group,
                 allow_remote_include,
+                bloom_prefilter,
+                bloom_max_bytes,
             )
         }
         Commands::Parse { path, pretty } => commands::cmd_parse(path, pretty),
@@ -695,6 +731,8 @@ fn main() {
             input_format,
             syslog_tz,
             fail_on_detection,
+            bloom_prefilter,
+            bloom_max_bytes,
         } => {
             let had_matches = commands::cmd_eval(
                 rules,
@@ -712,6 +750,8 @@ fn main() {
                 timestamp_fields,
                 input_format,
                 syslog_tz,
+                bloom_prefilter,
+                bloom_max_bytes,
             );
             if fail_on_detection && had_matches {
                 process::exit(exit_code::FINDINGS);
@@ -801,6 +841,8 @@ fn cmd_daemon(
     #[cfg(feature = "daemon-nats")] replay_policy: rsigma_runtime::ReplayPolicy,
     #[cfg(feature = "daemon-nats")] consumer_group: Option<String>,
     allow_remote_include: bool,
+    bloom_prefilter: bool,
+    bloom_max_bytes: Option<usize>,
 ) {
     // Set up structured logging
     tracing_subscriber::fmt()
@@ -875,6 +917,8 @@ fn cmd_daemon(
         consumer_group,
         state_restore_mode,
         allow_remote_include,
+        bloom_prefilter,
+        bloom_max_bytes,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/tests/cli_eval.rs
+++ b/crates/rsigma-cli/tests/cli_eval.rs
@@ -79,6 +79,66 @@ fn eval_single_event_match() {
 }
 
 #[test]
+fn eval_bloom_prefilter_flag_is_accepted() {
+    // Smoke test: --bloom-prefilter must be accepted and produce the same
+    // match output as the default path. Bloom is purely an optimization;
+    // results must be identical.
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args([
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--bloom-prefilter",
+            "--event",
+            r#"{"CommandLine": "download malware.exe"}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Test Rule"));
+}
+
+#[test]
+fn eval_bloom_prefilter_with_max_bytes() {
+    // --bloom-max-bytes pairs with --bloom-prefilter; both must be accepted.
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args([
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--bloom-prefilter",
+            "--bloom-max-bytes",
+            "131072", // 128 KB
+            "--event",
+            r#"{"CommandLine": "download malware.exe"}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Test Rule"));
+}
+
+#[test]
+fn eval_bloom_prefilter_rejects_non_matching_event() {
+    // Pure-digit event cannot share trigrams with the alphabetical needles
+    // in the test rule. Bloom rejects, --bloom-prefilter must produce
+    // identical (no-match) output.
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args([
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--bloom-prefilter",
+            "--event",
+            r#"{"CommandLine": "0123456789"}"#,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No matches"));
+}
+
+#[test]
 fn eval_single_event_no_match() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -365,6 +365,29 @@ transformations:
     value: 5m
 ```
 
+## Bloom Pre-Filter (Opt-In)
+
+The engine can build a per-field bloom filter at rule-load time over every positive substring needle (`Contains` / `StartsWith` / `EndsWith` / `AhoCorasickSet`). When enabled, `Engine::evaluate` short-circuits any positive substring detection item whose field value cannot possibly contain a needle trigram, skipping the matcher entirely.
+
+**Off by default.** The per-event probe (trigram extraction + double hashing) costs ~1 µs on a typical CommandLine field. On rule sets where most events overlap with at least one needle, the probe is pure overhead. The bloom only pays off on substring-heavy rule sets paired with mostly-non-matching events (e.g. high-volume telemetry against an active threat-intel ruleset).
+
+```rust
+let mut engine = Engine::new();
+engine.set_bloom_prefilter(true);
+// Optional: tighten or relax the 1 MB default budget.
+engine.set_bloom_max_bytes(2 * 1024 * 1024);
+engine.add_collection(&collection)?;
+```
+
+CLI equivalents on `rsigma eval` and `rsigma daemon`:
+
+```
+--bloom-prefilter              # enable
+--bloom-max-bytes <BYTES>      # override 1 MB default
+```
+
+Always benchmark against representative events before flipping it on; the `eval_bloom_rejection` Criterion group in `crates/rsigma-eval/benches/eval.rs` reports throughput with both default-off and bloom-on engines so you can size the win on your corpus.
+
 ## Constants and Limits
 
 | Constant | Value | Purpose |

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -104,6 +104,19 @@ impl CorrelationEngine {
         self.engine.set_include_event(include);
     }
 
+    /// Forward to [`crate::Engine::set_bloom_prefilter`] on the inner
+    /// detection engine. Off by default; the optimization helps only on
+    /// substring-heavy rule sets paired with mostly-non-matching events.
+    pub fn set_bloom_prefilter(&mut self, enabled: bool) {
+        self.engine.set_bloom_prefilter(enabled);
+    }
+
+    /// Forward to [`crate::Engine::set_bloom_max_bytes`] on the inner
+    /// detection engine.
+    pub fn set_bloom_max_bytes(&mut self, max_bytes: usize) {
+        self.engine.set_bloom_max_bytes(max_bytes);
+    }
+
     /// Set the global correlation event mode.
     ///
     /// - `None`: no event storage (default)

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -84,6 +84,10 @@ pub struct Engine {
     /// streams against an active threat-intel ruleset) opt in via
     /// [`Engine::set_bloom_prefilter`].
     bloom_prefilter: bool,
+    /// Memory budget the bloom builder is allowed to consume across all
+    /// per-field filters. `None` means use the crate default
+    /// (`bloom_index::DEFAULT_MAX_TOTAL_BYTES`, 1 MB).
+    bloom_max_bytes: Option<usize>,
 }
 
 impl Engine {
@@ -97,6 +101,7 @@ impl Engine {
             rule_index: RuleIndex::empty(),
             bloom_index: FieldBloomIndex::empty(),
             bloom_prefilter: false,
+            bloom_max_bytes: None,
         }
     }
 
@@ -110,6 +115,7 @@ impl Engine {
             rule_index: RuleIndex::empty(),
             bloom_index: FieldBloomIndex::empty(),
             bloom_prefilter: false,
+            bloom_max_bytes: None,
         }
     }
 
@@ -134,6 +140,27 @@ impl Engine {
     /// Returns whether bloom pre-filtering is currently enabled.
     pub fn bloom_prefilter_enabled(&self) -> bool {
         self.bloom_prefilter
+    }
+
+    /// Set the memory budget for the per-field bloom index.
+    ///
+    /// Must be called **before** `add_collection` / `add_rule` for the new
+    /// budget to take effect on the existing rule set; otherwise it is
+    /// applied at the next index rebuild. The default budget is 1 MB,
+    /// shared across all per-field filters. Lower the cap on memory-
+    /// constrained deployments; raise it for large rule sets where the
+    /// default starts evicting useful filters.
+    pub fn set_bloom_max_bytes(&mut self, max_bytes: usize) {
+        self.bloom_max_bytes = Some(max_bytes);
+        if !self.rules.is_empty() {
+            self.rebuild_index();
+        }
+    }
+
+    /// Returns the configured bloom memory budget, if one has been set
+    /// explicitly. `None` means the crate default (1 MB) is in use.
+    pub fn bloom_max_bytes(&self) -> Option<usize> {
+        self.bloom_max_bytes
     }
 
     /// Set global `include_event` — when `true`, all match results include
@@ -311,7 +338,10 @@ impl Engine {
     /// so they share a single rebuild path.
     fn rebuild_index(&mut self) {
         self.rule_index = RuleIndex::build(&self.rules);
-        self.bloom_index = FieldBloomIndex::build(&self.rules);
+        self.bloom_index = match self.bloom_max_bytes {
+            Some(budget) => FieldBloomIndex::build_with_budget(&self.rules, budget),
+            None => FieldBloomIndex::build(&self.rules),
+        };
     }
 
     /// Evaluate an event against candidate rules using the inverted index.

--- a/crates/rsigma-runtime/src/engine.rs
+++ b/crates/rsigma-runtime/src/engine.rs
@@ -21,6 +21,12 @@ pub struct RuntimeEngine {
     include_event: bool,
     source_resolver: Option<Arc<dyn SourceResolver>>,
     allow_remote_include: bool,
+    /// Opt-in bloom-filter pre-filtering of positive substring matchers.
+    /// Forwarded to the inner detection engine on every rule reload.
+    bloom_prefilter: bool,
+    /// Optional override for the bloom memory budget in bytes. `None`
+    /// means use the eval crate default.
+    bloom_max_bytes: Option<usize>,
 }
 
 enum EngineVariant {
@@ -51,7 +57,22 @@ impl RuntimeEngine {
             include_event,
             source_resolver: None,
             allow_remote_include: false,
+            bloom_prefilter: false,
+            bloom_max_bytes: None,
         }
+    }
+
+    /// Enable or disable bloom-filter pre-filtering on the inner detection
+    /// engine. Off by default. Applies on the next `load_rules()`; pre-load
+    /// callers should set this before calling `load_rules()`.
+    pub fn set_bloom_prefilter(&mut self, enabled: bool) {
+        self.bloom_prefilter = enabled;
+    }
+
+    /// Override the bloom memory budget on the inner detection engine.
+    /// Applies on the next `load_rules()`.
+    pub fn set_bloom_max_bytes(&mut self, max_bytes: usize) {
+        self.bloom_max_bytes = Some(max_bytes);
     }
 
     /// Set a source resolver for dynamic pipeline sources.
@@ -177,6 +198,10 @@ impl RuntimeEngine {
         if has_correlations {
             let mut engine = CorrelationEngine::new(self.corr_config.clone());
             engine.set_include_event(self.include_event);
+            if let Some(budget) = self.bloom_max_bytes {
+                engine.set_bloom_max_bytes(budget);
+            }
+            engine.set_bloom_prefilter(self.bloom_prefilter);
             for p in &self.pipelines {
                 engine.add_pipeline(p.clone());
             }
@@ -198,6 +223,10 @@ impl RuntimeEngine {
         } else {
             let mut engine = Engine::new();
             engine.set_include_event(self.include_event);
+            if let Some(budget) = self.bloom_max_bytes {
+                engine.set_bloom_max_bytes(budget);
+            }
+            engine.set_bloom_prefilter(self.bloom_prefilter);
             for p in &self.pipelines {
                 engine.add_pipeline(p.clone());
             }


### PR DESCRIPTION
## Summary

`Engine::set_bloom_prefilter` was only reachable programmatically after #102 merged. This PR wires the toggle through the daemon and eval subcommands so operators can flip it at deploy time without touching code, and adds a paired `--bloom-max-bytes` knob for the per-engine memory budget.

## Engine API additions

- `Engine::set_bloom_max_bytes(usize)` overrides the 1 MB default for the per-field bloom budget. The setter rebuilds the index immediately if rules are already loaded; otherwise the budget applies on the next `add_collection` / `add_rule` call.
- `Engine::bloom_max_bytes() -> Option<usize>` exposes the override (`None` means crate default).
- `CorrelationEngine` gains forwarding setters for both bloom knobs so the daemon's correlation path picks them up too.

## Runtime + CLI wiring

- `RuntimeEngine` carries `bloom_prefilter: bool` and `bloom_max_bytes: Option<usize>`. Both setters apply on every `load_rules()` (detection-only AND correlation variants), so hot reloads keep the toggle.
- `DaemonConfig` adds matching fields, populated from new CLI flags.
- `cmd_eval` and its detection-only / correlation helpers accept the toggle and forward to the inner engines.

## New CLI flags (on both `rsigma daemon` and `rsigma eval`)

- `--bloom-prefilter`: enable opt-in bloom pre-filtering. Off by default because the per-event probe (~1 µs on a typical CommandLine) outweighs the savings on rule sets where most events overlap with at least one needle's trigrams.
- `--bloom-max-bytes <BYTES>`: override the 1 MB default. No effect without `--bloom-prefilter`. Lower the cap on memory-constrained deployments; raise it for very large rule sets where the default starts evicting useful filters.

## Why opt-in

Flagged because the optimization only pays off on substring-heavy rule sets paired with mostly-non-matching events. The `eval_bloom_rejection` benchmark in `crates/rsigma-eval/benches/eval.rs` reports throughput with both default-off and bloom-on engines so deployments can size the win on their own corpus before flipping the flag.

## Tests

- `eval_bloom_prefilter_flag_is_accepted`: flag passes through and produces the same match output as the default path.
- `eval_bloom_prefilter_with_max_bytes`: paired memory budget flag at 128 KB.
- `eval_bloom_prefilter_rejects_non_matching_event`: short-circuit path with a digit-only event that shares zero trigrams with the rule's needles.

All workspace tests pass; clippy + fmt clean.

## Documentation

- `crates/rsigma-eval/README.md` gains a "Bloom Pre-Filter (Opt-In)" section with the trade-off explanation and CLI/library equivalents.
- `crates/rsigma-cli/README.md` lists the new flags in both the `daemon` and `eval` flag tables.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] CLI integration tests for the flag (`cli_eval` suite)