### PR TITLE
chore(deps): drop serde_yaml rename, use yaml_serde directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ The daemon emits Prometheus metrics on `/metrics` and structured JSON logs to st
 
 Everything starts with a Sigma rule in YAML format:
 
-- **Parsing:** `serde_yaml` deserializes the YAML into a raw value, then `rsigma-parser` turns it into a strongly-typed AST. A PEG grammar (`sigma.pest`) handles the document structure while a Pratt parser (`condition.rs`) handles condition expressions. Supporting modules define value types (`value.rs`: `SigmaStr`, wildcards, timespans) and AST nodes (`ast.rs`: modifiers, enums). The result is a `SigmaRule`, `CorrelationRule`, `FilterRule`, or `SigmaCollection`.
+- **Parsing:** `yaml_serde` deserializes the YAML into a raw value, then `rsigma-parser` turns it into a strongly-typed AST. A PEG grammar (`sigma.pest`) handles the document structure while a Pratt parser (`condition.rs`) handles condition expressions. Supporting modules define value types (`value.rs`: `SigmaStr`, wildcards, timespans) and AST nodes (`ast.rs`: modifiers, enums). The result is a `SigmaRule`, `CorrelationRule`, `FilterRule`, or `SigmaCollection`.
 
 From there, the AST can go in three directions depending on what you need:
 
