### PR TITLE
feat: comprehensive daemon and CLI observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -4933,6 +4934,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,19 @@ Input formats are selected via `--input-format` on the CLI or `InputFormat` in t
 
 See [`examples/jsonl_stdin.rs`](crates/rsigma-runtime/examples/jsonl_stdin.rs) and [`examples/tail_syslog.rs`](crates/rsigma-runtime/examples/tail_syslog.rs) for complete working examples.
 
+## Observability
+
+The daemon emits Prometheus metrics on `/metrics` and structured JSON logs to stderr via [`tracing`](https://docs.rs/tracing). Verbosity is controlled with `RUST_LOG` (default `info`). Useful filter targets:
+
+| Filter | Surfaces |
+|--------|----------|
+| `RUST_LOG=info,tower_http=debug` | HTTP API access logs (method, URI, status, latency) for every REST request |
+| `RUST_LOG=info,rsigma=debug` | batch processing spans, DLQ routing, OTLP per-request fields, snapshot save duration |
+| `RUST_LOG=info,rsigma_runtime::sources=debug` | dynamic source resolution and refresh scheduler |
+| `RUST_LOG=info,rsigma_eval=debug` | correlation engine internals (chain depth, hard-cap eviction at `warn`) |
+
+`tracing` spans installed on hot paths (batch processing, source resolution, OTLP ingest, rule loading) double as profiling hooks consumable by `tokio-console` or `tracing-timing` without code changes. Non-daemon subcommands default to human-readable output; pass `--log-format json` (or `text`) to additionally install a stderr subscriber for CI/log aggregation use cases.
+
 ## Architecture
 
 Everything starts with a Sigma rule in YAML format:

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 
 [features]
 default = ["daemon"]
-daemon = ["rsigma-runtime", "tokio", "axum", "async-trait", "prometheus", "notify", "rusqlite"]
+daemon = ["rsigma-runtime", "tokio", "axum", "async-trait", "prometheus", "notify", "rusqlite", "tower-http"]
 daemon-nats = ["daemon", "rsigma-runtime/nats", "async-nats", "tokio-stream", "time"]
 daemon-otlp = ["daemon", "rsigma-runtime/otlp", "prost", "tonic", "flate2", "tokio-stream"]
 logfmt = ["rsigma-runtime/logfmt"]
@@ -48,6 +48,7 @@ async-trait = { version = "0.1", optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 notify = { version = "8.2", optional = true }
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
+tower-http = { version = "0.6", features = ["trace"], optional = true }
 async-nats = { version = "0.47", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 time = { version = "0.3", optional = true }

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -334,7 +334,16 @@ curl -X POST http://localhost:9090/v1/logs \
 
 The per-rule labeled counters (`_by_rule_total`) enable per-rule alerting in Grafana or other Prometheus-based tools. A single PromQL query like `increase(rsigma_detection_matches_by_rule_total[5m]) > 0` produces separate alert instances for each `{rule_title, level}` combination. The aggregate counters (`_total`) remain for lightweight total-throughput monitoring.
 
-**Logging:** structured JSON to stderr, configurable via `RUST_LOG` environment variable (default: `info`).
+**Logging:** structured JSON to stderr, configurable via `RUST_LOG` environment variable (default: `info`). Useful filter targets:
+
+- `RUST_LOG=info,tower_http=debug` — HTTP API access logs (method, URI, status, latency) for every request to `/api/v1/*`, `/healthz`, `/metrics`.
+- `RUST_LOG=info,rsigma=debug` — verbose batch processing (`Batch processed` events with `batch_size`, `matches`, `elapsed_ms`), DLQ routing, source resolution timing, state snapshot duration, and OTLP per-request fields.
+- `RUST_LOG=info,rsigma_runtime::sources=debug` — dynamic source resolution and refresh scheduler details.
+- `RUST_LOG=info,rsigma_eval=debug` — correlation engine internals (chain depth limits, hard-cap eviction warnings already emit at `warn`).
+
+The `tracing` spans installed on hot paths (batch processing, source resolution, OTLP ingest, rule loading) double as profiling hooks consumable by `tokio-console` or `tracing-timing` without code changes—just swap in the corresponding subscriber layer.
+
+**CLI subcommand logging:** non-daemon subcommands (`eval`, `lint`, `validate`, `convert`, `fields`, `parse`, `resolve`) default to human-readable stdout/stderr output only. Pass the global `--log-format json` (or `--log-format text`) to additionally install a tracing subscriber on stderr for CI/log aggregation use cases. Verbosity follows `RUST_LOG` (default `info`). Human-readable output is unchanged when the flag is set.
 
 **State persistence:** when `--state-db` is set, correlation state (window entries, suppression timestamps, event buffers) is persisted to a SQLite database. State is loaded on startup, saved periodically (default every 30s, configurable via `--state-save-interval`), and saved on graceful shutdown. This allows correlation windows to survive daemon restarts. For example, an `event_count` correlation that saw 2 of 3 required events before a restart will resume from 2 after restarting. The database uses WAL journal mode and stores a single JSON snapshot row. Correlation entries are keyed by stable rule identifiers (id/name), so state survives rule reloads even if internal ordering changes.
 

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -170,6 +170,12 @@ fn cmd_eval_with_correlations(
         engine.correlation_rule_count(),
         rules_path.display(),
     );
+    tracing::info!(
+        detection_rules = engine.detection_rule_count(),
+        correlation_rules = engine.correlation_rule_count(),
+        rules_path = %rules_path.display(),
+        "Rules loaded",
+    );
 
     match event_source {
         EventSource::SingleJson(json_str) => {
@@ -422,6 +428,12 @@ fn cmd_eval_detection_only(
         "Loaded {} rules from {}",
         engine.rule_count(),
         rules_path.display()
+    );
+    tracing::info!(
+        detection_rules = engine.rule_count(),
+        correlation_rules = 0,
+        rules_path = %rules_path.display(),
+        "Rules loaded",
     );
 
     match event_source {

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -152,6 +152,15 @@ pub(crate) fn cmd_lint(
         warnings_colored,
         infos_colored,
     );
+    tracing::info!(
+        files = total_files,
+        passed,
+        failed = failed_files,
+        errors = total_errors,
+        warnings = total_warnings,
+        infos = total_infos,
+        "Lint summary",
+    );
 
     // 6. Apply fixes if requested
     if apply_fix {

--- a/crates/rsigma-cli/src/commands/validate.rs
+++ b/crates/rsigma-cli/src/commands/validate.rs
@@ -77,6 +77,15 @@ pub(crate) fn cmd_validate(
             println!("  Correlation rules: {correlations}");
             println!("  Filter rules:      {filters}");
             println!("  Parse errors:      {parse_errors}");
+            tracing::info!(
+                total,
+                detection_rules = rules,
+                correlation_rules = correlations,
+                filter_rules = filters,
+                parse_errors,
+                rules_path = %path.display(),
+                "Validation parsed",
+            );
 
             let mut engine = Engine::new();
             for p in &pipelines {

--- a/crates/rsigma-cli/src/daemon/health.rs
+++ b/crates/rsigma-cli/src/daemon/health.rs
@@ -24,3 +24,21 @@ impl HealthState {
         self.ready.load(Ordering::Acquire)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_ready_records_transition_correctly() {
+        let state = HealthState::new();
+        assert!(!state.is_ready());
+        state.set_ready(true);
+        assert!(state.is_ready());
+        // No-op transition: still ready, no panic, no flip.
+        state.set_ready(true);
+        assert!(state.is_ready());
+        state.set_ready(false);
+        assert!(!state.is_ready());
+    }
+}

--- a/crates/rsigma-cli/src/daemon/health.rs
+++ b/crates/rsigma-cli/src/daemon/health.rs
@@ -14,7 +14,10 @@ impl HealthState {
     }
 
     pub fn set_ready(&self, ready: bool) {
-        self.ready.store(ready, Ordering::Release);
+        let previous = self.ready.swap(ready, Ordering::AcqRel);
+        if previous != ready {
+            tracing::info!(ready, "Readiness state changed");
+        }
     }
 
     pub fn is_ready(&self) -> bool {

--- a/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
+++ b/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use rsigma_eval::pipeline::sources::{DynamicSource, SourceType};
 use rsigma_runtime::sources::{ResolvedValue, SourceError, SourceResolver};
+use tracing::Instrument;
 
 use super::metrics::Metrics;
 
@@ -43,57 +44,64 @@ impl SourceResolver for InstrumentedResolver {
             source_id = %source.id,
             source_type = source_type_label,
         );
-        let _enter = span.enter();
 
-        let start = Instant::now();
-        let result = self.inner.resolve(source).await;
-        let elapsed = start.elapsed();
-        let elapsed_secs = elapsed.as_secs_f64();
+        // Use Instrument rather than .enter() because the inner resolve can do
+        // long-running async work (HTTP, command, file IO); .enter() across
+        // .await produces confused span nesting on the multi-threaded runtime.
+        async move {
+            let start = Instant::now();
+            let result = self.inner.resolve(source).await;
+            let elapsed = start.elapsed();
 
-        self.metrics.source_resolve_latency.observe(elapsed_secs);
+            self.metrics
+                .source_resolve_latency
+                .observe(elapsed.as_secs_f64());
 
-        match &result {
-            Ok(value) => {
-                if value.from_cache {
-                    self.metrics.source_cache_hits.inc();
-                }
-                self.metrics
-                    .source_last_resolved
-                    .with_label_values(&[source.id.as_str()])
-                    .set(
-                        std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs_f64(),
+            match &result {
+                Ok(value) => {
+                    if value.from_cache {
+                        self.metrics.source_cache_hits.inc();
+                    }
+                    self.metrics
+                        .source_last_resolved
+                        .with_label_values(&[source.id.as_str()])
+                        .set(
+                            std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs_f64(),
+                        );
+                    tracing::debug!(
+                        cache_hit = value.from_cache,
+                        duration_ms = elapsed.as_millis() as u64,
+                        "Source resolved",
                     );
-                tracing::debug!(
-                    cache_hit = value.from_cache,
-                    duration_ms = elapsed.as_millis() as u64,
-                    "Source resolved",
-                );
+                }
+                Err(e) => {
+                    let error_kind = match &e.kind {
+                        rsigma_runtime::SourceErrorKind::Fetch(_) => "Fetch",
+                        rsigma_runtime::SourceErrorKind::Parse(_) => "Parse",
+                        rsigma_runtime::SourceErrorKind::Extract(_) => "Extract",
+                        rsigma_runtime::SourceErrorKind::Timeout => "Timeout",
+                        rsigma_runtime::SourceErrorKind::ResourceLimit(_) => "ResourceLimit",
+                    };
+                    self.metrics
+                        .source_resolve_errors
+                        .with_label_values(&[source.id.as_str(), error_kind])
+                        .inc();
+                    tracing::warn!(
+                        error_kind,
+                        error = %e,
+                        duration_ms = elapsed.as_millis() as u64,
+                        "Source resolution failed",
+                    );
+                }
             }
-            Err(e) => {
-                let error_kind = match &e.kind {
-                    rsigma_runtime::SourceErrorKind::Fetch(_) => "Fetch",
-                    rsigma_runtime::SourceErrorKind::Parse(_) => "Parse",
-                    rsigma_runtime::SourceErrorKind::Extract(_) => "Extract",
-                    rsigma_runtime::SourceErrorKind::Timeout => "Timeout",
-                    rsigma_runtime::SourceErrorKind::ResourceLimit(_) => "ResourceLimit",
-                };
-                self.metrics
-                    .source_resolve_errors
-                    .with_label_values(&[source.id.as_str(), error_kind])
-                    .inc();
-                tracing::warn!(
-                    error_kind,
-                    error = %e,
-                    duration_ms = elapsed.as_millis() as u64,
-                    "Source resolution failed",
-                );
-            }
-        }
 
-        result
+            result
+        }
+        .instrument(span)
+        .await
     }
 }
 

--- a/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
+++ b/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
@@ -38,11 +38,19 @@ impl SourceResolver for InstrumentedResolver {
             .with_label_values(&[source.id.as_str(), source_type_label])
             .inc();
 
+        let span = tracing::debug_span!(
+            "resolve_source",
+            source_id = %source.id,
+            source_type = source_type_label,
+        );
+        let _enter = span.enter();
+
         let start = Instant::now();
         let result = self.inner.resolve(source).await;
-        let elapsed = start.elapsed().as_secs_f64();
+        let elapsed = start.elapsed();
+        let elapsed_secs = elapsed.as_secs_f64();
 
-        self.metrics.source_resolve_latency.observe(elapsed);
+        self.metrics.source_resolve_latency.observe(elapsed_secs);
 
         match &result {
             Ok(value) => {
@@ -58,6 +66,11 @@ impl SourceResolver for InstrumentedResolver {
                             .unwrap_or_default()
                             .as_secs_f64(),
                     );
+                tracing::debug!(
+                    cache_hit = value.from_cache,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "Source resolved",
+                );
             }
             Err(e) => {
                 let error_kind = match &e.kind {
@@ -71,6 +84,12 @@ impl SourceResolver for InstrumentedResolver {
                     .source_resolve_errors
                     .with_label_values(&[source.id.as_str(), error_kind])
                     .inc();
+                tracing::warn!(
+                    error_kind,
+                    error = %e,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "Source resolution failed",
+                );
             }
         }
 

--- a/crates/rsigma-cli/src/daemon/reload.rs
+++ b/crates/rsigma-cli/src/daemon/reload.rs
@@ -14,19 +14,32 @@ pub fn spawn_file_watcher(
 ) -> Option<RecommendedWatcher> {
     let tx = reload_tx.clone();
     let mut watcher = match RecommendedWatcher::new(
-        move |res: Result<Event, notify::Error>| {
-            if let Ok(event) = res
-                && matches!(
+        move |res: Result<Event, notify::Error>| match res {
+            Ok(event) => {
+                if matches!(
                     event.kind,
                     EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
-                )
-            {
-                let is_yaml = event.paths.iter().any(|p| {
-                    matches!(p.extension().and_then(|e| e.to_str()), Some("yml" | "yaml"))
-                });
-                if is_yaml {
-                    let _ = tx.try_send(());
+                ) {
+                    let is_yaml = event.paths.iter().any(|p| {
+                        matches!(p.extension().and_then(|e| e.to_str()), Some("yml" | "yaml"))
+                    });
+                    if is_yaml {
+                        match tx.try_send(()) {
+                            Ok(()) => {}
+                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                tracing::debug!(
+                                    "Reload channel full, event coalesced into pending reload"
+                                );
+                            }
+                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                tracing::warn!("Reload channel closed, watcher event dropped");
+                            }
+                        }
+                    }
                 }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "File watcher error");
             }
         },
         notify::Config::default(),

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -17,6 +17,8 @@ use rsigma_runtime::{
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tower_http::trace::TraceLayer;
+#[cfg(feature = "daemon-otlp")]
+use tracing::Instrument;
 
 /// A dead-letter queue entry for events that fail processing.
 #[derive(Serialize)]
@@ -618,79 +620,84 @@ pub async fn run_daemon(config: DaemonConfig) {
                 batch_size = initial_batch_size,
                 input_format = ?input_format,
             );
-            let _batch_guard = batch_span.enter();
 
-            // Pre-parse: route parse failures to DLQ before processing.
-            let mut valid_payloads = Vec::with_capacity(batch.len());
-            let mut valid_tokens = Vec::with_capacity(batch.len());
+            // Use Instrument rather than .enter() because the batch processing
+            // awaits on multiple channels; .enter() across .await produces
+            // confused span nesting on the multi-threaded runtime.
+            let shutdown = tracing::Instrument::instrument(
+                async {
+                    let mut valid_payloads = Vec::with_capacity(batch.len());
+                    let mut valid_tokens = Vec::with_capacity(batch.len());
 
-            for raw_event in batch {
-                if dlq_enabled
-                    && !raw_event.payload.trim().is_empty()
-                    && rsigma_runtime::parse_line(&raw_event.payload, &input_format).is_none()
-                {
-                    tracing::debug!("Event routed to DLQ: parse error");
-                    if engine_dlq_tx
-                        .send(DlqEntry {
-                            original_event: raw_event.payload,
-                            error: "parse error".to_string(),
-                            timestamp: chrono::Utc::now().to_rfc3339(),
-                        })
-                        .await
-                        .is_err()
-                    {
-                        tracing::warn!("DLQ channel closed, parse-error event dropped");
+                    for raw_event in batch {
+                        if dlq_enabled
+                            && !raw_event.payload.trim().is_empty()
+                            && rsigma_runtime::parse_line(&raw_event.payload, &input_format)
+                                .is_none()
+                        {
+                            tracing::debug!("Event routed to DLQ: parse error");
+                            if engine_dlq_tx
+                                .send(DlqEntry {
+                                    original_event: raw_event.payload,
+                                    error: "parse error".to_string(),
+                                    timestamp: chrono::Utc::now().to_rfc3339(),
+                                })
+                                .await
+                                .is_err()
+                            {
+                                tracing::warn!("DLQ channel closed, parse-error event dropped");
+                            }
+                            if engine_ack_tx.send(raw_event.ack_token).await.is_err() {
+                                return true;
+                            }
+                            continue;
+                        }
+                        valid_payloads.push(raw_event.payload);
+                        valid_tokens.push(raw_event.ack_token);
                     }
-                    if engine_ack_tx.send(raw_event.ack_token).await.is_err() {
-                        break;
+
+                    if valid_payloads.is_empty() {
+                        return false;
                     }
-                    continue;
-                }
-                valid_payloads.push(raw_event.payload);
-                valid_tokens.push(raw_event.ack_token);
-            }
 
-            if valid_payloads.is_empty() {
-                engine_metrics.observe_pipeline_latency(pipeline_start.elapsed().as_secs_f64());
-                continue;
-            }
+                    let process_start = std::time::Instant::now();
+                    let results: Vec<ProcessResult> = engine_processor.process_batch_with_format(
+                        &valid_payloads,
+                        &input_format,
+                        Some(&filter_fn),
+                    );
+                    let process_elapsed_ms = process_start.elapsed().as_millis() as u64;
+                    let match_count = results
+                        .iter()
+                        .filter(|r| !r.detections.is_empty() || !r.correlations.is_empty())
+                        .count();
+                    tracing::debug!(
+                        batch_size = valid_payloads.len(),
+                        matches = match_count,
+                        elapsed_ms = process_elapsed_ms,
+                        "Batch processed",
+                    );
 
-            let process_start = std::time::Instant::now();
-            let results: Vec<ProcessResult> = engine_processor.process_batch_with_format(
-                &valid_payloads,
-                &input_format,
-                Some(&filter_fn),
-            );
-            let process_elapsed_ms = process_start.elapsed().as_millis() as u64;
-            let match_count = results
-                .iter()
-                .filter(|r| !r.detections.is_empty() || !r.correlations.is_empty())
-                .count();
-            tracing::debug!(
-                batch_size = valid_payloads.len(),
-                matches = match_count,
-                elapsed_ms = process_elapsed_ms,
-                "Batch processed",
-            );
-
-            let mut shutdown = false;
-
-            for (result, ack_token) in results.into_iter().zip(valid_tokens) {
-                if result.detections.is_empty() && result.correlations.is_empty() {
-                    if engine_ack_tx.send(ack_token).await.is_err() {
-                        tracing::debug!("Ack channel closed, engine shutting down");
-                        shutdown = true;
-                        break;
+                    for (result, ack_token) in results.into_iter().zip(valid_tokens) {
+                        if result.detections.is_empty() && result.correlations.is_empty() {
+                            if engine_ack_tx.send(ack_token).await.is_err() {
+                                tracing::debug!("Ack channel closed, engine shutting down");
+                                return true;
+                            }
+                            continue;
+                        }
+                        engine_metrics.on_output_queue_depth_change(1);
+                        if sink_tx.send((result, vec![ack_token])).await.is_err() {
+                            tracing::debug!("Sink channel closed, engine shutting down");
+                            return true;
+                        }
                     }
-                    continue;
-                }
-                engine_metrics.on_output_queue_depth_change(1);
-                if sink_tx.send((result, vec![ack_token])).await.is_err() {
-                    tracing::debug!("Sink channel closed, engine shutting down");
-                    shutdown = true;
-                    break;
-                }
-            }
+
+                    false
+                },
+                batch_span,
+            )
+            .await;
 
             engine_metrics.observe_pipeline_latency(pipeline_start.elapsed().as_secs_f64());
 
@@ -1370,7 +1377,8 @@ async fn otlp_http_logs(
     let content_type = headers
         .get(axum::http::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/x-protobuf");
+        .unwrap_or("application/x-protobuf")
+        .to_string();
 
     let is_proto = content_type.starts_with("application/x-protobuf")
         || content_type.starts_with("application/protobuf");
@@ -1378,121 +1386,123 @@ async fn otlp_http_logs(
     let encoding = if is_proto { "protobuf" } else { "json" };
 
     let span = tracing::debug_span!("otlp_ingest", transport = "http", encoding);
-    let _enter = span.enter();
+    async move {
+        if !is_proto && !is_json {
+            state
+                .metrics
+                .otlp_errors
+                .with_label_values(&["http", "unsupported_content_type"])
+                .inc();
+            return (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "unsupported content-type: {content_type} \
+                         (expected application/x-protobuf or application/json)"
+                    )
+                })),
+            )
+                .into_response();
+        }
 
-    if !is_proto && !is_json {
+        let body = match otlp_maybe_decompress(&headers, body) {
+            Ok(b) => b,
+            Err(e) => {
+                state
+                    .metrics
+                    .otlp_errors
+                    .with_label_values(&["http", "decompression"])
+                    .inc();
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!("decompression error: {e}")
+                    })),
+                )
+                    .into_response();
+            }
+        };
+
+        let request = if is_proto {
+            use prost::Message;
+            match rsigma_runtime::ExportLogsServiceRequest::decode(body) {
+                Ok(req) => req,
+                Err(e) => {
+                    state
+                        .metrics
+                        .otlp_errors
+                        .with_label_values(&["http", "decode"])
+                        .inc();
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": format!("protobuf decode error: {e}")
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        } else {
+            match serde_json::from_slice::<rsigma_runtime::ExportLogsServiceRequest>(&body) {
+                Ok(req) => req,
+                Err(e) => {
+                    state
+                        .metrics
+                        .otlp_errors
+                        .with_label_values(&["http", "decode"])
+                        .inc();
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": format!("JSON decode error: {e}")
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        };
+
         state
             .metrics
-            .otlp_errors
-            .with_label_values(&["http", "unsupported_content_type"])
+            .otlp_requests
+            .with_label_values(&["http", encoding])
             .inc();
-        return (
-            StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            Json(serde_json::json!({
-                "error": format!(
-                    "unsupported content-type: {content_type} \
-                     (expected application/x-protobuf or application/json)"
+
+        let raw_events = rsigma_runtime::logs_request_to_raw_events(&request);
+        let record_count = raw_events.len();
+        state.metrics.otlp_log_records.inc_by(record_count as u64);
+        tracing::debug!(record_count, "OTLP logs ingested");
+
+        for event in raw_events {
+            if state.otlp_event_tx.send(event).await.is_err() {
+                state
+                    .metrics
+                    .otlp_errors
+                    .with_label_values(&["http", "channel_closed"])
+                    .inc();
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({
+                        "error": "event channel closed"
+                    })),
                 )
+                    .into_response();
+            }
+        }
+
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "partialSuccess": {
+                    "rejectedLogRecords": 0,
+                    "errorMessage": ""
+                }
             })),
         )
-            .into_response();
+            .into_response()
     }
-
-    let body = match otlp_maybe_decompress(&headers, body) {
-        Ok(b) => b,
-        Err(e) => {
-            state
-                .metrics
-                .otlp_errors
-                .with_label_values(&["http", "decompression"])
-                .inc();
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": format!("decompression error: {e}")
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let request = if is_proto {
-        use prost::Message;
-        match rsigma_runtime::ExportLogsServiceRequest::decode(body) {
-            Ok(req) => req,
-            Err(e) => {
-                state
-                    .metrics
-                    .otlp_errors
-                    .with_label_values(&["http", "decode"])
-                    .inc();
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "error": format!("protobuf decode error: {e}")
-                    })),
-                )
-                    .into_response();
-            }
-        }
-    } else {
-        match serde_json::from_slice::<rsigma_runtime::ExportLogsServiceRequest>(&body) {
-            Ok(req) => req,
-            Err(e) => {
-                state
-                    .metrics
-                    .otlp_errors
-                    .with_label_values(&["http", "decode"])
-                    .inc();
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "error": format!("JSON decode error: {e}")
-                    })),
-                )
-                    .into_response();
-            }
-        }
-    };
-
-    state
-        .metrics
-        .otlp_requests
-        .with_label_values(&["http", encoding])
-        .inc();
-
-    let raw_events = rsigma_runtime::logs_request_to_raw_events(&request);
-    let record_count = raw_events.len();
-    state.metrics.otlp_log_records.inc_by(record_count as u64);
-    tracing::debug!(record_count, "OTLP logs ingested");
-
-    for event in raw_events {
-        if state.otlp_event_tx.send(event).await.is_err() {
-            state
-                .metrics
-                .otlp_errors
-                .with_label_values(&["http", "channel_closed"])
-                .inc();
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({
-                    "error": "event channel closed"
-                })),
-            )
-                .into_response();
-        }
-    }
-
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "partialSuccess": {
-                "rejectedLogRecords": 0,
-                "errorMessage": ""
-            }
-        })),
-    )
-        .into_response()
+    .instrument(span)
+    .await
 }
 
 #[cfg(feature = "daemon-otlp")]
@@ -1530,31 +1540,33 @@ impl rsigma_runtime::LogsService for OtlpLogsGrpcService {
         request: tonic::Request<rsigma_runtime::ExportLogsServiceRequest>,
     ) -> Result<tonic::Response<rsigma_runtime::ExportLogsServiceResponse>, tonic::Status> {
         let span = tracing::debug_span!("otlp_ingest", transport = "grpc", encoding = "protobuf");
-        let _enter = span.enter();
+        async move {
+            self.metrics
+                .otlp_requests
+                .with_label_values(&["grpc", "protobuf"])
+                .inc();
 
-        self.metrics
-            .otlp_requests
-            .with_label_values(&["grpc", "protobuf"])
-            .inc();
+            let raw_events = rsigma_runtime::logs_request_to_raw_events(&request.into_inner());
+            let record_count = raw_events.len();
+            self.metrics.otlp_log_records.inc_by(record_count as u64);
+            tracing::debug!(record_count, "OTLP logs ingested");
 
-        let raw_events = rsigma_runtime::logs_request_to_raw_events(&request.into_inner());
-        let record_count = raw_events.len();
-        self.metrics.otlp_log_records.inc_by(record_count as u64);
-        tracing::debug!(record_count, "OTLP logs ingested");
+            for event in raw_events {
+                self.event_tx.send(event).await.map_err(|_| {
+                    self.metrics
+                        .otlp_errors
+                        .with_label_values(&["grpc", "channel_closed"])
+                        .inc();
+                    tonic::Status::unavailable("event channel closed")
+                })?;
+            }
 
-        for event in raw_events {
-            self.event_tx.send(event).await.map_err(|_| {
-                self.metrics
-                    .otlp_errors
-                    .with_label_values(&["grpc", "channel_closed"])
-                    .inc();
-                tonic::Status::unavailable("event channel closed")
-            })?;
+            Ok(tonic::Response::new(
+                rsigma_runtime::ExportLogsServiceResponse::default(),
+            ))
         }
-
-        Ok(tonic::Response::new(
-            rsigma_runtime::ExportLogsServiceResponse::default(),
-        ))
+        .instrument(span)
+        .await
     }
 }
 

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -440,10 +440,23 @@ pub async fn run_daemon(config: DaemonConfig) {
                 interval.tick().await;
                 if let Some(snapshot) = save_processor.export_state() {
                     let position = source_position_from_atomics(&save_hw_seq, &save_hw_ts);
+                    let snapshot_size = serde_json::to_vec(&snapshot).map(|v| v.len()).unwrap_or(0);
+                    let window_count = snapshot.windows.len();
+                    let save_start = std::time::Instant::now();
                     if let Err(e) = save_store.save(&snapshot, position.as_ref()).await {
-                        tracing::warn!(error = %e, "Failed to save periodic state snapshot");
+                        tracing::warn!(
+                            error = %e,
+                            size_bytes = snapshot_size,
+                            windows = window_count,
+                            "Failed to save periodic state snapshot",
+                        );
                     } else {
-                        tracing::debug!("Periodic state snapshot saved");
+                        tracing::debug!(
+                            duration_ms = save_start.elapsed().as_millis() as u64,
+                            size_bytes = snapshot_size,
+                            windows = window_count,
+                            "Periodic state snapshot saved",
+                        );
                     }
                 }
             }
@@ -811,12 +824,16 @@ pub async fn run_daemon(config: DaemonConfig) {
 
         if let Some(h) = source_handle {
             h.abort();
+            tracing::info!("Source task aborted");
         }
 
         let drain = async {
             let _ = sink_handle.await;
+            tracing::debug!("Sink task finished");
             let _ = dlq_handle.await;
+            tracing::debug!("DLQ task finished");
             let _ = ack_handle.await;
+            tracing::debug!("Ack task finished");
         };
         if tokio::time::timeout(drain_duration, drain).await.is_err() {
             tracing::warn!(
@@ -826,8 +843,11 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
     } else {
         let _ = sink_handle.await;
+        tracing::debug!("Sink task finished");
         let _ = dlq_handle.await;
+        tracing::debug!("DLQ task finished");
         let _ = ack_handle.await;
+        tracing::debug!("Ack task finished");
     }
 
     // Save state on shutdown

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -1357,6 +1357,9 @@ async fn otlp_http_logs(
     let is_json = content_type.starts_with("application/json");
     let encoding = if is_proto { "protobuf" } else { "json" };
 
+    let span = tracing::debug_span!("otlp_ingest", transport = "http", encoding);
+    let _enter = span.enter();
+
     if !is_proto && !is_json {
         state
             .metrics
@@ -1439,10 +1442,9 @@ async fn otlp_http_logs(
         .inc();
 
     let raw_events = rsigma_runtime::logs_request_to_raw_events(&request);
-    state
-        .metrics
-        .otlp_log_records
-        .inc_by(raw_events.len() as u64);
+    let record_count = raw_events.len();
+    state.metrics.otlp_log_records.inc_by(record_count as u64);
+    tracing::debug!(record_count, "OTLP logs ingested");
 
     for event in raw_events {
         if state.otlp_event_tx.send(event).await.is_err() {
@@ -1507,15 +1509,18 @@ impl rsigma_runtime::LogsService for OtlpLogsGrpcService {
         &self,
         request: tonic::Request<rsigma_runtime::ExportLogsServiceRequest>,
     ) -> Result<tonic::Response<rsigma_runtime::ExportLogsServiceResponse>, tonic::Status> {
+        let span = tracing::debug_span!("otlp_ingest", transport = "grpc", encoding = "protobuf");
+        let _enter = span.enter();
+
         self.metrics
             .otlp_requests
             .with_label_values(&["grpc", "protobuf"])
             .inc();
 
         let raw_events = rsigma_runtime::logs_request_to_raw_events(&request.into_inner());
-        self.metrics
-            .otlp_log_records
-            .inc_by(raw_events.len() as u64);
+        let record_count = raw_events.len();
+        self.metrics.otlp_log_records.inc_by(record_count as u64);
+        tracing::debug!(record_count, "OTLP logs ingested");
 
         for event in raw_events {
             self.event_tx.send(event).await.map_err(|_| {

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -16,6 +16,7 @@ use rsigma_runtime::{
 };
 use serde::Serialize;
 use tokio::sync::mpsc;
+use tower_http::trace::TraceLayer;
 
 /// A dead-letter queue entry for events that fail processing.
 #[derive(Serialize)]
@@ -349,7 +350,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     #[cfg(feature = "daemon-otlp")]
     let app = app.route("/v1/logs", post(otlp_http_logs));
 
-    let app = app.with_state(app_state);
+    let app = app.layer(TraceLayer::new_for_http()).with_state(app_state);
 
     let listener = tokio::net::TcpListener::bind(config.api_addr)
         .await

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -598,7 +598,14 @@ pub async fn run_daemon(config: DaemonConfig) {
                     Err(_) => break,
                 }
             }
-            engine_metrics.observe_batch_size(batch.len() as u64);
+            let initial_batch_size = batch.len();
+            engine_metrics.observe_batch_size(initial_batch_size as u64);
+            let batch_span = tracing::debug_span!(
+                "process_batch",
+                batch_size = initial_batch_size,
+                input_format = ?input_format,
+            );
+            let _batch_guard = batch_span.enter();
 
             // Pre-parse: route parse failures to DLQ before processing.
             let mut valid_payloads = Vec::with_capacity(batch.len());
@@ -609,13 +616,18 @@ pub async fn run_daemon(config: DaemonConfig) {
                     && !raw_event.payload.trim().is_empty()
                     && rsigma_runtime::parse_line(&raw_event.payload, &input_format).is_none()
                 {
-                    let _ = engine_dlq_tx
+                    tracing::debug!("Event routed to DLQ: parse error");
+                    if engine_dlq_tx
                         .send(DlqEntry {
                             original_event: raw_event.payload,
                             error: "parse error".to_string(),
                             timestamp: chrono::Utc::now().to_rfc3339(),
                         })
-                        .await;
+                        .await
+                        .is_err()
+                    {
+                        tracing::warn!("DLQ channel closed, parse-error event dropped");
+                    }
                     if engine_ack_tx.send(raw_event.ack_token).await.is_err() {
                         break;
                     }
@@ -630,10 +642,22 @@ pub async fn run_daemon(config: DaemonConfig) {
                 continue;
             }
 
+            let process_start = std::time::Instant::now();
             let results: Vec<ProcessResult> = engine_processor.process_batch_with_format(
                 &valid_payloads,
                 &input_format,
                 Some(&filter_fn),
+            );
+            let process_elapsed_ms = process_start.elapsed().as_millis() as u64;
+            let match_count = results
+                .iter()
+                .filter(|r| !r.detections.is_empty() || !r.correlations.is_empty())
+                .count();
+            tracing::debug!(
+                batch_size = valid_payloads.len(),
+                matches = match_count,
+                elapsed_ms = process_elapsed_ms,
+                "Batch processed",
             );
 
             let mut shutdown = false;
@@ -714,7 +738,9 @@ pub async fn run_daemon(config: DaemonConfig) {
     // DLQ writer task: writes DLQ entries to the configured DLQ sink.
     let dlq_metrics = metrics.clone();
     let dlq_handle = tokio::spawn(async move {
+        tracing::debug!("DLQ task started");
         let mut dlq_sink = dlq_sink;
+        let mut no_sink_logged = false;
         while let Some(entry) = dlq_rx.recv().await {
             dlq_metrics.dlq_events.inc();
             if let Some(ref mut sink) = dlq_sink {
@@ -722,8 +748,12 @@ pub async fn run_daemon(config: DaemonConfig) {
                 if let Err(e) = sink.send_raw(&json).await {
                     tracing::warn!(error = %e, "Failed to write to DLQ sink");
                 }
+            } else if !no_sink_logged {
+                tracing::debug!("DLQ entry counted but no sink configured (use --dlq to persist)");
+                no_sink_logged = true;
             }
         }
+        tracing::debug!("DLQ task finished");
     });
 
     // Ack task: resolves ack tokens after the sink confirms delivery.

--- a/crates/rsigma-cli/src/daemon/store.rs
+++ b/crates/rsigma-cli/src/daemon/store.rs
@@ -46,6 +46,8 @@ impl SqliteStateStore {
 
         Self::migrate(&conn)?;
 
+        tracing::debug!(path = %path.display(), "State store opened");
+
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })
@@ -75,6 +77,10 @@ impl SqliteStateStore {
                 "#,
             )
             .map_err(|e| format!("migrate source position columns: {e}"))?;
+            tracing::debug!(
+                added_columns = "source_sequence,source_timestamp",
+                "State store schema migrated",
+            );
         }
 
         Ok(())

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -21,8 +21,27 @@ use serde_json_path::JsonPath;
 #[command(about = "Parse, validate, and evaluate Sigma detection rules")]
 #[command(version)]
 struct Cli {
+    /// Emit structured diagnostic logs to stderr (for CI / log aggregation).
+    ///
+    /// When set, initializes a tracing-subscriber on stderr using the chosen
+    /// format. Verbosity is controlled via the RUST_LOG environment variable
+    /// (default: info). Human-readable stdout/stderr output is unchanged;
+    /// this flag only adds machine-readable diagnostic logs alongside it.
+    ///
+    /// Has no effect on the `daemon` subcommand, which always logs JSON.
+    #[arg(long = "log-format", value_enum, global = true)]
+    log_format: Option<LogFormat>,
+
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum LogFormat {
+    /// Structured JSON (one object per line).
+    Json,
+    /// Human-readable text with ANSI colors when stderr is a TTY.
+    Text,
 }
 
 #[derive(Subcommand)]
@@ -569,6 +588,16 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
 
+    // Daemon installs its own JSON subscriber unconditionally; only init for
+    // other subcommands when the user opts in via --log-format.
+    #[cfg(feature = "daemon")]
+    let is_daemon = matches!(cli.command, Commands::Daemon { .. });
+    #[cfg(not(feature = "daemon"))]
+    let is_daemon = false;
+    if !is_daemon && let Some(format) = cli.log_format {
+        init_cli_log_subscriber(format);
+    }
+
     match cli.command {
         #[cfg(feature = "daemon")]
         Commands::Daemon {
@@ -822,6 +851,28 @@ fn main() {
             pretty,
             dry_run,
         } => commands::cmd_resolve(pipelines, source, pretty, dry_run),
+    }
+}
+
+/// Initialize a stderr tracing subscriber for non-daemon subcommands.
+///
+/// Verbosity follows `RUST_LOG` and defaults to `info`. Errors during global
+/// subscriber registration are ignored so the CLI keeps working even if the
+/// flag is passed twice or another consumer of the process already installed
+/// a subscriber.
+fn init_cli_log_subscriber(format: LogFormat) {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr);
+    match format {
+        LogFormat::Json => {
+            let _ = builder.json().try_init();
+        }
+        LogFormat::Text => {
+            let _ = builder.try_init();
+        }
     }
 }
 

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -963,6 +963,17 @@ impl CorrelationEngine {
             let target = self.config.max_state_entries * 9 / 10;
             let excess = self.state.len() - target;
 
+            log::warn!(
+                "Correlation state hard cap reached ({} entries, max {}); \
+                 evicting {} stalest entries to {} (90% capacity). \
+                 This indicates high-cardinality traffic; consider raising \
+                 max_state_entries or shortening correlation windows.",
+                self.state.len(),
+                self.config.max_state_entries,
+                excess,
+                target,
+            );
+
             // Collect keys with their latest timestamp, sort by oldest first
             let mut by_staleness: Vec<_> = self
                 .state

--- a/crates/rsigma-runtime/src/engine.rs
+++ b/crates/rsigma-runtime/src/engine.rs
@@ -182,6 +182,10 @@ impl RuntimeEngine {
     ///
     /// Dynamic pipeline sources are resolved if a source resolver is configured.
     pub fn load_rules(&mut self) -> Result<EngineStats, String> {
+        let load_span = tracing::info_span!("load_rules", rules_path = %self.rules_path.display());
+        let _enter = load_span.enter();
+        let load_start = std::time::Instant::now();
+
         if !self.pipeline_paths.is_empty() {
             self.pipelines = reload_pipelines(&self.pipeline_paths)?;
         }
@@ -239,6 +243,12 @@ impl RuntimeEngine {
                 state_entries: engine.state_count(),
             };
             self.engine = EngineVariant::WithCorrelations(Box::new(engine));
+            tracing::debug!(
+                detection_rules = stats.detection_rules,
+                correlation_rules = stats.correlation_rules,
+                duration_ms = load_start.elapsed().as_millis() as u64,
+                "Rule load complete",
+            );
             Ok(stats)
         } else {
             let mut engine = Engine::new();
@@ -262,6 +272,12 @@ impl RuntimeEngine {
                 state_entries: 0,
             };
             self.engine = EngineVariant::DetectionOnly(Box::new(engine));
+            tracing::debug!(
+                detection_rules = stats.detection_rules,
+                correlation_rules = stats.correlation_rules,
+                duration_ms = load_start.elapsed().as_millis() as u64,
+                "Rule load complete",
+            );
             Ok(stats)
         }
     }
@@ -357,6 +373,9 @@ fn load_collection(path: &Path) -> Result<SigmaCollection, String> {
             count = collection.errors.len(),
             "Parse errors while loading rules"
         );
+        for (i, err) in collection.errors.iter().take(3).enumerate() {
+            tracing::warn!(index = i + 1, error = %err, "Rule parse error detail");
+        }
     }
 
     Ok(collection)

--- a/crates/rsigma-runtime/src/io/mod.rs
+++ b/crates/rsigma-runtime/src/io/mod.rs
@@ -135,8 +135,16 @@ impl Sink {
                 #[cfg(feature = "nats")]
                 Sink::Nats(s) => s.send(result).await,
                 Sink::FanOut(sinks) => {
-                    for sink in sinks {
-                        sink.send(result).await?;
+                    for (idx, sink) in sinks.iter_mut().enumerate() {
+                        if let Err(e) = sink.send(result).await {
+                            tracing::warn!(
+                                sink_index = idx,
+                                sink_type = sink.kind_label(),
+                                error = %e,
+                                "Fan-out child sink failed",
+                            );
+                            return Err(e);
+                        }
                     }
                     Ok(())
                 }
@@ -157,13 +165,32 @@ impl Sink {
                 #[cfg(feature = "nats")]
                 Sink::Nats(s) => s.send_raw(json).await,
                 Sink::FanOut(sinks) => {
-                    for sink in sinks {
-                        sink.send_raw(json).await?;
+                    for (idx, sink) in sinks.iter_mut().enumerate() {
+                        if let Err(e) = sink.send_raw(json).await {
+                            tracing::warn!(
+                                sink_index = idx,
+                                sink_type = sink.kind_label(),
+                                error = %e,
+                                "Fan-out child sink failed (raw)",
+                            );
+                            return Err(e);
+                        }
                     }
                     Ok(())
                 }
             }
         })
+    }
+
+    /// Short label for the sink variant, used in structured logs.
+    fn kind_label(&self) -> &'static str {
+        match self {
+            Sink::Stdout(_) => "stdout",
+            Sink::File(_) => "file",
+            #[cfg(feature = "nats")]
+            Sink::Nats(_) => "nats",
+            Sink::FanOut(_) => "fanout",
+        }
     }
 }
 
@@ -188,6 +215,7 @@ pub fn spawn_source<S: EventSource>(
                     Err(tokio::sync::mpsc::error::TrySendError::Full(raw_event)) => {
                         m.on_back_pressure();
                         m.on_input_queue_depth_change(1);
+                        tracing::warn!("Input channel full, backpressure applied");
                         if event_tx.send(raw_event).await.is_err() {
                             tracing::debug!("Event channel closed, source shutting down");
                             break;

--- a/crates/rsigma-runtime/src/io/nats_sink.rs
+++ b/crates/rsigma-runtime/src/io/nats_sink.rs
@@ -55,37 +55,48 @@ impl NatsSink {
             return Ok(());
         }
 
+        let mut published = 0_usize;
         for m in &result.detections {
             let json = serde_json::to_string(m)?;
-            self.jetstream
-                .publish(self.subject.clone(), json.into())
-                .await
-                .map_err(|e| RuntimeError::Io(std::io::Error::other(e)))?
-                .await
-                .map_err(|e| RuntimeError::Io(std::io::Error::other(e)))?;
+            self.publish_one(&json).await?;
+            published += 1;
         }
 
         for m in &result.correlations {
             let json = serde_json::to_string(m)?;
-            self.jetstream
-                .publish(self.subject.clone(), json.into())
-                .await
-                .map_err(|e| RuntimeError::Io(std::io::Error::other(e)))?
-                .await
-                .map_err(|e| RuntimeError::Io(std::io::Error::other(e)))?;
+            self.publish_one(&json).await?;
+            published += 1;
         }
 
+        tracing::debug!(
+            subject = %self.subject,
+            messages = published,
+            "NATS messages published",
+        );
         Ok(())
     }
 
     /// Publish a pre-serialized JSON string directly to the JetStream subject.
     pub async fn send_raw(&self, json: &str) -> Result<(), RuntimeError> {
-        self.jetstream
+        self.publish_one(json).await?;
+        tracing::debug!(subject = %self.subject, "NATS message published (raw)");
+        Ok(())
+    }
+
+    /// Publish a single JSON payload, logging a warning on failure before returning.
+    async fn publish_one(&self, json: &str) -> Result<(), RuntimeError> {
+        let ack = self
+            .jetstream
             .publish(self.subject.clone(), json.to_string().into())
             .await
-            .map_err(|e| RuntimeError::Io(std::io::Error::other(e)))?
-            .await
-            .map_err(|e| RuntimeError::Io(std::io::Error::other(e)))?;
+            .map_err(|e| {
+                tracing::warn!(subject = %self.subject, error = %e, "NATS publish failed");
+                RuntimeError::Io(std::io::Error::other(e))
+            })?;
+        ack.await.map_err(|e| {
+            tracing::warn!(subject = %self.subject, error = %e, "NATS publish ack failed");
+            RuntimeError::Io(std::io::Error::other(e))
+        })?;
         Ok(())
     }
 }

--- a/crates/rsigma-runtime/src/io/nats_source.rs
+++ b/crates/rsigma-runtime/src/io/nats_source.rs
@@ -118,7 +118,10 @@ impl EventSource for NatsSource {
                     tracing::warn!(error = %e, "NATS message error");
                     continue;
                 }
-                None => return None,
+                None => {
+                    tracing::debug!("NATS stream ended");
+                    return None;
+                }
             }
         }
     }

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -172,6 +172,7 @@ impl SourceResolver for DefaultSourceResolver {
 
         match result {
             Ok(value) => {
+                tracing::debug!(source_id = %source.id, "Source fetched successfully");
                 self.cache.store(&source.id, &value.data);
                 Ok(value)
             }

--- a/crates/rsigma-runtime/src/sources/refresh.rs
+++ b/crates/rsigma-runtime/src/sources/refresh.rs
@@ -207,6 +207,8 @@ impl RefreshScheduler {
                 continue;
             }
 
+            let refresh_count = to_resolve.len();
+            let refresh_start = std::time::Instant::now();
             match resolve_all(
                 resolver.as_ref(),
                 &to_resolve.iter().map(|s| (*s).clone()).collect::<Vec<_>>(),
@@ -214,10 +216,20 @@ impl RefreshScheduler {
             .await
             {
                 Ok(resolved) => {
+                    tracing::debug!(
+                        sources = refresh_count,
+                        duration_ms = refresh_start.elapsed().as_millis() as u64,
+                        "Scheduled refresh completed",
+                    );
                     let _ = result_tx.send(Some(RefreshResult { resolved }));
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "Background source refresh failed");
+                    tracing::warn!(
+                        error = %e,
+                        sources = refresh_count,
+                        duration_ms = refresh_start.elapsed().as_millis() as u64,
+                        "Background source refresh failed",
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes observability gaps across the rsigma daemon and CLI across the three pillars: structured logs, distributed tracing spans, and profiling readiness. All new instrumentation flows through the existing `tracing-subscriber` (JSON, env-filter) and is controlled via `RUST_LOG`. Spans are designed to be consumable by future `tokio-console` or `tracing-opentelemetry` exporters without code changes.

### Phases (one commit each)

| Commit | Phase | Scope |
|--------|-------|-------|
| `03dae89` | 1 | `tower-http` `TraceLayer` on the Axum router for HTTP API access logs |
| `7b50a82` | 2 | Batch processing span; DLQ parse-failure, send-failure, and task lifecycle logging |
| `7bd2ab6` | 3 | Source resolution span in `InstrumentedResolver`; debug events in `DefaultSourceResolver` and the refresh scheduler |
| `301e5d4` | 4 | Warn when correlation state hard-cap eviction triggers (eval engine memory pressure) |
| `e93b50f` | 5 | NATS source/sink lifecycle, `spawn_source` backpressure warn, fan-out per-sink labels |
| `4481b30` | 6 | Rule load diagnostics: span with duration, first 3 parse error details |
| `ab961e2` | 7 | OTLP per-request tracing for both HTTP and gRPC handlers |
| `04a4250` | 8 | Daemon lifecycle: shutdown per-task logs, health state transitions, file watcher errors, snapshot duration/size, SQLite migration logs |
| `b5b67eb` | 9 | Global `--log-format <json\|text>` for non-daemon CLI subcommands |

Plus:

| Commit | Scope |
|--------|-------|
| `1602d8a` | Unit test for `HealthState::set_ready` transitions |
| `86ec6ad` | Root README and CLI README updated with `RUST_LOG` filter targets |
| `ee9a5d8` | **Correctness fix:** replace `EnteredSpan` across `.await` with `tracing::Instrument` to avoid confused span nesting on the multi-threaded runtime |

### Why this matters

Operators previously had Prometheus metrics for most things but few structured log signals on the hot path. Specifically missing:

- No HTTP API access logs (method, URI, status, latency).
- Batch processing, source resolution, OTLP ingest, and rule loading emitted zero tracing spans, so distributed-trace and profiling tools had nothing to consume.
- DLQ entries were dropped silently (`let _ = engine_dlq_tx.send(...).await`), and the DLQ task had no lifecycle logging.
- Correlation state hard-cap eviction silently dropped entries under memory pressure.
- NATS sinks and the fan-out sink had no structured logs for failures, making partial-delivery debugging difficult.
- Rule parse errors logged only a count, not the actual error messages.
- Daemon lifecycle (graceful shutdown, health state transitions, file watcher errors) was largely silent.

### Verbosity knobs

| Filter | Surfaces |
|--------|----------|
| `RUST_LOG=info,tower_http=debug` | HTTP API access logs |
| `RUST_LOG=info,rsigma=debug` | batch processing spans, DLQ routing, OTLP per-request fields, snapshot save duration |
| `RUST_LOG=info,rsigma_runtime::sources=debug` | dynamic source resolution and refresh scheduler |
| `RUST_LOG=info,rsigma_eval=debug` | correlation engine internals |

## Test plan

- [x] ` cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — 1307 tests passing
- [x] `cargo audit` — only the pre-existing `encoding` warning from `evtx`
- [x] New unit test covers `HealthState::set_ready` transition logic
- [ ] Manual smoke test: `RUST_LOG=info,tower_http=debug,rsigma=debug cargo run -- daemon ...` and confirm access log + batch processing events appear in JSON output on stderr