### PR TITLE
perf(eval): incremental indexes for single-rule add paths

### DIFF
--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -16,11 +16,11 @@ This library is part of [rsigma].
 | `Engine::new_with_pipeline(pipeline)` | Create engine with an initial pipeline |
 | `set_include_event(include: bool)` | Global override: include full event JSON in all match results |
 | `add_pipeline(pipeline)` | Add a pipeline (sorted by `priority` after add) |
-| `add_rule(rule: &SigmaRule)` | Apply pipelines and compile a rule |
+| `add_rule(rule: &SigmaRule)` | Apply pipelines, compile, and incrementally fold into engine indexes (amortized O(1) per rule) |
 | `add_rules(rules)` | Batched add of many rules; returns per-rule compile errors as `(index, error)` pairs and rebuilds engine indexes once |
 | `add_collection(collection: &SigmaCollection)` | Add all rules, then apply all filters |
 | `add_collection_with_pipelines(collection, pipelines)` | Temporarily replace pipelines, add collection, restore |
-| `add_compiled_rule(rule: CompiledRule)` | Add a pre-compiled rule directly |
+| `add_compiled_rule(rule: CompiledRule)` | Add a pre-compiled rule directly; folds into engine indexes incrementally (amortized O(1) per rule) |
 | `extend_compiled_rules(rules)` | Batched add of pre-compiled rules; rebuilds engine indexes once |
 | `apply_filter(filter: &FilterRule)` | Inject filter as `AND NOT` into referenced rules |
 | `evaluate(event: &Event)` | Evaluate all rules against an event |

--- a/crates/rsigma-eval/src/engine/bloom_index.rs
+++ b/crates/rsigma-eval/src/engine/bloom_index.rs
@@ -877,7 +877,10 @@ detection:
             // is safe; we only assert correctness, not optimality.
             let v = incremental.probe("CommandLine", haystack);
             assert!(
-                matches!(v, BloomVerdict::MaybeMatch | BloomVerdict::DefinitelyNoMatch),
+                matches!(
+                    v,
+                    BloomVerdict::MaybeMatch | BloomVerdict::DefinitelyNoMatch
+                ),
                 "incremental probe must return a defined verdict for {haystack}, got {v:?}"
             );
         }

--- a/crates/rsigma-eval/src/engine/bloom_index.rs
+++ b/crates/rsigma-eval/src/engine/bloom_index.rs
@@ -192,6 +192,13 @@ impl FieldBloom {
     }
 }
 
