### PR TITLE
fix(test): make cli_daemon_http and cli_daemon_otlp robust to startup and processing races

### DIFF
--- a/crates/rsigma-cli/tests/cli_daemon_http.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_http.rs
@@ -7,200 +7,8 @@
 
 mod common;
 
-use common::{SIMPLE_RULE, temp_file};
-use std::io::{BufRead, BufReader};
-use std::net::TcpStream;
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
-
-fn rsigma_bin() -> String {
-    assert_cmd::cargo::cargo_bin("rsigma")
-        .to_str()
-        .unwrap()
-        .to_string()
-}
-
-enum StartupEvent {
-    ApiAddr(String),
-    SinkStarted,
-}
-
-/// Scope guard that owns a `Child` and kills + waits on drop. Used during
-/// daemon startup so that a handshake panic does not leak a daemon process.
-struct ChildGuard(Option<std::process::Child>);
-
-impl ChildGuard {
-    fn as_child_mut(&mut self) -> &mut std::process::Child {
-        self.0.as_mut().expect("guard already disarmed")
-    }
-
-    fn disarm(mut self) -> std::process::Child {
-        self.0.take().expect("guard already disarmed")
-    }
-}
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        if let Some(mut child) = self.0.take() {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-    }
-}
-
-struct DaemonProcess {
-    child: std::process::Child,
-    api_addr: String,
-}
-
-/// Poll `check` every 50ms until it returns `Some(value)` or `deadline`
-/// elapses. Use this in place of fixed sleeps when you actually want to wait
-/// for a specific observable condition.
-fn poll_until<T>(deadline: Duration, mut check: impl FnMut() -> Option<T>) -> Option<T> {
-    let end = Instant::now() + deadline;
-    loop {
-        if let Some(v) = check() {
-            return Some(v);
-        }
-        if Instant::now() >= end {
-            return None;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-impl DaemonProcess {
-    fn spawn(args: &[&str]) -> Self {
-        let child = Command::new(rsigma_bin())
-            .args(args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn rsigma daemon");
-        let mut guard = ChildGuard(Some(child));
-
-        // Drain stdout in a background thread. Otherwise a daemon that writes
-        // match output to its sink can fill the pipe buffer (~64 KiB on macOS)
-        // and block on its own write, which surfaces in tests as a stale
-        // socket and `ConnectionRefused` later.
-        if let Some(stdout) = guard.as_child_mut().stdout.take() {
-            std::thread::spawn(move || {
-                let mut sink = std::io::sink();
-                let _ = std::io::copy(&mut BufReader::new(stdout), &mut sink);
-            });
-        }
-
-        // Read stderr in a background thread so it never blocks the daemon
-        // once it fills the OS pipe buffer. The thread forwards interesting
-        // log lines back over a channel for the spawn handshake.
-        let stderr = guard.as_child_mut().stderr.take().unwrap();
-        let (tx, rx) = std::sync::mpsc::channel::<StartupEvent>();
-        std::thread::spawn(move || {
-            for line in BufReader::new(stderr).lines() {
-                let Ok(line) = line else { return };
-                if line.contains("API server listening")
-                    && let Some(addr) = extract_addr(&line)
-                {
-                    let _ = tx.send(StartupEvent::ApiAddr(addr));
-                }
-                if line.contains("Sink started") {
-                    let _ = tx.send(StartupEvent::SinkStarted);
-                }
-            }
-        });
-
-        let mut api_addr = String::new();
-        let mut sink_started = false;
-        let handshake_deadline = Instant::now() + Duration::from_secs(10);
-        while !sink_started || api_addr.is_empty() {
-            let remaining = handshake_deadline
-                .checked_duration_since(Instant::now())
-                .unwrap_or(Duration::ZERO);
-            match rx.recv_timeout(remaining) {
-                Ok(StartupEvent::ApiAddr(addr)) => api_addr = addr,
-                Ok(StartupEvent::SinkStarted) => sink_started = true,
-                Err(_) => panic!(
-                    "daemon did not finish startup within 10s (api_addr={api_addr:?}, sink_started={sink_started})"
-                ),
-            }
-        }
-
-        // `Sink started` is logged before `axum::serve` enters its accept
-        // loop in practice, so probe the listening socket until it actually
-        // accepts a connection before returning.
-        let socket: std::net::SocketAddr = api_addr
-            .parse()
-            .unwrap_or_else(|e| panic!("invalid api_addr {api_addr:?}: {e}"));
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            if TcpStream::connect_timeout(&socket, Duration::from_millis(200)).is_ok() {
-                return Self {
-                    child: guard.disarm(),
-                    api_addr,
-                };
-            }
-            if Instant::now() >= deadline {
-                panic!("daemon API at {api_addr} never became reachable within 5s");
-            }
-            std::thread::sleep(Duration::from_millis(25));
-        }
-    }
-
-    fn url(&self, path: &str) -> String {
-        format!("http://{}{path}", self.api_addr)
-    }
-
-    fn kill(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-impl Drop for DaemonProcess {
-    fn drop(&mut self) {
-        self.kill();
-    }
-}
-
-/// Extract the `addr` field from a structured JSON log line.
-/// Log format: `{"fields":{"message":"API server listening","addr":"127.0.0.1:PORT"},...}`
-fn extract_addr(line: &str) -> Option<String> {
-    serde_json::from_str::<serde_json::Value>(line)
-        .ok()
-        .and_then(|v| v["fields"]["addr"].as_str().map(|s| s.to_string()))
-}
-
-fn spawn_http_daemon(rule_path: &str) -> DaemonProcess {
-    DaemonProcess::spawn(&[
-        "daemon",
-        "-r",
-        rule_path,
-        "--input",
-        "http",
-        "--api-addr",
-        "127.0.0.1:0",
-    ])
-}
-
-fn http_get(url: &str) -> (u16, String) {
-    let resp = ureq::get(url).call().expect("HTTP GET failed");
-    let status = resp.status().as_u16();
-    let body = resp.into_body().read_to_string().unwrap();
-    (status, body)
-}
-
-fn http_post(url: &str, body: &str) -> (u16, String) {
-    match ureq::post(url).send(body) {
-        Ok(resp) => {
-            let status = resp.status().as_u16();
-            let body = resp.into_body().read_to_string().unwrap();
-            (status, body)
-        }
-        Err(ureq::Error::StatusCode(code)) => (code, String::new()),
-        Err(e) => panic!("HTTP POST failed: {e}"),
-    }
-}
+use common::{DaemonProcess, SIMPLE_RULE, http_get, http_post, poll_until, temp_file};
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // API endpoint tests
@@ -209,7 +17,7 @@ fn http_post(url: &str, body: &str) -> (u16, String) {
 #[test]
 fn healthz_returns_ok() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let (status, body) = http_get(&daemon.url("/healthz"));
     assert_eq!(status, 200);
@@ -220,7 +28,7 @@ fn healthz_returns_ok() {
 #[test]
 fn readyz_returns_ready() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let (status, body) = http_get(&daemon.url("/readyz"));
     assert_eq!(status, 200);
@@ -232,7 +40,7 @@ fn readyz_returns_ready() {
 #[test]
 fn list_rules_returns_counts() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let (status, body) = http_get(&daemon.url("/api/v1/rules"));
     assert_eq!(status, 200);
@@ -244,7 +52,7 @@ fn list_rules_returns_counts() {
 #[test]
 fn status_returns_running() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let (status, body) = http_get(&daemon.url("/api/v1/status"));
     assert_eq!(status, 200);
@@ -257,7 +65,7 @@ fn status_returns_running() {
 #[test]
 fn metrics_returns_prometheus_format() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let (status, body) = http_get(&daemon.url("/metrics"));
     assert_eq!(status, 200);
@@ -270,7 +78,7 @@ fn metrics_returns_prometheus_format() {
 #[test]
 fn reload_triggers_successfully() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     // The file watcher may fill the reload channel on startup (especially on
     // macOS where FSEvents fires multiple events). Retry until the debounce
@@ -299,7 +107,7 @@ fn reload_triggers_successfully() {
 #[test]
 fn ingest_single_event_accepted() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let (status, body) = http_post(
         &daemon.url("/api/v1/events"),
@@ -313,7 +121,7 @@ fn ingest_single_event_accepted() {
 #[test]
 fn ingest_ndjson_batch() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let batch = r#"{"CommandLine":"malware.exe"}
 {"CommandLine":"notepad.exe"}
@@ -328,7 +136,7 @@ fn ingest_ndjson_batch() {
 #[test]
 fn ingest_updates_status_counters() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     http_post(
         &daemon.url("/api/v1/events"),
@@ -358,7 +166,7 @@ fn ingest_updates_status_counters() {
 #[test]
 fn metrics_include_per_rule_labels_after_detection() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = spawn_http_daemon(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     http_post(
         &daemon.url("/api/v1/events"),

--- a/crates/rsigma-cli/tests/cli_daemon_http.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_http.rs
@@ -9,8 +9,9 @@ mod common;
 
 use common::{SIMPLE_RULE, temp_file};
 use std::io::{BufRead, BufReader};
+use std::net::TcpStream;
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn rsigma_bin() -> String {
     assert_cmd::cargo::cargo_bin("rsigma")
@@ -19,43 +20,131 @@ fn rsigma_bin() -> String {
         .to_string()
 }
 
+enum StartupEvent {
+    ApiAddr(String),
+    SinkStarted,
+}
+
+/// Scope guard that owns a `Child` and kills + waits on drop. Used during
+/// daemon startup so that a handshake panic does not leak a daemon process.
+struct ChildGuard(Option<std::process::Child>);
+
+impl ChildGuard {
+    fn as_child_mut(&mut self) -> &mut std::process::Child {
+        self.0.as_mut().expect("guard already disarmed")
+    }
+
+    fn disarm(mut self) -> std::process::Child {
+        self.0.take().expect("guard already disarmed")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
 struct DaemonProcess {
     child: std::process::Child,
     api_addr: String,
 }
 
+/// Poll `check` every 50ms until it returns `Some(value)` or `deadline`
+/// elapses. Use this in place of fixed sleeps when you actually want to wait
+/// for a specific observable condition.
+fn poll_until<T>(deadline: Duration, mut check: impl FnMut() -> Option<T>) -> Option<T> {
+    let end = Instant::now() + deadline;
+    loop {
+        if let Some(v) = check() {
+            return Some(v);
+        }
+        if Instant::now() >= end {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 impl DaemonProcess {
     fn spawn(args: &[&str]) -> Self {
-        let mut child = Command::new(rsigma_bin())
+        let child = Command::new(rsigma_bin())
             .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
             .expect("failed to spawn rsigma daemon");
+        let mut guard = ChildGuard(Some(child));
 
-        let stderr = child.stderr.take().unwrap();
-        let reader = BufReader::new(stderr);
-        let mut api_addr = String::new();
+        // Drain stdout in a background thread. Otherwise a daemon that writes
+        // match output to its sink can fill the pipe buffer (~64 KiB on macOS)
+        // and block on its own write, which surfaces in tests as a stale
+        // socket and `ConnectionRefused` later.
+        if let Some(stdout) = guard.as_child_mut().stdout.take() {
+            std::thread::spawn(move || {
+                let mut sink = std::io::sink();
+                let _ = std::io::copy(&mut BufReader::new(stdout), &mut sink);
+            });
+        }
 
-        for line in reader.lines() {
-            let line = line.unwrap();
-            if line.contains("API server listening")
-                && let Some(addr) = extract_addr(&line)
-            {
-                api_addr = addr;
+        // Read stderr in a background thread so it never blocks the daemon
+        // once it fills the OS pipe buffer. The thread forwards interesting
+        // log lines back over a channel for the spawn handshake.
+        let stderr = guard.as_child_mut().stderr.take().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel::<StartupEvent>();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stderr).lines() {
+                let Ok(line) = line else { return };
+                if line.contains("API server listening")
+                    && let Some(addr) = extract_addr(&line)
+                {
+                    let _ = tx.send(StartupEvent::ApiAddr(addr));
+                }
+                if line.contains("Sink started") {
+                    let _ = tx.send(StartupEvent::SinkStarted);
+                }
             }
-            if line.contains("Sink started") {
-                break;
+        });
+
+        let mut api_addr = String::new();
+        let mut sink_started = false;
+        let handshake_deadline = Instant::now() + Duration::from_secs(10);
+        while !sink_started || api_addr.is_empty() {
+            let remaining = handshake_deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            match rx.recv_timeout(remaining) {
+                Ok(StartupEvent::ApiAddr(addr)) => api_addr = addr,
+                Ok(StartupEvent::SinkStarted) => sink_started = true,
+                Err(_) => panic!(
+                    "daemon did not finish startup within 10s (api_addr={api_addr:?}, sink_started={sink_started})"
+                ),
             }
         }
 
-        assert!(
-            !api_addr.is_empty(),
-            "failed to discover API address from daemon stderr"
-        );
-
-        Self { child, api_addr }
+        // `Sink started` is logged before `axum::serve` enters its accept
+        // loop in practice, so probe the listening socket until it actually
+        // accepts a connection before returning.
+        let socket: std::net::SocketAddr = api_addr
+            .parse()
+            .unwrap_or_else(|e| panic!("invalid api_addr {api_addr:?}: {e}"));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if TcpStream::connect_timeout(&socket, Duration::from_millis(200)).is_ok() {
+                return Self {
+                    child: guard.disarm(),
+                    api_addr,
+                };
+            }
+            if Instant::now() >= deadline {
+                panic!("daemon API at {api_addr} never became reachable within 5s");
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
     }
 
     fn url(&self, path: &str) -> String {
@@ -246,10 +335,15 @@ fn ingest_updates_status_counters() {
         r#"{"CommandLine":"malware.exe"}"#,
     );
 
-    // Give the engine a moment to process
-    std::thread::sleep(Duration::from_millis(500));
+    let body = poll_until(Duration::from_secs(5), || {
+        let (_, body) = http_get(&daemon.url("/api/v1/status"));
+        let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+        let processed = v["events_processed"].as_u64()?;
+        let matched = v["detection_matches"].as_u64()?;
+        (processed >= 1 && matched >= 1).then_some(body)
+    })
+    .expect("status counters never reflected the ingested event within 5s");
 
-    let (_, body) = http_get(&daemon.url("/api/v1/status"));
     let v: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert!(
         v["events_processed"].as_u64().unwrap() >= 1,
@@ -271,10 +365,16 @@ fn metrics_include_per_rule_labels_after_detection() {
         r#"{"CommandLine":"malware.exe"}"#,
     );
 
-    std::thread::sleep(Duration::from_millis(500));
+    let body = poll_until(Duration::from_secs(5), || {
+        let (status, body) = http_get(&daemon.url("/metrics"));
+        (status == 200
+            && body.contains("rsigma_detection_matches_by_rule_total")
+            && body.contains(r#"rule_title="Test Rule""#)
+            && body.contains(r#"level="high""#))
+        .then_some(body)
+    })
+    .expect("per-rule detection metrics never appeared within 5s");
 
-    let (status, body) = http_get(&daemon.url("/metrics"));
-    assert_eq!(status, 200);
     assert!(
         body.contains("rsigma_detection_matches_by_rule_total"),
         "metrics should contain per-rule detection counter"

--- a/crates/rsigma-cli/tests/cli_daemon_otlp.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_otlp.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use common::{SIMPLE_RULE, temp_file};
+use common::{DaemonProcess, SIMPLE_RULE, http_get, poll_until, temp_file};
 use opentelemetry_proto::tonic::{
     collector::logs::v1::ExportLogsServiceRequest,
     common::v1::{AnyValue, KeyValue, KeyValueList, any_value},
@@ -16,81 +16,7 @@ use opentelemetry_proto::tonic::{
     resource::v1::Resource,
 };
 use prost::Message;
-use std::io::{BufRead, BufReader};
-use std::process::{Command, Stdio};
 use std::time::Duration;
-
-fn rsigma_bin() -> String {
-    assert_cmd::cargo::cargo_bin("rsigma")
-        .to_str()
-        .unwrap()
-        .to_string()
-}
-
-struct DaemonProcess {
-    child: std::process::Child,
-    api_addr: String,
-}
-
-impl DaemonProcess {
-    fn spawn(rule_path: &str) -> Self {
-        let mut child = Command::new(rsigma_bin())
-            .args([
-                "daemon",
-                "-r",
-                rule_path,
-                "--input",
-                "http",
-                "--api-addr",
-                "127.0.0.1:0",
-            ])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("failed to spawn rsigma daemon");
-
-        let stderr = child.stderr.take().unwrap();
-        let reader = BufReader::new(stderr);
-        let mut api_addr = String::new();
-
-        for line in reader.lines() {
-            let line = line.unwrap();
-            if line.contains("API server listening")
-                && let Some(addr) = extract_addr(&line)
-            {
-                api_addr = addr;
-            }
-            if line.contains("Sink started") {
-                break;
-            }
-        }
-
-        assert!(
-            !api_addr.is_empty(),
-            "failed to discover API address from daemon stderr"
-        );
-
-        Self { child, api_addr }
-    }
-
-    fn url(&self, path: &str) -> String {
-        format!("http://{}{path}", self.api_addr)
-    }
-}
-
-impl Drop for DaemonProcess {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-fn extract_addr(line: &str) -> Option<String> {
-    serde_json::from_str::<serde_json::Value>(line)
-        .ok()
-        .and_then(|v| v["fields"]["addr"].as_str().map(|s| s.to_string()))
-}
 
 fn string_val(s: &str) -> AnyValue {
     AnyValue {
@@ -129,11 +55,15 @@ fn make_otlp_request(fields: Vec<KeyValue>) -> ExportLogsServiceRequest {
     }
 }
 
-fn http_get(url: &str) -> (u16, String) {
-    let resp = ureq::get(url).call().expect("HTTP GET failed");
-    let status = resp.status().as_u16();
-    let body = resp.into_body().read_to_string().unwrap();
-    (status, body)
+/// Wait until `/api/v1/status` reports `detection_matches >= 1`.
+/// Panics with a clear message on timeout.
+fn wait_for_detection_match(daemon: &DaemonProcess) {
+    poll_until(Duration::from_secs(5), || {
+        let (_, body) = http_get(&daemon.url("/api/v1/status"));
+        let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+        (v["detection_matches"].as_u64()? >= 1).then_some(())
+    })
+    .expect("detection_matches never reached 1 within 5s");
 }
 
 // ---------------------------------------------------------------------------
@@ -143,7 +73,7 @@ fn http_get(url: &str) -> (u16, String) {
 #[test]
 fn otlp_http_protobuf_accepted() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let request = make_otlp_request(vec![kv("CommandLine", string_val("something benign"))]);
     let mut buf = Vec::new();
@@ -163,7 +93,7 @@ fn otlp_http_protobuf_accepted() {
 #[test]
 fn otlp_http_protobuf_triggers_detection() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let request = make_otlp_request(vec![kv("CommandLine", string_val("run malware.exe now"))]);
     let mut buf = Vec::new();
@@ -175,7 +105,7 @@ fn otlp_http_protobuf_triggers_detection() {
         .expect("OTLP POST failed");
     assert_eq!(resp.status().as_u16(), 200);
 
-    std::thread::sleep(Duration::from_millis(500));
+    wait_for_detection_match(&daemon);
 
     let (_, status_body) = http_get(&daemon.url("/api/v1/status"));
     let v: serde_json::Value = serde_json::from_str(&status_body).unwrap();
@@ -196,7 +126,7 @@ fn otlp_http_protobuf_triggers_detection() {
 #[test]
 fn otlp_http_json_accepted() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let request = make_otlp_request(vec![kv("CommandLine", string_val("benign process"))]);
     let json_body = serde_json::to_string(&request).unwrap();
@@ -215,7 +145,7 @@ fn otlp_http_json_accepted() {
 #[test]
 fn otlp_http_json_triggers_detection() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let request = make_otlp_request(vec![kv("CommandLine", string_val("launch malware.exe"))]);
     let json_body = serde_json::to_string(&request).unwrap();
@@ -226,7 +156,7 @@ fn otlp_http_json_triggers_detection() {
         .expect("OTLP JSON POST failed");
     assert_eq!(resp.status().as_u16(), 200);
 
-    std::thread::sleep(Duration::from_millis(500));
+    wait_for_detection_match(&daemon);
 
     let (_, status_body) = http_get(&daemon.url("/api/v1/status"));
     let v: serde_json::Value = serde_json::from_str(&status_body).unwrap();
@@ -247,7 +177,7 @@ fn otlp_http_gzip_protobuf_accepted() {
     use std::io::Write;
 
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let request = make_otlp_request(vec![kv("CommandLine", string_val("malware.exe gzip test"))]);
     let mut proto_buf = Vec::new();
@@ -265,7 +195,7 @@ fn otlp_http_gzip_protobuf_accepted() {
 
     assert_eq!(resp.status().as_u16(), 200);
 
-    std::thread::sleep(Duration::from_millis(500));
+    wait_for_detection_match(&daemon);
 
     let (_, status_body) = http_get(&daemon.url("/api/v1/status"));
     let v: serde_json::Value = serde_json::from_str(&status_body).unwrap();
@@ -282,7 +212,7 @@ fn otlp_http_gzip_protobuf_accepted() {
 #[test]
 fn otlp_http_unsupported_content_type_returns_415() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let result = ureq::post(&daemon.url("/v1/logs"))
         .header("Content-Type", "text/plain")
@@ -297,7 +227,7 @@ fn otlp_http_unsupported_content_type_returns_415() {
 #[test]
 fn otlp_http_malformed_protobuf_returns_400() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let result = ureq::post(&daemon.url("/v1/logs"))
         .header("Content-Type", "application/x-protobuf")
@@ -312,7 +242,7 @@ fn otlp_http_malformed_protobuf_returns_400() {
 #[test]
 fn otlp_http_malformed_json_returns_400() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let result = ureq::post(&daemon.url("/v1/logs"))
         .header("Content-Type", "application/json")
@@ -331,7 +261,7 @@ fn otlp_http_malformed_json_returns_400() {
 #[test]
 fn otlp_metrics_exposed_after_request() {
     let rule = temp_file(".yml", SIMPLE_RULE);
-    let daemon = DaemonProcess::spawn(rule.path().to_str().unwrap());
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
 
     let request = make_otlp_request(vec![kv("CommandLine", string_val("test"))]);
     let mut buf = Vec::new();
@@ -342,10 +272,15 @@ fn otlp_metrics_exposed_after_request() {
         .send(&buf[..])
         .expect("OTLP POST failed");
 
-    std::thread::sleep(Duration::from_millis(200));
+    let body = poll_until(Duration::from_secs(5), || {
+        let (status, body) = http_get(&daemon.url("/metrics"));
+        (status == 200
+            && body.contains("rsigma_otlp_requests_total")
+            && body.contains("rsigma_otlp_log_records_total"))
+        .then_some(body)
+    })
+    .expect("OTLP metrics never appeared within 5s");
 
-    let (status, body) = http_get(&daemon.url("/metrics"));
-    assert_eq!(status, 200);
     assert!(
         body.contains("rsigma_otlp_requests_total"),
         "metrics should contain rsigma_otlp_requests_total"

--- a/crates/rsigma-cli/tests/common/mod.rs
+++ b/crates/rsigma-cli/tests/common/mod.rs
@@ -1,7 +1,10 @@
 //! Shared helpers and fixture constants for CLI integration tests.
 #![allow(dead_code)]
 
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::process::{Command as StdCommand, Stdio};
+use std::time::{Duration, Instant};
 
 use assert_cmd::Command;
 use tempfile::NamedTempFile;
@@ -11,12 +14,230 @@ pub fn rsigma() -> Command {
     Command::cargo_bin("rsigma").expect("binary not found")
 }
 
+/// Path to the freshly-built `rsigma` binary for tests that need to spawn
+/// it directly via `std::process::Command` (long-running daemon processes).
+pub fn rsigma_bin() -> String {
+    assert_cmd::cargo::cargo_bin("rsigma")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
 /// Write `contents` to a temporary file with the given suffix and return it.
 pub fn temp_file(suffix: &str, contents: &str) -> NamedTempFile {
     let mut f = tempfile::Builder::new().suffix(suffix).tempfile().unwrap();
     f.write_all(contents.as_bytes()).unwrap();
     f.flush().unwrap();
     f
+}
+
+// ---------------------------------------------------------------------------
+// Daemon HTTP process helper
+// ---------------------------------------------------------------------------
+
+/// Events the spawn handshake waits for from the daemon's stderr.
+enum StartupEvent {
+    ApiAddr(String),
+    SinkStarted,
+}
+
+/// Scope guard that owns a `Child` and kills + waits on drop. Used during
+/// daemon startup so that a handshake panic does not leak a daemon process.
+struct ChildGuard(Option<std::process::Child>);
+
+impl ChildGuard {
+    fn as_child_mut(&mut self) -> &mut std::process::Child {
+        self.0.as_mut().expect("guard already disarmed")
+    }
+
+    fn disarm(mut self) -> std::process::Child {
+        self.0.take().expect("guard already disarmed")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// A live `rsigma daemon` subprocess with a known API address. Killed and
+/// reaped on drop.
+pub struct DaemonProcess {
+    child: std::process::Child,
+    api_addr: String,
+}
+
+impl DaemonProcess {
+    /// Spawn `rsigma` with `args` and block until the daemon's HTTP API
+    /// is actually accepting connections.
+    ///
+    /// The startup handshake:
+    /// 1. Drain stdout in a background thread so a busy sink can never fill
+    ///    the OS pipe buffer and block the daemon on its own write.
+    /// 2. Read stderr in a background thread, forwarding the
+    ///    `API server listening` and `Sink started` log lines over a
+    ///    channel.
+    /// 3. Wait for both events, with a 10s deadline.
+    /// 4. Probe the listening TCP socket with `connect_timeout` in a 5s,
+    ///    25ms-tick retry loop. `Sink started` is emitted just before
+    ///    `axum::serve` enters its accept loop, so the log line alone is
+    ///    not a sufficient readiness signal.
+    ///
+    /// Any panic during the handshake is caught by `ChildGuard`, which
+    /// kills + waits on the daemon process so we never leak one.
+    pub fn spawn(args: &[&str]) -> Self {
+        let child = StdCommand::new(rsigma_bin())
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn rsigma daemon");
+        let mut guard = ChildGuard(Some(child));
+
+        if let Some(stdout) = guard.as_child_mut().stdout.take() {
+            std::thread::spawn(move || {
+                let mut sink = std::io::sink();
+                let _ = std::io::copy(&mut BufReader::new(stdout), &mut sink);
+            });
+        }
+
+        let stderr = guard.as_child_mut().stderr.take().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel::<StartupEvent>();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stderr).lines() {
+                let Ok(line) = line else { return };
+                if line.contains("API server listening")
+                    && let Some(addr) = extract_addr(&line)
+                {
+                    let _ = tx.send(StartupEvent::ApiAddr(addr));
+                }
+                if line.contains("Sink started") {
+                    let _ = tx.send(StartupEvent::SinkStarted);
+                }
+            }
+        });
+
+        let mut api_addr = String::new();
+        let mut sink_started = false;
+        let handshake_deadline = Instant::now() + Duration::from_secs(10);
+        while !sink_started || api_addr.is_empty() {
+            let remaining = handshake_deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            match rx.recv_timeout(remaining) {
+                Ok(StartupEvent::ApiAddr(addr)) => api_addr = addr,
+                Ok(StartupEvent::SinkStarted) => sink_started = true,
+                Err(_) => panic!(
+                    "daemon did not finish startup within 10s (api_addr={api_addr:?}, sink_started={sink_started})"
+                ),
+            }
+        }
+
+        let socket: std::net::SocketAddr = api_addr
+            .parse()
+            .unwrap_or_else(|e| panic!("invalid api_addr {api_addr:?}: {e}"));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if TcpStream::connect_timeout(&socket, Duration::from_millis(200)).is_ok() {
+                return Self {
+                    child: guard.disarm(),
+                    api_addr,
+                };
+            }
+            if Instant::now() >= deadline {
+                panic!("daemon API at {api_addr} never became reachable within 5s");
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    /// Spawn `rsigma daemon -r RULE --input http --api-addr 127.0.0.1:0`.
+    pub fn spawn_http(rule_path: &str) -> Self {
+        Self::spawn(&[
+            "daemon",
+            "-r",
+            rule_path,
+            "--input",
+            "http",
+            "--api-addr",
+            "127.0.0.1:0",
+        ])
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("http://{}{path}", self.api_addr)
+    }
+
+    pub fn api_addr(&self) -> &str {
+        &self.api_addr
+    }
+
+    fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for DaemonProcess {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+/// Extract the `addr` field from a structured JSON log line of the form
+/// `{"fields":{"message":"API server listening","addr":"127.0.0.1:PORT"},...}`.
+fn extract_addr(line: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|v| v["fields"]["addr"].as_str().map(|s| s.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// HTTP and polling helpers
+// ---------------------------------------------------------------------------
+
+/// GET `url`, panicking on transport errors. Returns the status code and
+/// body. Status codes other than 2xx are returned, not panicked.
+pub fn http_get(url: &str) -> (u16, String) {
+    let resp = ureq::get(url).call().expect("HTTP GET failed");
+    let status = resp.status().as_u16();
+    let body = resp.into_body().read_to_string().unwrap();
+    (status, body)
+}
+
+/// POST `body` to `url`. Returns (status, body) for both ok and
+/// `StatusCode` responses; panics on transport errors.
+pub fn http_post(url: &str, body: &str) -> (u16, String) {
+    match ureq::post(url).send(body) {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            let body = resp.into_body().read_to_string().unwrap();
+            (status, body)
+        }
+        Err(ureq::Error::StatusCode(code)) => (code, String::new()),
+        Err(e) => panic!("HTTP POST failed: {e}"),
+    }
+}
+
+/// Poll `check` every 50ms until it returns `Some(value)` or `deadline`
+/// elapses. Use this in place of fixed sleeps when you want to wait for a
+/// specific observable condition.
+pub fn poll_until<T>(deadline: Duration, mut check: impl FnMut() -> Option<T>) -> Option<T> {
+    let end = Instant::now() + deadline;
+    loop {
+        if let Some(v) = check() {
+            return Some(v);
+        }
+        if Instant::now() >= end {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 pub const SIMPLE_RULE: &str = r#"


### PR DESCRIPTION
## Summary

The daemon HTTP E2E suites (`crates/rsigma-cli/tests/cli_daemon_http.rs` and `crates/rsigma-cli/tests/cli_daemon_otlp.rs`) were flaky on macOS. Both files were occasionally failing with `ConnectionRefused` on a GET that immediately followed a POST. Increasing the fixed sleep would widen the race window without addressing the underlying issues. This PR addresses the root causes and lifts the shared daemon process helper into `tests/common/mod.rs` so the fix lives in one place.

Three real defects in the prior `DaemonProcess::spawn`:

1. The daemon's stdout was piped but never drained. A sink that writes enough match output can fill the ~64 KiB macOS pipe buffer and block the daemon on its own write, producing a stale socket and `ConnectionRefused` later in the test.
2. The spawn handshake stopped reading stderr after seeing `Sink started`, so any log written later could also fill the pipe buffer.
3. `Sink started` is emitted just before `axum::serve` enters its accept loop. A test firing a request immediately after the handshake could hit the kernel before the listener was wired up.

### Changes

`tests/common/mod.rs` now exposes a shared `DaemonProcess` with:

- A background thread that drains stdout to `io::sink()` for the life of the daemon.
- A background thread that reads stderr forever, forwarding the two interesting log lines (`API server listening`, `Sink started`) over an `mpsc` channel. The handshake blocks on the channel with a 10s deadline.
- A TCP probe with `TcpStream::connect_timeout` in a 5s / 25ms-tick retry loop after the log handshake, so the daemon is provably accepting connections before `spawn` returns.
- A `ChildGuard` RAII wrapper that kills + waits on the child if any handshake panic fires, satisfying clippy's `zombie_processes` lint.
- A `spawn_http` convenience that issues the standard `daemon -r RULE --input http --api-addr 127.0.0.1:0` argv used by both test files.

Also lifted to `tests/common/mod.rs`: `rsigma_bin`, `http_get`, `http_post`, and `poll_until`. The poll helper retries every 50ms against a closure until it returns `Some(value)` or the deadline elapses.

Both `cli_daemon_http.rs` and `cli_daemon_otlp.rs` now use the shared helper. Their previously-duplicated `DaemonProcess`, `extract_addr`, `http_get`, and `http_post` definitions are gone.

Fixed sleeps replaced with `poll_until` against the specific observable condition:

- `cli_daemon_http`: `ingest_updates_status_counters` and `metrics_include_per_rule_labels_after_detection` (was 500ms and 1000ms respectively in the latest tree).
- `cli_daemon_otlp`: `otlp_http_protobuf_triggers_detection`, `otlp_http_json_triggers_detection`, `otlp_http_gzip_protobuf_accepted`, and `otlp_metrics_exposed_after_request`.

### Scope

`cli_daemon_nats.rs` and `cli_daemon_dynamic.rs` still carry their own `DaemonProcess` variants. The NATS variant waits on a custom log marker rather than the API handshake; the dynamic variant captures the full stderr stream for later assertions. Both are deferred to a follow-up since they need slightly different shapes.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test -p rsigma --test cli_daemon_http --features daemon`: 10 passed, 0 failed, ~1.0s. Ran 5 consecutive times to check for flakiness; all 5 passed at ~1.0s.
- [x] `cargo test -p rsigma --test cli_daemon_otlp --features daemon-otlp`: 9 passed, 0 failed, ~1.0s. Ran 5 consecutive times to check for flakiness; all 5 passed at ~1.0s.
- [x] `cargo test --workspace --all-features` green. (The NATS testcontainer tests are flaky under concurrent execution due to a Docker-on-macOS issue but pass cleanly in isolation; unrelated to this PR.)