### PR TITLE
perf(eval): batch rule loading to avoid O(N²) index rebuilds

### DIFF
--- a/crates/rsigma-cli/src/commands/validate.rs
+++ b/crates/rsigma-cli/src/commands/validate.rs
@@ -92,17 +92,20 @@ pub(crate) fn cmd_validate(
                 engine.add_pipeline(p.clone());
             }
 
-            let mut compile_ok = 0usize;
-            let mut compile_errors: Vec<String> = Vec::new();
-            for rule in &collection.rules {
-                match engine.add_rule(rule) {
-                    Ok(()) => compile_ok += 1,
-                    Err(e) => {
-                        let id = rule.id.as_deref().unwrap_or(&rule.title);
-                        compile_errors.push(format!("{id}: {e}"));
-                    }
-                }
-            }
+            // Batch all rules through `add_rules` so the inverted index and
+            // bloom filter rebuild exactly once for the whole corpus instead
+            // of once per rule (the latter is O(N²) and turns 3K-rule loads
+            // into a multi-minute stall).
+            let batch_errors = engine.add_rules(&collection.rules);
+            let compile_ok = collection.rules.len() - batch_errors.len();
+            let compile_errors: Vec<String> = batch_errors
+                .into_iter()
+                .map(|(idx, e)| {
+                    let rule = &collection.rules[idx];
+                    let id = rule.id.as_deref().unwrap_or(&rule.title);
+                    format!("{id}: {e}")
+                })
+                .collect();
 
             if !pipelines.is_empty() {
                 println!("  Pipeline applied:  {} pipeline(s)", pipelines.len(),);

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -17,9 +17,11 @@ This library is part of [rsigma].
 | `set_include_event(include: bool)` | Global override: include full event JSON in all match results |
 | `add_pipeline(pipeline)` | Add a pipeline (sorted by `priority` after add) |
 | `add_rule(rule: &SigmaRule)` | Apply pipelines and compile a rule |
+| `add_rules(rules)` | Batched add of many rules; returns per-rule compile errors as `(index, error)` pairs and rebuilds engine indexes once |
 | `add_collection(collection: &SigmaCollection)` | Add all rules, then apply all filters |
 | `add_collection_with_pipelines(collection, pipelines)` | Temporarily replace pipelines, add collection, restore |
 | `add_compiled_rule(rule: CompiledRule)` | Add a pre-compiled rule directly |
+| `extend_compiled_rules(rules)` | Batched add of pre-compiled rules; rebuilds engine indexes once |
 | `apply_filter(filter: &FilterRule)` | Inject filter as `AND NOT` into referenced rules |
 | `evaluate(event: &Event)` | Evaluate all rules against an event |
 | `evaluate_with_logsource(event, logsource)` | Evaluate with logsource-based pre-filtering |

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -247,11 +247,31 @@ impl CorrelationEngine {
     /// Add all rules and correlations from a parsed collection.
     ///
     /// Detection rules are added first (so they're available for correlation
-    /// references), then correlation rules.
+    /// references), then correlation rules. Detection rules are compiled
+    /// sequentially and then pushed to the inner engine in a single batch,
+    /// so the inverted index and bloom filter are rebuilt exactly once for
+    /// the whole collection. Without this batching, large rule sets
+    /// (multi-thousand rules) hit an O(N²) rebuild cost on load.
     pub fn add_collection(&mut self, collection: &SigmaCollection) -> Result<()> {
-        for rule in &collection.rules {
-            self.add_rule(rule)?;
+        let mut compiled_batch = Vec::with_capacity(collection.rules.len());
+        if self.pipelines.is_empty() {
+            for rule in &collection.rules {
+                self.apply_custom_attributes(&rule.custom_attributes);
+                self.rule_ids.push((rule.id.clone(), rule.name.clone()));
+                compiled_batch.push(crate::compiler::compile_rule(rule)?);
+            }
+        } else {
+            for rule in &collection.rules {
+                let mut transformed = rule.clone();
+                apply_pipelines(&self.pipelines, &mut transformed)?;
+                self.apply_custom_attributes(&transformed.custom_attributes);
+                self.rule_ids
+                    .push((transformed.id.clone(), transformed.name.clone()));
+                // Bypass the inner engine's pipelines (would double-transform)
+                compiled_batch.push(crate::compiler::compile_rule(&transformed)?);
+            }
         }
+        self.engine.extend_compiled_rules(compiled_batch);
         // Apply filter rules to the inner engine's detection rules
         for filter in &collection.filters {
             self.engine.apply_filter(filter)?;

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -18,7 +18,7 @@ use rsigma_parser::{
 use crate::compiler::{
     CompiledRule, compile_detection, compile_rule, evaluate_rule, evaluate_rule_with_bloom,
 };
-use crate::error::Result;
+use crate::error::{EvalError, Result};
 use crate::event::Event;
 use crate::pipeline::{Pipeline, apply_pipelines};
 use crate::result::MatchResult;
@@ -249,17 +249,41 @@ impl Engine {
     ///
     /// If pipelines are set, the rule is cloned and transformed before compilation.
     /// The inverted index is rebuilt after adding the rule.
+    ///
+    /// Loading many rules through this method in a loop costs O(N²) in the
+    /// rule count because every call triggers a full index rebuild. Use
+    /// [`Engine::add_rules`] or [`Engine::add_collection`] for bulk loads.
     pub fn add_rule(&mut self, rule: &SigmaRule) -> Result<()> {
-        let compiled = if self.pipelines.is_empty() {
-            compile_rule(rule)?
-        } else {
-            let mut transformed = rule.clone();
-            apply_pipelines(&self.pipelines, &mut transformed)?;
-            compile_rule(&transformed)?
-        };
+        let compiled = self.compile_with_pipelines(rule)?;
         self.rules.push(compiled);
         self.rebuild_index();
         Ok(())
+    }
+
+    /// Add many parsed Sigma rules in a single batch.
+    ///
+    /// Each rule is compiled (with the engine's pipelines applied, if any)
+    /// and pushed onto the rule set. Compilation errors are collected and
+    /// returned as `(rule_index_in_input, error)` pairs without aborting the
+    /// batch; rules that did compile remain loaded. The inverted index and
+    /// per-field bloom filter are rebuilt **once** at the end of the batch.
+    ///
+    /// Prefer this over a loop of [`Engine::add_rule`] when loading large
+    /// rule sets: the per-call rebuild is O(N) in the total rule count, so
+    /// per-rule adds turn a 3K-rule corpus into O(N²) work.
+    pub fn add_rules<'a, I>(&mut self, rules: I) -> Vec<(usize, EvalError)>
+    where
+        I: IntoIterator<Item = &'a SigmaRule>,
+    {
+        let mut errors = Vec::new();
+        for (idx, rule) in rules.into_iter().enumerate() {
+            match self.compile_with_pipelines(rule) {
+                Ok(compiled) => self.rules.push(compiled),
+                Err(e) => errors.push((idx, e)),
+            }
+        }
+        self.rebuild_index();
+        errors
     }
 
     /// Add all detection rules from a parsed collection, then apply filters.
@@ -269,13 +293,7 @@ impl Engine {
     /// The inverted index is rebuilt once after all rules and filters are loaded.
     pub fn add_collection(&mut self, collection: &SigmaCollection) -> Result<()> {
         for rule in &collection.rules {
-            let compiled = if self.pipelines.is_empty() {
-                compile_rule(rule)?
-            } else {
-                let mut transformed = rule.clone();
-                apply_pipelines(&self.pipelines, &mut transformed)?;
-                compile_rule(&transformed)?
-            };
+            let compiled = self.compile_with_pipelines(rule)?;
             self.rules.push(compiled);
         }
         for filter in &collection.filters {
@@ -283,6 +301,19 @@ impl Engine {
         }
         self.rebuild_index();
         Ok(())
+    }
+
+    /// Compile a rule, applying any configured pipelines first. Shared by
+    /// the single- and batched-add paths so they stay behaviourally
+    /// identical.
+    fn compile_with_pipelines(&self, rule: &SigmaRule) -> Result<CompiledRule> {
+        if self.pipelines.is_empty() {
+            compile_rule(rule)
+        } else {
+            let mut transformed = rule.clone();
+            apply_pipelines(&self.pipelines, &mut transformed)?;
+            compile_rule(&transformed)
+        }
     }
 
     /// Add all detection rules from a collection, applying the given pipelines.
@@ -393,8 +424,23 @@ impl Engine {
     }
 
     /// Add a pre-compiled rule directly and rebuild the index.
+    ///
+    /// Use [`Engine::extend_compiled_rules`] when pushing many rules at
+    /// once; the per-call rebuild here is O(N) in the total rule count and
+    /// turns a tight loop into an O(N²) hot path.
     pub fn add_compiled_rule(&mut self, rule: CompiledRule) {
         self.rules.push(rule);
+        self.rebuild_index();
+    }
+
+    /// Add many pre-compiled rules in a single batch. The inverted index
+    /// and bloom filter are rebuilt exactly once at the end, regardless of
+    /// how many rules are appended.
+    pub fn extend_compiled_rules<I>(&mut self, rules: I)
+    where
+        I: IntoIterator<Item = CompiledRule>,
+    {
+        self.rules.extend(rules);
         self.rebuild_index();
     }
 

--- a/crates/rsigma-eval/src/engine/tests.rs
+++ b/crates/rsigma-eval/src/engine/tests.rs
@@ -1183,6 +1183,146 @@ level: low
 }
 
 #[test]
+fn test_add_rules_matches_per_rule_loop() {
+    let yaml = r#"
+title: Login
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+---
+title: Process Create
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+    condition: selection
+---
+title: Keyword
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+
+    let mut per_rule = Engine::new();
+    for rule in &collection.rules {
+        per_rule.add_rule(rule).unwrap();
+    }
+
+    let mut batched = Engine::new();
+    let errors = batched.add_rules(&collection.rules);
+    assert!(errors.is_empty());
+
+    assert_eq!(per_rule.rules().len(), batched.rules().len());
+
+    let evs = [
+        json!({"EventType": "login"}),
+        json!({"EventType": "process_create", "CommandLine": "whoami"}),
+        json!({"CommandLine": "whoami /all"}),
+        json!({"EventType": "file_create"}),
+    ];
+    for v in &evs {
+        let event = JsonEvent::borrow(v);
+        let a: Vec<_> = per_rule
+            .evaluate(&event)
+            .into_iter()
+            .map(|m| m.rule_title)
+            .collect();
+        let b: Vec<_> = batched
+            .evaluate(&event)
+            .into_iter()
+            .map(|m| m.rule_title)
+            .collect();
+        assert_eq!(a, b, "verdicts diverge for event {v}");
+    }
+}
+
+#[test]
+fn test_add_rules_collects_errors_without_aborting() {
+    let good = r#"
+title: Login
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+"#;
+    let bad = r#"
+title: Broken Reference
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'x'
+    condition: unknown_identifier
+"#;
+    let good_rule = parse_sigma_yaml(good).unwrap().rules.remove(0);
+    let bad_rule = parse_sigma_yaml(bad).unwrap().rules.remove(0);
+
+    let mut engine = Engine::new();
+    let errors = engine.add_rules([&good_rule, &bad_rule, &good_rule]);
+
+    // The bad rule fails; the two good rules still land in the engine.
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].0, 1);
+    assert_eq!(engine.rules().len(), 2);
+
+    let ev = json!({"EventType": "login"});
+    let matches = engine.evaluate(&JsonEvent::borrow(&ev));
+    assert_eq!(matches.len(), 2);
+}
+
+/// Regression: loading a multi-thousand rule corpus must stay linear in
+/// the rule count. The previous `add_rule` per-rule loop rebuilt the
+/// inverted index after every push, turning a 3K-rule load into a
+/// multi-minute O(N²) stall. Generating 2000 trivial rules and timing the
+/// batched load gives us a cheap, deterministic guard: even on a slow
+/// debug build this completes in well under a second, and the old
+/// per-rule path would blow well past the 30s ceiling.
+#[test]
+fn test_add_rules_scales_linearly_on_large_corpus() {
+    use std::time::Instant;
+
+    let mut yaml = String::new();
+    let n = 2000;
+    for i in 0..n {
+        if i > 0 {
+            yaml.push_str("---\n");
+        }
+        // Mix of exact-match (indexable) and substring (bloom-eligible)
+        // rules so both the rule index and the bloom rebuild are exercised.
+        yaml.push_str(&format!(
+            "title: Rule {i}\nlogsource:\n    product: windows\ndetection:\n    selection:\n        EventID: '{i}'\n        CommandLine|contains: 'needle{i}'\n    condition: selection\n"
+        ));
+    }
+    let collection = parse_sigma_yaml(&yaml).unwrap();
+    assert_eq!(collection.rules.len(), n);
+
+    let started = Instant::now();
+    let mut engine = Engine::new();
+    let errors = engine.add_rules(&collection.rules);
+    let elapsed = started.elapsed();
+
+    assert!(errors.is_empty());
+    assert_eq!(engine.rules().len(), n);
+    // 30s is a coarse ceiling that the linear path clears by ~100x but
+    // the old O(N²) rebuild would not get close to. Stay conservative so
+    // the test never flakes on overloaded CI runners.
+    assert!(
+        elapsed.as_secs() < 30,
+        "loading {n} rules took {elapsed:?}; suspect quadratic regression"
+    );
+}
+
+#[test]
 fn test_evaluate_batch_matches_sequential() {
     let yaml = r#"
 title: Login


### PR DESCRIPTION
## Summary

`Engine::add_rule` rebuilds the inverted index and per-field bloom on every call, so loading a rule set with `add_rule` in a loop is O(N²) in the rule count. The CLI `validate` command exercises this exact path, and on the 3120-rule SigmaHQ corpus it appeared to hang because it was paying ~3K full index rebuilds. `CorrelationEngine::add_collection` hit the same trap via the inner engine, so `rsigma eval`, the daemon, and every `RuntimeEngine` caller shared the bug.

This PR adds batched-load primitives to `rsigma-eval` and routes the slow callers through them.

## Impact

`rsigma validate` on the full 3120-rule SigmaHQ corpus on a MacBook M4 Pro:

| Build | Before | After |
|-------|-------:|------:|
| Debug | killed at 60s+ (never completed) | 2.2s |
| Release | ~25-30s extrapolated from 2390-rule subset | 0.5s |

The win (O(N)+O(1) → O(N)) comes from collapsing N per-rule rebuilds into a single rebuild: roughly an N× reduction in `RuleIndex::build` and `FieldBloomIndex::build` calls (3120 → 1), and the bloom builder is the dominant cost because it sweeps every detection on every rebuild to collect needles, trigram-dedup, and size each per-field filter. The same fix applies to the correlation engine, so daemon and eval rule loads also drop from O(N²) to O(N).

## Changes

- `Engine::add_rules<'a, I: IntoIterator<Item = &'a SigmaRule>>(&mut self, rules: I) -> Vec<(usize, EvalError)>` compiles each rule (applying configured pipelines), collects per-rule compile errors without aborting the batch, and rebuilds the engine indexes exactly once.
- `Engine::extend_compiled_rules<I: IntoIterator<Item = CompiledRule>>` does the same for pre-compiled rules, used by the correlation engine to avoid double pipeline application.
- `Engine::add_rule` and `Engine::add_collection` share a new `compile_with_pipelines` helper so single- and batch-add paths stay behaviourally identical.
- `rsigma validate` now sends the whole parsed collection through `add_rules` while preserving the existing per-rule compile-error reporting.
- `CorrelationEngine::add_collection` compiles each rule sequentially (with its own pipelines, custom-attribute handling, and `rule_ids` tracking), then pushes the resulting batch through `extend_compiled_rules` once. The single-rule `CorrelationEngine::add_rule` is unchanged.
- `crates/rsigma-eval/README.md` API table now lists the two new methods.

## Tests

- `test_add_rules_matches_per_rule_loop`: batched and per-rule paths produce identical evaluation verdicts across a mix of indexable and substring rules.
- `test_add_rules_collects_errors_without_aborting`: a bad rule between two good ones is reported via the returned `(index, error)` list while both good rules end up loaded.
- `test_add_rules_scales_linearly_on_large_corpus`: loads 2000 generated rules and asserts the call completes inside a deliberately generous 30s ceiling; the previous per-rule path would have timed out.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `rsigma validate ../sigma/rules/` against the full SigmaHQ corpus (3120 rules) in both debug and release builds.