### PR TITLE
feat(eval): differential fuzz target, pipeline-ordering test, threshold sweep

### DIFF
--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -8,12 +8,13 @@
 //! from each `FieldSpec` and produces the appropriate `CompiledMatcher` variant.
 
 mod helpers;
-mod optimizer;
+#[doc(hidden)]
+pub mod optimizer;
 #[cfg(test)]
 mod tests;
 
-// Test-only re-export so equivalence proptests in other modules can drive
-// the optimizer directly.
+// Re-export so equivalence proptests in other modules and the fuzz target
+// can drive the optimizer directly.
 #[cfg(test)]
 pub(crate) use optimizer::optimize_any_of as optimize_any_of_for_test;
 

--- a/crates/rsigma-eval/src/compiler/optimizer.rs
+++ b/crates/rsigma-eval/src/compiler/optimizer.rs
@@ -72,7 +72,7 @@ pub const REGEX_SET_THRESHOLD: usize = 3;
 /// 5. If all surviving children are pre-lowerable and there are >=
 ///    `CI_GROUP_THRESHOLD` of them, wrap the whole group in
 ///    `CaseInsensitiveGroup` (Any mode) to lower the haystack once.
-pub(crate) fn optimize_any_of(matchers: Vec<CompiledMatcher>) -> CompiledMatcher {
+pub fn optimize_any_of(matchers: Vec<CompiledMatcher>) -> CompiledMatcher {
     match matchers.len() {
         0 => return CompiledMatcher::AnyOf(Vec::new()),
         1 => {

--- a/crates/rsigma-eval/tests/regression_eval.rs
+++ b/crates/rsigma-eval/tests/regression_eval.rs
@@ -8,7 +8,7 @@
 //! files: the corpus is small enough that locality matters more than
 //! externalization, and a snapshot diff is easier to review in a PR.
 
-use rsigma_eval::{Engine, JsonEvent, MatchResult};
+use rsigma_eval::{Engine, JsonEvent, MatchResult, parse_pipeline};
 use rsigma_parser::parse_sigma_yaml;
 use serde_json::{Value, json};
 
@@ -289,4 +289,74 @@ level: medium
     engine.set_bloom_prefilter(false);
     let no_bloom = evaluate_corpus(&engine, &events);
     assert_eq!(no_bloom, expected);
+}
+
+#[test]
+fn optimizer_runs_after_pipeline_transformation() {
+    // A pipeline renames CommandLine -> process.command_line. The optimizer
+    // must see the post-pipeline field name, building the AhoCorasickSet
+    // for the transformed field. If the optimizer ran before the pipeline,
+    // the rule would still reference the original field and fail to match
+    // events with the ECS field name.
+    let yaml = r#"
+title: Post-Pipeline AC Check
+id: post-pipeline-ac
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains:
+            - 'whoami'
+            - 'mimikatz'
+            - 'powershell'
+            - 'invoke-expression'
+            - 'rundll32'
+            - 'regsvr32'
+            - 'certutil'
+            - 'bitsadmin'
+    condition: selection
+level: high
+"#;
+
+    let pipeline_yaml = r#"
+name: ECS Field Mapping
+priority: 10
+transformations:
+  - type: field_name_mapping
+    mapping:
+      CommandLine: process.command_line
+    rule_conditions:
+      - type: logsource
+        product: windows
+"#;
+
+    let collection = parse_sigma_yaml(yaml).expect("rules parse");
+    let pipeline = parse_pipeline(pipeline_yaml).expect("pipeline parse");
+
+    let mut engine = Engine::new_with_pipeline(pipeline);
+    engine.add_collection(&collection).expect("compile");
+
+    let events = vec![
+        // Uses ECS field name, should match via the renamed field.
+        json!({"process.command_line": "cmd /c whoami"}),
+        json!({"process.command_line": "MIMIKATZ.exe dump"}),
+        // Original field name should NOT match (pipeline renamed it).
+        json!({"CommandLine": "whoami"}),
+        // Unrelated field, no match.
+        json!({"Image": "notepad.exe"}),
+    ];
+    let actual = evaluate_corpus(&engine, &events);
+
+    let expected: Vec<Vec<String>> = vec![
+        vec!["Post-Pipeline AC Check".into()],
+        vec!["Post-Pipeline AC Check".into()],
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    ];
+
+    assert_eq!(
+        actual, expected,
+        "optimizer must run after pipeline field renaming"
+    );
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -67,6 +67,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -311,6 +314,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -885,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
  "bitflags",
  "libc",
@@ -1391,8 +1405,10 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
+ "ahash",
+ "aho-corasick",
  "base64",
  "chrono",
  "flate2",
@@ -1411,6 +1427,7 @@ dependencies = [
 name = "rsigma-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "libfuzzer-sys",
  "regex",
  "rsigma-eval",
@@ -1422,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "globset",
  "log",
@@ -1436,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1796,9 +1813,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2395,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ rsigma-runtime = { path = "../crates/rsigma-runtime", features = ["logfmt", "cef
 serde_json = "1"
 serde_yaml = { package = "yaml_serde", version = "0.10" }
 regex = "1"
+arbitrary = { version = "1", features = ["derive"] }
 
 [[bin]]
 name = "fuzz_parse_yaml"
@@ -84,4 +85,9 @@ doc = false
 [[bin]]
 name = "fuzz_http_response"
 path = "fuzz_targets/fuzz_http_response.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_eval_matcher_diff"
+path = "fuzz_targets/fuzz_eval_matcher_diff.rs"
 doc = false

--- a/fuzz/fuzz_targets/fuzz_eval_matcher_diff.rs
+++ b/fuzz/fuzz_targets/fuzz_eval_matcher_diff.rs
@@ -1,0 +1,67 @@
+#![no_main]
+
+use std::borrow::Cow;
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use rsigma_eval::compiler::optimizer::optimize_any_of;
+use rsigma_eval::event::{EventValue, JsonEvent};
+use rsigma_eval::matcher::CompiledMatcher;
+use serde_json::json;
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    needles: Vec<String>,
+    haystack: String,
+    case_insensitive: bool,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    if input.needles.is_empty() || input.needles.len() > 128 {
+        return;
+    }
+
+    let needles: Vec<&str> = input
+        .needles
+        .iter()
+        .filter(|n| !n.is_empty() && n.len() <= 256)
+        .map(String::as_str)
+        .collect();
+
+    if needles.is_empty() {
+        return;
+    }
+
+    let make_matchers = || -> Vec<CompiledMatcher> {
+        needles
+            .iter()
+            .map(|n| {
+                let value = if input.case_insensitive {
+                    n.to_lowercase()
+                } else {
+                    n.to_string()
+                };
+                CompiledMatcher::Contains {
+                    value,
+                    case_insensitive: input.case_insensitive,
+                }
+            })
+            .collect()
+    };
+
+    let unoptimized = CompiledMatcher::AnyOf(make_matchers());
+    let optimized = optimize_any_of(make_matchers());
+
+    let event_json = json!({});
+    let event = JsonEvent::borrow(&event_json);
+    let val = EventValue::Str(Cow::Borrowed(input.haystack.as_str()));
+
+    let unopt_result = unoptimized.matches(&val, &event);
+    let opt_result = optimized.matches(&val, &event);
+
+    assert_eq!(
+        unopt_result, opt_result,
+        "Mismatch: needles={needles:?}, haystack={:?}, ci={}",
+        input.haystack, input.case_insensitive
+    );
+});


### PR DESCRIPTION
## Summary

- Add `fuzz_eval_matcher_diff` cargo-fuzz target that differentially tests the optimizer: compares `AnyOf(Contains(...))` against `optimize_any_of(...)` on arbitrary needle/haystack inputs generated by `libfuzzer` + `arbitrary`.
- Add `optimizer_runs_after_pipeline_transformation` regression test verifying the compiler optimizer sees post-pipeline field names (a `field_name_mapping` pipeline renames `CommandLine` to `process.command_line`, and the rule with 8 `|contains` patterns still matches events using the ECS field name).
- Expose `compiler::optimizer::optimize_any_of` as `#[doc(hidden)] pub` so the fuzz crate can call it directly.
- Ran the existing `eval_ac_threshold_sweep` benchmark (p1/p2/p4/p8/p16/p32 x h100/h1K/h8K/h64K). Results confirm `AHO_CORASICK_THRESHOLD = 8` is well-chosen: throughput flattens at p8, and p16/p32 perform nearly identically since the AC automaton scans the haystack once regardless of pattern count.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo check` in `fuzz/` compiles the new target
- [x] AC threshold sweep benchmark run and results reviewed