### PR TITLE
chore(deps): combine Dependabot updates (#108, #109, #110)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
-      - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2.75.28
+      - uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,7 +107,7 @@ jobs:
           severity-cutoff: critical
           output-format: sarif
 
-      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+      - uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         if: always()
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
@@ -175,7 +175,7 @@ jobs:
           subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true
 
-      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with cosign
         run: cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${MANIFEST_DIGEST}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
+checksum = "31811585c7c5bc2f60f8b80d5a6b0f737115611dac47567d7f7d94562ebb180b"
 dependencies = [
  "base64",
  "bytes",
@@ -188,7 +188,7 @@ dependencies = [
  "nuid",
  "pin-project",
  "portable-atomic",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -198,7 +198,7 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -48,7 +48,7 @@ prometheus = { version = "0.14", default-features = false, optional = true }
 notify = { version = "8.2", optional = true }
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
 tower-http = { version = "0.6", features = ["trace"], optional = true }
-async-nats = { version = "0.47", optional = true }
+async-nats = { version = "0.48", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 time = { version = "0.3", optional = true }
 prost = { version = "0.14", optional = true }
@@ -61,7 +61,7 @@ predicates = "3.1.4"
 tempfile = "3.25.0"
 insta = "1.46"
 tokio = { version = "1", features = ["full"] }
-async-nats = "0.47"
+async-nats = "0.48"
 bytes = "1"
 futures = "0.3"
 testcontainers = "0.27"

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -43,7 +43,7 @@ notify = "8.2"
 
 # optional
 tokio-stream = { version = "0.1", optional = true }
-async-nats = { version = "0.47", optional = true }
+async-nats = { version = "0.48", optional = true }
 futures = { version = "0.3", optional = true }
 time = { version = "0.3", optional = true }
 evtx = { version = "0.11", optional = true, default-features = false }


### PR DESCRIPTION
## Summary

Combines three open Dependabot PRs into a single update:

- **#108** (patch-updates): `jsonschema` 0.46.3 -> 0.46.4 (regex panic fix), `tower-http` 0.6.9 -> 0.6.10, `tonic` 0.14.5 -> 0.14.6
- **#109**: `async-nats` 0.47 -> 0.48 (JetStream 2.14 features, non-utf8 panic fix, `thiserror` v2)
- **#110** (actions-updates): `taiki-e/install-action` v2.75.28 -> v2.77.1, `github/codeql-action` v4.35.2 -> v4.35.4, `sigstore/cosign-installer` v4.1.1 -> v4.1.2

All action SHAs verified against tagged releases. Cargo changelogs reviewed for supply chain safety.

Supersedes #108, #109, #110.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo test --workspace --all-features` (all tests pass)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo deny check`
- [ ] CI passes