### PR TITLE
chore(deps): batch Dependabot updates (2026-05-16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
-      - uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+      - uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2.77.3
         with:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.3"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe92a2f8b00686061eab5cdcfd6f382c27f2084456e7be90ae9f0fe4a30552a"
+checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
 dependencies = [
  "ahash",
  "bytecount",
@@ -4738,9 +4738,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4847,9 +4847,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -4907,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,18 +2768,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "js-sys",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64",
  "const-hex",
@@ -2787,21 +2787,21 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "serde_json",
  "tonic",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
+ "portable-atomic",
  "thiserror 2.0.18",
 ]
 

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -68,6 +68,6 @@ testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["nats"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde_json = "1"
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["gen-tonic", "logs", "with-serde"] }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic", "logs", "with-serde"] }
 prost = "0.14"
 flate2 = "1"

--- a/crates/rsigma-cli/tests/cli_daemon_otlp.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_otlp.rs
@@ -28,6 +28,7 @@ fn kv(key: &str, value: AnyValue) -> KeyValue {
     KeyValue {
         key: key.to_string(),
         value: Some(value),
+        ..Default::default()
     }
 }
 

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -47,7 +47,7 @@ async-nats = { version = "0.48", optional = true }
 futures = { version = "0.3", optional = true }
 time = { version = "0.3", optional = true }
 evtx = { version = "0.11", optional = true, default-features = false }
-opentelemetry-proto = { version = "0.31", default-features = false, features = ["gen-tonic", "logs", "with-serde"], optional = true }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic", "logs", "with-serde"], optional = true }
 prost = { version = "0.14", optional = true }
 
 [dev-dependencies]

--- a/crates/rsigma-runtime/src/io/otlp/convert.rs
+++ b/crates/rsigma-runtime/src/io/otlp/convert.rs
@@ -163,7 +163,10 @@ fn any_value_to_json(value: &AnyValue) -> Value {
             Value::Object(m)
         }
         Some(any_value::Value::BytesValue(bytes)) => Value::String(hex::encode(bytes)),
-        None => Value::Null,
+        // StringValueStrindex references a string in ProfilesDictionary.string_table
+        // and is exclusive to the Profiling signal. Per the OTLP spec, non-Profiling
+        // receivers must treat its presence as if the value were absent.
+        Some(any_value::Value::StringValueStrindex(_)) | None => Value::Null,
     }
 }
 
@@ -202,6 +205,7 @@ mod tests {
         KeyValue {
             key: key.to_string(),
             value: Some(value),
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Summary

Combines the three currently open Dependabot PRs into a single review:

- #118 bump `taiki-e/install-action` from 2.77.1 to 2.77.3 (`actions-updates` group)
- #117 bump `opentelemetry-proto` from 0.31.0 to 0.32.0
- #116 bump the `patch-updates` group (`tokio` 1.52.2 -> 1.52.3, `jsonschema` 0.46.3 -> 0.46.4, `tower-http` 0.6.9 -> 0.6.10, `tonic` 0.14.5 -> 0.14.6)

Cherry-picked from the original Dependabot branches with one follow-up commit to handle source-breaking schema additions in `opentelemetry-proto` 0.32:

- `any_value::Value` gained a new `StringValueStrindex(i32)` variant for the Profiling signal. Per the OTLP spec, non-Profiling receivers must treat it as if the value were absent, so it's mapped to `Value::Null` in `any_value_to_json`.
- `KeyValue` gained a new `key_strindex` field. Test helpers now use `..Default::default()` so they stay forward-compatible with future additions.

Closes #118, closes #117, closes #116.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo check --workspace --all-targets --locked`
- [ ] CI green