### PR TITLE
chore(deps): bump yamlpath/yamlpatch to 1.25.2 and watch fuzz/Cargo.lock in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: cargo
+    directory: "/fuzz"
+    schedule:
+      interval: weekly
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "subfeature"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e860b3674e63a4ec53f99c94fe596c64cb17e94776e15c03d856e826a459e2"
+checksum = "c7a12b8bd1c18886edb6412ca26de28cf3e44be4ba5aeb41d14fb911ef2dab63"
 dependencies = [
  "memchr",
  "regex",
@@ -5047,9 +5047,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-iter"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9381a9c1ad0edfe47eda0218c94bcced73741be660a00baa2ceabaa9289375f"
+checksum = "d9199d1d8f51defb45b2a55af0545460e0a0265dfde45bdf412b33d13e09b923"
 dependencies = [
  "tree-sitter",
 ]
@@ -5881,9 +5881,9 @@ dependencies = [
 
 [[package]]
 name = "yamlpatch"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29204c690e53bb66d04e9cb6d7c34075f087d81f7ef5d8ee77c2c2081da7414"
+checksum = "f5c7aa995e374499b0decb17a2fa138430d6cd4683705e905e1e6619635d5fbd"
 dependencies = [
  "indexmap 2.14.0",
  "line-index",
@@ -5897,9 +5897,9 @@ dependencies = [
 
 [[package]]
 name = "yamlpath"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee69e8a2c397c2cdd831389213743f92e48f5998d32d650d40767e919ee663e"
+checksum = "582de007205c6ff9e4c1e57bf23955922e8020dd9fd479146ab2bb45138b44b4"
 dependencies = [
  "line-index",
  "self_cell",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_json_path = "0.7.2"
 jsonschema = "0.46"
 ureq = "3"
 dirs = "6"
-yamlpath = "1.24"
+yamlpath = "1.25"
 yamlpatch = "1.25"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }


### PR DESCRIPTION
## Summary

Two small dependency-housekeeping changes folded into one PR.

- Bump `yamlpath` and `yamlpatch` to `1.25.2` in `crates/rsigma-cli/Cargo.toml`. This picks up the `serde_yaml` to `yaml_serde` rename shipped by zizmorcore/zizmor#2015 so the manifest, source code, and compiler diagnostics all refer to the same crate, and aligns the `yamlpath` constraint with `yamlpatch` (both `1.25` now). Resolved versions in `Cargo.lock`: `yamlpath 1.25.2`, `yamlpatch 1.25.2`, plus transitive `subfeature 1.25.2` and `tree-sitter-iter 1.25.2`.
- Add a second `cargo` ecosystem entry to `.github/dependabot.yml` pointed at `/fuzz`. The fuzz workspace is excluded from the root workspace, so its `Cargo.lock` was invisible to the existing Dependabot config that targets `/`. Without this, `fuzz/Cargo.lock` drifts and any local cargo command that touches it can bleed incidental dependency bumps into unrelated PRs.

## Test plan

- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features`
- [x] `.github/dependabot.yml` is YAML and verified against [GitHub's schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) by re-reading the diff; Dependabot will validate on push.