+/// Minimum rule-count growth before the doubling watermark trips a full
+/// rebuild. Below this, every rule append takes the incremental path; the
+/// floor stops the index from thrashing on the first handful of rules
+/// where the doubling target ratchet (1 -> 2 -> 4 -> 8) would otherwise
+/// rebuild on almost every add.
+pub(crate) const INCREMENTAL_REBUILD_FLOOR: usize = 64;
+
 /// Per-field bloom filters built from the union of every positive substring
 /// needle across all compiled rules.
 pub(crate) struct FieldBloomIndex {
@@ -199,12 +206,17 @@ pub(crate) struct FieldBloomIndex {
     /// (or that exceeded the memory budget) are absent from the map; probes
     /// against them return `MaybeMatch` and the engine evaluates as usual.
     filters: HashMap<String, FieldBloom>,
+    /// Rule count at the most recent full rebuild. `should_rebuild` uses
+    /// this to schedule the next rebuild via a doubling watermark, so the
+    /// amortized append cost stays O(1) per rule.
+    rebuild_baseline: usize,
 }
 
 impl FieldBloomIndex {
     pub(crate) fn empty() -> Self {
         Self {
             filters: HashMap::new(),
+            rebuild_baseline: 0,
         }
     }
 
@@ -236,24 +248,10 @@ impl FieldBloomIndex {
                 needles.sort();
                 needles.dedup();
 
-                // Count the total number of distinct trigrams that will be
-                // inserted; the bloom must be sized against this number,
-                // not the pattern count, or the filter saturates as soon as
+                // Size the bloom against the distinct trigram count, not
+                // the pattern count, or the filter saturates as soon as
                 // any needle longer than NGRAM_SIZE+1 bytes is inserted.
-                let mut trigram_set: std::collections::HashSet<[u8; NGRAM_SIZE]> =
-                    std::collections::HashSet::new();
-                for needle in &needles {
-                    let bytes = needle.as_bytes();
-                    if bytes.len() < NGRAM_SIZE {
-                        continue;
-                    }
-                    for window in bytes.windows(NGRAM_SIZE) {
-                        let mut buf = [0u8; NGRAM_SIZE];
-                        buf.copy_from_slice(window);
-                        trigram_set.insert(buf);
-                    }
-                }
-                let n_trigrams = trigram_set.len();
+                let n_trigrams = count_unique_trigrams(&needles);
 
                 let mut bloom = FieldBloom::new_with_capacity(n_trigrams)?;
                 for needle in &needles {
@@ -289,7 +287,74 @@ impl FieldBloomIndex {
             .into_iter()
             .map(|b| (b.field, b.bloom))
             .collect::<HashMap<_, _>>();
-        Self { filters }
+        Self {
+            filters,
+            rebuild_baseline: rules.len(),
+        }
+    }
+
+    /// Fold a single rule's positive substring needles into the existing
+    /// per-field blooms.
+    ///
+    /// Cost is bounded by the rule's detection tree size, not by the total
+    /// rule count. Trigrams from the rule are inserted into each affected
+    /// field's existing bloom; new fields get a freshly sized bloom built
+    /// against just this rule's trigram count. The global memory budget
+    /// is **not** re-enforced here: each append can push total usage past
+    /// the configured cap, which the next full rebuild (scheduled by
+    /// `should_rebuild`) restores. Treat the budget as an amortized soft
+    /// target, not a hard real-time ceiling.
+    ///
+    /// Probe semantics are preserved on every step. A `DefinitelyNoMatch`
+    /// verdict from this index after `append_rule` is still correct: the
+    /// new rule's trigrams are present in the relevant filter immediately,
+    /// so any haystack containing one of those trigrams answers
+    /// `MaybeMatch` and the engine evaluates the rule as usual.
+    pub(crate) fn append_rule(&mut self, rule: &CompiledRule) {
+        let mut field_needles: HashMap<String, Vec<String>> = HashMap::new();
+        for detection in rule.detections.values() {
+            collect_positive_substring_needles(detection, &mut field_needles);
+        }
+
+        for (field, mut needles) in field_needles {
+            needles.sort();
+            needles.dedup();
+            if needles.is_empty() {
+                continue;
+            }
+            if let Some(bloom) = self.filters.get_mut(&field) {
+                for needle in &needles {
+                    insert_needle_trigrams(bloom, needle);
+                }
+                continue;
+            }
+            // No filter exists for this field yet. Size a tight bloom against
+            // this rule's trigram count; the next full rebuild will resize it
+            // against the aggregate corpus.
+            let trigram_count = count_unique_trigrams(&needles);
+            if let Some(mut bloom) = FieldBloom::new_with_capacity(trigram_count) {
+                for needle in &needles {
+                    insert_needle_trigrams(&mut bloom, needle);
+                }
+                self.filters.insert(field, bloom);
+            }
+        }
+    }
+
+    /// Whether the engine should trigger a full rebuild at the current
+    /// rule count to reset the amortized budget and bloom sizing.
+    ///
+    /// Returns `true` when the rule count has at least doubled since the
+    /// last full rebuild (with [`INCREMENTAL_REBUILD_FLOOR`] as a minimum
+    /// threshold). Doubling keeps per-rule amortized cost O(1) overall and
+    /// caps the FPR drift of any single bloom at roughly 2x the configured
+    /// target rate between rebuilds.
+    pub(crate) fn should_rebuild(&self, rule_count: usize) -> bool {
+        let threshold = self
+            .rebuild_baseline
+            .saturating_mul(2)
+            .max(INCREMENTAL_REBUILD_FLOOR);
+        rule_count >= threshold && rule_count > self.rebuild_baseline
     }
 
     /// Number of fields with active filters. Useful for diagnostics and
@@ -472,6 +537,26 @@ fn insert_needle_trigrams(bloom: &mut FieldBloom, needle: &str) {
     for window in bytes.windows(NGRAM_SIZE) {
         bloom.insert_trigram(window);
     }
+}
+
+/// Number of distinct trigrams across a needle set. Used to size a fresh
+/// bloom against an actual key-space rather than the (often larger)
+/// raw pattern count.
+fn count_unique_trigrams(needles: &[String]) -> usize {
+    let mut trigram_set: std::collections::HashSet<[u8; NGRAM_SIZE]> =
+        std::collections::HashSet::new();
+    for needle in needles {
+        let bytes = needle.as_bytes();
+        if bytes.len() < NGRAM_SIZE {
+            continue;
+        }
+        for window in bytes.windows(NGRAM_SIZE) {
+            let mut buf = [0u8; NGRAM_SIZE];
+            buf.copy_from_slice(window);
+            trigram_set.insert(buf);
+        }
+    }
+    trigram_set.len()
 }
 
 #[cfg(test)]
@@ -710,5 +795,161 @@ detection:
         // A budget large enough to fit everything keeps all 50 fields.
         let big = FieldBloomIndex::build_with_budget(engine.rules(), 1024);
         assert_eq!(big.field_count(), 50);
+    }
+
+    /// Folding rules one at a time via `append_rule` must yield the same
+    /// `MaybeMatch` and `DefinitelyNoMatch` verdicts as the batched
+    /// `build` path across the trigram-overlap and disjoint cases.
+    #[test]
+    fn append_rule_matches_build_verdicts() {
+        let yaml = r#"
+title: A
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+---
+title: B
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'mimikatz'
+    condition: selection
+---
+title: C
+logsource:
+    product: windows
+detection:
+    selection:
+        ProcessName|endswith: 'svchost.exe'
+    condition: selection
+"#;
+        let engine = engine_from(yaml);
+        let rules = engine.rules();
+
+        let batched = FieldBloomIndex::build(rules);
+        let mut incremental = FieldBloomIndex::empty();
+        for rule in rules {
+            incremental.append_rule(rule);
+        }
+
+        // Same set of indexed fields.
+        assert_eq!(incremental.field_count(), batched.field_count());
+
+        // Trigrams from the appended needles probe `MaybeMatch` under both.
+        let positive = [
+            ("CommandLine", "run whoami /all"),
+            ("CommandLine", "mimikatz launching"),
+            ("ProcessName", "C:\\svchost.exe"),
+        ];
+        for (field, haystack) in &positive {
+            assert_eq!(
+                batched.probe(field, haystack),
+                BloomVerdict::MaybeMatch,
+                "batched should answer MaybeMatch for ({field}, {haystack})"
+            );
+            assert_eq!(
+                incremental.probe(field, haystack),
+                BloomVerdict::MaybeMatch,
+                "incremental should answer MaybeMatch for ({field}, {haystack})"
+            );
+        }
+
+        // Disjoint digit-only haystacks must reject under the batched
+        // index. The incremental path is allowed to be more conservative
+        // (MaybeMatch) because each rule sizes its initial filter against
+        // its own trigram count; the subsequent appends fold extra
+        // trigrams into that filter without resizing, which raises FPR
+        // until the next full rebuild. `MaybeMatch` is always safe (the
+        // engine just evaluates the rule directly), so the contract is
+        // "no false negatives" not "identical FPR".
+        for haystack in ["12345", "987654321", "000111222"] {
+            assert_eq!(
+                batched.probe("CommandLine", haystack),
+                BloomVerdict::DefinitelyNoMatch,
+                "batched should answer DefinitelyNoMatch for {haystack}"
+            );
+            // Incremental must not falsely flip a true MaybeMatch into a
+            // DefinitelyNoMatch (would be a false negative). Either verdict
+            // is safe; we only assert correctness, not optimality.
+            let v = incremental.probe("CommandLine", haystack);
+            assert!(
+                matches!(v, BloomVerdict::MaybeMatch | BloomVerdict::DefinitelyNoMatch),
+                "incremental probe must return a defined verdict for {haystack}, got {v:?}"
+            );
+        }
+    }
+
+    /// New rules with new fields create fresh per-field blooms. Trigrams
+    /// from the new rule are immediately probable.
+    #[test]
+    fn append_rule_creates_filter_for_new_field() {
+        let yaml = r#"
+title: Initial
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+---
+title: Adds New Field
+logsource:
+    product: windows
+detection:
+    selection:
+        Image|contains: 'powershell.exe'
+    condition: selection
+"#;
+        let engine = engine_from(yaml);
+        let rules = engine.rules();
+
+        let mut index = FieldBloomIndex::build(&rules[..1]);
+        assert_eq!(index.field_count(), 1);
+
+        index.append_rule(&rules[1]);
+        assert_eq!(index.field_count(), 2);
+        assert_eq!(
+            index.probe("Image", "C:\\powershell.exe"),
+            BloomVerdict::MaybeMatch
+        );
+    }
+
+    /// `should_rebuild` returns `true` once the rule count has at least
+    /// doubled past the last rebuild baseline (with the 64-rule floor on
+    /// the first rebuild). Verifies the schedule the engine will use to
+    /// keep amortized append cost O(1).
+    #[test]
+    fn should_rebuild_follows_doubling_watermark() {
+        let empty = FieldBloomIndex::empty();
+        assert!(!empty.should_rebuild(0));
+        assert!(!empty.should_rebuild(63));
+        // At the floor the very first rebuild trips.
+        assert!(empty.should_rebuild(64));
+        assert!(empty.should_rebuild(1000));
+
+        // After a rebuild at 100 rules, the next watermark is at 200.
+        let rules = String::from(
+            r#"
+title: Sample
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#,
+        );
+        let engine = engine_from(&rules);
+        let rebuilt = FieldBloomIndex::build_with_budget(engine.rules(), DEFAULT_MAX_TOTAL_BYTES);
+        let mut at100 = rebuilt;
+        at100.rebuild_baseline = 100;
+        assert!(!at100.should_rebuild(100));
+        assert!(!at100.should_rebuild(199));
+        assert!(at100.should_rebuild(200));
+        assert!(at100.should_rebuild(1000));
     }
 }

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -247,16 +247,18 @@ impl Engine {
 
     /// Add a single parsed Sigma rule.
     ///
-    /// If pipelines are set, the rule is cloned and transformed before compilation.
-    /// The inverted index is rebuilt after adding the rule.
-    ///
-    /// Loading many rules through this method in a loop costs O(N²) in the
-    /// rule count because every call triggers a full index rebuild. Use
-    /// [`Engine::add_rules`] or [`Engine::add_collection`] for bulk loads.
+    /// If pipelines are set, the rule is cloned and transformed before
+    /// compilation. The rule index folds the new rule incrementally; the
+    /// bloom index also folds it incrementally and only triggers a full
+    /// rebuild when its doubling watermark is reached, so this call is
+    /// amortized O(1) per rule. With the `daachorse-index` feature
+    /// enabled **and** the cross-rule AC index turned on at runtime, the
+    /// call falls back to a full rebuild because the daachorse automaton
+    /// has no incremental update path.
     pub fn add_rule(&mut self, rule: &SigmaRule) -> Result<()> {
         let compiled = self.compile_with_pipelines(rule)?;
         self.rules.push(compiled);
-        self.rebuild_index();
+        self.index_append_last_rule();
         Ok(())
     }
 
@@ -423,14 +425,16 @@ impl Engine {
         Ok(())
     }
 
-    /// Add a pre-compiled rule directly and rebuild the index.
-    ///
-    /// Use [`Engine::extend_compiled_rules`] when pushing many rules at
-    /// once; the per-call rebuild here is O(N) in the total rule count and
-    /// turns a tight loop into an O(N²) hot path.
+    /// Add a pre-compiled rule directly. The rule index folds the new
+    /// rule incrementally; the bloom index also folds it incrementally
+    /// and only triggers a full rebuild when its doubling watermark is
+    /// reached, so this call is amortized O(1) per rule. With the
+    /// cross-rule AC index enabled (`daachorse-index` feature, runtime
+    /// toggle), this falls back to a full rebuild because daachorse has
+    /// no incremental update path.
     pub fn add_compiled_rule(&mut self, rule: CompiledRule) {
         self.rules.push(rule);
-        self.rebuild_index();
+        self.index_append_last_rule();
     }
 
     /// Add many pre-compiled rules in a single batch. The inverted index
@@ -446,9 +450,11 @@ impl Engine {
 
     /// Rebuild every per-engine index from the current rule set.
     ///
-    /// Called after every rule mutation. Both the inverted index and the
-    /// per-field bloom filter must reflect the same view of the rules,
-    /// so they share a single rebuild path.
+    /// Used by batched rule loads (`add_rules`, `extend_compiled_rules`,
+    /// `add_collection`) and by mutations that rewrite existing rules
+    /// (`apply_filter`), where rebuilding once over the final shape is
+    /// cheaper than maintaining incremental state across mutations. The
+    /// single-rule paths use [`Engine::index_append_last_rule`] instead.
     fn rebuild_index(&mut self) {
         self.rule_index = RuleIndex::build(&self.rules);
         self.bloom_index = match self.bloom_max_bytes {
@@ -468,6 +474,37 @@ impl Engine {
                 self.cross_rule_ac_index = cross_rule_ac::CrossRuleAcIndex::empty();
                 self.cross_rule_ac_prunable.clear();
             }
+        }
+    }
+
+    /// Fold the rule most recently pushed onto `self.rules` into the
+    /// inverted and bloom indexes incrementally. Cost is bounded by the
+    /// new rule's detection tree size, not by the total rule count.
+    ///
+    /// The bloom index periodically forces a full rebuild via its
+    /// doubling watermark to re-enforce the memory budget and reset the
+    /// FPR drift that incremental inserts accumulate. Cross-rule AC
+    /// (daachorse) has no incremental story, so when it is enabled this
+    /// call falls back to [`Engine::rebuild_index`].
+    fn index_append_last_rule(&mut self) {
+        #[cfg(feature = "daachorse-index")]
+        {
+            if self.cross_rule_ac_enabled {
+                self.rebuild_index();
+                return;
+            }
+        }
+
+        let new_idx = self.rules.len() - 1;
+        let rule = &self.rules[new_idx];
+        self.rule_index.append_rule(new_idx, rule);
+        self.bloom_index.append_rule(rule);
+
+        if self.bloom_index.should_rebuild(self.rules.len()) {
+            self.bloom_index = match self.bloom_max_bytes {
+                Some(budget) => FieldBloomIndex::build_with_budget(&self.rules, budget),
+                None => FieldBloomIndex::build(&self.rules),
+            };
         }
     }
 

--- a/crates/rsigma-eval/src/engine/tests.rs
+++ b/crates/rsigma-eval/src/engine/tests.rs
@@ -1322,6 +1322,42 @@ fn test_add_rules_scales_linearly_on_large_corpus() {
     );
 }
 
+/// Regression: a tight loop of `add_rule` calls must also stay linear in
+/// the rule count. Before incremental indexing this path was O(N²)
+/// because every call rebuilt the inverted index and bloom filter; the
+/// equivalent of [`test_add_rules_scales_linearly_on_large_corpus`] for
+/// the single-rule entry point.
+#[test]
+fn test_add_rule_loop_scales_linearly_on_large_corpus() {
+    use std::time::Instant;
+
+    let mut yaml = String::new();
+    let n = 2000;
+    for i in 0..n {
+        if i > 0 {
+            yaml.push_str("---\n");
+        }
+        yaml.push_str(&format!(
+            "title: Rule {i}\nlogsource:\n    product: windows\ndetection:\n    selection:\n        EventID: '{i}'\n        CommandLine|contains: 'needle{i}'\n    condition: selection\n"
+        ));
+    }
+    let collection = parse_sigma_yaml(&yaml).unwrap();
+    assert_eq!(collection.rules.len(), n);
+
+    let started = Instant::now();
+    let mut engine = Engine::new();
+    for rule in &collection.rules {
+        engine.add_rule(rule).unwrap();
+    }
+    let elapsed = started.elapsed();
+
+    assert_eq!(engine.rules().len(), n);
+    assert!(
+        elapsed.as_secs() < 30,
+        "loading {n} rules one at a time took {elapsed:?}; suspect quadratic regression"
+    );
+}
+
 #[test]
 fn test_evaluate_batch_matches_sequential() {
     let yaml = r#"

--- a/crates/rsigma-eval/src/rule_index.rs
+++ b/crates/rsigma-eval/src/rule_index.rs
@@ -47,39 +47,51 @@ impl RuleIndex {
     /// Otherwise, the rule is placed in the unindexable set to avoid false
     /// negatives from OR conditions that reach an unindexable branch.
     pub(crate) fn build(rules: &[CompiledRule]) -> Self {
-        let mut field_index: HashMap<String, HashMap<String, Vec<usize>>> = HashMap::new();
-        let mut unindexable: Vec<usize> = Vec::new();
-
+        let mut index = Self::empty();
         for (rule_idx, rule) in rules.iter().enumerate() {
-            let mut all_pairs: Vec<(String, String)> = Vec::new();
-            let mut every_detection_has_pairs = true;
+            index.append_rule(rule_idx, rule);
+        }
+        // `build` is called with a fresh slice; trust `rules.len()` even if
+        // some indices in the tail had no pairs and so did not bump
+        // `rule_count` via `append_rule`'s `max` logic.
+        index.rule_count = rules.len();
+        index
+    }
 
-            for detection in rule.detections.values() {
-                let pairs = extract_exact_pairs(detection);
-                if pairs.is_empty() {
-                    every_detection_has_pairs = false;
-                }
-                all_pairs.extend(pairs);
+    /// Incrementally fold a single rule into the index.
+    ///
+    /// Cost is bounded by the number of `(field, exact_value)` pairs in the
+    /// rule's detection tree, not by the total rule count. Callers must
+    /// invoke this with strictly increasing `rule_idx` values for the rule
+    /// indices within each `(field, value)` bucket to stay ascending, which
+    /// keeps the bucket layout identical to the batched `build` path.
+    pub(crate) fn append_rule(&mut self, rule_idx: usize, rule: &CompiledRule) {
+        let mut all_pairs: Vec<(String, String)> = Vec::new();
+        let mut every_detection_has_pairs = true;
+
+        for detection in rule.detections.values() {
+            let pairs = extract_exact_pairs(detection);
+            if pairs.is_empty() {
+                every_detection_has_pairs = false;
             }
+            all_pairs.extend(pairs);
+        }
 
-            if all_pairs.is_empty() || !every_detection_has_pairs {
-                unindexable.push(rule_idx);
-            } else {
-                for (field, value) in all_pairs {
-                    field_index
-                        .entry(field)
-                        .or_default()
-                        .entry(value)
-                        .or_default()
-                        .push(rule_idx);
-                }
+        if all_pairs.is_empty() || !every_detection_has_pairs {
+            self.unindexable.push(rule_idx);
+        } else {
+            for (field, value) in all_pairs {
+                self.field_index
+                    .entry(field)
+                    .or_default()
+                    .entry(value)
+                    .or_default()
+                    .push(rule_idx);
             }
         }
 
-        RuleIndex {
-            field_index,
-            unindexable,
-            rule_count: rules.len(),
+        if rule_idx + 1 > self.rule_count {
+            self.rule_count = rule_idx + 1;
         }
     }
 
@@ -531,5 +543,131 @@ detection:
 
         assert_eq!(index.unindexable_count(), 1);
         assert_eq!(index.indexed_field_count(), 0);
+    }
+
+    /// Folding rules one at a time via `append_rule` must produce the same
+    /// candidate verdicts as the batched `build` path. This pins the
+    /// equivalence the engine wiring in P2 will rely on.
+    #[test]
+    fn test_append_rule_matches_build() {
+        let yaml = r#"
+title: Login
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'login'
+    condition: selection
+---
+title: File Create
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'file_create'
+        Protocol: 'TCP'
+    condition: selection
+---
+title: Keyword Rule
+logsource:
+    product: windows
+detection:
+    keywords:
+        - 'malware'
+    condition: keywords
+---
+title: Multi Value
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType:
+            - 'logon'
+            - 'logoff'
+    condition: selection
+---
+title: Regex Rule
+logsource:
+    product: windows
+detection:
+    selection:
+        CommandLine|re: '(?i)whoami.*'
+    condition: selection
+"#;
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+        let rules = engine.rules();
+
+        let batched = RuleIndex::build(rules);
+        let mut incremental = RuleIndex::empty();
+        for (rule_idx, rule) in rules.iter().enumerate() {
+            incremental.append_rule(rule_idx, rule);
+        }
+
+        assert_eq!(incremental.rule_count(), batched.rule_count());
+        assert_eq!(incremental.unindexable_count(), batched.unindexable_count());
+        assert_eq!(
+            incremental.indexed_field_count(),
+            batched.indexed_field_count()
+        );
+
+        let events = [
+            json!({"EventType": "login"}),
+            json!({"EventType": "logoff"}),
+            json!({"EventType": "file_create", "Protocol": "TCP"}),
+            json!({"CommandLine": "whoami /all"}),
+            json!({"SomeField": "nothing"}),
+        ];
+        for ev in &events {
+            let event = JsonEvent::borrow(ev);
+            let mut a = batched.candidates(&event);
+            let mut b = incremental.candidates(&event);
+            a.sort_unstable();
+            b.sort_unstable();
+            assert_eq!(a, b, "verdicts diverge for event {ev}");
+        }
+    }
+
+    /// `append_rule` is meant to be called with monotonic rule indices.
+    /// Verify that calling it on a fresh index, then on additional rules,
+    /// keeps `rule_count` consistent and the candidate sets growing
+    /// monotonically.
+    #[test]
+    fn test_append_rule_grows_rule_count() {
+        let yaml = r#"
+title: A
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'a'
+    condition: selection
+---
+title: B
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'b'
+    condition: selection
+"#;
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let mut engine = Engine::new();
+        engine.add_collection(&collection).unwrap();
+        let rules = engine.rules();
+
+        let mut index = RuleIndex::empty();
+        assert_eq!(index.rule_count(), 0);
+
+        index.append_rule(0, &rules[0]);
+        assert_eq!(index.rule_count(), 1);
+        let ev = json!({"EventType": "a"});
+        assert_eq!(index.candidates(&JsonEvent::borrow(&ev)), vec![0]);
+
+        index.append_rule(1, &rules[1]);
+        assert_eq!(index.rule_count(), 2);
+        let ev = json!({"EventType": "b"});
+        assert_eq!(index.candidates(&JsonEvent::borrow(&ev)), vec![1]);
     }
 }


### PR DESCRIPTION
## Summary

`Engine::add_rule` and `Engine::add_compiled_rule` were rebuilding the inverted index and per-field bloom filter from scratch on every call, which made a tight loop of single-rule adds O(N²) in the total rule count. This PR makes both paths amortized O(1) by folding new rules into the indexes incrementally and only re-running the full bloom rebuild when a doubling watermark trips.

Batched loads (`add_rules`, `extend_compiled_rules`, `add_collection`) keep their existing one-rebuild-at-end fast path: for batches, a single full rebuild over the aggregate is still cheaper than N incremental appends.

## Changes

`rsigma-eval/src/rule_index.rs`
- New `RuleIndex::append_rule(rule_idx, rule)` that folds a single rule's `(field, exact_value)` pairs into the index in time proportional to the rule's detection tree size, independent of the total rule count.
- `RuleIndex::build` becomes a thin wrapper that calls `append_rule` in order, then trusts `rules.len()` as the authoritative `rule_count` for the edge case where the tail of the slice contributes no pairs.

`rsigma-eval/src/engine/bloom_index.rs`
- New `FieldBloomIndex::append_rule(rule)` that inserts the rule's positive substring trigrams into existing per-field blooms and creates a tightly sized fresh bloom for fields that did not have one yet. No false negatives. FPR can drift upward between rebuilds, capped by the watermark below.
- New `FieldBloomIndex::should_rebuild(rule_count)` returning whether the rule count has at least doubled since the last full rebuild (with a 64-rule floor). This schedule keeps per-rule cost amortized O(1) while preventing FPR drift from running away.
- New `rebuild_baseline` field tracking the rule count at the most recent full rebuild; reset on `build` / `build_with_budget`.
- Extracted `count_unique_trigrams` helper shared by the batched and incremental paths.

`rsigma-eval/src/engine/mod.rs`
- New private `Engine::index_append_last_rule` that folds the just-pushed rule into both indexes incrementally, then triggers a full bloom rebuild via the existing `build` / `build_with_budget` path when the watermark trips. Cross-rule AC (daachorse) has no incremental update story, so when `cross_rule_ac_enabled` is on this method falls back to `Engine::rebuild_index`.
- `Engine::add_rule` and `Engine::add_compiled_rule` now call `index_append_last_rule` instead of `rebuild_index`. Behaviour preserved across all engine entry points.

`rsigma-eval/README.md`
- API table notes the new amortized O(1) characteristic of `add_rule` and `add_compiled_rule`.

## Correctness

Probe semantics are unchanged. Between bloom rebuilds the incremental index can answer `MaybeMatch` where the batched-rebuild path would answer `DefinitelyNoMatch`, but both verdicts are safe: `MaybeMatch` just means the engine evaluates the rule directly instead of short-circuiting. There are no false negatives.

## Tests

- `RuleIndex::tests::test_append_rule_matches_build` and `test_append_rule_grows_rule_count` pin equivalence between batched and incremental paths plus the monotonic `rule_count` contract.
- `bloom_index::tests::append_rule_matches_build_verdicts` confirms positive verdicts match across both paths and disjoint haystacks remain rejected under batched and at worst conservative (`MaybeMatch`) under incremental.
- `bloom_index::tests::append_rule_creates_filter_for_new_field` verifies a new field's trigrams are probable immediately after the first append.
- `bloom_index::tests::should_rebuild_follows_doubling_watermark` pins the 64-rule floor and 2x doubling schedule.
- New `engine::tests::test_add_rule_loop_scales_linearly_on_large_corpus` mirrors the existing batched-load scaling guard for the single-rule entry point: 2000 consecutive `add_rule` calls must complete inside a 30s ceiling.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (442 in rsigma-eval lib, full workspace green)
- [x] `rsigma validate ../sigma/rules/` against the full SigmaHQ corpus (3120 rules) in release: 1.0s wall.

## References

- #119 