### PR TITLE
feat(eval): opt-in cross-rule Aho-Corasick prefilter via daachorse

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -111,6 +111,39 @@ Time to evaluate one event against N compiled rules.
 
 Wildcard/regex matching scales O(1) with rule count thanks to compiled pattern sets.
 
+### Aho-Corasick Threshold Sweep (0.10.0)
+
+Single rule with N `|contains` patterns evaluated against 50 randomly generated events at varying haystack lengths. Drove the choice of `AHO_CORASICK_THRESHOLD = 8` in `compiler/optimizer.rs`. Throughput is per event.
+
+| Patterns | h=100 B | h=1 KB | h=8 KB | h=64 KB |
+|---------:|---------|--------|--------|---------|
+| 1  | 13.0 Melem/s (3.84 us / batch) | 7.77 Melem/s (6.43 us) | 1.85 Melem/s (27.1 us) | 248 Kelem/s (201.4 us) |
+| 2  | 10.5 Melem/s (4.77 us) | 2.33 Melem/s (21.5 us) | 345 Kelem/s (144.8 us) | 42.3 Kelem/s (1.18 ms) |
+| 4  | 9.08 Melem/s (5.51 us) | 2.03 Melem/s (24.6 us) | 293 Kelem/s (170.8 us) | 35.6 Kelem/s (1.40 ms) |
+| **8**  | **5.17 Melem/s (9.68 us)** | **620 Kelem/s (80.6 us)** | **79.0 Kelem/s (633.1 us)** | **9.76 Kelem/s (5.12 ms)** |
+| 16 | 5.19 Melem/s (9.63 us) | 628 Kelem/s (79.6 us) | 78.6 Kelem/s (636.4 us) | 9.67 Kelem/s (5.17 ms) |
+| 32 | 4.99 Melem/s (10.0 us) | 607 Kelem/s (82.3 us) | 76.4 Kelem/s (654.4 us) | 8.88 Kelem/s (5.63 ms) |
+
+Throughput flattens at p=8: p16 and p32 perform within ~3% of p8 because the AC automaton scans the haystack once regardless of pattern count. Below 8 patterns, the sequential `str::contains` path with SIMD acceleration (memchr / Two-Way) wins. The crossover is clearly at 8.
+
+Run with `cargo bench -p rsigma-eval --bench eval -- eval_ac_threshold_sweep`.
+
+### Cross-Rule Aho-Corasick Pre-Filter, `daachorse-index` feature (0.10.0)
+
+200 non-matching events evaluated against N pure-substring rules. Best-case workload for the cross-rule index: every rule is AC-prunable (every detection consists exclusively of positive substring matchers, no negation in conditions), and every event has zero pattern hits across all fields.
+
+| Rules  | Off (default)            | On (`set_cross_rule_ac(true)`)   | Speedup     |
+|-------:|--------------------------|----------------------------------|-------------|
+| 1,000  | 17.34 ms (11.5 Kelem/s)  | 253.0 us (790 Kelem/s)           | **~68x**    |
+| 5,000  | 85.51 ms (2.34 Kelem/s)  | 883.0 us (226 Kelem/s)           | **~97x**    |
+| 10,000 | 173.37 ms (1.15 Kelem/s) | 1.71 ms (117 Kelem/s)            | **~101x**   |
+
+The cross-rule index turns O(rules × patterns) per event into O(haystack_length) for the AC scan, so throughput is essentially constant in rule count once the index is enabled.
+
+For typical mixed workloads (substring + exact + regex rules, events that hit multiple fields, smaller rule sets) the index adds build-time and lookup overhead with smaller wins or none, and can even cause a slowdown. **Off by default.** Enable via `Engine::set_cross_rule_ac(true)` programmatically, or `--cross-rule-ac` on `rsigma daemon` / `rsigma eval` (requires the `daachorse-index` Cargo feature). Always benchmark against representative data before flipping it on.
+
+Run with `cargo bench -p rsigma-eval --features daachorse-index --bench eval -- eval_cross_rule_ac`.
+
 ---
 
 ## Correlation Engine (`rsigma-eval`)
@@ -266,6 +299,8 @@ Full pipeline: resolve source, expand templates, apply value_placeholders, evalu
 
 ## Key Observations
 