@@ -385,7 +385,7 @@ Feature-gated items are marked with \* in the diagram.
 
 ```
                     ┌──────────────────┐
-   YAML input ───>  │   serde_yaml     │──> Raw YAML Value
+   YAML input ───>  │   yaml_serde     │──> Raw YAML Value
                     └──────────────────┘
                              │
                              ▼

--- a/assets/architecture.mmd
+++ b/assets/architecture.mmd
@@ -1,6 +1,6 @@
 flowchart TD
     YAML["YAML input"]
-    SERDE["serde_yaml"]
+    SERDE["yaml_serde"]
     EVENTS["Log events"]
     OUTPUT["MatchResult · CorrelationResult\nrule title · id · level · tags\nmatched selections · field matches\naggregated values · optional events"]
     QUERIES["SQL · SPL · KQL · Lucene"]

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -27,7 +27,7 @@ rsigma-runtime = { path = "../rsigma-runtime", version = "0.11.0", optional = tr
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 jaq-interpret = "1.5.0"
 jaq-parse = "1.0.3"
 serde_json_path = "0.7.2"

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -853,7 +853,7 @@ transformations:
 | Format | Description |
 |--------|-------------|
 | `json` | Parsed with serde_json |
-| `yaml` | Parsed with serde_yaml |
+| `yaml` | Parsed with yaml_serde |
 | `lines` | One value per line (produces a JSON array of strings) |
 | `csv` | Comma-separated values |
 

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -370,8 +370,8 @@ fn validate_file_against_schema(
         }
     };
 
-    for doc in serde_yaml::Deserializer::from_str(&content) {
-        let yaml_value: serde_yaml::Value = match serde_yaml::Value::deserialize(doc) {
+    for doc in yaml_serde::Deserializer::from_str(&content) {
+        let yaml_value: yaml_serde::Value = match yaml_serde::Value::deserialize(doc) {
             Ok(v) => v,
             Err(_) => continue,
         };
@@ -379,7 +379,7 @@ fn validate_file_against_schema(
         // Skip action fragments
         if let Some(m) = yaml_value.as_mapping()
             && let Some(action) = m
-                .get(serde_yaml::Value::String("action".into()))
+                .get(yaml_serde::Value::String("action".into()))
                 .and_then(|v| v.as_str())
             && matches!(action, "global" | "reset" | "repeat")
         {

--- a/crates/rsigma-cli/src/fix.rs
+++ b/crates/rsigma-cli/src/fix.rs
@@ -50,7 +50,7 @@ fn apply_single_fix_patch(
         FixPatch::ReplaceValue { path, new_value } => {
             let yp = yamlpatch::Patch {
                 route: json_pointer_to_route(path),
-                operation: yamlpatch::Op::Replace(serde_yaml::Value::String(new_value.clone())),
+                operation: yamlpatch::Op::Replace(yaml_serde::Value::String(new_value.clone())),
             };
             yamlpatch::apply_yaml_patches(doc, &[yp]).map_err(|e| e.to_string())
         }
@@ -229,7 +229,7 @@ mod tests {
         let route = json_pointer_to_route("/status");
         let patch = yamlpatch::Patch {
             route,
-            operation: yamlpatch::Op::Replace(serde_yaml::Value::String(
+            operation: yamlpatch::Op::Replace(yaml_serde::Value::String(
                 "experimental".to_string(),
             )),
         };

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -14,7 +14,7 @@ rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.11.0" }
 thiserror = "2"
 serde_json = "1"
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 regex = "1"
 ipnet = "2"
 log = "0.4"

--- a/crates/rsigma-convert/src/backends/postgres/mod.rs
+++ b/crates/rsigma-convert/src/backends/postgres/mod.rs
@@ -198,7 +198,7 @@ impl PostgresBackend {
     /// **schema**: `custom_attributes["postgres.schema"]` > `state["schema"]` > `self.schema`
     fn resolve_table(
         &self,
-        custom_attrs: &HashMap<String, serde_yaml::Value>,
+        custom_attrs: &HashMap<String, yaml_serde::Value>,
         state: &HashMap<String, serde_json::Value>,
     ) -> Result<String> {
         let table = custom_attrs

--- a/crates/rsigma-convert/src/backends/postgres/tests.rs
+++ b/crates/rsigma-convert/src/backends/postgres/tests.rs
@@ -962,11 +962,11 @@ fn test_resolve_table_custom_attrs_override_all() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "postgres.table".to_string(),
-        serde_yaml::Value::String("my_events".to_string()),
+        yaml_serde::Value::String("my_events".to_string()),
     );
     attrs.insert(
         "postgres.schema".to_string(),
-        serde_yaml::Value::String("custom".to_string()),
+        yaml_serde::Value::String("custom".to_string()),
     );
     let mut state = HashMap::new();
     state.insert("table".to_string(), serde_json::json!("pipeline_events"));
@@ -983,7 +983,7 @@ fn test_resolve_table_custom_table_only() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "postgres.table".to_string(),
-        serde_yaml::Value::String("my_events".to_string()),
+        yaml_serde::Value::String("my_events".to_string()),
     );
     let state = HashMap::new();
     assert_eq!(backend.resolve_table(&attrs, &state).unwrap(), "my_events");
@@ -996,7 +996,7 @@ fn test_resolve_table_empty_schema_treated_as_none() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "postgres.schema".to_string(),
-        serde_yaml::Value::String(String::new()),
+        yaml_serde::Value::String(String::new()),
     );
     let state = HashMap::new();
     // Empty schema in custom_attrs removes the schema prefix

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -17,7 +17,7 @@ daachorse-index = ["dep:daachorse"]
 rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 regex = "1"
 aho-corasick = "1"
 ahash = "0.8"

--- a/crates/rsigma-eval/src/compiler/helpers.rs
+++ b/crates/rsigma-eval/src/compiler/helpers.rs
@@ -20,12 +20,12 @@ pub(super) fn pattern_matches(pattern: &str, name: &str) -> bool {
     pattern == name
 }
 
-/// Convert a `serde_yaml::Value` to a `serde_json::Value`.
-pub(super) fn yaml_to_json(value: &serde_yaml::Value) -> serde_json::Value {
+/// Convert a `yaml_serde::Value` to a `serde_json::Value`.
+pub(super) fn yaml_to_json(value: &yaml_serde::Value) -> serde_json::Value {
     match value {
-        serde_yaml::Value::Null => serde_json::Value::Null,
-        serde_yaml::Value::Bool(b) => serde_json::Value::Bool(*b),
-        serde_yaml::Value::Number(n) => {
+        yaml_serde::Value::Null => serde_json::Value::Null,
+        yaml_serde::Value::Bool(b) => serde_json::Value::Bool(*b),
+        yaml_serde::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 serde_json::Value::Number(i.into())
             } else if let Some(u) = n.as_u64() {
@@ -39,24 +39,24 @@ pub(super) fn yaml_to_json(value: &serde_yaml::Value) -> serde_json::Value {
                 serde_json::Value::Null
             }
         }
-        serde_yaml::Value::String(s) => serde_json::Value::String(s.clone()),
-        serde_yaml::Value::Sequence(seq) => {
+        yaml_serde::Value::String(s) => serde_json::Value::String(s.clone()),
+        yaml_serde::Value::Sequence(seq) => {
             serde_json::Value::Array(seq.iter().map(yaml_to_json).collect())
         }
-        serde_yaml::Value::Mapping(map) => {
+        yaml_serde::Value::Mapping(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .filter_map(|(k, v)| Some((k.as_str()?.to_string(), yaml_to_json(v))))
                 .collect();
             serde_json::Value::Object(obj)
         }
-        serde_yaml::Value::Tagged(tagged) => yaml_to_json(&tagged.value),
+        yaml_serde::Value::Tagged(tagged) => yaml_to_json(&tagged.value),
     }
 }
 
 /// Convert a map of YAML values to a map of JSON values.
 pub(crate) fn yaml_to_json_map(
-    map: &std::collections::HashMap<String, serde_yaml::Value>,
+    map: &std::collections::HashMap<String, yaml_serde::Value>,
 ) -> std::collections::HashMap<String, serde_json::Value> {
     map.iter()
         .map(|(k, v)| (k.clone(), yaml_to_json(v)))

--- a/crates/rsigma-eval/src/compiler/tests.rs
+++ b/crates/rsigma-eval/src/compiler/tests.rs
@@ -444,7 +444,7 @@ fn test_compile_timestamp_month_modifier() {
 
 fn make_test_sigma_rule(
     title: &str,
-    custom_attributes: HashMap<String, serde_yaml::Value>,
+    custom_attributes: HashMap<String, yaml_serde::Value>,
 ) -> SigmaRule {
     use rsigma_parser::{Detections, LogSource};
     SigmaRule {
@@ -498,7 +498,7 @@ fn test_include_event_custom_attribute() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "rsigma.include_event".to_string(),
-        serde_yaml::Value::String("true".to_string()),
+        yaml_serde::Value::String("true".to_string()),
     );
     let rule = make_test_sigma_rule("Include Event Test", attrs);
 

--- a/crates/rsigma-eval/src/correlation/tests.rs
+++ b/crates/rsigma-eval/src/correlation/tests.rs
@@ -778,23 +778,23 @@ fn test_extract_event_id_common_fields() {
 fn test_compile_correlation_with_custom_attributes() {
     use rsigma_parser::*;
 
-    let mut custom_attributes: HashMap<String, serde_yaml::Value> =
+    let mut custom_attributes: HashMap<String, yaml_serde::Value> =
         std::collections::HashMap::new();
     custom_attributes.insert(
         "rsigma.correlation_event_mode".to_string(),
-        serde_yaml::Value::String("refs".to_string()),
+        yaml_serde::Value::String("refs".to_string()),
     );
     custom_attributes.insert(
         "rsigma.max_correlation_events".to_string(),
-        serde_yaml::Value::String("25".to_string()),
+        yaml_serde::Value::String("25".to_string()),
     );
     custom_attributes.insert(
         "rsigma.suppress".to_string(),
-        serde_yaml::Value::String("5m".to_string()),
+        yaml_serde::Value::String("5m".to_string()),
     );
     custom_attributes.insert(
         "rsigma.action".to_string(),
-        serde_yaml::Value::String("reset".to_string()),
+        yaml_serde::Value::String("reset".to_string()),
     );
 
     let rule = CorrelationRule {

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -178,7 +178,7 @@ impl CorrelationEngine {
     ///   Only applied when the CLI did not already set `--action`.
     fn apply_custom_attributes(
         &mut self,
-        attrs: &std::collections::HashMap<String, serde_yaml::Value>,
+        attrs: &std::collections::HashMap<String, yaml_serde::Value>,
     ) {
         // rsigma.timestamp_field — prepend to priority list, skip duplicates
         if let Some(field) = attrs.get("rsigma.timestamp_field").and_then(|v| v.as_str())

--- a/crates/rsigma-eval/src/correlation_engine/tests.rs
+++ b/crates/rsigma-eval/src/correlation_engine/tests.rs
@@ -1782,10 +1782,10 @@ fn test_no_suppression_fires_every_event() {
 
 fn yaml_str_attrs<const N: usize>(
     pairs: [(&str, &str); N],
-) -> std::collections::HashMap<String, serde_yaml::Value> {
+) -> std::collections::HashMap<String, yaml_serde::Value> {
     pairs
         .into_iter()
-        .map(|(k, v)| (k.to_string(), serde_yaml::Value::String(v.to_string())))
+        .map(|(k, v)| (k.to_string(), yaml_serde::Value::String(v.to_string())))
         .collect()
 }
 

--- a/crates/rsigma-eval/src/pipeline/finalizers.rs
+++ b/crates/rsigma-eval/src/pipeline/finalizers.rs
@@ -70,25 +70,25 @@ impl Finalizer {
     }
 
     /// Parse a finalizer from a YAML mapping.
-    pub fn from_yaml(mapping: &serde_yaml::Value) -> Option<Self> {
+    pub fn from_yaml(mapping: &yaml_serde::Value) -> Option<Self> {
         let obj = mapping.as_mapping()?;
-        let type_val = obj.get(serde_yaml::Value::String("type".to_string()))?;
+        let type_val = obj.get(yaml_serde::Value::String("type".to_string()))?;
         let type_str = type_val.as_str()?;
 
         match type_str {
             "concat" => {
                 let separator = obj
-                    .get(serde_yaml::Value::String("separator".to_string()))
+                    .get(yaml_serde::Value::String("separator".to_string()))
                     .and_then(|v| v.as_str())
                     .unwrap_or(" ")
                     .to_string();
                 let prefix = obj
-                    .get(serde_yaml::Value::String("prefix".to_string()))
+                    .get(yaml_serde::Value::String("prefix".to_string()))
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
                 let suffix = obj
-                    .get(serde_yaml::Value::String("suffix".to_string()))
+                    .get(yaml_serde::Value::String("suffix".to_string()))
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
@@ -101,7 +101,7 @@ impl Finalizer {
 
             "json" => {
                 let indent = obj
-                    .get(serde_yaml::Value::String("indent".to_string()))
+                    .get(yaml_serde::Value::String("indent".to_string()))
                     .and_then(|v| v.as_u64())
                     .map(|n| n as usize);
                 Some(Finalizer::Json { indent })
@@ -109,7 +109,7 @@ impl Finalizer {
 
             "template" => {
                 let template = obj
-                    .get(serde_yaml::Value::String("template".to_string()))
+                    .get(yaml_serde::Value::String("template".to_string()))
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_parse_concat_finalizer() {
-        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+        let yaml = yaml_serde::from_str::<yaml_serde::Value>(
             r#"
 type: concat
 separator: " OR "
@@ -154,7 +154,7 @@ suffix: ")"
 
     #[test]
     fn test_parse_json_finalizer() {
-        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+        let yaml = yaml_serde::from_str::<yaml_serde::Value>(
             r#"
 type: json
 indent: 2
@@ -172,7 +172,7 @@ indent: 2
 
     #[test]
     fn test_parse_template_finalizer() {
-        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+        let yaml = yaml_serde::from_str::<yaml_serde::Value>(
             r#"
 type: template
 template: "source={source} ({query})"

--- a/crates/rsigma-eval/src/pipeline/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/mod.rs
@@ -362,7 +362,7 @@ fn apply_correlation_transformation(
 
         Transformation::SetCustomAttribute { attribute, value } => {
             corr.custom_attributes
-                .insert(attribute.clone(), serde_yaml::Value::String(value.clone()));
+                .insert(attribute.clone(), yaml_serde::Value::String(value.clone()));
             Ok(true)
         }
 

--- a/crates/rsigma-eval/src/pipeline/parsing.rs
+++ b/crates/rsigma-eval/src/pipeline/parsing.rs
@@ -25,7 +25,7 @@ use super::{Pipeline, TransformationItem};
 
 /// Parse a pipeline from a YAML string.
 pub fn parse_pipeline(yaml: &str) -> Result<Pipeline> {
-    let value: serde_yaml::Value = serde_yaml::from_str(yaml)
+    let value: yaml_serde::Value = yaml_serde::from_str(yaml)
         .map_err(|e| EvalError::InvalidModifiers(format!("pipeline YAML parse error: {e}")))?;
     parse_pipeline_value(&value)
 }
@@ -37,8 +37,8 @@ pub fn parse_pipeline_file(path: &Path) -> Result<Pipeline> {
     parse_pipeline(&content)
 }
 
-/// Parse a pipeline from a `serde_yaml::Value`.
-fn parse_pipeline_value(value: &serde_yaml::Value) -> Result<Pipeline> {
+/// Parse a pipeline from a `yaml_serde::Value`.
+fn parse_pipeline_value(value: &yaml_serde::Value) -> Result<Pipeline> {
     let obj = value.as_mapping().ok_or_else(|| {
         EvalError::InvalidModifiers("pipeline YAML must be a mapping".to_string())
     })?;
@@ -89,21 +89,21 @@ fn parse_pipeline_value(value: &serde_yaml::Value) -> Result<Pipeline> {
     })
 }
 
-fn ykey(s: &str) -> serde_yaml::Value {
-    serde_yaml::Value::String(s.to_string())
+fn ykey(s: &str) -> yaml_serde::Value {
+    yaml_serde::Value::String(s.to_string())
 }
 
-fn parse_vars(value: Option<&serde_yaml::Value>) -> HashMap<String, Vec<String>> {
+fn parse_vars(value: Option<&yaml_serde::Value>) -> HashMap<String, Vec<String>> {
     let mut vars = HashMap::new();
-    if let Some(serde_yaml::Value::Mapping(m)) = value {
+    if let Some(yaml_serde::Value::Mapping(m)) = value {
         for (k, v) in m {
             if let Some(key) = k.as_str() {
                 let values = match v {
-                    serde_yaml::Value::Sequence(seq) => seq
+                    yaml_serde::Value::Sequence(seq) => seq
                         .iter()
                         .filter_map(|item| item.as_str().map(String::from))
                         .collect(),
-                    serde_yaml::Value::String(s) => vec![s.clone()],
+                    yaml_serde::Value::String(s) => vec![s.clone()],
                     _ => Vec::new(),
                 };
                 vars.insert(key.to_string(), values);
@@ -114,7 +114,7 @@ fn parse_vars(value: Option<&serde_yaml::Value>) -> HashMap<String, Vec<String>>
 }
 
 /// Parse a YAML value as a sequence of transformation items.
-pub fn parse_transformation_items(value: &serde_yaml::Value) -> Result<Vec<TransformationItem>> {
+pub fn parse_transformation_items(value: &yaml_serde::Value) -> Result<Vec<TransformationItem>> {
     let items = value.as_sequence().ok_or_else(|| {
         EvalError::InvalidModifiers("transformations must be a sequence".to_string())
     })?;
@@ -122,7 +122,7 @@ pub fn parse_transformation_items(value: &serde_yaml::Value) -> Result<Vec<Trans
     items.iter().map(parse_transformation_item).collect()
 }
 
-fn parse_transformation_item(value: &serde_yaml::Value) -> Result<TransformationItem> {
+fn parse_transformation_item(value: &yaml_serde::Value) -> Result<TransformationItem> {
     let obj = value.as_mapping().ok_or_else(|| {
         EvalError::InvalidModifiers("transformation item must be a mapping".to_string())
     })?;
@@ -180,7 +180,7 @@ fn parse_transformation_item(value: &serde_yaml::Value) -> Result<Transformation
     })
 }
 
-fn parse_transformation(obj: &serde_yaml::Mapping) -> Result<Transformation> {
+fn parse_transformation(obj: &yaml_serde::Mapping) -> Result<Transformation> {
     let type_str = obj
         .get(ykey("type"))
         .and_then(|v| v.as_str())
@@ -424,7 +424,7 @@ fn parse_transformation(obj: &serde_yaml::Mapping) -> Result<Transformation> {
             let items_yaml = obj
                 .get(ykey("items"))
                 .or_else(|| obj.get(ykey("transformations")));
-            let items = if let Some(serde_yaml::Value::Sequence(seq)) = items_yaml {
+            let items = if let Some(yaml_serde::Value::Sequence(seq)) = items_yaml {
                 let mut parsed = Vec::new();
                 for entry in seq {
                     parsed.push(parse_transformation_item(entry)?);
@@ -446,7 +446,7 @@ fn parse_transformation(obj: &serde_yaml::Mapping) -> Result<Transformation> {
 // Condition YAML parsing
 // =============================================================================
 
-fn parse_rule_conditions(value: &serde_yaml::Value) -> Result<Vec<NamedRuleCondition>> {
+fn parse_rule_conditions(value: &yaml_serde::Value) -> Result<Vec<NamedRuleCondition>> {
     let items = value.as_sequence().ok_or_else(|| {
         EvalError::InvalidModifiers("rule_conditions must be a sequence".to_string())
     })?;
@@ -454,7 +454,7 @@ fn parse_rule_conditions(value: &serde_yaml::Value) -> Result<Vec<NamedRuleCondi
     items.iter().map(parse_rule_condition).collect()
 }
 
-fn parse_rule_condition(value: &serde_yaml::Value) -> Result<NamedRuleCondition> {
+fn parse_rule_condition(value: &yaml_serde::Value) -> Result<NamedRuleCondition> {
     let obj = value.as_mapping().ok_or_else(|| {
         EvalError::InvalidModifiers("rule condition must be a mapping".to_string())
     })?;
@@ -568,7 +568,7 @@ fn parse_rule_condition(value: &serde_yaml::Value) -> Result<NamedRuleCondition>
 }
 
 fn parse_detection_item_conditions(
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
 ) -> Result<Vec<DetectionItemCondition>> {
     let items = value.as_sequence().ok_or_else(|| {
         EvalError::InvalidModifiers("detection_item_conditions must be a sequence".to_string())
@@ -577,7 +577,7 @@ fn parse_detection_item_conditions(
     items.iter().map(parse_detection_item_condition).collect()
 }
 
-fn parse_detection_item_condition(value: &serde_yaml::Value) -> Result<DetectionItemCondition> {
+fn parse_detection_item_condition(value: &yaml_serde::Value) -> Result<DetectionItemCondition> {
     let obj = value.as_mapping().ok_or_else(|| {
         EvalError::InvalidModifiers("detection item condition must be a mapping".to_string())
     })?;
@@ -647,7 +647,7 @@ fn parse_detection_item_condition(value: &serde_yaml::Value) -> Result<Detection
     }
 }
 
-fn parse_field_name_conditions(value: &serde_yaml::Value) -> Result<Vec<FieldNameCondition>> {
+fn parse_field_name_conditions(value: &yaml_serde::Value) -> Result<Vec<FieldNameCondition>> {
     let items = value.as_sequence().ok_or_else(|| {
         EvalError::InvalidModifiers("field_name_conditions must be a sequence".to_string())
     })?;
@@ -655,7 +655,7 @@ fn parse_field_name_conditions(value: &serde_yaml::Value) -> Result<Vec<FieldNam
     items.iter().map(parse_field_name_condition).collect()
 }
 
-fn parse_field_name_condition(value: &serde_yaml::Value) -> Result<FieldNameCondition> {
+fn parse_field_name_condition(value: &yaml_serde::Value) -> Result<FieldNameCondition> {
     let obj = value.as_mapping().ok_or_else(|| {
         EvalError::InvalidModifiers("field name condition must be a mapping".to_string())
     })?;
@@ -722,9 +722,9 @@ fn parse_field_name_condition(value: &serde_yaml::Value) -> Result<FieldNameCond
 // YAML parsing helpers
 // =============================================================================
 
-fn parse_string_mapping(value: Option<&serde_yaml::Value>) -> Result<HashMap<String, String>> {
+fn parse_string_mapping(value: Option<&yaml_serde::Value>) -> Result<HashMap<String, String>> {
     let mut map = HashMap::new();
-    if let Some(serde_yaml::Value::Mapping(m)) = value {
+    if let Some(yaml_serde::Value::Mapping(m)) = value {
         for (k, v) in m {
             if let (Some(key), Some(val)) = (k.as_str(), v.as_str()) {
                 map.insert(key.to_string(), val.to_string());
@@ -745,15 +745,15 @@ fn parse_string_mapping(value: Option<&serde_yaml::Value>) -> Result<HashMap<Str
 ///     - quux
 /// ```
 fn parse_string_or_list_mapping(
-    value: Option<&serde_yaml::Value>,
+    value: Option<&yaml_serde::Value>,
 ) -> Result<HashMap<String, Vec<String>>> {
     let mut map = HashMap::new();
-    if let Some(serde_yaml::Value::Mapping(m)) = value {
+    if let Some(yaml_serde::Value::Mapping(m)) = value {
         for (k, v) in m {
             if let Some(key) = k.as_str() {
                 let values = match v {
-                    serde_yaml::Value::String(s) => vec![s.clone()],
-                    serde_yaml::Value::Sequence(seq) => {
+                    yaml_serde::Value::String(s) => vec![s.clone()],
+                    yaml_serde::Value::Sequence(seq) => {
                         let mut strings = Vec::with_capacity(seq.len());
                         for item in seq {
                             if let Some(s) = item.as_str() {
@@ -779,14 +779,14 @@ fn parse_string_or_list_mapping(
     Ok(map)
 }
 
-fn parse_value_mapping(value: Option<&serde_yaml::Value>) -> Result<HashMap<String, SigmaValue>> {
+fn parse_value_mapping(value: Option<&yaml_serde::Value>) -> Result<HashMap<String, SigmaValue>> {
     let mut map = HashMap::new();
-    if let Some(serde_yaml::Value::Mapping(m)) = value {
+    if let Some(yaml_serde::Value::Mapping(m)) = value {
         for (k, v) in m {
             if let Some(key) = k.as_str() {
                 let sv = match v {
-                    serde_yaml::Value::String(s) => SigmaValue::String(SigmaString::new(s)),
-                    serde_yaml::Value::Number(n) => {
+                    yaml_serde::Value::String(s) => SigmaValue::String(SigmaString::new(s)),
+                    yaml_serde::Value::Number(n) => {
                         if let Some(i) = n.as_i64() {
                             SigmaValue::Integer(i)
                         } else if let Some(f) = n.as_f64() {
@@ -795,8 +795,8 @@ fn parse_value_mapping(value: Option<&serde_yaml::Value>) -> Result<HashMap<Stri
                             SigmaValue::Null
                         }
                     }
-                    serde_yaml::Value::Bool(b) => SigmaValue::Bool(*b),
-                    serde_yaml::Value::Null => SigmaValue::Null,
+                    yaml_serde::Value::Bool(b) => SigmaValue::Bool(*b),
+                    yaml_serde::Value::Null => SigmaValue::Null,
                     _ => SigmaValue::Null,
                 };
                 map.insert(key.to_string(), sv);
@@ -822,18 +822,18 @@ fn build_field_matcher(fields: Vec<String>, is_regex: bool) -> Result<FieldMatch
     }
 }
 
-fn parse_string_list(value: Option<&serde_yaml::Value>) -> Vec<String> {
+fn parse_string_list(value: Option<&yaml_serde::Value>) -> Vec<String> {
     match value {
-        Some(serde_yaml::Value::Sequence(seq)) => seq
+        Some(yaml_serde::Value::Sequence(seq)) => seq
             .iter()
             .filter_map(|item| item.as_str().map(String::from))
             .collect(),
-        Some(serde_yaml::Value::String(s)) => vec![s.clone()],
+        Some(yaml_serde::Value::String(s)) => vec![s.clone()],
         _ => Vec::new(),
     }
 }
 
-fn parse_finalizers(value: &serde_yaml::Value) -> Vec<Finalizer> {
+fn parse_finalizers(value: &yaml_serde::Value) -> Vec<Finalizer> {
     if let Some(seq) = value.as_sequence() {
         seq.iter().filter_map(Finalizer::from_yaml).collect()
     } else {
@@ -846,7 +846,7 @@ fn parse_finalizers(value: &serde_yaml::Value) -> Vec<Finalizer> {
 // =============================================================================
 
 /// Parse the `sources` section of a pipeline YAML.
-fn parse_sources(value: &serde_yaml::Value) -> Result<Vec<DynamicSource>> {
+fn parse_sources(value: &yaml_serde::Value) -> Result<Vec<DynamicSource>> {
     let items = value
         .as_sequence()
         .ok_or_else(|| EvalError::InvalidModifiers("sources must be a sequence".to_string()))?;
@@ -855,7 +855,7 @@ fn parse_sources(value: &serde_yaml::Value) -> Result<Vec<DynamicSource>> {
 }
 
 /// Parse a single dynamic source declaration.
-fn parse_dynamic_source(value: &serde_yaml::Value) -> Result<DynamicSource> {
+fn parse_dynamic_source(value: &yaml_serde::Value) -> Result<DynamicSource> {
     let obj = value
         .as_mapping()
         .ok_or_else(|| EvalError::InvalidModifiers("source must be a mapping".to_string()))?;
@@ -981,7 +981,7 @@ fn parse_dynamic_source(value: &serde_yaml::Value) -> Result<DynamicSource> {
 /// - A plain string (always treated as jq): `extract: ".emails[]"`
 /// - A structured mapping: `extract: { expr: "$.emails[*]", type: jsonpath }`
 fn parse_extract_expr(
-    value: Option<&serde_yaml::Value>,
+    value: Option<&yaml_serde::Value>,
     source_id: &str,
 ) -> Result<Option<ExtractExpr>> {
     let Some(val) = value else {
@@ -1027,7 +1027,7 @@ fn parse_extract_expr(
     )))
 }
 
-fn parse_data_format(value: Option<&serde_yaml::Value>) -> DataFormat {
+fn parse_data_format(value: Option<&yaml_serde::Value>) -> DataFormat {
     match value.and_then(|v| v.as_str()) {
         Some("json") => DataFormat::Json,
         Some("yaml" | "yml") => DataFormat::Yaml,
@@ -1037,7 +1037,7 @@ fn parse_data_format(value: Option<&serde_yaml::Value>) -> DataFormat {
     }
 }
 
-fn parse_refresh_policy(value: Option<&serde_yaml::Value>) -> RefreshPolicy {
+fn parse_refresh_policy(value: Option<&yaml_serde::Value>) -> RefreshPolicy {
     match value.and_then(|v| v.as_str()) {
         Some("once") => RefreshPolicy::Once,
         Some("watch") => RefreshPolicy::Watch,
@@ -1054,7 +1054,7 @@ fn parse_refresh_policy(value: Option<&serde_yaml::Value>) -> RefreshPolicy {
     }
 }
 
-fn parse_error_policy(value: Option<&serde_yaml::Value>) -> ErrorPolicy {
+fn parse_error_policy(value: Option<&yaml_serde::Value>) -> ErrorPolicy {
     match value.and_then(|v| v.as_str()) {
         Some("use_cached") => ErrorPolicy::UseCached,
         Some("fail") => ErrorPolicy::Fail,
@@ -1063,7 +1063,7 @@ fn parse_error_policy(value: Option<&serde_yaml::Value>) -> ErrorPolicy {
     }
 }
 
-fn parse_duration_field(value: Option<&serde_yaml::Value>) -> Option<Duration> {
+fn parse_duration_field(value: Option<&yaml_serde::Value>) -> Option<Duration> {
     value.and_then(|v| v.as_str()).and_then(parse_duration_str)
 }
 
@@ -1088,9 +1088,9 @@ fn parse_duration_str(s: &str) -> Option<Duration> {
     }
 }
 
-fn parse_string_headers(value: Option<&serde_yaml::Value>) -> HashMap<String, String> {
+fn parse_string_headers(value: Option<&yaml_serde::Value>) -> HashMap<String, String> {
     let mut map = HashMap::new();
-    if let Some(serde_yaml::Value::Mapping(m)) = value {
+    if let Some(yaml_serde::Value::Mapping(m)) = value {
         for (k, v) in m {
             if let (Some(key), Some(val)) = (k.as_str(), v.as_str()) {
                 map.insert(key.to_string(), val.to_string());
@@ -1100,13 +1100,13 @@ fn parse_string_headers(value: Option<&serde_yaml::Value>) -> HashMap<String, St
     map
 }
 
-fn parse_command_field(value: Option<&serde_yaml::Value>) -> Result<Vec<String>> {
+fn parse_command_field(value: Option<&yaml_serde::Value>) -> Result<Vec<String>> {
     match value {
-        Some(serde_yaml::Value::Sequence(seq)) => Ok(seq
+        Some(yaml_serde::Value::Sequence(seq)) => Ok(seq
             .iter()
             .filter_map(|item| item.as_str().map(String::from))
             .collect()),
-        Some(serde_yaml::Value::String(s)) => Ok(vec![s.clone()]),
+        Some(yaml_serde::Value::String(s)) => Ok(vec![s.clone()]),
         _ => Ok(Vec::new()),
     }
 }
@@ -1158,11 +1158,11 @@ fn source_ref_regex() -> &'static Regex {
 
 /// Scan the entire pipeline YAML for `${source.*}` template references and
 /// `include` directives, returning all found references.
-fn scan_source_refs(obj: &serde_yaml::Mapping) -> Vec<SourceRef> {
+fn scan_source_refs(obj: &yaml_serde::Mapping) -> Vec<SourceRef> {
     let mut refs = Vec::new();
 
     // Scan vars
-    if let Some(serde_yaml::Value::Mapping(vars)) = obj.get(ykey("vars")) {
+    if let Some(yaml_serde::Value::Mapping(vars)) = obj.get(ykey("vars")) {
         for (k, v) in vars {
             if let (Some(var_name), Some(s)) = (k.as_str(), yaml_value_as_str(v)) {
                 for cap in source_ref_regex().captures_iter(s) {
@@ -1180,7 +1180,7 @@ fn scan_source_refs(obj: &serde_yaml::Mapping) -> Vec<SourceRef> {
     }
 
     // Scan transformations
-    if let Some(serde_yaml::Value::Sequence(transforms)) = obj.get(ykey("transformations")) {
+    if let Some(yaml_serde::Value::Sequence(transforms)) = obj.get(ykey("transformations")) {
         for (idx, item) in transforms.iter().enumerate() {
             if let Some(mapping) = item.as_mapping() {
                 // Check for `include` directive
@@ -1212,7 +1212,7 @@ fn scan_source_refs(obj: &serde_yaml::Mapping) -> Vec<SourceRef> {
     }
 
     // Scan finalizers
-    if let Some(serde_yaml::Value::Sequence(finalizers)) = obj.get(ykey("finalizers")) {
+    if let Some(yaml_serde::Value::Sequence(finalizers)) = obj.get(ykey("finalizers")) {
         for (idx, item) in finalizers.iter().enumerate() {
             if let Some(mapping) = item.as_mapping() {
                 for (field_key, field_val) in mapping {
@@ -1229,13 +1229,13 @@ fn scan_source_refs(obj: &serde_yaml::Mapping) -> Vec<SourceRef> {
 
 /// Recursively scan a YAML value for `${source.*}` references.
 fn scan_yaml_value_for_refs(
-    value: &serde_yaml::Value,
+    value: &yaml_serde::Value,
     transform_index: usize,
     field_name: &str,
     refs: &mut Vec<SourceRef>,
 ) {
     match value {
-        serde_yaml::Value::String(s) => {
+        yaml_serde::Value::String(s) => {
             for cap in source_ref_regex().captures_iter(s) {
                 refs.push(SourceRef {
                     source_id: cap[1].to_string(),
@@ -1248,7 +1248,7 @@ fn scan_yaml_value_for_refs(
                 });
             }
         }
-        serde_yaml::Value::Mapping(m) => {
+        yaml_serde::Value::Mapping(m) => {
             for (k, v) in m {
                 let nested_field = if let Some(key) = k.as_str() {
                     format!("{field_name}.{key}")
@@ -1258,7 +1258,7 @@ fn scan_yaml_value_for_refs(
                 scan_yaml_value_for_refs(v, transform_index, &nested_field, refs);
             }
         }
-        serde_yaml::Value::Sequence(seq) => {
+        yaml_serde::Value::Sequence(seq) => {
             for item in seq {
                 scan_yaml_value_for_refs(item, transform_index, field_name, refs);
             }
@@ -1268,6 +1268,6 @@ fn scan_yaml_value_for_refs(
 }
 
 /// Helper to get a string from a YAML value (including tagged strings).
-fn yaml_value_as_str(value: &serde_yaml::Value) -> Option<&str> {
+fn yaml_value_as_str(value: &yaml_serde::Value) -> Option<&str> {
     value.as_str()
 }

--- a/crates/rsigma-eval/src/pipeline/sources.rs
+++ b/crates/rsigma-eval/src/pipeline/sources.rs
@@ -31,7 +31,7 @@ pub struct DynamicSource {
     /// Whether the daemon must resolve this source before processing events.
     pub required: bool,
     /// Fallback value if the source cannot be resolved.
-    pub default: Option<serde_yaml::Value>,
+    pub default: Option<yaml_serde::Value>,
 }
 
 /// Type-specific configuration for a dynamic source.
@@ -112,7 +112,7 @@ pub enum ErrorPolicy {
 pub enum DataFormat {
     /// JSON (parsed with serde_json).
     Json,
-    /// YAML (parsed with serde_yaml).
+    /// YAML (parsed with yaml_serde).
     Yaml,
     /// One value per line.
     Lines,

--- a/crates/rsigma-eval/src/pipeline/tests.rs
+++ b/crates/rsigma-eval/src/pipeline/tests.rs
@@ -889,7 +889,7 @@ transformations:
 
     assert_eq!(
         corr.custom_attributes["rsigma.action"],
-        serde_yaml::Value::String("reset".to_string())
+        yaml_serde::Value::String("reset".to_string())
     );
 }
 

--- a/crates/rsigma-eval/src/pipeline/transformations/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations/mod.rs
@@ -149,7 +149,7 @@ pub enum Transformation {
     /// Set a custom attribute on the rule.
     ///
     /// Stores the key-value pair in `SigmaRule.custom_attributes` as a
-    /// `serde_yaml::Value::String`. Backends / engines can read these to
+    /// `yaml_serde::Value::String`. Backends / engines can read these to
     /// modify per-rule behavior (e.g. `rsigma.suppress`, `rsigma.action`).
     /// Mirrors pySigma's `SetCustomAttributeTransformation`.
     SetCustomAttribute { attribute: String, value: String },
@@ -439,7 +439,7 @@ impl Transformation {
 
             Transformation::SetCustomAttribute { attribute, value } => {
                 rule.custom_attributes
-                    .insert(attribute.clone(), serde_yaml::Value::String(value.clone()));
+                    .insert(attribute.clone(), yaml_serde::Value::String(value.clone()));
                 Ok(true)
             }
 

--- a/crates/rsigma-lsp/src/diagnostics.rs
+++ b/crates/rsigma-lsp/src/diagnostics.rs
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn extract_range_from_yaml_error() {
-        // serde_yaml typical error format
+        // yaml_serde typical error format
         let msg = "invalid type: string \"foo\", expected a mapping at line 5 column 3";
         let text = "title: Test\nstatus: test\nlevel: high\nlogsource:\n  foo\n";
         let index = LineIndex::new(text);

--- a/crates/rsigma-parser/Cargo.toml
+++ b/crates/rsigma-parser/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 pest = "2"
 pest_derive = "2"
 serde = { version = "1", features = ["derive"] }
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 serde_json = "1"
 thiserror = "2"
 

--- a/crates/rsigma-parser/README.md
+++ b/crates/rsigma-parser/README.md
@@ -66,7 +66,7 @@ Fix types are yamlpath/yamlpatch-agnostic (all owned data, no external dependenc
 
 ### Multi-Document Behavior
 
-1. `serde_yaml::Deserializer` yields documents separated by `---`.
+1. `yaml_serde::Deserializer` yields documents separated by `---`.
 2. Non-mapping documents are skipped; errors are accumulated in `collection.errors`.
 3. YAML parse errors stop iteration (the deserializer may not recover from malformed input).
 4. **Collection actions:**
@@ -183,7 +183,7 @@ When the `re` modifier is present, string values are parsed with `SigmaValue::fr
 - **Extended (string):** `"rule_a and rule_b"` for temporal types — parsed as a boolean expression over rule references.
 - **Default (temporal, no condition):** `Threshold { predicates: [(Gte, 1)], field: None }`.
 - **Timeframe/timespan:** The parser accepts both `timeframe` and `timespan` keys.
-- **Custom attributes:** Both detection and correlation rules expose a unified `custom_attributes` map (`HashMap<String, serde_yaml::Value>`). It merges (a) any arbitrary top-level YAML key that is not part of the Sigma schema, (b) entries of the optional top-level `custom_attributes:` mapping (explicit block wins over arbitrary keys of the same name), and (c) values set by pipeline `SetCustomAttribute` transformations (applied last, last-write-wins). Engines read `rsigma.*` extensions (`rsigma.suppress`, `rsigma.action`, `rsigma.correlation_event_mode`, etc.) from this map.
+- **Custom attributes:** Both detection and correlation rules expose a unified `custom_attributes` map (`HashMap<String, yaml_serde::Value>`). It merges (a) any arbitrary top-level YAML key that is not part of the Sigma schema, (b) entries of the optional top-level `custom_attributes:` mapping (explicit block wins over arbitrary keys of the same name), and (c) values set by pipeline `SetCustomAttribute` transformations (applied last, last-write-wins). Engines read `rsigma.*` extensions (`rsigma.suppress`, `rsigma.action`, `rsigma.correlation_event_mode`, etc.) from this map.
 
 ## Filter Rules
 
@@ -358,7 +358,7 @@ The `schema_violation` lint rule optionally validates rules against a JSON schem
 
 | Error | When |
 |-------|------|
-| `Yaml` | serde_yaml parse failure |
+| `Yaml` | yaml_serde parse failure |
 | `Condition` | Condition expression parse failure (PEG/Pratt); carries optional `SourceLocation` with line/column |
 | `UnknownModifier` | Unknown modifier in field spec |
 | `NotIsNotAModifier` | The literal string `\|not` was used as a modifier; Sigma expresses negation at the condition level (`condition: not selection`) or via `\|neq` for inequality. Surfaced with guidance on how to rewrite the rule |

--- a/crates/rsigma-parser/src/ast.rs
+++ b/crates/rsigma-parser/src/ast.rs
@@ -458,7 +458,7 @@ pub struct SigmaRule {
     /// Mirrors pySigma's `SigmaRule.custom_attributes` dict. Engines and
     /// backends can read these to modify per-rule behavior.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_attributes: HashMap<String, serde_yaml::Value>,
+    pub custom_attributes: HashMap<String, yaml_serde::Value>,
 }
 
 // =============================================================================
@@ -617,7 +617,7 @@ pub struct CorrelationRule {
     /// Engine-level `rsigma.*` extensions (e.g. `rsigma.correlation_event_mode`,
     /// `rsigma.suppress`, `rsigma.action`) are read from here.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_attributes: HashMap<String, serde_yaml::Value>,
+    pub custom_attributes: HashMap<String, yaml_serde::Value>,
 }
 
 // =============================================================================
@@ -665,7 +665,7 @@ pub struct FilterRule {
 
     /// Custom attributes attached to the filter rule.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub custom_attributes: HashMap<String, serde_yaml::Value>,
+    pub custom_attributes: HashMap<String, yaml_serde::Value>,
 }
 
 // =============================================================================

--- a/crates/rsigma-parser/src/error.rs
+++ b/crates/rsigma-parser/src/error.rs
@@ -23,7 +23,7 @@ impl fmt::Display for SourceLocation {
 #[non_exhaustive]
 pub enum SigmaParserError {
     #[error("YAML parsing error: {0}")]
-    Yaml(#[from] serde_yaml::Error),
+    Yaml(#[from] yaml_serde::Error),
 
     #[error("{}", format_with_location(.0, .1))]
     Condition(String, Option<SourceLocation>),

--- a/crates/rsigma-parser/src/lib.rs
+++ b/crates/rsigma-parser/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! - **PEG grammar** ([`pest`]) for condition expression parsing with correct operator
 //!   precedence (`NOT` > `AND` > `OR`) and Pratt parsing
-//! - **serde_yaml** for YAML structure deserialization
+//! - **yaml_serde** for YAML structure deserialization
 //! - **Custom parsing** for field modifiers, wildcard strings, and timespan values
 //!
 //! ## Quick Start

--- a/crates/rsigma-parser/src/lint/mod.rs
+++ b/crates/rsigma-parser/src/lint/mod.rs
@@ -1,6 +1,6 @@
 //! Built-in linter for Sigma rules, correlations, and filters.
 //!
-//! Validates raw `serde_yaml::Value` documents against the Sigma specification
+//! Validates raw `yaml_serde::Value` documents against the Sigma specification
 //! v2.1.0 constraints — catching metadata issues that the parser silently
 //! ignores (invalid enums, date formats, tag patterns, etc.).
 //!
@@ -10,7 +10,7 @@
 //! use rsigma_parser::lint::{lint_yaml_value, Severity};
 //!
 //! let yaml = "title: Test\nlogsource:\n  category: test\ndetection:\n  sel:\n    field: value\n  condition: sel\n";
-//! let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+//! let value: yaml_serde::Value = yaml_serde::from_str(yaml).unwrap();
 //! let warnings = lint_yaml_value(&value);
 //! for w in &warnings {
 //!     if w.severity == Severity::Error {
@@ -27,7 +27,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 // =============================================================================
 // Public types
@@ -362,18 +362,18 @@ pub(crate) fn key(s: &str) -> &'static Value {
         .unwrap_or_else(|| panic!("lint key not pre-cached: \"{s}\" — add it to KEY_CACHE"))
 }
 
-pub(crate) fn get_str<'a>(m: &'a serde_yaml::Mapping, k: &str) -> Option<&'a str> {
+pub(crate) fn get_str<'a>(m: &'a yaml_serde::Mapping, k: &str) -> Option<&'a str> {
     m.get(key(k)).and_then(|v| v.as_str())
 }
 
 pub(crate) fn get_mapping<'a>(
-    m: &'a serde_yaml::Mapping,
+    m: &'a yaml_serde::Mapping,
     k: &str,
-) -> Option<&'a serde_yaml::Mapping> {
+) -> Option<&'a yaml_serde::Mapping> {
     m.get(key(k)).and_then(|v| v.as_mapping())
 }
 
-pub(crate) fn get_seq<'a>(m: &'a serde_yaml::Mapping, k: &str) -> Option<&'a serde_yaml::Sequence> {
+pub(crate) fn get_seq<'a>(m: &'a yaml_serde::Mapping, k: &str) -> Option<&'a yaml_serde::Sequence> {
     m.get(key(k)).and_then(|v| v.as_sequence())
 }
 
@@ -483,7 +483,7 @@ impl DocType {
     }
 }
 
-fn detect_doc_type(m: &serde_yaml::Mapping) -> DocType {
+fn detect_doc_type(m: &yaml_serde::Mapping) -> DocType {
     if m.contains_key(key("correlation")) {
         DocType::Correlation
     } else if m.contains_key(key("filter")) {
@@ -493,7 +493,7 @@ fn detect_doc_type(m: &serde_yaml::Mapping) -> DocType {
     }
 }
 
-fn is_action_fragment(m: &serde_yaml::Mapping) -> bool {
+fn is_action_fragment(m: &yaml_serde::Mapping) -> bool {
     matches!(get_str(m, "action"), Some("global" | "reset" | "repeat"))
 }
 
@@ -535,7 +535,7 @@ pub fn lint_yaml_value(value: &Value) -> Vec<LintWarning> {
 pub fn lint_yaml_str(text: &str) -> Vec<LintWarning> {
     let mut all_warnings = Vec::new();
 
-    for doc in serde_yaml::Deserializer::from_str(text) {
+    for doc in yaml_serde::Deserializer::from_str(text) {
         let value: Value = match Value::deserialize(doc) {
             Ok(v) => v,
             Err(e) => {
@@ -767,7 +767,7 @@ struct RawLintConfig {
 impl LintConfig {
     pub fn load(path: &Path) -> crate::error::Result<Self> {
         let content = std::fs::read_to_string(path)?;
-        let raw: RawLintConfig = serde_yaml::from_str(&content)?;
+        let raw: RawLintConfig = yaml_serde::from_str(&content)?;
 
         let disabled_rules: HashSet<String> = raw.disabled_rules.into_iter().collect();
         let mut severity_overrides = HashMap::new();
@@ -1069,7 +1069,7 @@ mod tests {
     use super::*;
 
     fn yaml_value(yaml: &str) -> Value {
-        serde_yaml::from_str(yaml).unwrap()
+        yaml_serde::from_str(yaml).unwrap()
     }
 
     fn lint(yaml: &str) -> Vec<LintWarning> {
@@ -1110,7 +1110,7 @@ tags:
 
     #[test]
     fn not_a_mapping() {
-        let v: serde_yaml::Value = serde_yaml::from_str("- item1\n- item2").unwrap();
+        let v: yaml_serde::Value = yaml_serde::from_str("- item1\n- item2").unwrap();
         let w = lint_yaml_value(&v);
         assert!(has_rule(&w, LintRule::NotAMapping));
     }

--- a/crates/rsigma-parser/src/lint/rules/correlation.rs
+++ b/crates/rsigma-parser/src/lint/rules/correlation.rs
@@ -40,7 +40,7 @@ fn is_valid_timespan(s: &str) -> bool {
     !num_part.is_empty() && num_part.chars().all(|c| c.is_ascii_digit())
 }
 
-pub(crate) fn lint_correlation_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
+pub(crate) fn lint_correlation_rule(m: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
     let Some(corr_val) = m.get(key("correlation")) else {
         warnings.push(err(
             LintRule::MissingCorrelation,
@@ -163,7 +163,7 @@ pub(crate) fn lint_correlation_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<
 }
 
 fn lint_correlation_condition(
-    cond: &serde_yaml::Mapping,
+    cond: &yaml_serde::Mapping,
     corr_type: &str,
     warnings: &mut Vec<LintWarning>,
 ) {
@@ -204,8 +204,8 @@ mod tests {
     use super::super::super::{LintRule, LintWarning, Severity, lint_yaml_value};
     use super::*;
 
-    fn yaml_value(yaml: &str) -> serde_yaml::Value {
-        serde_yaml::from_str(yaml).unwrap()
+    fn yaml_value(yaml: &str) -> yaml_serde::Value {
+        yaml_serde::from_str(yaml).unwrap()
     }
 
     fn lint(yaml: &str) -> Vec<LintWarning> {

--- a/crates/rsigma-parser/src/lint/rules/detection.rs
+++ b/crates/rsigma-parser/src/lint/rules/detection.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use super::super::{
     FixPatch, LintRule, LintWarning, err, get_mapping, get_seq, get_str, key, safe_fix, warning,
@@ -45,7 +45,7 @@ fn is_valid_logsource_value(s: &str) -> bool {
         })
 }
 
-pub(crate) fn lint_detection_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
+pub(crate) fn lint_detection_rule(m: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
     // ── level ─────────────────────────────────────────────────────────────
     if !m.contains_key(key("level")) {
         warnings.push(warning(
@@ -301,7 +301,7 @@ pub(crate) fn lint_detection_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<Li
     }
 }
 
-pub(crate) fn lint_logsource(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
+pub(crate) fn lint_logsource(m: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
     if let Some(ls) = get_mapping(m, "logsource") {
         for field in &["category", "product", "service"] {
             if let Some(val) = get_str(ls, field)
@@ -358,7 +358,7 @@ fn has_deprecated_aggregation(condition: &str) -> bool {
 }
 
 /// Checks detection logic: null in value lists, single-value |all, empty value lists.
-fn lint_detection_logic(det: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
+fn lint_detection_logic(det: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
     for (det_key, det_val) in det {
         let det_key_str = det_key.as_str().unwrap_or("");
         if det_key_str == "condition" || det_key_str == "timeframe" {
@@ -581,8 +581,8 @@ mod tests {
     use super::super::super::{Fix, FixPatch, LintRule, LintWarning, Severity, lint_yaml_value};
     use super::*;
 
-    fn yaml_value(yaml: &str) -> serde_yaml::Value {
-        serde_yaml::from_str(yaml).unwrap()
+    fn yaml_value(yaml: &str) -> yaml_serde::Value {
+        yaml_serde::from_str(yaml).unwrap()
     }
 
     fn lint(yaml: &str) -> Vec<LintWarning> {

--- a/crates/rsigma-parser/src/lint/rules/filter.rs
+++ b/crates/rsigma-parser/src/lint/rules/filter.rs
@@ -1,7 +1,7 @@
 use super::super::{FixPatch, LintRule, LintWarning, err, key, safe_fix, warning};
 use super::detection::lint_logsource;
 
-pub(crate) fn lint_filter_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
+pub(crate) fn lint_filter_rule(m: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
     // ── filter section ───────────────────────────────────────────────────
     let Some(filter_val) = m.get(key("filter")) else {
         warnings.push(err(
@@ -24,9 +24,9 @@ pub(crate) fn lint_filter_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintW
     // ── filter.rules ─────────────────────────────────────────────────────
     if let Some(rules_val) = filter.get(key("rules")) {
         match rules_val {
-            serde_yaml::Value::Sequence(_) => {}
-            serde_yaml::Value::String(s) if s.eq_ignore_ascii_case("any") => {}
-            serde_yaml::Value::String(_) => {}
+            yaml_serde::Value::Sequence(_) => {}
+            yaml_serde::Value::String(s) if s.eq_ignore_ascii_case("any") => {}
+            yaml_serde::Value::String(_) => {}
             _ => {
                 warnings.push(err(
                     LintRule::MissingFilterRules,
@@ -102,8 +102,8 @@ pub(crate) fn lint_filter_rule(m: &serde_yaml::Mapping, warnings: &mut Vec<LintW
 mod tests {
     use super::super::super::{Fix, FixPatch, LintRule, LintWarning, Severity, lint_yaml_value};
 
-    fn yaml_value(yaml: &str) -> serde_yaml::Value {
-        serde_yaml::from_str(yaml).unwrap()
+    fn yaml_value(yaml: &str) -> yaml_serde::Value {
+        yaml_serde::from_str(yaml).unwrap()
     }
 
     fn lint(yaml: &str) -> Vec<LintWarning> {

--- a/crates/rsigma-parser/src/lint/rules/metadata.rs
+++ b/crates/rsigma-parser/src/lint/rules/metadata.rs
@@ -1,4 +1,4 @@
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use super::super::{
     Fix, FixDisposition, FixPatch, LintRule, LintWarning, Severity, closest_match, err, info, key,
@@ -49,13 +49,13 @@ fn is_valid_date(s: &str) -> bool {
     day <= max_day
 }
 
-/// Extract a date string from a YAML value, handling serde_yaml auto-parsing.
+/// Extract a date string from a YAML value, handling yaml_serde auto-parsing.
 ///
-/// `serde_yaml` sometimes deserialises `YYYY-MM-DD` as a tagged/non-string
+/// `yaml_serde` sometimes deserialises `YYYY-MM-DD` as a tagged/non-string
 /// type. This helper coerces such values back to a trimmed string.
 fn extract_date_string(raw: &Value) -> Option<String> {
     raw.as_str().map(|s| s.to_string()).or_else(|| {
-        serde_yaml::to_string(raw)
+        yaml_serde::to_string(raw)
             .ok()
             .map(|s| s.trim().to_string())
     })
@@ -77,7 +77,7 @@ pub(crate) fn is_valid_uuid(s: &str) -> bool {
         .all(|(part, &len)| part.len() == len && part.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
-pub(crate) fn lint_shared(m: &serde_yaml::Mapping, warnings: &mut Vec<LintWarning>) {
+pub(crate) fn lint_shared(m: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
     // ── title ────────────────────────────────────────────────────────────
     match super::super::get_str(m, "title") {
         None => warnings.push(err(
@@ -279,8 +279,8 @@ mod tests {
     use super::super::super::{Fix, LintRule, LintWarning, Severity, lint_yaml_value};
     use super::*;
 
-    fn yaml_value(yaml: &str) -> serde_yaml::Value {
-        serde_yaml::from_str(yaml).unwrap()
+    fn yaml_value(yaml: &str) -> yaml_serde::Value {
+        yaml_serde::from_str(yaml).unwrap()
     }
 
     fn lint(yaml: &str) -> Vec<LintWarning> {

--- a/crates/rsigma-parser/src/lint/rules/shared.rs
+++ b/crates/rsigma-parser/src/lint/rules/shared.rs
@@ -62,7 +62,7 @@ pub(crate) const KNOWN_KEYS_FILTER: &[&str] = &[
 
 /// Check for unknown top-level keys that are likely typos of known keys.
 pub(crate) fn lint_unknown_keys(
-    m: &serde_yaml::Mapping,
+    m: &yaml_serde::Mapping,
     doc_type: DocType,
     warnings: &mut Vec<LintWarning>,
 ) {
@@ -104,8 +104,8 @@ pub(crate) fn lint_unknown_keys(
 mod tests {
     use super::super::super::{Fix, FixPatch, LintRule, LintWarning, Severity, lint_yaml_value};
 
-    fn yaml_value(yaml: &str) -> serde_yaml::Value {
-        serde_yaml::from_str(yaml).unwrap()
+    fn yaml_value(yaml: &str) -> yaml_serde::Value {
+        yaml_serde::from_str(yaml).unwrap()
     }
 
     fn lint(yaml: &str) -> Vec<LintWarning> {

--- a/crates/rsigma-parser/src/parser/correlation.rs
+++ b/crates/rsigma-parser/src/parser/correlation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use crate::ast::*;
 use crate::condition::parse_condition;
@@ -138,7 +138,7 @@ pub(super) fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
 ///
 /// Reference: pySigma correlations.py SigmaCorrelationCondition.from_dict
 fn parse_correlation_condition(
-    corr: &serde_yaml::Mapping,
+    corr: &yaml_serde::Mapping,
     correlation_type: CorrelationType,
 ) -> Result<CorrelationCondition> {
     let condition_val = corr.get(val_key("condition"));
@@ -223,7 +223,7 @@ fn parse_correlation_condition(
 }
 
 /// Parse correlation field aliases.
-fn parse_correlation_aliases(corr: &serde_yaml::Mapping) -> Vec<FieldAlias> {
+fn parse_correlation_aliases(corr: &yaml_serde::Mapping) -> Vec<FieldAlias> {
     let Some(Value::Mapping(aliases_map)) = corr.get(val_key("aliases")) else {
         return Vec::new();
     };

--- a/crates/rsigma-parser/src/parser/detection.rs
+++ b/crates/rsigma-parser/src/parser/detection.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use crate::ast::*;
 use crate::condition::parse_condition;

--- a/crates/rsigma-parser/src/parser/filter.rs
+++ b/crates/rsigma-parser/src/parser/filter.rs
@@ -1,4 +1,4 @@
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use crate::ast::*;
 use crate::error::{Result, SigmaParserError};
@@ -48,7 +48,7 @@ pub(super) fn parse_filter_rule(value: &Value) -> Result<FilterRule> {
     // Parse detection from filter.selection + filter.condition
     // (Sigma filter spec: selection/condition live inside the filter section).
     let detection = if let Some(fm) = filter_mapping {
-        let mut det_map = serde_yaml::Mapping::new();
+        let mut det_map = yaml_serde::Mapping::new();
         for (k, v) in fm.iter() {
             let key_str = k.as_str().unwrap_or("");
             if key_str != "rules" {

--- a/crates/rsigma-parser/src/parser/mod.rs
+++ b/crates/rsigma-parser/src/parser/mod.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use serde::Deserialize;
-use serde_yaml::Value;
+use yaml_serde::Value;
 
 use crate::ast::*;
 use crate::error::{Result, SigmaParserError};
@@ -42,7 +42,7 @@ pub fn parse_sigma_yaml(yaml: &str) -> Result<SigmaCollection> {
     let mut global: Option<Value> = None;
     let mut previous: Option<Value> = None;
 
-    for doc in serde_yaml::Deserializer::from_str(yaml) {
+    for doc in yaml_serde::Deserializer::from_str(yaml) {
         let value: Value = match Value::deserialize(doc) {
             Ok(v) => v,
             Err(e) => {
@@ -230,7 +230,7 @@ fn parse_document(value: &Value) -> Result<SigmaDocument> {
 /// Pipeline transformations such as `SetCustomAttribute` are applied later
 /// and can further override both sources.
 pub(super) fn collect_custom_attributes(
-    m: &serde_yaml::Mapping,
+    m: &yaml_serde::Mapping,
     standard_keys: &[&str],
 ) -> HashMap<String, Value> {
     let mut attrs: HashMap<String, Value> = m
@@ -309,11 +309,11 @@ pub(super) fn val_key(s: &str) -> Value {
     Value::String(s.to_string())
 }
 
-pub(super) fn get_str<'a>(m: &'a serde_yaml::Mapping, key: &str) -> Option<&'a str> {
+pub(super) fn get_str<'a>(m: &'a yaml_serde::Mapping, key: &str) -> Option<&'a str> {
     m.get(val_key(key)).and_then(|v| v.as_str())
 }
 
-pub(super) fn get_str_list(m: &serde_yaml::Mapping, key: &str) -> Vec<String> {
+pub(super) fn get_str_list(m: &yaml_serde::Mapping, key: &str) -> Vec<String> {
     match m.get(val_key(key)) {
         Some(Value::String(s)) => vec![s.clone()],
         Some(Value::Sequence(seq)) => seq
@@ -339,8 +339,8 @@ fn deep_merge(dest: Value, src: Value) -> crate::error::Result<Value> {
     };
 
     fn merge_level(
-        dest: &mut serde_yaml::Mapping,
-        src: serde_yaml::Mapping,
+        dest: &mut yaml_serde::Mapping,
+        src: yaml_serde::Mapping,
         depth: usize,
     ) -> crate::error::Result<()> {
         if depth > MAX_DEPTH {

--- a/crates/rsigma-parser/src/parser/tests.rs
+++ b/crates/rsigma-parser/src/parser/tests.rs
@@ -1356,12 +1356,12 @@ correlation:
 
 #[test]
 fn deep_merge_handles_deeply_nested_global() {
-    use serde_yaml::Value;
+    use yaml_serde::Value;
 
     fn nested_map(depth: usize) -> Value {
         let mut v = Value::String("leaf".into());
         for i in (0..depth).rev() {
-            let mut map = serde_yaml::Mapping::new();
+            let mut map = yaml_serde::Mapping::new();
             map.insert(Value::String(format!("k{i}")), v);
             v = Value::Mapping(map);
         }
@@ -1379,12 +1379,12 @@ fn deep_merge_handles_deeply_nested_global() {
 
 #[test]
 fn deep_merge_succeeds_at_reasonable_depth() {
-    use serde_yaml::Value;
+    use yaml_serde::Value;
 
     fn nested_map(depth: usize) -> Value {
         let mut v = Value::String("leaf".into());
         for i in (0..depth).rev() {
-            let mut map = serde_yaml::Mapping::new();
+            let mut map = yaml_serde::Mapping::new();
             map.insert(Value::String(format!("k{i}")), v);
             v = Value::Mapping(map);
         }

--- a/crates/rsigma-parser/src/value.rs
+++ b/crates/rsigma-parser/src/value.rs
@@ -173,11 +173,11 @@ pub enum SigmaValue {
 }
 
 impl SigmaValue {
-    /// Create a SigmaValue from a serde_yaml::Value.
-    pub fn from_yaml(v: &serde_yaml::Value) -> Self {
+    /// Create a SigmaValue from a yaml_serde::Value.
+    pub fn from_yaml(v: &yaml_serde::Value) -> Self {
         match v {
-            serde_yaml::Value::String(s) => SigmaValue::String(SigmaString::new(s)),
-            serde_yaml::Value::Number(n) => {
+            yaml_serde::Value::String(s) => SigmaValue::String(SigmaString::new(s)),
+            yaml_serde::Value::Number(n) => {
                 if let Some(i) = n.as_i64() {
                     SigmaValue::Integer(i)
                 } else if let Some(f) = n.as_f64() {
@@ -186,8 +186,8 @@ impl SigmaValue {
                     SigmaValue::Null
                 }
             }
-            serde_yaml::Value::Bool(b) => SigmaValue::Bool(*b),
-            serde_yaml::Value::Null => SigmaValue::Null,
+            yaml_serde::Value::Bool(b) => SigmaValue::Bool(*b),
+            yaml_serde::Value::Null => SigmaValue::Null,
             _ => SigmaValue::String(SigmaString::new(&format!("{v:?}"))),
         }
     }

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -23,7 +23,7 @@ rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.11.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde_json = "1"
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 thiserror = "2"
 tracing = "0.1"
 arc-swap = "1"

--- a/crates/rsigma-runtime/src/sources/file.rs
+++ b/crates/rsigma-runtime/src/sources/file.rs
@@ -44,7 +44,7 @@ pub fn parse_data(raw: &str, format: DataFormat) -> Result<serde_json::Value, So
             kind: SourceErrorKind::Parse(format!("invalid JSON: {e}")),
         }),
         DataFormat::Yaml => {
-            let yaml: serde_yaml::Value = serde_yaml::from_str(raw).map_err(|e| SourceError {
+            let yaml: yaml_serde::Value = yaml_serde::from_str(raw).map_err(|e| SourceError {
                 source_id: String::new(),
                 kind: SourceErrorKind::Parse(format!("invalid YAML: {e}")),
             })?;

--- a/crates/rsigma-runtime/src/sources/include.rs
+++ b/crates/rsigma-runtime/src/sources/include.rs
@@ -119,10 +119,10 @@ fn parse_transformation_array(data: &serde_json::Value) -> Result<Vec<Transforma
         return Err("include source data must be an array of transformation objects".to_string());
     }
 
-    // Convert JSON -> YAML string -> serde_yaml::Value, then use the eval parser
+    // Convert JSON -> YAML string -> yaml_serde::Value, then use the eval parser
     let yaml_str =
         serde_json::to_string(data).map_err(|e| format!("include serialization: {e}"))?;
-    let yaml_val: serde_yaml::Value = serde_yaml::from_str(&yaml_str)
+    let yaml_val: yaml_serde::Value = yaml_serde::from_str(&yaml_str)
         .map_err(|e| format!("include data is not valid YAML: {e}"))?;
 
     rsigma_eval::parse_transformation_items(&yaml_val)

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -266,12 +266,12 @@ pub async fn resolve_all_with_state(
     Ok(resolved)
 }
 
-/// Convert a `serde_yaml::Value` to a `serde_json::Value`.
-pub fn yaml_value_to_json(yaml: &serde_yaml::Value) -> serde_json::Value {
+/// Convert a `yaml_serde::Value` to a `serde_json::Value`.
+pub fn yaml_value_to_json(yaml: &yaml_serde::Value) -> serde_json::Value {
     match yaml {
-        serde_yaml::Value::Null => serde_json::Value::Null,
-        serde_yaml::Value::Bool(b) => serde_json::Value::Bool(*b),
-        serde_yaml::Value::Number(n) => {
+        yaml_serde::Value::Null => serde_json::Value::Null,
+        yaml_serde::Value::Bool(b) => serde_json::Value::Bool(*b),
+        yaml_serde::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 serde_json::Value::Number(i.into())
             } else if let Some(u) = n.as_u64() {
@@ -282,16 +282,16 @@ pub fn yaml_value_to_json(yaml: &serde_yaml::Value) -> serde_json::Value {
                 serde_json::Value::Null
             }
         }
-        serde_yaml::Value::String(s) => serde_json::Value::String(s.clone()),
-        serde_yaml::Value::Sequence(seq) => {
+        yaml_serde::Value::String(s) => serde_json::Value::String(s.clone()),
+        yaml_serde::Value::Sequence(seq) => {
             serde_json::Value::Array(seq.iter().map(yaml_value_to_json).collect())
         }
-        serde_yaml::Value::Mapping(map) => {
+        yaml_serde::Value::Mapping(map) => {
             let obj = map
                 .iter()
                 .map(|(k, v)| {
                     let key = match k {
-                        serde_yaml::Value::String(s) => s.clone(),
+                        yaml_serde::Value::String(s) => s.clone(),
                         other => format!("{other:?}"),
                     };
                     (key, yaml_value_to_json(v))
@@ -299,6 +299,6 @@ pub fn yaml_value_to_json(yaml: &serde_yaml::Value) -> serde_json::Value {
                 .collect();
             serde_json::Value::Object(obj)
         }
-        serde_yaml::Value::Tagged(tagged) => yaml_value_to_json(&tagged.value),
+        yaml_serde::Value::Tagged(tagged) => yaml_value_to_json(&tagged.value),
     }
 }

--- a/crates/rsigma-runtime/tests/sources_integration.rs
+++ b/crates/rsigma-runtime/tests/sources_integration.rs
@@ -358,7 +358,7 @@ async fn resolver_use_default_on_failure() {
     let resolver = DefaultSourceResolver::new();
 
     let default_val =
-        serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("fallback@corp.com".into())]);
+        yaml_serde::Value::Sequence(vec![yaml_serde::Value::String("fallback@corp.com".into())]);
 
     let source = DynamicSource {
         id: "missing_source".to_string(),

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "globset",
  "log",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ rsigma-parser = { path = "../crates/rsigma-parser" }
 rsigma-eval = { path = "../crates/rsigma-eval" }
 rsigma-runtime = { path = "../crates/rsigma-runtime", features = ["logfmt", "cef"] }
 serde_json = "1"
-serde_yaml = { package = "yaml_serde", version = "0.10" }
+yaml_serde = "0.10"
 regex = "1"
 arbitrary = { version = "1", features = ["derive"] }
 

--- a/fuzz/fuzz_targets/fuzz_include_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_include_parse.rs
@@ -8,7 +8,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(s) {
         if json.is_array() {
             if let Ok(yaml_str) = serde_json::to_string(&json) {
-                if let Ok(yaml_val) = serde_yaml::from_str::<serde_yaml::Value>(&yaml_str) {
+                if let Ok(yaml_val) = yaml_serde::from_str::<yaml_serde::Value>(&yaml_str) {
                     let _ = rsigma_eval::parse_transformation_items(&yaml_val);
                 }
             }
@@ -16,7 +16,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     // Path 2: direct YAML parse -> transformation items
-    if let Ok(yaml_val) = serde_yaml::from_str::<serde_yaml::Value>(s) {
+    if let Ok(yaml_val) = yaml_serde::from_str::<yaml_serde::Value>(s) {
         let _ = rsigma_eval::parse_transformation_items(&yaml_val);
     }
 });


### PR DESCRIPTION
## Summary

- Drop the `serde_yaml = { package = "yaml_serde", version = "0.10" }` rename across all six member manifests in favor of `yaml_serde = "0.10"`, and rename ~199 source references from `serde_yaml::` to `yaml_serde::`. Docs and the architecture diagram are updated to match. `CHANGELOG.md` entries that describe the original migration are preserved as historical record.
- Motivation: the rename made the manifest, source, and compiler errors disagree about which crate was in use. When `yamlpatch 1.25.0` migrated its own public `Op::Replace(serde_yaml::Value)` signature from real `serde_yaml 0.9` to `yaml_serde 0.10`, the resulting build error against the previously-published `rsigma 0.11.0` ("expected `yaml_serde::Value`, found `serde_yaml::Value`") was effectively unreadable because two opposite renames (`serde_yaml = yaml_serde` and `yamlpatch_yaml = serde_yaml`) collided in the same Cargo.toml. Using the real crate name avoids that confusion permanently.
- No behavior change. The `yaml_serde 0.10` crate is the long-term replacement for the deprecated `serde_yaml 0.9` and was already what we were using, just under a different name.

## Test plan

- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features` (unit + integration + doc tests pass)