### PR TITLE
bench(eval): add rule_load comparison across load entry points

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -68,6 +68,25 @@ Wildcard/regex rule parsing is O(1) due to pattern caching (only the first parse
 | 1,000 | 961.9 us |
 | 5,000 | 4.90 ms |
 
+### Rule Load Paths (0.11.x)
+
+Apple M4 Pro, macOS, release build, 2026-05-16. Compares the three engine entry points for loading rules at large N. `add_collection` and `add_rules` rebuild the inverted and bloom indexes once at the end of the batch; `add_rule` in a loop folds each rule incrementally with an amortized-doubling bloom rebuild (64-rule floor, 2x ratchet).
+
+| Rules   | `add_collection`           | `add_rules`               | `add_rule` loop           |
+|--------:|----------------------------|----------------------------|----------------------------|
+| 1,000   | 1.15 ms (1.15 us/rule)     | 1.17 ms (1.17 us/rule)     | 1.64 ms (1.64 us/rule)     |
+| 10,000  | 11.82 ms (1.18 us/rule)    | 11.85 ms (1.18 us/rule)    | 17.23 ms (1.72 us/rule)    |
+| 100,000 | 121.65 ms (1.22 us/rule)   | 122.13 ms (1.22 us/rule)   | 166.07 ms (1.66 us/rule)   |
+
+All three paths scale linearly in the rule count. Per-rule cost is essentially constant from 1K to 100K, confirming the O(N) total complexity:
+
+- `add_collection` and `add_rules` cost roughly 1.2 us/rule. The fixed per-batch cost is dominated by the final inverted index + bloom build over the aggregate.
+- `add_rule` in a loop costs roughly 1.65 us/rule, about 40% more than the batched paths. The overhead is the per-rule incremental insert plus the ~11 doubling-watermark rebuilds the bloom triggers between 1 and 100K rules. There is no quadratic blowup; the constant factor pays for the incremental contract.
+
+The takeaway is that `add_rule` is no longer a foot-gun for bulk loads. Batched APIs are still slightly faster and remain the recommended path for cold-load scenarios; the single-rule path exists for cases where the caller wants per-rule error reporting (`rsigma validate`) or per-rule mutation semantics.
+
+Run with `cargo bench -p rsigma-eval --bench eval -- rule_load`.
+
 ### Single Event Evaluation
 
 Time to evaluate one event against N compiled rules.

--- a/crates/rsigma-eval/benches/eval.rs
+++ b/crates/rsigma-eval/benches/eval.rs
@@ -38,6 +38,70 @@ fn bench_compile_rules(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: rule load paths at large N
+//
+// Compares the three engine entry points used by validate / daemon /
+// library callers. All three should scale linearly in the rule count;
+// `add_collection` and `add_rules` rebuild the inverted and bloom
+// indexes once at the end of the batch, while `add_rule` in a loop
+// folds each rule incrementally with an amortized-doubling bloom
+// rebuild.
+// ---------------------------------------------------------------------------
+
+fn bench_rule_load(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rule_load");
+    // Each iteration builds an engine from scratch, so keep the sample
+    // count modest to bound wall-clock time at 100K rules.
+    group.sample_size(10);
+
+    for n in [1_000, 10_000, 100_000] {
+        let yaml = datagen::gen_n_rules(n);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("add_collection", n),
+            &collection,
+            |b, collection| {
+                b.iter(|| {
+                    let mut engine = Engine::new();
+                    engine.add_collection(black_box(collection)).unwrap();
+                    black_box(&engine);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("add_rules", n),
+            &collection,
+            |b, collection| {
+                b.iter(|| {
+                    let mut engine = Engine::new();
+                    let errs = engine.add_rules(black_box(&collection.rules));
+                    debug_assert!(errs.is_empty());
+                    black_box(&engine);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("add_rule_loop", n),
+            &collection,
+            |b, collection| {
+                b.iter(|| {
+                    let mut engine = Engine::new();
+                    for rule in black_box(&collection.rules) {
+                        engine.add_rule(rule).unwrap();
+                    }
+                    black_box(&engine);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Benchmark: evaluate 1 event against N rules
 // ---------------------------------------------------------------------------
 
@@ -476,6 +540,7 @@ fn bench_eval_regex_heavy(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_compile_rules,
+    bench_rule_load,
     bench_eval_single_event,
     bench_eval_throughput,
     bench_eval_batch,
@@ -492,6 +557,7 @@ criterion_group!(
 criterion_group!(
     benches,
     bench_compile_rules,
+    bench_rule_load,
     bench_eval_single_event,
     bench_eval_throughput,
     bench_eval_batch,


### PR DESCRIPTION
## Summary

Adds a Criterion benchmark group `rule_load` that compares the three rule-load entry points on `Engine` at 1K / 10K / 100K rules and records the numbers in `BENCHMARKS.md` under a new "Rule Load Paths (0.11.x)" subsection.

The benchmark exists to give empirical confirmation that all three paths scale linearly in the rule count after PR #121 made the single-rule `add_rule` amortized O(1). The existing functional regression test (`test_add_rule_loop_scales_linearly_on_large_corpus`) already guards against quadratic reintroduction; this PR is the matching numerical evidence.

## Results

M4 Pro, release build, 2026-05-16. Median time from Criterion, 10 samples per benchmark.

| Rules   | `add_collection`           | `add_rules`                  | `add_rule` loop              |
|--------:|----------------------------|------------------------------|------------------------------|
| 1,000   | 1.15 ms (1.15 us/rule)     | 1.17 ms (1.17 us/rule)       | 1.64 ms (1.64 us/rule)       |
| 10,000  | 11.82 ms (1.18 us/rule)    | 11.85 ms (1.18 us/rule)      | 17.23 ms (1.72 us/rule)      |
| 100,000 | 121.65 ms (1.22 us/rule)   | 122.13 ms (1.22 us/rule)     | 166.07 ms (1.66 us/rule)     |

Per-rule cost stays flat from 1K to 100K across all three paths, confirming O(N) total complexity. The single-rule loop costs roughly 40% more per rule than the batched paths, which is the amortized overhead of the incremental insert plus the doubling-watermark bloom rebuilds along the way. No quadratic blowup.

## Changes

- New `bench_rule_load` group in [`crates/rsigma-eval/benches/eval.rs`](crates/rsigma-eval/benches/eval.rs), wired into both `daachorse-index` and default `criterion_group!` macros.
- New "Rule Load Paths (0.11.x)" subsection in [`BENCHMARKS.md`](BENCHMARKS.md), inserted between "Rule Compilation" and "Single Event Evaluation".

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo bench -p rsigma-eval --bench eval -- rule_load`