+- **AC threshold is empirically 8**: substring-list throughput flattens at 8 patterns once Aho-Corasick takes over. p16/p32 perform within ~3% of p8; below 8, the sequential `str::contains` SIMD path (memchr / Two-Way) is faster.
+- **Cross-rule AC is order-of-magnitude on substring-only rule sets**: with the `daachorse-index` feature enabled, 200 non-matching events against 10K pure-substring rules dropped from 173 ms to 1.71 ms (~101x). Off by default; only worth enabling for substring-heavy rule sets where most events don't match (e.g., threat-intel feeds against high-volume telemetry).
 - **Detection is fast**: ~400K events/sec with 100 rules in pure evaluation mode, scaling linearly with event count.
 - **Runtime overhead is negative**: LogProcessor with JSON batching is actually faster than raw Engine evaluation due to batch-level optimizations and format-aware parsing.
 - **Rule count scales well**: Increasing from 100 to 1000 rules has minimal per-event cost increase (~50%) thanks to indexed field matching.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d87f75bbe32ee10609201e09e818537df81c3acb436be2b78f47cc85d139475"
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3734,6 +3740,7 @@ dependencies = [
  "base64",
  "chrono",
  "criterion",
+ "daachorse",
  "flate2",
  "ipnet",
  "log",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -17,6 +17,7 @@ daemon-otlp = ["daemon", "rsigma-runtime/otlp", "prost", "tonic", "flate2", "tok
 logfmt = ["rsigma-runtime/logfmt"]
 cef = ["rsigma-runtime/cef"]
 evtx = ["rsigma-runtime/evtx"]
+daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.10.0" }

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -934,10 +934,11 @@ Resolved values are cached in memory (and optionally SQLite). The cache supports
 | `logfmt` | off | Enables `logfmt` input format in `daemon` and `eval` |
 | `cef` | off | Enables CEF (ArcSight) input format in `daemon` and `eval` |
 | `evtx` | off | Enables EVTX (Windows Event Log) input format |
+| `daachorse-index` | off | Enables the `--cross-rule-ac` flag and links in [daachorse](https://crates.io/crates/daachorse) for cross-rule Aho-Corasick pre-filtering of large substring-heavy rule sets |
 
 ```bash
 # Build with all features
-cargo build --release --features daemon-nats,daemon-otlp,logfmt,cef,evtx
+cargo build --release --features daemon-nats,daemon-otlp,logfmt,cef,evtx,daachorse-index
 
 # Build without daemon (parser, eval, convert, lint only)
 cargo build --release --no-default-features

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -147,6 +147,7 @@ Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-r
 | `--timestamp-field` | repeatable | `[]` | Event field(s) for timestamp extraction |
 | `--bloom-prefilter` | flag | `false` | Enable bloom-filter pre-filtering of positive substring matchers (workload-dependent; see `crates/rsigma-eval/README.md`) |
 | `--bloom-max-bytes` | integer | **1048576** | Memory budget for the bloom index (no effect without `--bloom-prefilter`) |
+| `--cross-rule-ac` | flag | `false` | Enable cross-rule Aho-Corasick pre-filter (requires `--features daachorse-index`; see `crates/rsigma-eval/README.md`) |
 | `--buffer-size` | integer | **10000** | Bounded channel capacity for source-to-engine and engine-to-sink queues |
 | `--batch-size` | integer | **1** | Maximum events per engine lock acquisition (reduces mutex overhead under load) |
 | `--drain-timeout` | integer | **5** | Seconds to wait for in-flight events to drain on shutdown |
@@ -376,6 +377,7 @@ Evaluate JSON events against Sigma detection and correlation rules.
 | `--fail-on-detection` | flag | `false` | Exit with code 1 when any detection or correlation fires. Useful for CI/CD pipelines |
 | `--bloom-prefilter` | flag | `false` | Enable bloom-filter pre-filtering of positive substring matchers (see `crates/rsigma-eval/README.md` for the trade-off) |
 | `--bloom-max-bytes` | integer | **1048576** | Memory budget for the bloom index (no effect without `--bloom-prefilter`) |
+| `--cross-rule-ac` | flag | `false` | Enable cross-rule Aho-Corasick pre-filter (requires `--features daachorse-index`; see `crates/rsigma-eval/README.md`) |
 
 \* Feature-gated: `logfmt` requires the `logfmt` feature, `cef` requires the `cef` feature, `evtx` requires the `evtx` feature.
 

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -66,6 +66,7 @@ pub(crate) fn cmd_eval(
     syslog_tz: String,
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
+    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
 ) -> bool {
     let collection = crate::load_collection(&rules_path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
@@ -108,6 +109,8 @@ pub(crate) fn cmd_eval(
             &syslog_tz,
             bloom_prefilter,
             bloom_max_bytes,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac,
         )
     } else {
         cmd_eval_detection_only(
@@ -122,6 +125,8 @@ pub(crate) fn cmd_eval(
             &syslog_tz,
             bloom_prefilter,
             bloom_max_bytes,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac,
         )
     }
 }
@@ -141,6 +146,7 @@ fn cmd_eval_with_correlations(
     syslog_tz_str: &str,
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
+    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
 ) -> bool {
     let mut engine = CorrelationEngine::new(config);
     engine.set_include_event(include_event);
@@ -148,6 +154,8 @@ fn cmd_eval_with_correlations(
         engine.set_bloom_max_bytes(budget);
     }
     engine.set_bloom_prefilter(bloom_prefilter);
+    #[cfg(feature = "daachorse-index")]
+    engine.set_cross_rule_ac(cross_rule_ac);
     for p in pipelines {
         engine.add_pipeline(p.clone());
     }
@@ -392,6 +400,7 @@ fn cmd_eval_detection_only(
     syslog_tz_str: &str,
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
+    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
 ) -> bool {
     let mut engine = Engine::new();
     engine.set_include_event(include_event);
@@ -399,6 +408,8 @@ fn cmd_eval_detection_only(
         engine.set_bloom_max_bytes(budget);
     }
     engine.set_bloom_prefilter(bloom_prefilter);
+    #[cfg(feature = "daachorse-index")]
+    engine.set_cross_rule_ac(cross_rule_ac);
     for p in pipelines {
         engine.add_pipeline(p.clone());
     }

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -95,6 +95,12 @@ pub struct DaemonConfig {
     /// Optional override for the bloom memory budget (bytes). `None` means
     /// the crate default (1 MB).
     pub bloom_max_bytes: Option<usize>,
+    /// Enable the cross-rule Aho-Corasick pre-filter. Off by default;
+    /// benefit is workload-dependent (large rule sets with shared
+    /// substring patterns). Available behind the `daachorse-index`
+    /// Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    pub cross_rule_ac: bool,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
@@ -123,6 +129,8 @@ pub async fn run_daemon(config: DaemonConfig) {
     if let Some(budget) = config.bloom_max_bytes {
         engine.set_bloom_max_bytes(budget);
     }
+    #[cfg(feature = "daachorse-index")]
+    engine.set_cross_rule_ac(config.cross_rule_ac);
 
     // Set up dynamic source resolver if any pipeline has dynamic sources
     let has_dynamic = config.pipelines.iter().any(|p| p.is_dynamic());

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -342,6 +342,23 @@ enum Commands {
         /// `--bloom-prefilter` is set.
         #[arg(long = "bloom-max-bytes")]
         bloom_max_bytes: Option<usize>,
+
+        /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
+        ///
+        /// Off by default. When enabled, the engine builds a single
+        /// per-field `DoubleArrayAhoCorasick` over every rule's positive
+        /// substring needles and drops AC-prunable rules (pure positive
+        /// substring detections, no negation) from the candidate set when
+        /// none of their patterns match the event. Pays off only on rule
+        /// sets > ~5K rules with many shared substring patterns
+        /// (threat-intel feeds, IOC packs). For smaller rule sets the
+        /// per-rule Aho-Corasick matcher is already optimal. Build time
+        /// scales linearly with total pattern count; pattern count per
+        /// field is capped at 100K. Available when compiled with the
+        /// `daachorse-index` Cargo feature.
+        #[cfg(feature = "daachorse-index")]
+        #[arg(long = "cross-rule-ac")]
+        cross_rule_ac: bool,
     },
 
     /// Evaluate events against Sigma rules
@@ -449,6 +466,13 @@ enum Commands {
         /// No effect unless `--bloom-prefilter` is set.
         #[arg(long = "bloom-max-bytes")]
         bloom_max_bytes: Option<usize>,
+
+        /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
+        /// See `rsigma daemon --help` for the trade-off. Available when
+        /// compiled with the `daachorse-index` Cargo feature.
+        #[cfg(feature = "daachorse-index")]
+        #[arg(long = "cross-rule-ac")]
+        cross_rule_ac: bool,
     },
 
     /// Convert Sigma rules to backend-native queries
@@ -601,6 +625,8 @@ fn main() {
             allow_remote_include,
             bloom_prefilter,
             bloom_max_bytes,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac,
         } => {
             #[cfg(feature = "daemon-nats")]
             let nats_auth = NatsAuthArgs {
@@ -673,6 +699,8 @@ fn main() {
                 allow_remote_include,
                 bloom_prefilter,
                 bloom_max_bytes,
+                #[cfg(feature = "daachorse-index")]
+                cross_rule_ac,
             )
         }
         Commands::Parse { path, pretty } => commands::cmd_parse(path, pretty),
@@ -733,6 +761,8 @@ fn main() {
             fail_on_detection,
             bloom_prefilter,
             bloom_max_bytes,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac,
         } => {
             let had_matches = commands::cmd_eval(
                 rules,
@@ -752,6 +782,8 @@ fn main() {
                 syslog_tz,
                 bloom_prefilter,
                 bloom_max_bytes,
+                #[cfg(feature = "daachorse-index")]
+                cross_rule_ac,
             );
             if fail_on_detection && had_matches {
                 process::exit(exit_code::FINDINGS);
@@ -843,6 +875,7 @@ fn cmd_daemon(
     allow_remote_include: bool,
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
+    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
 ) {
     // Set up structured logging
     tracing_subscriber::fmt()
@@ -919,6 +952,8 @@ fn cmd_daemon(
         allow_remote_include,
         bloom_prefilter,
         bloom_max_bytes,
+        #[cfg(feature = "daachorse-index")]
+        cross_rule_ac,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 
 [features]
 parallel = ["rayon"]
+daachorse-index = ["dep:daachorse"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.10.0" }
@@ -27,6 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 flate2 = "1"
 log = "0.4"
 rayon = { version = "1", optional = true }
+daachorse = { version = "3", optional = true }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -24,6 +24,12 @@ This library is part of [rsigma].
 | `evaluate(event: &Event)` | Evaluate all rules against an event |
 | `evaluate_with_logsource(event, logsource)` | Evaluate with logsource-based pre-filtering |
 | `evaluate_batch(events: &[&Event])` | Evaluate all rules against multiple events (parallel with `parallel` feature) |
+| `set_bloom_prefilter(enabled: bool)` | Enable opt-in bloom-filter pre-filtering of positive substring matchers (off by default; see [Bloom Pre-Filter](#bloom-pre-filter-opt-in)) |
+| `bloom_prefilter_enabled()` | Whether bloom pre-filtering is currently enabled |
+| `set_bloom_max_bytes(max_bytes: usize)` | Override the bloom memory budget (default: 1 MB) |
+| `bloom_max_bytes()` | Configured bloom memory budget, or `None` if using the default |
+| `set_cross_rule_ac(enabled: bool)` | Enable opt-in cross-rule Aho-Corasick pre-filter (requires `daachorse-index` feature; see [Cross-Rule AC Index](#cross-rule-aho-corasick-index-opt-in-feature-gated)) |
+| `cross_rule_ac_enabled()` | Whether the cross-rule AC pre-filter is currently enabled (`daachorse-index` only) |
 | `rule_count()` | Number of loaded rules |
 | `rules()` | Access the compiled rules slice |
 
@@ -45,6 +51,9 @@ This library is part of [rsigma].
 | `state_count()` | Number of active correlation state entries |
 | `event_buffer_count()` | Total events stored across all buffers |
 | `event_buffer_bytes()` | Total bytes of compressed event data |
+| `set_bloom_prefilter(enabled: bool)` | Forward to the inner detection engine (off by default) |
+| `set_bloom_max_bytes(max_bytes: usize)` | Forward to the inner detection engine |
+| `set_cross_rule_ac(enabled: bool)` | Forward to the inner detection engine (requires `daachorse-index` feature) |
 
 ### Compilation
 

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -388,6 +388,40 @@ CLI equivalents on `rsigma eval` and `rsigma daemon`:
 
 Always benchmark against representative events before flipping it on; the `eval_bloom_rejection` Criterion group in `crates/rsigma-eval/benches/eval.rs` reports throughput with both default-off and bloom-on engines so you can size the win on your corpus.
 
+## Cross-Rule Aho-Corasick Index (Opt-In, Feature-Gated)
+
+For deployments with very large rule sets (> ~5K rules) and many shared substring patterns (threat-intel feeds, IOC packs), the engine can build a single per-field [`DoubleArrayAhoCorasick`](https://crates.io/crates/daachorse) automaton over every rule's positive substring needles. At eval time, the engine scans each indexed field once with the per-field automaton and drops AC-prunable rules from the candidate set when none of their patterns hit the event.
+
+A rule is AC-prunable when:
+
+- It has at least one positive substring detection item, AND
+- Every detection consists exclusively of positive substring matchers (`Contains` / `StartsWith` / `EndsWith` / `AhoCorasickSet`, possibly nested under `AnyOf`/`AllOf`/`CaseInsensitiveGroup`), AND
+- No condition expression contains `Not`.
+
+These rules can be safely pruned because their firing requires at least one substring to match. Rules with `Exact`, `Regex`, `Numeric`, `Cidr`, etc. matchers, or with `not` selectors in their conditions, are kept in the candidate set unfiltered.
+
+**Off by default.** For smaller rule sets the per-rule [`AhoCorasickSet`] matcher is already optimal; the cross-rule index only adds build time and lookup overhead. Pattern count per field is capped at 100K (rules referencing fields above that cap are kept unfiltered). Build time scales linearly with total pattern count.
+
+Enable via the `daachorse-index` Cargo feature:
+
+```toml
+rsigma-eval = { version = "0.10", features = ["daachorse-index"] }
+```
+
+```rust
+let mut engine = Engine::new();
+engine.set_cross_rule_ac(true);
+engine.add_collection(&collection)?;
+```
+
+CLI equivalents on `rsigma eval` and `rsigma daemon` (when the CLI is compiled with the feature):
+
+```
+--cross-rule-ac
+```
+
+Always benchmark against representative rule sets and event streams before flipping it on; the `eval_cross_rule_ac` Criterion group reports throughput at 1K / 5K / 10K rules with the index on and off.
+
 ## Constants and Limits
 
 | Constant | Value | Purpose |

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -373,6 +373,68 @@ fn bench_eval_bloom_rejection(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: cross-rule Aho-Corasick prefilter (daachorse-index feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daachorse-index")]
+fn bench_eval_cross_rule_ac(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eval_cross_rule_ac");
+    group.sample_size(20);
+
+    // Pure-substring rules amplify the cross-rule index's win because every
+    // rule is AC-prunable and shares the same field. Mix non-matching
+    // events with a small fraction of matches to model a typical
+    // threat-intel deployment where most events are benign.
+    let event_values = datagen::gen_non_matching_events(200);
+    let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
+
+    for n_rules in [1_000usize, 5_000, 10_000] {
+        let yaml = datagen::gen_n_substring_only_rules(n_rules);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+
+        let mut off_engine = Engine::new();
+        off_engine.add_collection(&collection).unwrap();
+
+        let mut on_engine = Engine::new();
+        on_engine.set_cross_rule_ac(true);
+        on_engine.add_collection(&collection).unwrap();
+
+        group.throughput(criterion::Throughput::Elements(events.len() as u64));
+
+        let off_label = format!("{n_rules}r_off");
+        group.bench_with_input(
+            BenchmarkId::new("default", &off_label),
+            &(&off_engine, &events),
+            |b, (engine, events)| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for event in *events {
+                        total += engine.evaluate(black_box(event)).len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+
+        let on_label = format!("{n_rules}r_on");
+        group.bench_with_input(
+            BenchmarkId::new("cross_rule_ac", &on_label),
+            &(&on_engine, &events),
+            |b, (engine, events)| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for event in *events {
+                        total += engine.evaluate(black_box(event)).len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Benchmark: regex-heavy rules
 // ---------------------------------------------------------------------------
 
@@ -410,6 +472,23 @@ fn bench_eval_regex_heavy(c: &mut Criterion) {
 // Criterion harness
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "daachorse-index")]
+criterion_group!(
+    benches,
+    bench_compile_rules,
+    bench_eval_single_event,
+    bench_eval_throughput,
+    bench_eval_batch,
+    bench_eval_contains_heavy,
+    bench_eval_ac_threshold_sweep,
+    bench_eval_regex_set_heavy,
+    bench_eval_bloom_rejection,
+    bench_eval_cross_rule_ac,
+    bench_eval_wildcard_heavy,
+    bench_eval_regex_heavy,
+);
+
+#[cfg(not(feature = "daachorse-index"))]
 criterion_group!(
     benches,
     bench_compile_rules,

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -117,6 +117,14 @@ impl CorrelationEngine {
         self.engine.set_bloom_max_bytes(max_bytes);
     }
 
+    /// Forward to [`crate::Engine::set_cross_rule_ac`] on the inner
+    /// detection engine. Off by default. Available behind the
+    /// `daachorse-index` Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    pub fn set_cross_rule_ac(&mut self, enabled: bool) {
+        self.engine.set_cross_rule_ac(enabled);
+    }
+
     /// Set the global correlation event mode.
     ///
     /// - `None`: no event storage (default)

--- a/crates/rsigma-eval/src/engine/cross_rule_ac.rs
+++ b/crates/rsigma-eval/src/engine/cross_rule_ac.rs
@@ -1,0 +1,693 @@
+//! Cross-rule Aho-Corasick index over positive substring patterns.
+//!
+//! At rule load time, builds a single double-array Aho-Corasick automaton per
+//! event field over every positive substring needle from every loaded rule.
+//! At eval time, the engine scans each indexed field once with the per-field
+//! automaton and produces a `Vec<bool>` (one entry per rule) that is `true`
+//! iff at least one of the rule's positive substring patterns matched
+//! somewhere on the event.
+//!
+//! When a rule is **AC-prunable** (see [`rule_is_ac_prunable`]), the engine
+//! drops it from the candidate set when its bit in the hit vector is `false`.
+//! AC-prunable rules are exactly those whose firing requires at least one
+//! positive substring match, so dropping on "no hit" is provably safe.
+//!
+//! # Why daachorse
+//!
+//! For very large pattern sets (>10K patterns total across all rules),
+//! daachorse's compact double-array structure is ~3-5x faster and uses ~56%
+//! less memory than the equivalent NFA/DFA built by `aho-corasick`. At this
+//! scale, `aho-corasick`'s Teddy SIMD prefilter is disabled because Teddy
+//! supports up to ~100 patterns, so the comparison narrows to double-array
+//! AC vs full DFA AC.
+//!
+//! For smaller rule sets, the per-rule Phase 1 [`AhoCorasickSet`] matchers
+//! are already optimal; this index is gated behind the `daachorse-index`
+//! feature and turned on explicitly via [`crate::Engine::set_cross_rule_ac`].
+//!
+//! [`AhoCorasickSet`]: crate::matcher::CompiledMatcher::AhoCorasickSet
+
+use std::collections::HashMap;
+
+use daachorse::DoubleArrayAhoCorasick;
+use rsigma_parser::ConditionExpr;
+
+use crate::compiler::{CompiledDetection, CompiledRule};
+use crate::event::{Event, EventValue};
+use crate::matcher::CompiledMatcher;
+
+/// Maximum number of patterns indexed per field. Beyond this cap the field
+/// falls back to no cross-rule automaton (rules on that field are kept in
+/// the candidate set unfiltered). Sized so that even pathologically large
+/// IOC rule packs don't bloat the engine's memory footprint past tens of
+/// megabytes per field.
+pub(crate) const MAX_PATTERNS_PER_FIELD: usize = 100_000;
+
+/// Per-field cross-rule automaton.
+struct FieldAc {
+    automaton: DoubleArrayAhoCorasick<u32>,
+    /// `pattern_id → rule indices`. A pattern can be reused across multiple
+    /// rules, so the inner vector is small but unbounded. Kept as `Vec<u32>`
+    /// instead of a `HashSet` because iteration order doesn't matter and
+    /// duplicates are deduped at insert time.
+    pattern_to_rules: Vec<Vec<u32>>,
+}
+
+/// Cross-rule Aho-Corasick index. Built from a slice of compiled rules,
+/// holds at most one automaton per indexed field. Fields without any
+/// positive substring item across the whole rule set are absent from the
+/// map.
+pub(crate) struct CrossRuleAcIndex {
+    per_field: HashMap<String, FieldAc>,
+    rule_count: usize,
+}
+
+impl CrossRuleAcIndex {
+    pub(crate) fn empty() -> Self {
+        Self {
+            per_field: HashMap::new(),
+            rule_count: 0,
+        }
+    }
+
+    /// Returns true when the index contains no per-field automaton. The
+    /// engine uses this to skip the scan entirely on rule sets that don't
+    /// benefit from the cross-rule index.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.per_field.is_empty()
+    }
+
+    /// Build the index from the engine's compiled rules.
+    ///
+    /// Walks every rule, collects `(field, lowered_needle, rule_idx)`
+    /// triples, deduplicates patterns per field, and builds one
+    /// `DoubleArrayAhoCorasick` per field. Fields whose pattern count
+    /// exceeds [`MAX_PATTERNS_PER_FIELD`] are dropped (no automaton built);
+    /// rules referencing such fields are not pruned by the index but still
+    /// evaluated normally.
+    pub(crate) fn build(rules: &[CompiledRule]) -> Self {
+        // (field, needle) → rule indices that own this pattern on that
+        // field. The pattern strings are pre-lowered (Sigma is case-
+        // insensitive by default; we lower up-front because daachorse has
+        // no built-in CI matching).
+        let mut per_field: HashMap<String, HashMap<String, Vec<u32>>> = HashMap::new();
+
+        for (rule_idx, rule) in rules.iter().enumerate() {
+            let rule_idx_u32 = u32::try_from(rule_idx).unwrap_or(u32::MAX);
+            for detection in rule.detections.values() {
+                collect_rule_needles(detection, rule_idx_u32, &mut per_field);
+            }
+        }
+
+        // Build one automaton per field with patterns in stable order. The
+        // build order assigns pattern ids 0..n_patterns; we keep
+        // `pattern_to_rules` aligned to that order.
+        let mut built: HashMap<String, FieldAc> = HashMap::new();
+        for (field, needle_to_rules) in per_field {
+            if needle_to_rules.is_empty() {
+                continue;
+            }
+            if needle_to_rules.len() > MAX_PATTERNS_PER_FIELD {
+                log::debug!(
+                    "cross-rule AC: field '{field}' has {} patterns (> {MAX_PATTERNS_PER_FIELD}); falling back",
+                    needle_to_rules.len()
+                );
+                continue;
+            }
+
+            // Sort by pattern string for deterministic id assignment so
+            // rebuilds produce identical state on identical inputs.
+            let mut entries: Vec<(String, Vec<u32>)> = needle_to_rules.into_iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let mut patterns: Vec<String> = Vec::with_capacity(entries.len());
+            let mut pattern_to_rules: Vec<Vec<u32>> = Vec::with_capacity(entries.len());
+            for (pattern, mut rule_ids) in entries {
+                rule_ids.sort_unstable();
+                rule_ids.dedup();
+                patterns.push(pattern);
+                pattern_to_rules.push(rule_ids);
+            }
+
+            match DoubleArrayAhoCorasick::<u32>::new(&patterns) {
+                Ok(automaton) => {
+                    built.insert(
+                        field,
+                        FieldAc {
+                            automaton,
+                            pattern_to_rules,
+                        },
+                    );
+                }
+                Err(e) => {
+                    log::warn!(
+                        "cross-rule AC: failed to build automaton for field '{field}' ({} patterns): {e}",
+                        patterns.len()
+                    );
+                }
+            }
+        }
+
+        Self {
+            per_field: built,
+            rule_count: rules.len(),
+        }
+    }
+
+    /// Number of fields with active automatons. Used for diagnostics and
+    /// tests; not on the hot path.
+    #[cfg(test)]
+    pub(crate) fn field_count(&self) -> usize {
+        self.per_field.len()
+    }
+
+    /// Mark every rule whose at least one positive substring pattern matches
+    /// the event. `hits` must have length `self.rule_count`; entries are
+    /// updated in place (set to `true` for matched rules).
+    ///
+    /// The caller is expected to start with `hits` either zeroed (for an
+    /// AC-only filter) or pre-marked for non-AC-prunable rules (so the
+    /// vector represents the union of "rule must be evaluated" reasons).
+    pub(crate) fn mark_hits<E: Event>(&self, event: &E, hits: &mut [bool]) {
+        debug_assert_eq!(hits.len(), self.rule_count);
+
+        for (field, ac) in &self.per_field {
+            // Pull the field value off the event. Only string values feed
+            // the automaton; arrays, numbers, and nested objects answer
+            // `MaybeMatch` (we set no bits for them and let those rules
+            // evaluate normally via the candidate set).
+            let value = match event.get_field(field) {
+                Some(EventValue::Str(s)) => s,
+                _ => continue,
+            };
+
+            // Sigma matches case-insensitively by default; the index stores
+            // pre-lowered needles, so the haystack must be lowered too.
+            let lowered = crate::matcher::ascii_lowercase_cow(&value);
+
+            for m in ac.automaton.find_overlapping_iter(lowered.as_bytes()) {
+                let pattern_id = m.value() as usize;
+                if let Some(rule_ids) = ac.pattern_to_rules.get(pattern_id) {
+                    for &rid in rule_ids {
+                        let idx = rid as usize;
+                        if let Some(slot) = hits.get_mut(idx) {
+                            *slot = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Collect `(field, lowered_needle) → rule_idx` triples from a detection
+/// tree. `Not(...)` subtrees contribute nothing because their negation
+/// inverts the match logic and the AC index can only prove pattern
+/// presence, not absence.
+fn collect_rule_needles(
+    detection: &CompiledDetection,
+    rule_idx: u32,
+    out: &mut HashMap<String, HashMap<String, Vec<u32>>>,
+) {
+    match detection {
+        CompiledDetection::AllOf(items) => {
+            for item in items {
+                if let Some(field) = &item.field {
+                    extract_from_matcher(
+                        &item.matcher,
+                        field,
+                        /*negated=*/ false,
+                        rule_idx,
+                        out,
+                    );
+                }
+            }
+        }
+        CompiledDetection::AnyOf(subs) => {
+            for sub in subs {
+                collect_rule_needles(sub, rule_idx, out);
+            }
+        }
+        CompiledDetection::Keywords(_) => {
+            // Field-less; the cross-rule index is per-field so keywords are
+            // out of scope. Phase 1's per-rule Aho-Corasick still handles
+            // keyword detections optimally.
+        }
+    }
+}
+
+fn extract_from_matcher(
+    m: &CompiledMatcher,
+    field: &str,
+    negated: bool,
+    rule_idx: u32,
+    out: &mut HashMap<String, HashMap<String, Vec<u32>>>,
+) {
+    if negated {
+        return;
+    }
+    match m {
+        CompiledMatcher::Contains { value, .. }
+        | CompiledMatcher::StartsWith { value, .. }
+        | CompiledMatcher::EndsWith { value, .. } => {
+            push_needle(out, field, value, rule_idx);
+        }
+        CompiledMatcher::AhoCorasickSet { needles, .. } => {
+            for needle in needles {
+                push_needle(out, field, needle, rule_idx);
+            }
+        }
+        CompiledMatcher::AnyOf(children) | CompiledMatcher::AllOf(children) => {
+            for child in children {
+                extract_from_matcher(child, field, negated, rule_idx, out);
+            }
+        }
+        CompiledMatcher::CaseInsensitiveGroup { children, .. } => {
+            for child in children {
+                extract_from_matcher(child, field, negated, rule_idx, out);
+            }
+        }
+        CompiledMatcher::Not(inner) => {
+            extract_from_matcher(inner, field, true, rule_idx, out);
+        }
+        // Exact, Regex, RegexSetMatch, Cidr, Numeric*, Exists, BoolEq,
+        // FieldRef, Null, Expand, TimestampPart: not substring-prunable.
+        // Exact is excluded because the rule index already pre-filters it
+        // at the rule level.
+        _ => {}
+    }
+}
+
+fn push_needle(
+    out: &mut HashMap<String, HashMap<String, Vec<u32>>>,
+    field: &str,
+    needle: &str,
+    rule_idx: u32,
+) {
+    if needle.is_empty() {
+        return;
+    }
+    out.entry(field.to_string())
+        .or_default()
+        .entry(needle.to_string())
+        .or_default()
+        .push(rule_idx);
+}
+
+/// Conservative analysis: `true` iff dropping the rule on "zero AC hits" is
+/// provably correct.
+///
+/// A rule is AC-prunable when:
+/// 1. It has at least one positive substring detection item somewhere.
+/// 2. Every detection in the rule is built exclusively from positive
+///    substring matchers (Contains/StartsWith/EndsWith/AhoCorasickSet,
+///    optionally nested under AnyOf/AllOf/CaseInsensitiveGroup). No Exact,
+///    Regex, Numeric, FieldRef, Cidr, Expand, Not, etc.
+/// 3. No condition expression contains `Not`, `not 1 of`, etc. (Negated
+///    selectors invert match polarity, so "no substring hits" no longer
+///    implies "rule cannot fire".)
+///
+/// Under these constraints, the rule fires iff some substring matches some
+/// field, so a `false` AC verdict provably implies the rule cannot fire.
+pub(crate) fn rule_is_ac_prunable(rule: &CompiledRule) -> bool {
+    if rule.detections.is_empty() {
+        return false;
+    }
+
+    let mut has_positive_substring = false;
+    for detection in rule.detections.values() {
+        let mut found = false;
+        if !detection_is_pure_positive_substring(detection, &mut found) {
+            return false;
+        }
+        has_positive_substring |= found;
+    }
+    if !has_positive_substring {
+        return false;
+    }
+
+    rule.conditions.iter().all(condition_is_negation_free)
+}
+
+/// Returns `true` if every leaf in the detection is a positive substring
+/// matcher. Sets `*found_positive_substring = true` if at least one
+/// substring leaf was seen (to distinguish empty/keyword-only detections
+/// from genuine substring detections).
+fn detection_is_pure_positive_substring(
+    detection: &CompiledDetection,
+    found_positive_substring: &mut bool,
+) -> bool {
+    match detection {
+        CompiledDetection::AllOf(items) => {
+            if items.is_empty() {
+                return false;
+            }
+            for item in items {
+                if item.field.is_none() {
+                    return false;
+                }
+                if item.exists.is_some() {
+                    return false;
+                }
+                if !matcher_is_pure_positive_substring(&item.matcher, found_positive_substring) {
+                    return false;
+                }
+            }
+            true
+        }
+        CompiledDetection::AnyOf(subs) => {
+            if subs.is_empty() {
+                return false;
+            }
+            for sub in subs {
+                if !detection_is_pure_positive_substring(sub, found_positive_substring) {
+                    return false;
+                }
+            }
+            true
+        }
+        // Keywords are field-less and the cross-rule index is per-field, so
+        // we conservatively reject keyword detections from AC pruning.
+        CompiledDetection::Keywords(_) => false,
+    }
+}
+
+fn matcher_is_pure_positive_substring(
+    matcher: &CompiledMatcher,
+    found_positive_substring: &mut bool,
+) -> bool {
+    match matcher {
+        CompiledMatcher::Contains { .. }
+        | CompiledMatcher::StartsWith { .. }
+        | CompiledMatcher::EndsWith { .. }
+        | CompiledMatcher::AhoCorasickSet { .. } => {
+            *found_positive_substring = true;
+            true
+        }
+        CompiledMatcher::AnyOf(children) | CompiledMatcher::AllOf(children) => {
+            !children.is_empty()
+                && children
+                    .iter()
+                    .all(|c| matcher_is_pure_positive_substring(c, found_positive_substring))
+        }
+        CompiledMatcher::CaseInsensitiveGroup { children, .. } => {
+            !children.is_empty()
+                && children
+                    .iter()
+                    .all(|c| matcher_is_pure_positive_substring(c, found_positive_substring))
+        }
+        // Anything else (Exact, Regex, RegexSetMatch, Cidr, Numeric*,
+        // FieldRef, Null, BoolEq, Exists, Expand, TimestampPart, Not)
+        // breaks the AC-prunable invariant.
+        _ => false,
+    }
+}
+
+fn condition_is_negation_free(cond: &ConditionExpr) -> bool {
+    match cond {
+        // Sigma's `not 1 of selection_*` is parsed as `Not(Selector { ... })`,
+        // so any `Not` node anywhere in the tree disqualifies the rule from
+        // AC pruning.
+        ConditionExpr::Not(_) => false,
+        ConditionExpr::Identifier(_) => true,
+        ConditionExpr::Selector { .. } => true,
+        ConditionExpr::And(parts) | ConditionExpr::Or(parts) => {
+            parts.iter().all(condition_is_negation_free)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Engine;
+    use crate::event::JsonEvent;
+    use rsigma_parser::parse_sigma_yaml;
+    use serde_json::json;
+
+    fn engine_from(yaml: &str) -> Engine {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+        engine
+    }
+
+    fn build_index(yaml: &str) -> (Engine, CrossRuleAcIndex) {
+        let engine = engine_from(yaml);
+        let index = CrossRuleAcIndex::build(engine.rules());
+        (engine, index)
+    }
+
+    #[test]
+    fn empty_when_no_substring_patterns() {
+        let yaml = r#"
+title: Exact Only
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+"#;
+        let (_, index) = build_index(yaml);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn populates_per_field_automaton() {
+        let yaml = r#"
+title: Contains Heavy
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains:
+            - 'whoami'
+            - 'mimikatz'
+            - 'powershell'
+    condition: selection
+"#;
+        let (_, index) = build_index(yaml);
+        assert_eq!(index.field_count(), 1);
+    }
+
+    #[test]
+    fn marks_hits_for_matching_rule() {
+        let yaml = r#"
+title: Whoami Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+---
+title: Mimikatz Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'mimikatz'
+    condition: selection
+"#;
+        let (engine, index) = build_index(yaml);
+        let mut hits = vec![false; engine.rule_count()];
+        let ev = json!({"CommandLine": "execute whoami /all"});
+        index.mark_hits(&JsonEvent::borrow(&ev), &mut hits);
+        assert!(hits[0], "first rule should hit on 'whoami'");
+        assert!(!hits[1], "second rule should not hit");
+    }
+
+    #[test]
+    fn marks_hits_case_insensitive() {
+        let yaml = r#"
+title: Whoami Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let (engine, index) = build_index(yaml);
+        let mut hits = vec![false; engine.rule_count()];
+        let ev = json!({"CommandLine": "execute WHOAMI /all"});
+        index.mark_hits(&JsonEvent::borrow(&ev), &mut hits);
+        assert!(hits[0], "haystack lowering must match upper-case input");
+    }
+
+    #[test]
+    fn negated_substring_excluded_from_index() {
+        let yaml = r#"
+title: Negated
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|not: 'whoami'
+    condition: selection
+"#;
+        let (_, index) = build_index(yaml);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn ahocorasick_needles_indexed() {
+        let yaml = r#"
+title: AC Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains:
+            - 'mimikatz'
+            - 'powershell'
+            - 'rundll32'
+            - 'regsvr32'
+            - 'certutil'
+            - 'bitsadmin'
+            - 'mshta'
+            - 'wscript'
+    condition: selection
+"#;
+        let (engine, index) = build_index(yaml);
+        let mut hits = vec![false; engine.rule_count()];
+        let ev = json!({"CommandLine": "rundll32.exe foo"});
+        index.mark_hits(&JsonEvent::borrow(&ev), &mut hits);
+        assert!(hits[0]);
+    }
+
+    #[test]
+    fn shared_pattern_marks_multiple_rules() {
+        let yaml = r#"
+title: Rule A
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+---
+title: Rule B
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let (engine, index) = build_index(yaml);
+        let mut hits = vec![false; engine.rule_count()];
+        let ev = json!({"CommandLine": "whoami /all"});
+        index.mark_hits(&JsonEvent::borrow(&ev), &mut hits);
+        assert!(hits[0] && hits[1]);
+    }
+
+    #[test]
+    fn ac_prunable_pure_substring_rule() {
+        let yaml = r#"
+title: Pure Contains
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let engine = engine_from(yaml);
+        assert!(rule_is_ac_prunable(&engine.rules()[0]));
+    }
+
+    #[test]
+    fn ac_prunable_rejects_mixed_exact_and_substring() {
+        let yaml = r#"
+title: Mixed
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+        let engine = engine_from(yaml);
+        assert!(!rule_is_ac_prunable(&engine.rules()[0]));
+    }
+
+    #[test]
+    fn ac_prunable_rejects_negation_in_condition() {
+        let yaml = r#"
+title: Negated Condition
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    other:
+        CommandLine|contains: 'admin'
+    condition: selection and not other
+"#;
+        let engine = engine_from(yaml);
+        assert!(!rule_is_ac_prunable(&engine.rules()[0]));
+    }
+
+    #[test]
+    fn ac_prunable_rejects_keywords() {
+        let yaml = r#"
+title: Keyword Only
+logsource:
+    product: windows
+detection:
+    keywords:
+        - 'suspicious'
+        - 'malware'
+    condition: keywords
+"#;
+        let engine = engine_from(yaml);
+        assert!(!rule_is_ac_prunable(&engine.rules()[0]));
+    }
+
+    #[test]
+    fn ac_prunable_accepts_anyof_substring_values() {
+        let yaml = r#"
+title: AnyOf Substrings
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains:
+            - 'whoami'
+            - 'mimikatz'
+            - 'powershell'
+    condition: selection
+"#;
+        let engine = engine_from(yaml);
+        assert!(rule_is_ac_prunable(&engine.rules()[0]));
+    }
+
+    #[test]
+    fn cap_drops_overflowing_field() {
+        // Build a synthetic rule set with > MAX_PATTERNS_PER_FIELD distinct
+        // patterns on the same field. The builder must skip the field
+        // rather than panicking.
+        let mut yaml = String::new();
+        let n = MAX_PATTERNS_PER_FIELD + 5;
+        for i in 0..n {
+            yaml.push_str(&format!(
+                "title: R{i}\n\
+                 id: r-{i:08}\n\
+                 logsource:\n\
+                 \x20   product: windows\n\
+                 detection:\n\
+                 \x20   selection:\n\
+                 \x20       CommandLine|contains: 'pat-{i:08}'\n\
+                 \x20   condition: selection\n\
+                 ---\n",
+            ));
+        }
+        let engine = engine_from(&yaml);
+        let index = CrossRuleAcIndex::build(engine.rules());
+        // Field is dropped, so the index is empty for CommandLine.
+        assert!(index.is_empty());
+    }
+}

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -5,6 +5,8 @@
 //! reduce the number of rules evaluated per event.
 
 pub(crate) mod bloom_index;
+#[cfg(feature = "daachorse-index")]
+pub(crate) mod cross_rule_ac;
 mod filters;
 #[cfg(test)]
 mod tests;
@@ -88,6 +90,27 @@ pub struct Engine {
     /// per-field filters. `None` means use the crate default
     /// (`bloom_index::DEFAULT_MAX_TOTAL_BYTES`, 1 MB).
     bloom_max_bytes: Option<usize>,
+    /// Cross-rule Aho-Corasick index for substring patterns, gated on the
+    /// `daachorse-index` feature. Built only when [`cross_rule_ac_enabled`]
+    /// is `true`; [`cross_rule_ac_prunable`] is the conservative per-rule
+    /// flag computed at the same time so the `evaluate` hot path can drop
+    /// rules safely.
+    ///
+    /// [`cross_rule_ac_enabled`]: Self::cross_rule_ac_enabled
+    /// [`cross_rule_ac_prunable`]: Self::cross_rule_ac_prunable
+    #[cfg(feature = "daachorse-index")]
+    cross_rule_ac_index: cross_rule_ac::CrossRuleAcIndex,
+    /// Toggle for the cross-rule AC pre-filter. Off by default; the index
+    /// only pays off on rule sets > 5K rules with many shared substring
+    /// patterns. See [`Engine::set_cross_rule_ac`].
+    #[cfg(feature = "daachorse-index")]
+    cross_rule_ac_enabled: bool,
+    /// Per-rule conservative AC-prunability flag. `true` iff the rule's
+    /// firing requires at least one positive substring match (no `Exact`,
+    /// `Regex`, `Numeric`, `Not`, etc.), so dropping the rule on a
+    /// "no AC hit" verdict is provably correct.
+    #[cfg(feature = "daachorse-index")]
+    cross_rule_ac_prunable: Vec<bool>,
 }
 
 impl Engine {
@@ -102,6 +125,12 @@ impl Engine {
             bloom_index: FieldBloomIndex::empty(),
             bloom_prefilter: false,
             bloom_max_bytes: None,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac_index: cross_rule_ac::CrossRuleAcIndex::empty(),
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac_enabled: false,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac_prunable: Vec::new(),
         }
     }
 
@@ -116,6 +145,12 @@ impl Engine {
             bloom_index: FieldBloomIndex::empty(),
             bloom_prefilter: false,
             bloom_max_bytes: None,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac_index: cross_rule_ac::CrossRuleAcIndex::empty(),
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac_enabled: false,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac_prunable: Vec::new(),
         }
     }
 
@@ -161,6 +196,38 @@ impl Engine {
     /// explicitly. `None` means the crate default (1 MB) is in use.
     pub fn bloom_max_bytes(&self) -> Option<usize> {
         self.bloom_max_bytes
+    }
+
+    /// Enable or disable the cross-rule Aho-Corasick pre-filter.
+    ///
+    /// When enabled, the engine builds a single per-field
+    /// `DoubleArrayAhoCorasick` automaton over every positive substring
+    /// needle from every rule and drops AC-prunable rules from the
+    /// candidate set when none of their patterns hit the event.
+    ///
+    /// Off by default. Pays off on large rule sets (> ~5K rules) with many
+    /// shared substring patterns (threat-intel feeds, IOC packs). For
+    /// smaller rule sets the per-rule [`AhoCorasickSet`] matcher already
+    /// handles the workload optimally; the cross-rule index only adds
+    /// build-time and lookup overhead. Benchmark with `eval_cross_rule_ac`
+    /// against representative rule sets before enabling in production.
+    ///
+    /// Available behind the `daachorse-index` Cargo feature.
+    ///
+    /// [`AhoCorasickSet`]: crate::matcher::CompiledMatcher::AhoCorasickSet
+    #[cfg(feature = "daachorse-index")]
+    pub fn set_cross_rule_ac(&mut self, enabled: bool) {
+        self.cross_rule_ac_enabled = enabled;
+        if enabled && !self.rules.is_empty() {
+            self.rebuild_index();
+        }
+    }
+
+    /// Returns whether the cross-rule AC pre-filter is currently enabled.
+    /// Available behind the `daachorse-index` Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    pub fn cross_rule_ac_enabled(&self) -> bool {
+        self.cross_rule_ac_enabled
     }
 
     /// Set global `include_event` — when `true`, all match results include
@@ -342,6 +409,20 @@ impl Engine {
             Some(budget) => FieldBloomIndex::build_with_budget(&self.rules, budget),
             None => FieldBloomIndex::build(&self.rules),
         };
+        #[cfg(feature = "daachorse-index")]
+        {
+            if self.cross_rule_ac_enabled {
+                self.cross_rule_ac_index = cross_rule_ac::CrossRuleAcIndex::build(&self.rules);
+                self.cross_rule_ac_prunable = self
+                    .rules
+                    .iter()
+                    .map(cross_rule_ac::rule_is_ac_prunable)
+                    .collect();
+            } else {
+                self.cross_rule_ac_index = cross_rule_ac::CrossRuleAcIndex::empty();
+                self.cross_rule_ac_prunable.clear();
+            }
+        }
     }
 
     /// Evaluate an event against candidate rules using the inverted index.
@@ -353,12 +434,52 @@ impl Engine {
         }
     }
 
+    /// Build the cross-rule AC keep-mask for `event`, or `None` when the
+    /// cross-rule index is disabled or empty (no filtering needed).
+    ///
+    /// `Some(mask)` answers "should this rule survive the cross-rule AC
+    /// filter": `mask[idx] = true` means keep, `false` means drop.
+    /// Non-AC-prunable rules are always kept.
+    #[cfg(feature = "daachorse-index")]
+    fn cross_rule_ac_keep_mask<E: Event>(&self, event: &E) -> Option<Vec<bool>> {
+        if !self.cross_rule_ac_enabled || self.cross_rule_ac_index.is_empty() {
+            return None;
+        }
+        let mut hits = vec![false; self.rules.len()];
+        self.cross_rule_ac_index.mark_hits(event, &mut hits);
+        // Compose: keep = !ac_prunable OR ac_hit. The prunable vector and
+        // the rule slice are kept aligned by `rebuild_index`.
+        for (idx, slot) in hits.iter_mut().enumerate() {
+            if !self
+                .cross_rule_ac_prunable
+                .get(idx)
+                .copied()
+                .unwrap_or(false)
+            {
+                *slot = true;
+            }
+        }
+        Some(hits)
+    }
+
+    #[cfg(not(feature = "daachorse-index"))]
+    #[inline(always)]
+    fn cross_rule_ac_keep_mask<E: Event>(&self, _event: &E) -> Option<Vec<bool>> {
+        None
+    }
+
     fn evaluate_no_bloom_path<E: Event>(&self, event: &E) -> Vec<MatchResult> {
         // The public `evaluate_rule` is not generic over `BloomLookup`, so
         // the no-bloom hot path lowers to straight-line code identical to
         // the pre-bloom engine.
+        let keep = self.cross_rule_ac_keep_mask(event);
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
+            if let Some(ref mask) = keep
+                && !mask[idx]
+            {
+                continue;
+            }
             let rule = &self.rules[idx];
             if let Some(mut m) = evaluate_rule(rule, event) {
                 if self.include_event && m.event.is_none() {
@@ -372,8 +493,14 @@ impl Engine {
 
     fn evaluate_with_bloom_path<E: Event>(&self, event: &E) -> Vec<MatchResult> {
         let bloom = BloomCache::new(&self.bloom_index, event);
+        let keep = self.cross_rule_ac_keep_mask(event);
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
+            if let Some(ref mask) = keep
+                && !mask[idx]
+            {
+                continue;
+            }
             let rule = &self.rules[idx];
             if let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom) {
                 if self.include_event && m.event.is_none() {
@@ -407,8 +534,14 @@ impl Engine {
         event: &E,
         event_logsource: &LogSource,
     ) -> Vec<MatchResult> {
+        let keep = self.cross_rule_ac_keep_mask(event);
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
+            if let Some(ref mask) = keep
+                && !mask[idx]
+            {
+                continue;
+            }
             let rule = &self.rules[idx];
             if logsource_matches(&rule.logsource, event_logsource)
                 && let Some(mut m) = evaluate_rule(rule, event)
@@ -428,8 +561,14 @@ impl Engine {
         event_logsource: &LogSource,
     ) -> Vec<MatchResult> {
         let bloom = BloomCache::new(&self.bloom_index, event);
+        let keep = self.cross_rule_ac_keep_mask(event);
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {
+            if let Some(ref mask) = keep
+                && !mask[idx]
+            {
+                continue;
+            }
             let rule = &self.rules[idx];
             if logsource_matches(&rule.logsource, event_logsource)
                 && let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom)

--- a/crates/rsigma-eval/tests/regression_eval.rs
+++ b/crates/rsigma-eval/tests/regression_eval.rs
@@ -360,3 +360,100 @@ transformations:
         "optimizer must run after pipeline field renaming"
     );
 }
+
+#[cfg(feature = "daachorse-index")]
+#[test]
+fn cross_rule_ac_preserves_match_results() {
+    // The cross-rule AC pre-filter is purely an optimization: enabling or
+    // disabling it must never change which rules fire on any event. This
+    // mirrors the bloom prefilter parity test for Phase 4.
+    let mut engine = engine_from(CONTAINS_HEAVY_RULES);
+
+    let events = vec![
+        json!({"EventType": "login", "Image": "C:/Windows/System32/explorer.exe"}),
+        json!({"Image": "C:/Tools/MIMIKATZ.exe", "CommandLine": "mimikatz.exe sekurlsa::logonpasswords"}),
+        json!({"Image": "C:/Windows/System32/powershell.exe", "CommandLine": "powershell.exe -enc aHR0cHM6Ly9ldmls"}),
+        json!({"Image": "/usr/bin/whoami", "CommandLine": "whoami /all"}),
+        json!({"Image": "/usr/bin/notepad.exe", "CommandLine": "notepad readme.txt"}),
+        // Pure-digit event: no positive substring patterns can hit, the
+        // cross-rule AC should drop AC-prunable rules; non-prunable rules
+        // (mixed with exact items) must still be evaluated.
+        json!({"Image": "0000000000", "CommandLine": "0000111122223333"}),
+        json!({}),
+    ];
+
+    let no_ac = evaluate_corpus(&engine, &events);
+
+    engine.set_cross_rule_ac(true);
+    let with_ac = evaluate_corpus(&engine, &events);
+
+    assert_eq!(no_ac, with_ac, "cross-rule AC changed match output");
+}
+
+#[cfg(feature = "daachorse-index")]
+#[test]
+fn cross_rule_ac_handles_negation_in_condition() {
+    // A rule with `not other` in its condition must NOT be classified as
+    // AC-prunable: dropping it on "no AC hit" would change semantics
+    // (the rule fires when the substring is absent).
+    let yaml = r#"
+title: Selection Without Substring
+id: selection-without-substring
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        EventType: 'process_create'
+    other:
+        CommandLine|contains: 'whoami'
+    condition: selection and not other
+level: medium
+"#;
+    let mut engine = engine_from(yaml);
+    engine.set_cross_rule_ac(true);
+
+    let events = vec![
+        // No 'whoami' in CommandLine; rule fires because `not other` is true.
+        json!({"EventType": "process_create", "CommandLine": "notepad foo"}),
+        // 'whoami' present; rule does NOT fire (other is true, negated to false).
+        json!({"EventType": "process_create", "CommandLine": "exec whoami"}),
+        // Pure digits; rule fires (whoami absent). The cross-rule AC must
+        // not drop this rule via "no hit" pruning.
+        json!({"EventType": "process_create", "CommandLine": "0123456789"}),
+    ];
+    let actual = evaluate_corpus(&engine, &events);
+
+    let expected: Vec<Vec<String>> = vec![
+        vec!["Selection Without Substring".into()],
+        Vec::<String>::new(),
+        vec!["Selection Without Substring".into()],
+    ];
+
+    assert_eq!(actual, expected);
+}
+
+#[cfg(feature = "daachorse-index")]
+#[test]
+fn cross_rule_ac_composes_with_bloom() {
+    // Both pre-filters can be enabled simultaneously. Output must remain
+    // identical to the no-prefilter baseline.
+    let mut engine = engine_from(CONTAINS_HEAVY_RULES);
+
+    let events = vec![
+        json!({"EventType": "login", "Image": "C:/Windows/System32/explorer.exe"}),
+        json!({"Image": "C:/Tools/MIMIKATZ.exe", "CommandLine": "mimikatz.exe foo"}),
+        json!({"Image": "/usr/bin/whoami", "CommandLine": "whoami /all"}),
+        json!({"Image": "0000000000", "CommandLine": "0000111122223333"}),
+    ];
+    let baseline = evaluate_corpus(&engine, &events);
+
+    engine.set_cross_rule_ac(true);
+    engine.set_bloom_prefilter(true);
+    let combined = evaluate_corpus(&engine, &events);
+
+    assert_eq!(
+        baseline, combined,
+        "cross-rule AC + bloom must agree with the no-prefilter baseline"
+    );
+}

--- a/crates/rsigma-parser/README.md
+++ b/crates/rsigma-parser/README.md
@@ -361,6 +361,7 @@ The `schema_violation` lint rule optionally validates rules against a JSON schem
 | `Yaml` | serde_yaml parse failure |
 | `Condition` | Condition expression parse failure (PEG/Pratt); carries optional `SourceLocation` with line/column |
 | `UnknownModifier` | Unknown modifier in field spec |
+| `NotIsNotAModifier` | The literal string `\|not` was used as a modifier; Sigma expresses negation at the condition level (`condition: not selection`) or via `\|neq` for inequality. Surfaced with guidance on how to rewrite the rule |
 | `InvalidFieldSpec` | Invalid field specification |
 | `InvalidRule` | Document not a mapping, or invalid structure |
 | `MissingField` | Required field missing (e.g. `title`, `detection`) |

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -16,6 +16,7 @@ otlp = ["opentelemetry-proto", "prost"]
 logfmt = []
 cef = []
 evtx = ["dep:evtx"]
+daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
 rsigma-parser = { path = "../rsigma-parser", version = "0.10.0" }

--- a/crates/rsigma-runtime/README.md
+++ b/crates/rsigma-runtime/README.md
@@ -134,6 +134,7 @@ let expanded_pipeline = TemplateExpander::expand(&pipeline, &resolved_map);
 | `evtx` | Enable EVTX (Windows Event Log) input adapter. Provides `EvtxFileReader` for reading `.evtx` files and iterating records as `serde_json::Value` |
 | `nats` | Enable NATS JetStream source and sink, NATS dynamic sources, and NATS control subject |
 | `otlp` | Enable OTLP log ingestion types and `LogRecord`-to-JSON conversion |
+| `daachorse-index` | Forward to `rsigma-eval/daachorse-index`. Enables `RuntimeEngine::set_cross_rule_ac` and the cross-rule Aho-Corasick pre-filter for large substring-heavy rule sets |
 
 ## License
 

--- a/crates/rsigma-runtime/src/engine.rs
+++ b/crates/rsigma-runtime/src/engine.rs
@@ -27,10 +27,15 @@ pub struct RuntimeEngine {
     /// Optional override for the bloom memory budget in bytes. `None`
     /// means use the eval crate default.
     bloom_max_bytes: Option<usize>,
+    /// Opt-in cross-rule Aho-Corasick pre-filter. Forwarded to the inner
+    /// detection engine on every rule reload. Available behind the
+    /// `daachorse-index` Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    cross_rule_ac: bool,
 }
 
 enum EngineVariant {
-    DetectionOnly(Engine),
+    DetectionOnly(Box<Engine>),
     WithCorrelations(Box<CorrelationEngine>),
 }
 
@@ -49,7 +54,7 @@ impl RuntimeEngine {
         include_event: bool,
     ) -> Self {
         RuntimeEngine {
-            engine: EngineVariant::DetectionOnly(Engine::new()),
+            engine: EngineVariant::DetectionOnly(Box::new(Engine::new())),
             pipelines,
             pipeline_paths: Vec::new(),
             rules_path,
@@ -59,6 +64,8 @@ impl RuntimeEngine {
             allow_remote_include: false,
             bloom_prefilter: false,
             bloom_max_bytes: None,
+            #[cfg(feature = "daachorse-index")]
+            cross_rule_ac: false,
         }
     }
 
@@ -73,6 +80,17 @@ impl RuntimeEngine {
     /// Applies on the next `load_rules()`.
     pub fn set_bloom_max_bytes(&mut self, max_bytes: usize) {
         self.bloom_max_bytes = Some(max_bytes);
+    }
+
+    /// Enable or disable the cross-rule Aho-Corasick pre-filter on the
+    /// inner detection engine. Off by default; the optimization helps only
+    /// on substring-heavy rule sets > ~5K rules. Applies on the next
+    /// `load_rules()`.
+    ///
+    /// Available behind the `daachorse-index` Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    pub fn set_cross_rule_ac(&mut self, enabled: bool) {
+        self.cross_rule_ac = enabled;
     }
 
     /// Set a source resolver for dynamic pipeline sources.
@@ -202,6 +220,8 @@ impl RuntimeEngine {
                 engine.set_bloom_max_bytes(budget);
             }
             engine.set_bloom_prefilter(self.bloom_prefilter);
+            #[cfg(feature = "daachorse-index")]
+            engine.set_cross_rule_ac(self.cross_rule_ac);
             for p in &self.pipelines {
                 engine.add_pipeline(p.clone());
             }
@@ -227,6 +247,8 @@ impl RuntimeEngine {
                 engine.set_bloom_max_bytes(budget);
             }
             engine.set_bloom_prefilter(self.bloom_prefilter);
+            #[cfg(feature = "daachorse-index")]
+            engine.set_cross_rule_ac(self.cross_rule_ac);
             for p in &self.pipelines {
                 engine.add_pipeline(p.clone());
             }
@@ -239,7 +261,7 @@ impl RuntimeEngine {
                 correlation_rules: 0,
                 state_entries: 0,
             };
-            self.engine = EngineVariant::DetectionOnly(engine);
+            self.engine = EngineVariant::DetectionOnly(Box::new(engine));
             Ok(stats)
         }
     }


### PR DESCRIPTION
## Summary

An opt-in cross-rule Aho-Corasick index built on [daachorse](https://crates.io/crates/daachorse), gated behind the new `daachorse-index` Cargo feature.

When enabled, the engine builds a single per-field `DoubleArrayAhoCorasick` automaton over every rule's positive substring needles and drops AC-prunable rules from the candidate set when none of their patterns hit the event. AC-prunable rules are conservatively classified: every detection must be built exclusively from positive substring matchers (`Contains` / `StartsWith` / `EndsWith` / `AhoCorasickSet`, optionally nested under `AnyOf` / `AllOf` / `CaseInsensitiveGroup`) and no condition may contain `Not`. Under those constraints, "no AC hit" provably implies the rule cannot fire.

Composes with Phase 4 (bloom): cross-rule AC drops whole rules, bloom short-circuits individual detection items.

## Public API (gated on `daachorse-index`)

- `Engine::set_cross_rule_ac(enabled)` / `Engine::cross_rule_ac_enabled()`
- `CorrelationEngine::set_cross_rule_ac(enabled)` (forwards to inner detection engine)
- `RuntimeEngine::set_cross_rule_ac(enabled)`
- CLI: `--cross-rule-ac` on `rsigma daemon` and `rsigma eval`

Off by default. Pattern count per field capped at 100K.

## Benchmarks

`eval_cross_rule_ac` group, 200 non-matching events against pure-substring rule sets (best-case workload):

| Rules  | Off (default)            | On (`set_cross_rule_ac(true)`)   | Speedup     |
|-------:|--------------------------|----------------------------------|-------------|
| 1,000  | 17.34 ms (11.5 Kelem/s)  | 253.0 us (790 Kelem/s)           | **~68x**    |
| 5,000  | 85.51 ms (2.34 Kelem/s)  | 883.0 us (226 Kelem/s)           | **~97x**    |
| 10,000 | 173.37 ms (1.15 Kelem/s) | 1.71 ms (117 Kelem/s)            | **~101x**   |

For typical mixed workloads the index adds overhead with smaller wins or none, which is why it is off by default. Recorded in `BENCHMARKS.md` alongside the AC threshold sweep.

## Test plan

- [x] `cargo test --workspace` passes (no feature)
- [x] `cargo test --workspace --features daachorse-index` passes
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] New unit tests in `engine/cross_rule_ac.rs`: extraction, dedup, hit marking, case-insensitive matching, shared patterns across rules, ac-prunable analysis (rejects mixed exact+substring, negation in conditions, keyword-only), 100K cap fallback
- [x] New differential regression tests in `tests/regression_eval.rs`: `cross_rule_ac_preserves_match_results`, `cross_rule_ac_handles_negation_in_condition`, `cross_rule_ac_composes_with_bloom`
- [x] `cargo bench -p rsigma-eval --features daachorse-index --bench eval -- eval_cross_rule_ac` runs cleanly with the throughput numbers above