### PR TITLE
feat(cli): group flat subcommands under noun-led command groups

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -83,7 +83,7 @@ All three paths scale linearly in the rule count. Per-rule cost is essentially c
 - `add_collection` and `add_rules` cost roughly 1.2 us/rule. The fixed per-batch cost is dominated by the final inverted index + bloom build over the aggregate.
 - `add_rule` in a loop costs roughly 1.65 us/rule, about 40% more than the batched paths. The overhead is the per-rule incremental insert plus the ~11 doubling-watermark rebuilds the bloom triggers between 1 and 100K rules. There is no quadratic blowup; the constant factor pays for the incremental contract.
 
-The takeaway is that `add_rule` is no longer a foot-gun for bulk loads. Batched APIs are still slightly faster and remain the recommended path for cold-load scenarios; the single-rule path exists for cases where the caller wants per-rule error reporting (`rsigma validate`) or per-rule mutation semantics.
+The takeaway is that `add_rule` is no longer a foot-gun for bulk loads. Batched APIs are still slightly faster and remain the recommended path for cold-load scenarios; the single-rule path exists for cases where the caller wants per-rule error reporting (`rsigma rule validate`) or per-rule mutation semantics.
 
 Run with `cargo bench -p rsigma-eval --bench eval -- rule_load`.
 
@@ -159,7 +159,7 @@ Run with `cargo bench -p rsigma-eval --bench eval -- eval_ac_threshold_sweep`.
 
 The cross-rule index turns O(rules × patterns) per event into O(haystack_length) for the AC scan, so throughput is essentially constant in rule count once the index is enabled.
 
-For typical mixed workloads (substring + exact + regex rules, events that hit multiple fields, smaller rule sets) the index adds build-time and lookup overhead with smaller wins or none, and can even cause a slowdown. **Off by default.** Enable via `Engine::set_cross_rule_ac(true)` programmatically, or `--cross-rule-ac` on `rsigma daemon` / `rsigma eval` (requires the `daachorse-index` Cargo feature). Always benchmark against representative data before flipping it on.
+For typical mixed workloads (substring + exact + regex rules, events that hit multiple fields, smaller rule sets) the index adds build-time and lookup overhead with smaller wins or none, and can even cause a slowdown. **Off by default.** Enable via `Engine::set_cross_rule_ac(true)` programmatically, or `--cross-rule-ac` on `rsigma engine daemon` / `rsigma engine eval` (requires the `daachorse-index` Cargo feature). Always benchmark against representative data before flipping it on.
 
 Run with `cargo bench -p rsigma-eval --features daachorse-index --bench eval -- eval_cross_rule_ac`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 All notable changes to RSigma are documented in this file.
 Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
+## [Unreleased]
+
+### CLI
+
+The 12 flat top-level subcommands are reorganized into five noun-led command groups so the CLI scales as more subcommands arrive (most immediately, `attack coverage` and `attack update` from the upcoming MITRE ATT&CK contributor PR). The flat aliases continue to work for one release as visible-deprecated forwarders, are hidden in the next release, and are removed in v1.0. Every existing invocation keeps working, so there is no breaking change in this release.
+
+**Migration:**
+
+| Old (flat) | New (grouped) |
+|------------|---------------|
+| `rsigma eval ...` | `rsigma engine eval ...` |
+| `rsigma daemon ...` | `rsigma engine daemon ...` |
+| `rsigma parse ...` | `rsigma rule parse ...` |
+| `rsigma validate ...` | `rsigma rule validate ...` |
+| `rsigma lint ...` | `rsigma rule lint ...` |
+| `rsigma fields ...` | `rsigma rule fields ...` |
+| `rsigma condition ...` | `rsigma rule condition ...` |
+| `rsigma stdin ...` | `rsigma rule stdin ...` |
+| `rsigma convert RULES ...` | `rsigma backend convert RULES ...` |
+| `rsigma list-targets` | `rsigma backend targets` |
+| `rsigma list-formats TARGET` | `rsigma backend formats TARGET` |
+| `rsigma resolve ...` | `rsigma pipeline resolve ...` |
+
+**What you'll see.** Invoking any flat alias prints one stderr line:
+
+```
+warning: `rsigma <old>` is deprecated; use `rsigma <new>` instead. This alias will be hidden in the next release and removed in v1.0.
+```
+
+stdout is unchanged. Exit codes are unchanged. Every flag accepted by the old form is accepted by the new form, with identical defaults and semantics.
+
+**Why noun-led groups.** Every group is a noun (`engine`, `rule`, `backend`, `pipeline`, `attack`), so command paths read as "rsigma's X tooling: do Y" rather than the awkward verb-on-verb chains a `run` or `convert` group would produce (`rsigma convert run RULES` vs the chosen `rsigma backend convert RULES`). The five groups are deliberately stable and small so future commands have an obvious home rather than landing as more top-level sprawl.
+
+**`attack` group reserved.** `rsigma attack --help` lists no subcommands in this release. The `AttackCommands` enum is intentionally empty and is populated by the separate MITRE ATT&CK contributor PR (see `idea-proposals/MITRE ATT&CK/`) with `attack coverage` and `attack update`. No new top-level `attack-coverage` or `attack-update` commands will ever ship; both land as `attack` subcommands.
+
+**Deprecation timeline.**
+
+- **This release**: flat aliases visible in `rsigma --help` with a `[deprecated]` tag, stderr warning on invocation. Every test, script, and pipeline keeps working.
+- **Next release**: `#[command(hide = true)]` removes the aliases from `--help` but the invocations still work.
+- **v1.0**: flat aliases removed.
+
+### Internal
+
+- The CLI dispatch layer is collapsed: each subcommand's clap arguments now live in `crates/rsigma-cli/src/commands/<name>.rs` as a `pub struct <Name>Args` deriving `clap::Args`, and the daemon's 35-field arg set + `cmd_daemon` body moved out of `main.rs` into a new `crates/rsigma-cli/src/commands/daemon.rs`. `main.rs` dropped from ~1360 lines to ~600 with no behavior change.
+
 ## [0.11.0] - 2026-05-14
 
 **TL;DR**

--- a/README.md
+++ b/README.md
@@ -110,19 +110,19 @@ cosign verify \
 
 ```bash
 # Evaluate a single event against Sigma rules
-rsigma eval -r rules/ -e '{"CommandLine": "cmd /c whoami"}'
+rsigma engine eval -r rules/ -e '{"CommandLine": "cmd /c whoami"}'
 
 # Stream NDJSON from stdin
-cat events.ndjson | rsigma eval -r rules/
+cat events.ndjson | rsigma engine eval -r rules/
 
 # Run as a daemon with hot-reload and Prometheus metrics
-rsigma daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
+rsigma engine daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
 
 # Accept events via HTTP POST
-rsigma daemon -r rules/ --input http
+rsigma engine daemon -r rules/ --input http
 
 # Convert rules to PostgreSQL SQL
-rsigma convert rules/ -t postgres
+rsigma backend convert rules/ -t postgres
 ```
 
 See the [CLI README](crates/rsigma-cli/) for complete documentation of all subcommands and flags.
@@ -133,18 +133,18 @@ The daemon accepts events from multiple sources. The `--input` flag selects the 
 
 ```bash
 # stdin (default): pipe events from any source
-hel run | rsigma daemon -r rules/ -p ecs.yml
+hel run | rsigma engine daemon -r rules/ -p ecs.yml
 
 # HTTP: POST NDJSON events to /api/v1/events
-rsigma daemon -r rules/ --input http
+rsigma engine daemon -r rules/ --input http
 curl -X POST http://localhost:9090/api/v1/events -d '{"CommandLine":"whoami"}'
 
 # NATS JetStream (requires daemon-nats feature)
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections
 
 # OTLP (requires daemon-otlp feature): always active alongside any --input mode
 # Agents (Grafana Alloy, Vector, Fluent Bit, OTel Collector) send logs to /v1/logs (HTTP) or gRPC
-rsigma daemon -r rules/ --input http
+rsigma engine daemon -r rules/ --input http
 curl -X POST http://localhost:9090/v1/logs -H 'Content-Type: application/json' -d '{"resourceLogs":[...]}'
 ```
 
@@ -154,23 +154,23 @@ Production-grade NATS JetStream support with authentication, at-least-once deliv
 
 ```bash
 # Credentials file authentication
-rsigma daemon -r rules/ --input nats://nats.example.com:4222/events.> --nats-creds /etc/rsigma/nats.creds
+rsigma engine daemon -r rules/ --input nats://nats.example.com:4222/events.> --nats-creds /etc/rsigma/nats.creds
 
 # Mutual TLS
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> \
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> \
   --nats-tls-cert client.pem --nats-tls-key client-key.pem --nats-require-tls
 
 # Replay from a point in time
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-time 2026-04-30T00:00:00Z
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-time 2026-04-30T00:00:00Z
 
 # Replay with automatic state restore (forward catch-up)
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-sequence 1001 --state-db state.db
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-sequence 1001 --state-db state.db
 
 # Consumer groups for horizontal scaling
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --consumer-group detection-workers
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --consumer-group detection-workers
 
 # Dead-letter queue for events that fail processing
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --dlq file:///var/log/rsigma-dlq.ndjson
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --dlq file:///var/log/rsigma-dlq.ndjson
 ```
 
 ### Input Formats and Pipelines
@@ -179,19 +179,19 @@ Events are parsed with auto-detection by default (JSON, syslog, plain text). Fea
 
 ```bash
 # With a processing pipeline for field mapping
-rsigma eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
+rsigma engine eval -r rules/ -p pipelines/ecs.yml -e '{"process.command_line": "whoami"}'
 
 # Explicit syslog with timezone offset
-tail -f /var/log/syslog | rsigma eval -r rules/ --input-format syslog --syslog-tz +0530
+tail -f /var/log/syslog | rsigma engine eval -r rules/ --input-format syslog --syslog-tz +0530
 
 # logfmt (requires logfmt feature)
-rsigma eval -r rules/ --input-format logfmt < app.log
+rsigma engine eval -r rules/ --input-format logfmt < app.log
 
 # CEF / ArcSight (requires cef feature)
-rsigma eval -r rules/ --input-format cef < arcsight.log
+rsigma engine eval -r rules/ --input-format cef < arcsight.log
 
 # EVTX / Windows Event Log (requires evtx feature)
-rsigma eval -r rules/ -e @security.evtx
+rsigma engine eval -r rules/ -e @security.evtx
 ```
 
 ### Dynamic Pipelines
@@ -231,10 +231,10 @@ transformations:
 
 ```bash
 # Test source resolution offline
-rsigma resolve -p pipeline.yml --pretty
+rsigma pipeline resolve -p pipeline.yml --pretty
 
 # Run the daemon with a dynamic pipeline
-rsigma daemon -r rules/ -p pipeline.yml
+rsigma engine daemon -r rules/ -p pipeline.yml
 ```
 
 Sources support four types (file, HTTP, command, NATS), multiple data formats (JSON, YAML, lines, CSV), three extraction languages (jq, JSONPath, CEL), configurable refresh policies, error handling with caching, and include directives for injecting entire transformation blocks. See the [CLI README](crates/rsigma-cli/README.md#dynamic-pipelines) for the full reference and the [runtime README](crates/rsigma-runtime/README.md) for the library API.
@@ -245,31 +245,31 @@ Convert Sigma rules into backend-native queries for historical threat hunting.
 
 ```bash
 # PostgreSQL SQL
-rsigma convert rules/ -t postgres
+rsigma backend convert rules/ -t postgres
 
 # PostgreSQL with OCSF field mapping
-rsigma convert rules/ -t postgres -p pipelines/ocsf_postgres.yml
+rsigma backend convert rules/ -t postgres -p pipelines/ocsf_postgres.yml
 
 # PostgreSQL views, TimescaleDB continuous aggregates, or sliding window correlation
-rsigma convert rules/ -t postgres -f view
-rsigma convert rules/ -t postgres -f continuous_aggregate
-rsigma convert rules/ -t postgres -f sliding_window
+rsigma backend convert rules/ -t postgres -f view
+rsigma backend convert rules/ -t postgres -f continuous_aggregate
+rsigma backend convert rules/ -t postgres -f sliding_window
 
 # JSONB mode: access fields inside a JSONB column
-rsigma convert rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
+rsigma backend convert rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
 
 # LynxDB search queries
-rsigma convert rules/ -t lynxdb
+rsigma backend convert rules/ -t lynxdb
 
 # List all fields referenced by a ruleset
-rsigma fields -r rules/
+rsigma rule fields -r rules/
 
 # Show fields after pipeline mapping
-rsigma fields -r rules/ -p ecs.yml --json
+rsigma rule fields -r rules/ -p ecs.yml --json
 
 # List available backends and formats
-rsigma list-targets
-rsigma list-formats postgres
+rsigma backend targets
+rsigma backend formats postgres
 ```
 
 ### Library Usage

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -16,36 +16,59 @@ cargo install rsigma
 
 ```bash
 # Single event (inline JSON)
-rsigma eval -r path/to/rules/ -e '{"CommandLine": "cmd /c whoami"}'
+rsigma engine eval -r path/to/rules/ -e '{"CommandLine": "cmd /c whoami"}'
 
 # Stream NDJSON from stdin
-cat events.ndjson | rsigma eval -r path/to/rules/
+cat events.ndjson | rsigma engine eval -r path/to/rules/
 
 # Long-running daemon with hot-reload, health checks, and Prometheus metrics
-hel run | rsigma daemon -r rules/ -p ecs_windows --api-addr 0.0.0.0:9090
+hel run | rsigma engine daemon -r rules/ -p ecs_windows --api-addr 0.0.0.0:9090
 
 # With a builtin pipeline (no external file needed)
-rsigma eval -r rules/ -p ecs_windows -e '{"process.command_line": "whoami"}'
+rsigma engine eval -r rules/ -p ecs_windows -e '{"process.command_line": "whoami"}'
 
 # Or use a custom pipeline YAML file
-rsigma eval -r rules/ -p pipelines/custom.yml -e '{"src_ip": "10.0.0.1"}'
+rsigma engine eval -r rules/ -p pipelines/custom.yml -e '{"src_ip": "10.0.0.1"}'
 
 # Convert rules to backend-native queries
-rsigma convert -r rules/ -t test
+rsigma backend convert -r rules/ -t test
 
 # Convert to PostgreSQL SQL
-rsigma convert -r rules/ -t postgres
+rsigma backend convert -r rules/ -t postgres
 
 # List all fields referenced by rules (with optional pipeline mapping)
-rsigma fields -r rules/ -p ecs_windows
+rsigma rule fields -r rules/ -p ecs_windows
 
 # List available conversion backends
-rsigma list-targets
+rsigma backend targets
 ```
 
 ## Subcommands
 
-### `parse`: Parse a single rule
+Commands are grouped into five noun-led groups: `engine` (eval / daemon), `rule` (parse / validate / lint / fields / condition / stdin), `backend` (convert / targets / formats), `pipeline` (resolve), and `attack` (reserved; populated by the upcoming MITRE ATT&CK contributor PR).
+
+### Migrating from the old flat commands
+
+Every flat top-level command still works for one release as a visible-deprecated alias. Invoking the old form prints a stderr warning and forwards to the same implementation; stdout, exit codes, and every flag are unchanged.
+
+| Old (flat, deprecated) | New (grouped) |
+|------------------------|---------------|
+| `rsigma eval ...` | `rsigma engine eval ...` |
+| `rsigma daemon ...` | `rsigma engine daemon ...` |
+| `rsigma parse ...` | `rsigma rule parse ...` |
+| `rsigma validate ...` | `rsigma rule validate ...` |
+| `rsigma lint ...` | `rsigma rule lint ...` |
+| `rsigma fields ...` | `rsigma rule fields ...` |
+| `rsigma condition ...` | `rsigma rule condition ...` |
+| `rsigma stdin ...` | `rsigma rule stdin ...` |
+| `rsigma convert RULES ...` | `rsigma backend convert RULES ...` |
+| `rsigma list-targets` | `rsigma backend targets` |
+| `rsigma list-formats TARGET` | `rsigma backend formats TARGET` |
+| `rsigma resolve ...` | `rsigma pipeline resolve ...` |
+
+Deprecation timeline: flat aliases are **visible** in `rsigma --help` this release (with `[deprecated]` in the about text), **hidden** from `--help` in the next release, and **removed** in v1.0. Migrate at your convenience within that window.
+
+### `rule parse`: Parse a single rule
 
 Parse a Sigma YAML file and output the AST as JSON.
 
@@ -55,13 +78,13 @@ Parse a Sigma YAML file and output the AST as JSON.
 | `--pretty` / `-p` | flag | **true** | Pretty-print JSON output |
 
 ```bash
-rsigma parse rule.yml            # print AST as pretty-printed JSON
-rsigma parse rule.yml --pretty   # same (default)
+rsigma rule parse rule.yml            # print AST as pretty-printed JSON
+rsigma rule parse rule.yml --pretty   # same (default)
 ```
 
 Note: pretty-print is on by default and cannot be disabled.
 
-### `validate`: Validate rules in a directory
+### `rule validate`: Validate rules in a directory
 
 Parse and compile all rules in a directory, reporting errors.
 
@@ -73,12 +96,12 @@ Parse and compile all rules in a directory, reporting errors.
 | `--resolve-sources` | flag | `false` | Also resolve dynamic pipeline sources during validation. Sources must be reachable (file/command/HTTP) for validation to pass |
 
 ```bash
-rsigma validate path/to/rules/ -v              # verbose output
-rsigma validate rules/ -p pipelines/ecs.yml    # validate with pipeline
-rsigma validate rules/ -p dynamic.yml --resolve-sources  # validate + test source resolution
+rsigma rule validate path/to/rules/ -v              # verbose output
+rsigma rule validate rules/ -p pipelines/ecs.yml    # validate with pipeline
+rsigma rule validate rules/ -p dynamic.yml --resolve-sources  # validate + test source resolution
 ```
 
-### `lint`: Lint rules against the Sigma specification
+### `rule lint`: Lint rules against the Sigma specification
 
 Run 66 built-in lint rules with optional JSON schema validation.
 
@@ -95,18 +118,18 @@ Run 66 built-in lint rules with optional JSON schema validation.
 | `--fail-level` | string | `"error"` | Minimum severity for non-zero exit: `error` (default), `warning`, or `info` |
 
 ```bash
-rsigma lint path/to/rules/                     # lint all rules
-rsigma lint path/to/rules/ -v                  # verbose (show passing files + info-only)
-rsigma lint path/to/rules/ --schema default    # + JSON schema validation (downloads + caches)
-rsigma lint rule.yml --schema my-schema.json   # local JSON schema
-rsigma lint path/to/rules/ --color always      # force color
-rsigma lint rules/ --disable missing_description,missing_author  # suppress specific rules
-rsigma lint rules/ --config my-lint.yml        # explicit config file
-rsigma lint rules/ --exclude "config/**"       # skip non-rule files
-rsigma lint rules/ --exclude "config/**" --exclude "**/unsupported/**"  # multiple patterns
-rsigma lint rules/ --fix                       # auto-fix safe issues
-rsigma lint rules/ --fail-level warning        # CI: fail on warnings too
-rsigma lint rules/ --fail-level info           # CI: fail on any finding
+rsigma rule lint path/to/rules/                     # lint all rules
+rsigma rule lint path/to/rules/ -v                  # verbose (show passing files + info-only)
+rsigma rule lint path/to/rules/ --schema default    # + JSON schema validation (downloads + caches)
+rsigma rule lint rule.yml --schema my-schema.json   # local JSON schema
+rsigma rule lint path/to/rules/ --color always      # force color
+rsigma rule lint rules/ --disable missing_description,missing_author  # suppress specific rules
+rsigma rule lint rules/ --config my-lint.yml        # explicit config file
+rsigma rule lint rules/ --exclude "config/**"       # skip non-rule files
+rsigma rule lint rules/ --exclude "config/**" --exclude "**/unsupported/**"  # multiple patterns
+rsigma rule lint rules/ --fix                       # auto-fix safe issues
+rsigma rule lint rules/ --fail-level warning        # CI: fail on warnings too
+rsigma rule lint rules/ --fail-level info           # CI: fail on any finding
 ```
 
 **Lint output summary format:**
@@ -117,14 +140,14 @@ Checked N file(s): X passed, Y failed (A error(s), B warning(s), C info(s))
 
 **Schema validation skips** documents with `action: global`, `action: reset`, or `action: repeat` (action fragments).
 
-### `daemon`: Run as a long-running detection service
+### `engine daemon`: Run as a long-running detection service
 
 Run rsigma as a long-running daemon that continuously reads NDJSON from stdin, evaluates against rules, writes matches to stdout, and exposes health/metrics/management APIs over HTTP.
 
-Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-reload: adding, modifying, or removing `.yml`/`.yaml` files in the rules directory or any pipeline file passed via `-p` triggers an automatic reload (rules and pipelines are re-read together). SIGHUP and the `/api/v1/reload` endpoint also trigger reloads. The daemon is designed for production deployment behind a log collector (e.g. `hel run | rsigma daemon ...`) or an event bus.
+Unlike `engine eval`, the daemon stays alive after stdin reaches EOF and supports hot-reload: adding, modifying, or removing `.yml`/`.yaml` files in the rules directory or any pipeline file passed via `-p` triggers an automatic reload (rules and pipelines are re-read together). SIGHUP and the `/api/v1/reload` endpoint also trigger reloads. The daemon is designed for production deployment behind a log collector (e.g. `hel run | rsigma engine daemon ...`) or an event bus.
 
 > [!TIP]
-> Correlation rules also work in `eval` mode within a single run (via stdin or `@file`), but daemon mode is recommended for continuous stateful tracking with hot-reload and state persistence.
+> Correlation rules also work in `engine eval` mode within a single run (via stdin or `@file`), but `engine daemon` mode is recommended for continuous stateful tracking with hot-reload and state persistence.
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -182,62 +205,62 @@ Unlike `eval`, the daemon stays alive after stdin reaches EOF and supports hot-r
 
 ```bash
 # Basic daemon: stream events, detect, output matches
-hel run | rsigma daemon -r rules/ -p ecs.yml
+hel run | rsigma engine daemon -r rules/ -p ecs.yml
 
 # Accept events via HTTP POST instead of stdin
-rsigma daemon -r rules/ --input http
+rsigma engine daemon -r rules/ --input http
 # Then: curl -X POST http://localhost:9090/api/v1/events -d '{"CommandLine":"whoami"}'
 
 # NATS JetStream source and sink
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --output nats://localhost:4222/detections
 
 # Fan-out: write detections to both stdout and a file
-hel run | rsigma daemon -r rules/ --output stdout --output file:///tmp/detections.ndjson
+hel run | rsigma engine daemon -r rules/ --output stdout --output file:///tmp/detections.ndjson
 
 # NATS with authentication (credentials file)
-rsigma daemon -r rules/ --input nats://nats.example.com:4222/events.> --nats-creds /etc/rsigma/nats.creds
+rsigma engine daemon -r rules/ --input nats://nats.example.com:4222/events.> --nats-creds /etc/rsigma/nats.creds
 
 # NATS with token auth (via environment variable)
-NATS_TOKEN=secret rsigma daemon -r rules/ --input nats://localhost:4222/events.>
+NATS_TOKEN=secret rsigma engine daemon -r rules/ --input nats://localhost:4222/events.>
 
 # NATS with mutual TLS
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> \
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> \
   --nats-tls-cert /etc/rsigma/client.pem --nats-tls-key /etc/rsigma/client-key.pem --nats-require-tls
 
 # Dead-letter queue for failed events
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> \
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> \
   --dlq file:///var/log/rsigma-dlq.ndjson
 
 # Replay from a specific stream sequence
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-sequence 42
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-sequence 42
 
 # Replay from a point in time
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-time 2026-04-30T00:00:00Z
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-time 2026-04-30T00:00:00Z
 
 # Start from the latest message, ignoring history
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-latest
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --replay-from-latest
 
 # Consumer groups for horizontal scaling
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> --consumer-group detection-workers
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> --consumer-group detection-workers
 
 # With SQLite state persistence (correlation state survives restarts)
-hel run | rsigma daemon -r rules/ -p ecs.yml --state-db ./rsigma-state.db
+hel run | rsigma engine daemon -r rules/ -p ecs.yml --state-db ./rsigma-state.db
 
 # Force clear state on startup (ignore any saved state)
-rsigma daemon -r rules/ --state-db ./state.db --clear-state
+rsigma engine daemon -r rules/ --state-db ./state.db --clear-state
 
 # Force restore state during replay (forward catch-up scenario)
-rsigma daemon -r rules/ --input nats://localhost:4222/events.> \
+rsigma engine daemon -r rules/ --input nats://localhost:4222/events.> \
   --state-db ./state.db --replay-from-sequence 1001 --keep-state
 
 # Skip events without timestamps for correlation (forensic replay)
-rsigma daemon -r rules/ --timestamp-fallback skip
+rsigma engine daemon -r rules/ --timestamp-fallback skip
 
 # Tune pipeline: micro-batch 64 events per lock, 50K buffer, 10s drain on shutdown
-rsigma daemon -r rules/ --batch-size 64 --buffer-size 50000 --drain-timeout 10
+rsigma engine daemon -r rules/ --batch-size 64 --buffer-size 50000 --drain-timeout 10
 
 # With all options
-rsigma daemon \
+rsigma engine daemon \
   -r rules/ \
   -p ecs.yml \
   --jq '.event' \
@@ -343,7 +366,7 @@ The per-rule labeled counters (`_by_rule_total`) enable per-rule alerting in Gra
 
 The `tracing` spans installed on hot paths (batch processing, source resolution, OTLP ingest, rule loading) double as profiling hooks consumable by `tokio-console` or `tracing-timing` without code changes—just swap in the corresponding subscriber layer.
 
-**CLI subcommand logging:** non-daemon subcommands (`eval`, `lint`, `validate`, `convert`, `fields`, `parse`, `resolve`) default to human-readable stdout/stderr output only. Pass the global `--log-format json` (or `--log-format text`) to additionally install a tracing subscriber on stderr for CI/log aggregation use cases. Verbosity follows `RUST_LOG` (default `info`). Human-readable output is unchanged when the flag is set.
+**CLI subcommand logging:** non-daemon subcommands (everything outside `rsigma engine daemon` — that is, `rsigma engine eval`, the `rsigma rule *` group, `rsigma backend *`, `rsigma pipeline resolve`) default to human-readable stdout/stderr output only. Pass the global `--log-format json` (or `--log-format text`) to additionally install a tracing subscriber on stderr for CI/log aggregation use cases. Verbosity follows `RUST_LOG` (default `info`). Human-readable output is unchanged when the flag is set.
 
 **State persistence:** when `--state-db` is set, correlation state (window entries, suppression timestamps, event buffers) is persisted to a SQLite database. State is loaded on startup, saved periodically (default every 30s, configurable via `--state-save-interval`), and saved on graceful shutdown. This allows correlation windows to survive daemon restarts. For example, an `event_count` correlation that saw 2 of 3 required events before a restart will resume from 2 after restarting. The database uses WAL journal mode and stores a single JSON snapshot row. Correlation entries are keyed by stable rule identifiers (id/name), so state survives rule reloads even if internal ordering changes.
 
@@ -359,7 +382,7 @@ The `tracing` spans installed on hot paths (batch processing, source resolution,
 
 **Feature flags:** the daemon subcommand requires the `daemon` feature (enabled by default). NATS flags require the `daemon-nats` feature. OTLP log ingestion (HTTP and gRPC) requires the `daemon-otlp` feature. To build without daemon dependencies: `cargo build --no-default-features`.
 
-### `eval`: Evaluate events against rules
+### `engine eval`: Evaluate events against rules
 
 Evaluate JSON events against Sigma detection and correlation rules.
 
@@ -394,24 +417,24 @@ Evaluate JSON events against Sigma detection and correlation rules.
 
 ```bash
 # Single event (inline JSON)
-rsigma eval -r path/to/rules/ -e '{"CommandLine": "whoami"}'
+rsigma engine eval -r path/to/rules/ -e '{"CommandLine": "whoami"}'
 
 # Read events from a file (@file syntax, streams as NDJSON, one event per line)
-rsigma eval -r path/to/rules/ -e @events.ndjson
+rsigma engine eval -r path/to/rules/ -e @events.ndjson
 
 # Stream NDJSON from stdin
-cat events.ndjson | rsigma eval -r path/to/rules/
+cat events.ndjson | rsigma engine eval -r path/to/rules/
 
 # With processing pipeline(s), applied in priority order
-rsigma eval -r rules/ -p sysmon.yml -p custom.yml -e '...'
+rsigma engine eval -r rules/ -p sysmon.yml -p custom.yml -e '...'
 ```
 
 The `@file` syntax is equivalent to piping the file via stdin but avoids the pipe:
 
 ```bash
 # These are equivalent:
-rsigma eval -r rules/ -e @events.ndjson
-cat events.ndjson | rsigma eval -r rules/
+rsigma engine eval -r rules/ -e @events.ndjson
+cat events.ndjson | rsigma engine eval -r rules/
 ```
 
 **EVTX (Windows Event Log) files** (requires `evtx` feature):
@@ -420,10 +443,10 @@ Files with a `.evtx` extension are automatically detected and parsed as binary W
 
 ```bash
 # Evaluate Sigma rules against a Windows Event Log file
-rsigma eval -r rules/ -e @security.evtx
+rsigma engine eval -r rules/ -e @security.evtx
 
 # With a pipeline and pretty output
-rsigma eval -r rules/ -p sysmon.yml -e @Microsoft-Windows-Sysmon.evtx --pretty
+rsigma engine eval -r rules/ -p sysmon.yml -e @Microsoft-Windows-Sysmon.evtx --pretty
 ```
 
 **Event extraction (jq / JSONPath):**
@@ -432,48 +455,48 @@ rsigma eval -r rules/ -p sysmon.yml -e @Microsoft-Windows-Sysmon.evtx --pretty
 
 ```bash
 # Unwrap nested payloads with jq syntax
-rsigma eval -r rules/ --jq '.event' -e '{"ts":"...","event":{"CommandLine":"whoami"}}'
+rsigma engine eval -r rules/ --jq '.event' -e '{"ts":"...","event":{"CommandLine":"whoami"}}'
 
 # JSONPath (RFC 9535)
-rsigma eval -r rules/ --jsonpath '$.event' -e '{"ts":"...","event":{"CommandLine":"whoami"}}'
+rsigma engine eval -r rules/ --jsonpath '$.event' -e '{"ts":"...","event":{"CommandLine":"whoami"}}'
 
 # Array unwrapping: yields one event per element
-rsigma eval -r rules/ --jq '.records[]' -e '{"records":[{"CommandLine":"whoami"},{"CommandLine":"id"}]}'
+rsigma engine eval -r rules/ --jq '.records[]' -e '{"records":[{"CommandLine":"whoami"},{"CommandLine":"id"}]}'
 
 # Stream with extraction
-hel run | rsigma eval -r rules/ -p ecs.yml --jq '.event'
+hel run | rsigma engine eval -r rules/ -p ecs.yml --jq '.event'
 ```
 
 **Detection output:**
 
 ```bash
 # Include the full matched event JSON in detection output
-rsigma eval -r rules/ --include-event -e '{"CommandLine": "whoami"}'
+rsigma engine eval -r rules/ --include-event -e '{"CommandLine": "whoami"}'
 ```
 
 **Correlation options:**
 
 ```bash
 # Suppress duplicate correlation alerts within a time window
-rsigma eval -r rules/ --suppress 5m < events.ndjson
+rsigma engine eval -r rules/ --suppress 5m < events.ndjson
 
 # Reset state after alert fires (default: alert)
-rsigma eval -r rules/ --suppress 5m --action reset < events.ndjson
+rsigma engine eval -r rules/ --suppress 5m --action reset < events.ndjson
 
 # Include full contributing events in correlation output (compressed in memory)
-rsigma eval -r rules/ --correlation-event-mode full < events.ndjson
+rsigma engine eval -r rules/ --correlation-event-mode full < events.ndjson
 
 # Include lightweight event references (timestamp + ID) instead
-rsigma eval -r rules/ --correlation-event-mode refs < events.ndjson
+rsigma engine eval -r rules/ --correlation-event-mode refs < events.ndjson
 
 # Cap stored events per correlation window (default: 10)
-rsigma eval -r rules/ --correlation-event-mode full --max-correlation-events 20 < events.ndjson
+rsigma engine eval -r rules/ --correlation-event-mode full --max-correlation-events 20 < events.ndjson
 
 # Suppress detection output (only show correlation alerts)
-rsigma eval -r rules/ --no-detections < events.ndjson
+rsigma engine eval -r rules/ --no-detections < events.ndjson
 
 # Custom timestamp field for correlation windowing
-rsigma eval -r rules/ --timestamp-field time < events.ndjson
+rsigma engine eval -r rules/ --timestamp-field time < events.ndjson
 ```
 
 ### Custom rule attributes
@@ -510,16 +533,16 @@ custom_attributes:
 level: high
 ```
 
-### `convert`: Convert rules to backend-native queries
+### `backend convert`: Convert rules to backend-native queries
 
 Convert Sigma rules into query strings for a specific backend (SQL, SPL, KQL, Lucene, etc.).
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
 | `<rules>` | positional, repeatable | required | Path(s) to Sigma rule file(s) or directory |
-| `--target` / `-t` | string | required | Backend target name (see `list-targets`) |
+| `--target` / `-t` | string | required | Backend target name (see `backend targets`) |
 | `--pipeline` / `-p` | repeatable | `[]` | Processing pipeline YAML file(s) |
-| `--format` / `-f` | string | `"default"` | Output format (see `list-formats`) |
+| `--format` / `-f` | string | `"default"` | Output format (see `backend formats`) |
 | `-O` / `--option` | repeatable | `[]` | Backend options as `key=value` pairs (e.g. `-O table=logs -O schema=public`) |
 | `--output` / `-o` | path | stdout | Write output to a file instead of stdout |
 | `--skip-unsupported` / `-s` | flag | `false` | Skip unsupported rules instead of failing |
@@ -529,54 +552,54 @@ Available backends: `test`, `postgres` (aliases: `postgresql`, `pg`).
 
 ```bash
 # Convert rules using the test backend
-rsigma convert rules/ -t test
+rsigma backend convert rules/ -t test
 
 # Convert with a pipeline and specific output format
-rsigma convert rules/ -t test -p pipelines/ecs.yml -f state
+rsigma backend convert rules/ -t test -p pipelines/ecs.yml -f state
 
 # Convert a single rule
-rsigma convert rule.yml -t test
+rsigma backend convert rule.yml -t test
 
 # Convert to PostgreSQL SQL
-rsigma convert rules/ -t postgres
+rsigma backend convert rules/ -t postgres
 
 # Convert to PostgreSQL with OCSF field mapping (single table)
-rsigma convert rules/ -t postgres -p pipelines/ocsf_postgres.yml
+rsigma backend convert rules/ -t postgres -p pipelines/ocsf_postgres.yml
 
 # Convert with per-logsource table routing (multi-table)
-rsigma convert rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
+rsigma backend convert rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
 
 # Generate PostgreSQL views
-rsigma convert rules/ -t postgres -f view
+rsigma backend convert rules/ -t postgres -f view
 
 # Generate TimescaleDB continuous aggregates
-rsigma convert rules/ -t postgres -f continuous_aggregate
+rsigma backend convert rules/ -t postgres -f continuous_aggregate
 
 # Custom backend options (table, schema, timestamp field, etc.)
-rsigma convert rules/ -t postgres -O table=security_logs -O schema=public -O timestamp_field=created_at
+rsigma backend convert rules/ -t postgres -O table=security_logs -O schema=public -O timestamp_field=created_at
 
 # JSONB mode: access fields inside a JSONB column
-rsigma convert rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
+rsigma backend convert rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
 
 # Skip rules that the backend does not support
-rsigma convert rules/ -t postgres --skip-unsupported
+rsigma backend convert rules/ -t postgres --skip-unsupported
 
 # Write output to a file
-rsigma convert rules/ -t postgres -o queries.sql
+rsigma backend convert rules/ -t postgres -o queries.sql
 ```
 
-### `list-targets`: List available conversion backends
+### `backend targets`: List available conversion backends
 
 List all registered conversion backend targets.
 
 ```bash
-rsigma list-targets
+rsigma backend targets
 # Output:
 #   test      Backend-neutral text queries for testing
 #   postgres  PostgreSQL/TimescaleDB SQL
 ```
 
-### `list-formats`: List output formats for a backend
+### `backend formats`: List output formats for a backend
 
 List the output formats supported by a specific backend.
 
@@ -585,7 +608,7 @@ List the output formats supported by a specific backend.
 | `<target>` | positional | required | Backend target name |
 
 ```bash
-rsigma list-formats postgres
+rsigma backend formats postgres
 # Output:
 #   default              Plain PostgreSQL SQL
 #   view                 CREATE OR REPLACE VIEW for each rule
@@ -594,7 +617,7 @@ rsigma list-formats postgres
 #   sliding_window       Correlation queries using window functions for per-row sliding detection
 ```
 
-### `fields`: List all fields referenced by Sigma rules
+### `rule fields`: List all fields referenced by Sigma rules
 
 Extract and display every field name referenced across detection rules, correlation rules, filter rules, and rule metadata. Useful for building a field catalog, auditing pipeline coverage, or understanding which fields a ruleset depends on.
 
@@ -618,26 +641,26 @@ When pipelines are provided, fields are shown after pipeline transformations (fi
 
 ```bash
 # List all fields in a ruleset
-rsigma fields -r rules/
+rsigma rule fields -r rules/
 
 # Show fields after ECS pipeline mapping
-rsigma fields -r rules/ -p pipelines/ecs.yml
+rsigma rule fields -r rules/ -p pipelines/ecs.yml
 
 # Exclude filter-contributed fields
-rsigma fields -r rules/ --no-filters
+rsigma rule fields -r rules/ --no-filters
 
 # JSON output for scripting
-rsigma fields -r rules/ --json
+rsigma rule fields -r rules/ --json
 
 # Pipe JSON to jq for further analysis
-rsigma fields -r rules/ --json | jq '.fields[] | select(.sources[] == "detection") | .field'
+rsigma rule fields -r rules/ --json | jq '.fields[] | select(.sources[] == "detection") | .field'
 ```
 
 **Table output** writes field data to stdout and a summary line to stderr, so you can pipe the table or redirect it without mixing in summary text.
 
 **JSON output** includes a `summary` object (rule/correlation/filter counts, unique fields, pipelines applied), a `fields` array, and when pipelines are applied, a `pipeline_mappings` array showing each field name transformation.
 
-### `resolve`: Test dynamic source resolution
+### `pipeline resolve`: Test dynamic source resolution
 
 Resolve all dynamic sources declared in the given pipeline(s) and print the resulting data as JSON. Useful for testing pipeline source configuration without running the daemon.
 
@@ -650,16 +673,16 @@ Resolve all dynamic sources declared in the given pipeline(s) and print the resu
 
 ```bash
 # Resolve all sources in a dynamic pipeline
-rsigma resolve -p pipelines/dynamic.yml --pretty
+rsigma pipeline resolve -p pipelines/dynamic.yml --pretty
 
 # Resolve a specific source by ID
-rsigma resolve -p pipelines/dynamic.yml --source threat_intel
+rsigma pipeline resolve -p pipelines/dynamic.yml --source threat_intel
 
 # Dry-run: list sources and metadata without fetching
-rsigma resolve -p pipelines/dynamic.yml --dry-run
+rsigma pipeline resolve -p pipelines/dynamic.yml --dry-run
 
 # Test multiple pipelines at once
-rsigma resolve -p pipeline1.yml -p pipeline2.yml
+rsigma pipeline resolve -p pipeline1.yml -p pipeline2.yml
 ```
 
 **Output format (normal mode):**
@@ -685,7 +708,7 @@ rsigma resolve -p pipeline1.yml -p pipeline2.yml
 }
 ```
 
-### `condition`: Parse a condition expression
+### `rule condition`: Parse a condition expression
 
 Parse a Sigma condition expression and output the AST as pretty-printed JSON. Output is always pretty-printed.
 
@@ -694,10 +717,10 @@ Parse a Sigma condition expression and output the AST as pretty-printed JSON. Ou
 | `expr` | positional | required | The condition expression to parse |
 
 ```bash
-rsigma condition 'selection and not filter'
+rsigma rule condition 'selection and not filter'
 ```
 
-### `stdin`: Parse YAML from stdin
+### `rule stdin`: Parse YAML from stdin
 
 Read a single Sigma YAML document from stdin and output the AST as JSON.
 
@@ -706,7 +729,7 @@ Read a single Sigma YAML document from stdin and output the AST as JSON.
 | `--pretty` / `-p` | flag | **true** | Pretty-print JSON output |
 
 ```bash
-cat rule.yml | rsigma stdin
+cat rule.yml | rsigma rule stdin
 ```
 
 ## File Discovery
@@ -720,15 +743,15 @@ All subcommands that accept a directory path scan recursively for `.yml` and `.y
 
 | Mode | Input format | Behavior |
 |------|-------------|----------|
-| `rsigma eval -e '...'` | Inline JSON string | Parses the string as a single JSON object and evaluates it |
-| `rsigma eval -e @path` | NDJSON file | Reads the file line-by-line as NDJSON (same behavior as stdin) |
-| `rsigma eval -e @path.evtx` | EVTX binary file | Parses the binary Windows Event Log file and evaluates each record (requires `evtx` feature) |
-| `rsigma eval` (no `--event`) | NDJSON from stdin | Each non-blank line is parsed as JSON. Blank lines are skipped. Exits after EOF |
-| `rsigma daemon` | NDJSON from stdin | Continuous stdin reader; stays alive after EOF. Exposes HTTP APIs for management |
-| `rsigma daemon --input http` | NDJSON via HTTP POST | Events sent to `POST /api/v1/events`. Stays alive, exposes all APIs |
-| `rsigma daemon --input nats://...` | NATS JetStream | Subscribes to a JetStream subject. At-least-once delivery with deferred ack |
+| `rsigma engine eval -e '...'` | Inline JSON string | Parses the string as a single JSON object and evaluates it |
+| `rsigma engine eval -e @path` | NDJSON file | Reads the file line-by-line as NDJSON (same behavior as stdin) |
+| `rsigma engine eval -e @path.evtx` | EVTX binary file | Parses the binary Windows Event Log file and evaluates each record (requires `evtx` feature) |
+| `rsigma engine eval` (no `--event`) | NDJSON from stdin | Each non-blank line is parsed as JSON. Blank lines are skipped. Exits after EOF |
+| `rsigma engine daemon` | NDJSON from stdin | Continuous stdin reader; stays alive after EOF. Exposes HTTP APIs for management |
+| `rsigma engine daemon --input http` | NDJSON via HTTP POST | Events sent to `POST /api/v1/events`. Stays alive, exposes all APIs |
+| `rsigma engine daemon --input nats://...` | NATS JetStream | Subscribes to a JetStream subject. At-least-once delivery with deferred ack |
 | OTLP (any `--input` mode) | OTLP protobuf/JSON via HTTP POST or gRPC | Agents send `ExportLogsServiceRequest` to `/v1/logs` (HTTP) or the gRPC `LogsService/Export` endpoint. Requires `daemon-otlp` feature |
-| `rsigma stdin` | Single YAML document | Parses as Sigma YAML → outputs AST as JSON |
+| `rsigma rule stdin` | Single YAML document | Parses as Sigma YAML → outputs AST as JSON |
 
 Event filters (`--jq`/`--jsonpath`) are applied to every event regardless of input mode.
 
@@ -937,7 +960,7 @@ Resolved values are cached in memory (and optionally SQLite). The cache supports
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `daemon` | **on** | Enables the `daemon` subcommand (tokio, axum, prometheus, notify, rusqlite) |
+| `daemon` | **on** | Enables the `engine daemon` subcommand (tokio, axum, prometheus, notify, rusqlite) |
 | `daemon-nats` | off | Enables NATS JetStream input/output, authentication, replay, and consumer groups (implies `daemon`) |
 | `daemon-otlp` | off | Enables OTLP log ingestion via HTTP (protobuf/JSON) and gRPC on `/v1/logs` (implies `daemon`) |
 | `logfmt` | off | Enables `logfmt` input format in `daemon` and `eval` |
@@ -967,16 +990,16 @@ cargo build --release --no-default-features
 Use `--fail-on-detection` with `eval` to fail a CI pipeline when a detection rule matches:
 
 ```bash
-rsigma eval -r rules/ --fail-on-detection -e @test-events.ndjson
+rsigma engine eval -r rules/ --fail-on-detection -e @test-events.ndjson
 echo $?  # 0 = no detections, 1 = detections fired, 2 = rule error, 3 = config error
 ```
 
 Use `--fail-level` with `lint` to control the minimum severity that triggers a non-zero exit:
 
 ```bash
-rsigma lint rules/ --fail-level warning   # exit 1 on warnings or errors
-rsigma lint rules/ --fail-level info      # exit 1 on any finding
-rsigma lint rules/                        # default: exit 1 only on errors
+rsigma rule lint rules/ --fail-level warning   # exit 1 on warnings or errors
+rsigma rule lint rules/ --fail-level info      # exit 1 on any finding
+rsigma rule lint rules/                        # default: exit 1 only on errors
 ```
 
 ## License

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -1,7 +1,43 @@
 use std::path::PathBuf;
 use std::process;
 
+use clap::Args;
 use rsigma_parser::{SigmaCollection, parse_sigma_directory, parse_sigma_file};
+
+/// Arguments for `rsigma backend convert` (and the deprecated `rsigma convert`).
+#[derive(Args, Debug)]
+pub(crate) struct ConvertArgs {
+    /// Path(s) to Sigma rule file(s) or directory
+    pub rules: Vec<PathBuf>,
+
+    /// Target backend (e.g. test)
+    #[arg(short, long)]
+    pub target: String,
+
+    /// Output format (backend-specific, default: "default")
+    #[arg(short, long, default_value = "default")]
+    pub format: String,
+
+    /// Processing pipeline(s) (repeatable). Accepts builtin names (ecs_windows, sysmon) or YAML file paths
+    #[arg(short = 'p', long = "pipeline")]
+    pub pipeline: Vec<PathBuf>,
+
+    /// Skip pipeline requirement check
+    #[arg(long)]
+    pub without_pipeline: bool,
+
+    /// Skip unsupported rules instead of failing
+    #[arg(short, long)]
+    pub skip_unsupported: bool,
+
+    /// Output file (default: stdout)
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// Backend options as key=value pairs (repeatable)
+    #[arg(short = 'O', long = "option")]
+    pub backend_options: Vec<String>,
+}
 
 fn get_backend(
     target: &str,
@@ -24,24 +60,25 @@ fn get_backend(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn cmd_convert(
-    rules: Vec<PathBuf>,
-    target: String,
-    format: String,
-    pipeline_paths: Vec<PathBuf>,
-    without_pipeline: bool,
-    skip_unsupported: bool,
-    output: Option<PathBuf>,
-    backend_options: Vec<String>,
-) {
+pub(crate) fn cmd_convert(args: ConvertArgs) {
+    let ConvertArgs {
+        rules,
+        target,
+        format,
+        pipeline: pipeline_paths,
+        without_pipeline,
+        skip_unsupported,
+        output,
+        backend_options,
+    } = args;
+
     let collection = load_collection_multi(&rules);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
     if pipelines.iter().any(|p| p.is_dynamic()) {
         eprintln!(
-            "  note: dynamic sources are not resolved by `rsigma convert`. \
-             Use `rsigma resolve` to inspect sources or `rsigma daemon` to evaluate \
+            "  note: dynamic sources are not resolved by `rsigma backend convert`. \
+             Use `rsigma pipeline resolve` to inspect sources or `rsigma engine daemon` to evaluate \
              events with dynamic pipelines."
         );
     }
@@ -119,6 +156,14 @@ pub(crate) fn cmd_list_formats(target: String) {
     for (name, desc) in backend.formats() {
         println!("  {name}  - {desc}");
     }
+}
+
+/// Wrapper for the deprecated flat `rsigma list-formats TARGET` form so the
+/// outer dispatch can pull the positional argument off a clap variant uniformly.
+#[derive(Args, Debug)]
+pub(crate) struct ListFormatsArgs {
+    /// Target backend name
+    pub target: String,
 }
 
 fn load_collection_multi(paths: &[PathBuf]) -> SigmaCollection {

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -1,0 +1,593 @@
+//! Daemon subcommand: long-running detection service.
+//!
+//! Hosts the `DaemonArgs` clap struct, the `cmd_daemon` entry point, and the
+//! input-format / timezone parsing helpers that used to live in `main.rs`.
+
+use std::path::PathBuf;
+use std::process;
+
+use clap::Args;
+
+use crate::daemon;
+use crate::exit_code;
+
+/// Arguments for `rsigma engine daemon` (and the deprecated `rsigma daemon`).
+#[derive(Args, Debug)]
+pub(crate) struct DaemonArgs {
+    /// Path to a Sigma rule file or directory of rules
+    #[arg(short, long)]
+    pub rules: PathBuf,
+
+    /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
+    #[arg(short = 'p', long = "pipeline")]
+    pub pipelines: Vec<PathBuf>,
+
+    /// jq filter to extract the event payload from each JSON object
+    #[arg(long = "jq", conflicts_with = "jsonpath")]
+    pub jq: Option<String>,
+
+    /// JSONPath (RFC 9535) query to extract the event payload
+    #[arg(long = "jsonpath", conflicts_with = "jq")]
+    pub jsonpath: Option<String>,
+
+    /// Include the full event JSON in each detection match output
+    #[arg(long = "include-event")]
+    pub include_event: bool,
+
+    /// Pretty-print JSON output
+    #[arg(long)]
+    pub pretty: bool,
+
+    /// Address for health, metrics, and API server (default: 0.0.0.0:9090)
+    #[arg(long = "api-addr", default_value = "0.0.0.0:9090")]
+    pub api_addr: String,
+
+    /// Suppression window for correlation alerts (e.g. 5m, 1h, 30s)
+    #[arg(long = "suppress")]
+    pub suppress: Option<String>,
+
+    /// Action after correlation fires: 'alert' (default) or 'reset'
+    #[arg(long = "action", value_parser = ["alert", "reset"])]
+    pub action: Option<String>,
+
+    /// Suppress detection output for correlation-only rules
+    #[arg(long = "no-detections")]
+    pub no_detections: bool,
+
+    /// Correlation event mode: none, full, or refs
+    #[arg(long = "correlation-event-mode", default_value = "none")]
+    pub correlation_event_mode: String,
+
+    /// Max events per correlation window group
+    #[arg(long = "max-correlation-events", default_value = "10")]
+    pub max_correlation_events: usize,
+
+    /// Event field name(s) for timestamp extraction in correlations
+    #[arg(long = "timestamp-field")]
+    pub timestamp_fields: Vec<String>,
+
+    /// Path to SQLite database for persisting correlation state across restarts.
+    /// When set, state is loaded on startup and saved periodically + on shutdown.
+    #[arg(long = "state-db")]
+    pub state_db: Option<PathBuf>,
+
+    /// Interval in seconds between periodic state snapshots (default: 30).
+    /// Only meaningful when --state-db is set.
+    #[arg(long = "state-save-interval", default_value = "30", value_parser = clap::value_parser!(u64).range(1..))]
+    pub state_save_interval: u64,
+
+    /// Event input source. Supported schemes: stdin, http, nats://<host>:<port>/<subject>
+    #[arg(long = "input", default_value = "stdin")]
+    pub input: String,
+
+    /// Detection output sink (can be repeated for fan-out).
+    /// Supported schemes: stdout, file://<path>, nats://<host>:<port>/<subject>
+    #[arg(long = "output", default_value = "stdout")]
+    pub output: Vec<String>,
+
+    /// Bounded channel capacity for source→engine and engine→sink queues.
+    /// Higher values absorb bursts; lower values apply back-pressure sooner.
+    #[arg(long = "buffer-size", default_value = "10000")]
+    pub buffer_size: usize,
+
+    /// Maximum events to process per engine lock acquisition.
+    /// Reduces mutex overhead under load. 1 = process one at a time (default).
+    #[arg(long = "batch-size", default_value = "1")]
+    pub batch_size: usize,
+
+    /// Seconds to wait for in-flight events to drain on shutdown (default: 5).
+    #[arg(long = "drain-timeout", default_value = "5")]
+    pub drain_timeout: u64,
+
+    /// Dead-letter queue target for events that fail processing.
+    /// Accepts same schemes as --output: stdout, file://<path>, nats://<host>:<port>/<subject>.
+    /// When not set, failed events are logged and discarded.
+    #[arg(long = "dlq")]
+    pub dlq: Option<String>,
+
+    /// Input log format for event parsing.
+    /// auto: try JSON → syslog → plain (default).
+    /// Explicit: json, syslog, plain, logfmt (requires logfmt feature),
+    /// cef (requires cef feature).
+    #[arg(long = "input-format", default_value = "auto")]
+    pub input_format: String,
+
+    /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
+    /// Only used when --input-format is syslog or auto. Defaults to UTC.
+    #[arg(long = "syslog-tz", default_value = "+00:00")]
+    pub syslog_tz: String,
+
+    /// NATS credentials file (.creds) for JWT + NKey authentication.
+    /// Also reads from NATS_CREDS environment variable.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-creds", env = "NATS_CREDS")]
+    pub nats_creds: Option<PathBuf>,
+
+    /// NATS authentication token. Also reads from NATS_TOKEN.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-token", env = "NATS_TOKEN", conflicts_with = "nats_creds")]
+    pub nats_token: Option<String>,
+
+    /// NATS username (requires --nats-password). Also reads from NATS_USER.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-user", env = "NATS_USER", requires = "nats_password", conflicts_with_all = ["nats_creds", "nats_token"])]
+    pub nats_user: Option<String>,
+
+    /// NATS password (requires --nats-user). Also reads from NATS_PASSWORD.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-password", env = "NATS_PASSWORD", requires = "nats_user")]
+    pub nats_password: Option<String>,
+
+    /// NATS NKey seed for authentication. Also reads from NATS_NKEY.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-nkey", env = "NATS_NKEY", conflicts_with_all = ["nats_creds", "nats_token", "nats_user"])]
+    pub nats_nkey: Option<String>,
+
+    /// TLS client certificate for mutual TLS with NATS.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-tls-cert", requires = "nats_tls_key")]
+    pub nats_tls_cert: Option<PathBuf>,
+
+    /// TLS client private key for mutual TLS with NATS.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-tls-key", requires = "nats_tls_cert")]
+    pub nats_tls_key: Option<PathBuf>,
+
+    /// Require TLS for NATS connections.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "nats-require-tls")]
+    pub nats_require_tls: bool,
+
+    /// Replay from a specific JetStream sequence number.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "replay-from-sequence", conflicts_with_all = ["replay_from_time", "replay_from_latest"])]
+    pub replay_from_sequence: Option<u64>,
+
+    /// Replay from a specific timestamp (ISO 8601, e.g. 2024-01-15T10:00:00Z).
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "replay-from-time", conflicts_with_all = ["replay_from_sequence", "replay_from_latest"])]
+    pub replay_from_time: Option<String>,
+
+    /// Start from the latest message, skipping stream history.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "replay-from-latest", conflicts_with_all = ["replay_from_sequence", "replay_from_time"])]
+    pub replay_from_latest: bool,
+
+    /// Clear correlation state on startup. When used with --replay-from-*,
+    /// forces a clean slate even if the replay starts after the stored position.
+    #[arg(long = "clear-state", conflicts_with = "keep_state")]
+    pub clear_state: bool,
+
+    /// Force restore correlation state even during replay. Use when you know
+    /// the replay starts after the last processed position (forward catch-up)
+    /// and want to preserve cross-boundary correlation windows.
+    #[arg(long = "keep-state", conflicts_with = "clear_state")]
+    pub keep_state: bool,
+
+    /// Behavior when no timestamp field is found in an event.
+    /// 'wallclock' (default): use wall-clock time for correlation windows.
+    /// 'skip': run detections but skip correlation state updates for that
+    /// event. Recommended for forensic replay of logs without timestamps.
+    #[arg(long = "timestamp-fallback", default_value = "wallclock",
+           value_parser = ["wallclock", "skip"])]
+    pub timestamp_fallback: String,
+
+    /// Consumer group name for NATS JetStream load balancing.
+    /// Multiple daemon instances using the same group name share the
+    /// workload via a single durable pull consumer.
+    #[cfg(feature = "daemon-nats")]
+    #[arg(long = "consumer-group", env = "RSIGMA_CONSUMER_GROUP")]
+    pub consumer_group: Option<String>,
+
+    /// Allow include directives to reference remote (HTTP/NATS) sources.
+    /// By default, includes are restricted to local sources (file/command)
+    /// for security. Use this flag to opt in to remote include resolution.
+    #[arg(long = "allow-remote-include")]
+    pub allow_remote_include: bool,
+
+    /// Enable bloom-filter pre-filtering of positive substring matchers.
+    ///
+    /// Off by default. When enabled, the engine builds a per-field bloom
+    /// over every rule's `|contains` / `|startswith` / `|endswith`
+    /// needles and short-circuits items whose field value cannot
+    /// possibly contain a needle trigram. The probe costs ~1 µs per
+    /// event, so this only pays off on rule sets where most events do
+    /// NOT match any pattern (e.g. high-volume telemetry against
+    /// substring-heavy threat-intel rules). Run the
+    /// `eval_bloom_rejection` benchmark on representative data before
+    /// flipping this on in production.
+    #[arg(long = "bloom-prefilter")]
+    pub bloom_prefilter: bool,
+
+    /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB
+    /// (1048576). Lower the cap on memory-constrained deployments;
+    /// raise it for very large rule sets where the default starts
+    /// evicting useful filters. Has no effect unless
+    /// `--bloom-prefilter` is set.
+    #[arg(long = "bloom-max-bytes")]
+    pub bloom_max_bytes: Option<usize>,
+
+    /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
+    ///
+    /// Off by default. When enabled, the engine builds a single
+    /// per-field `DoubleArrayAhoCorasick` over every rule's positive
+    /// substring needles and drops AC-prunable rules (pure positive
+    /// substring detections, no negation) from the candidate set when
+    /// none of their patterns match the event. Pays off only on rule
+    /// sets > ~5K rules with many shared substring patterns
+    /// (threat-intel feeds, IOC packs). For smaller rule sets the
+    /// per-rule Aho-Corasick matcher is already optimal. Build time
+    /// scales linearly with total pattern count; pattern count per
+    /// field is capped at 100K. Available when compiled with the
+    /// `daachorse-index` Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    #[arg(long = "cross-rule-ac")]
+    pub cross_rule_ac: bool,
+}
+
+/// Helper struct grouping NATS connection / auth flags so `cmd_daemon` does
+/// not balloon back to 30+ positional parameters once we destructure the args.
+#[cfg(feature = "daemon-nats")]
+pub(crate) struct NatsAuthArgs {
+    pub nats_creds: Option<PathBuf>,
+    pub nats_token: Option<String>,
+    pub nats_user: Option<String>,
+    pub nats_password: Option<String>,
+    pub nats_nkey: Option<String>,
+    pub nats_tls_cert: Option<PathBuf>,
+    pub nats_tls_key: Option<PathBuf>,
+    pub nats_require_tls: bool,
+}
+
+/// Entry point for `rsigma engine daemon` (and the deprecated `rsigma daemon`).
+pub(crate) fn cmd_daemon(args: DaemonArgs) {
+    let DaemonArgs {
+        rules: rules_path,
+        pipelines: pipeline_paths,
+        jq,
+        jsonpath,
+        include_event,
+        pretty,
+        api_addr,
+        suppress,
+        action,
+        no_detections,
+        correlation_event_mode,
+        max_correlation_events,
+        timestamp_fields,
+        state_db,
+        state_save_interval,
+        input,
+        output,
+        buffer_size,
+        batch_size,
+        drain_timeout,
+        dlq,
+        input_format,
+        syslog_tz,
+        #[cfg(feature = "daemon-nats")]
+        nats_creds,
+        #[cfg(feature = "daemon-nats")]
+        nats_token,
+        #[cfg(feature = "daemon-nats")]
+        nats_user,
+        #[cfg(feature = "daemon-nats")]
+        nats_password,
+        #[cfg(feature = "daemon-nats")]
+        nats_nkey,
+        #[cfg(feature = "daemon-nats")]
+        nats_tls_cert,
+        #[cfg(feature = "daemon-nats")]
+        nats_tls_key,
+        #[cfg(feature = "daemon-nats")]
+        nats_require_tls,
+        #[cfg(feature = "daemon-nats")]
+        replay_from_sequence,
+        #[cfg(feature = "daemon-nats")]
+        replay_from_time,
+        #[cfg(feature = "daemon-nats")]
+        replay_from_latest,
+        clear_state,
+        keep_state,
+        timestamp_fallback,
+        #[cfg(feature = "daemon-nats")]
+        consumer_group,
+        allow_remote_include,
+        bloom_prefilter,
+        bloom_max_bytes,
+        #[cfg(feature = "daachorse-index")]
+        cross_rule_ac,
+    } = args;
+
+    #[cfg(feature = "daemon-nats")]
+    let nats_auth = NatsAuthArgs {
+        nats_creds,
+        nats_token,
+        nats_user,
+        nats_password,
+        nats_nkey,
+        nats_tls_cert,
+        nats_tls_key,
+        nats_require_tls,
+    };
+
+    #[cfg(feature = "daemon-nats")]
+    let replay_policy = if let Some(seq) = replay_from_sequence {
+        rsigma_runtime::ReplayPolicy::FromSequence(seq)
+    } else if let Some(ref ts) = replay_from_time {
+        let t = time::OffsetDateTime::parse(ts, &time::format_description::well_known::Rfc3339)
+            .unwrap_or_else(|e| {
+                eprintln!("Invalid --replay-from-time '{ts}': {e}");
+                process::exit(exit_code::CONFIG_ERROR);
+            });
+        rsigma_runtime::ReplayPolicy::FromTime(t)
+    } else if replay_from_latest {
+        rsigma_runtime::ReplayPolicy::Latest
+    } else {
+        rsigma_runtime::ReplayPolicy::Resume
+    };
+
+    let state_restore_mode = if clear_state {
+        daemon::server::StateRestoreMode::ForceClear
+    } else if keep_state {
+        daemon::server::StateRestoreMode::ForceKeep
+    } else {
+        daemon::server::StateRestoreMode::Auto
+    };
+
+    run_daemon(
+        rules_path,
+        pipeline_paths,
+        jq,
+        jsonpath,
+        include_event,
+        pretty,
+        api_addr,
+        suppress,
+        action,
+        no_detections,
+        correlation_event_mode,
+        max_correlation_events,
+        timestamp_fields,
+        timestamp_fallback,
+        state_db,
+        state_save_interval,
+        input,
+        output,
+        buffer_size,
+        batch_size,
+        drain_timeout,
+        dlq,
+        input_format,
+        syslog_tz,
+        state_restore_mode,
+        #[cfg(feature = "daemon-nats")]
+        nats_auth,
+        #[cfg(feature = "daemon-nats")]
+        replay_policy,
+        #[cfg(feature = "daemon-nats")]
+        consumer_group,
+        allow_remote_include,
+        bloom_prefilter,
+        bloom_max_bytes,
+        #[cfg(feature = "daachorse-index")]
+        cross_rule_ac,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_daemon(
+    rules_path: PathBuf,
+    pipeline_paths: Vec<PathBuf>,
+    jq: Option<String>,
+    jsonpath: Option<String>,
+    include_event: bool,
+    pretty: bool,
+    api_addr: String,
+    suppress: Option<String>,
+    action: Option<String>,
+    no_detections: bool,
+    correlation_event_mode: String,
+    max_correlation_events: usize,
+    timestamp_fields: Vec<String>,
+    timestamp_fallback: String,
+    state_db: Option<PathBuf>,
+    state_save_interval: u64,
+    input: String,
+    output: Vec<String>,
+    buffer_size: usize,
+    batch_size: usize,
+    drain_timeout: u64,
+    dlq: Option<String>,
+    input_format: String,
+    syslog_tz: String,
+    state_restore_mode: daemon::server::StateRestoreMode,
+    #[cfg(feature = "daemon-nats")] nats_auth: NatsAuthArgs,
+    #[cfg(feature = "daemon-nats")] replay_policy: rsigma_runtime::ReplayPolicy,
+    #[cfg(feature = "daemon-nats")] consumer_group: Option<String>,
+    allow_remote_include: bool,
+    bloom_prefilter: bool,
+    bloom_max_bytes: Option<usize>,
+    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
+) {
+    use rsigma_eval::resolve_builtin_pipeline;
+
+    // Daemon installs its own JSON subscriber unconditionally so that operators
+    // get consistent structured logs regardless of CLI invocation flags.
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let pipelines = crate::load_pipelines(&pipeline_paths);
+    let event_filter = std::sync::Arc::new(crate::build_event_filter(jq, jsonpath));
+    let parsed_input_format = parse_input_format(&input_format, &syslog_tz);
+
+    let corr_config = crate::build_correlation_config(
+        suppress,
+        action,
+        no_detections,
+        correlation_event_mode,
+        max_correlation_events,
+        timestamp_fields,
+        &timestamp_fallback,
+    );
+
+    let addr: std::net::SocketAddr = api_addr.parse().unwrap_or_else(|e| {
+        eprintln!("Invalid API address '{api_addr}': {e}");
+        process::exit(exit_code::CONFIG_ERROR);
+    });
+
+    #[cfg(feature = "daemon-nats")]
+    let nats_config = rsigma_runtime::NatsConnectConfig {
+        credentials_file: nats_auth.nats_creds,
+        token: nats_auth.nats_token,
+        username: nats_auth.nats_user,
+        password: nats_auth.nats_password,
+        nkey: nats_auth.nats_nkey,
+        tls_client_cert: nats_auth.nats_tls_cert,
+        tls_client_key: nats_auth.nats_tls_key,
+        require_tls: nats_auth.nats_require_tls,
+        ..Default::default()
+    };
+
+    let file_pipeline_paths: Vec<PathBuf> = pipeline_paths
+        .into_iter()
+        .filter(|p| resolve_builtin_pipeline(p.to_str().unwrap_or("")).is_none())
+        .collect();
+
+    let config = daemon::server::DaemonConfig {
+        rules_path,
+        pipelines,
+        pipeline_paths: file_pipeline_paths,
+        corr_config,
+        include_event,
+        pretty,
+        api_addr: addr,
+        event_filter,
+        state_db,
+        state_save_interval,
+        input,
+        output,
+        buffer_size,
+        batch_size,
+        drain_timeout,
+        dlq,
+        input_format: parsed_input_format,
+        #[cfg(feature = "daemon-nats")]
+        nats_config,
+        #[cfg(feature = "daemon-nats")]
+        replay_policy,
+        #[cfg(feature = "daemon-nats")]
+        consumer_group,
+        state_restore_mode,
+        allow_remote_include,
+        bloom_prefilter,
+        bloom_max_bytes,
+        #[cfg(feature = "daachorse-index")]
+        cross_rule_ac,
+    };
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to create Tokio runtime: {e}");
+            process::exit(exit_code::CONFIG_ERROR);
+        });
+
+    rt.block_on(daemon::run_daemon(config));
+}
+
+// ---------------------------------------------------------------------------
+// Input format parsing
+// ---------------------------------------------------------------------------
+
+pub(crate) fn parse_input_format(format_str: &str, syslog_tz: &str) -> rsigma_runtime::InputFormat {
+    use rsigma_runtime::InputFormat;
+    use rsigma_runtime::input::SyslogConfig;
+
+    let tz_secs = parse_tz_offset(syslog_tz);
+
+    match format_str {
+        "auto" => InputFormat::Auto(SyslogConfig {
+            default_tz_offset_secs: tz_secs,
+        }),
+        "json" => InputFormat::Json,
+        "syslog" => InputFormat::Syslog(SyslogConfig {
+            default_tz_offset_secs: tz_secs,
+        }),
+        "plain" => InputFormat::Plain,
+        #[cfg(feature = "logfmt")]
+        "logfmt" => InputFormat::Logfmt,
+        #[cfg(feature = "cef")]
+        "cef" => InputFormat::Cef,
+        other => {
+            eprintln!("Unknown input format: '{other}'");
+            eprintln!("Supported formats: auto, json, syslog, plain");
+            #[cfg(feature = "logfmt")]
+            eprintln!("  (with logfmt feature): logfmt");
+            #[cfg(feature = "cef")]
+            eprintln!("  (with cef feature): cef");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+    }
+}
+
+/// Parse a timezone offset string like "+05:00" or "-08:00" into seconds east of UTC.
+fn parse_tz_offset(s: &str) -> i32 {
+    let s = s.trim();
+    if s == "UTC" || s == "utc" || s == "Z" || s == "+00:00" {
+        return 0;
+    }
+
+    let (sign, rest) = if let Some(rest) = s.strip_prefix('+') {
+        (1i32, rest)
+    } else if let Some(rest) = s.strip_prefix('-') {
+        (-1i32, rest)
+    } else {
+        eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
+        process::exit(exit_code::CONFIG_ERROR);
+    };
+
+    let parts: Vec<&str> = rest.split(':').collect();
+    if parts.len() != 2 {
+        eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
+        process::exit(exit_code::CONFIG_ERROR);
+    }
+
+    let hours: i32 = parts[0].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid timezone offset hours: '{}'", parts[0]);
+        process::exit(exit_code::CONFIG_ERROR);
+    });
+    let minutes: i32 = parts[1].parse().unwrap_or_else(|_| {
+        eprintln!("Invalid timezone offset minutes: '{}'", parts[1]);
+        process::exit(exit_code::CONFIG_ERROR);
+    });
+
+    sign * (hours * 3600 + minutes * 60)
+}

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -3,10 +3,120 @@ use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 use std::process;
 
+use clap::Args;
 use rsigma_eval::{CorrelationEngine, Engine, JsonEvent, Pipeline};
 use rsigma_parser::SigmaCollection;
 
 use crate::EventFilter;
+
+/// Arguments for `rsigma engine eval` (and the deprecated `rsigma eval`).
+#[derive(Args, Debug)]
+pub(crate) struct EvalArgs {
+    /// Path to a Sigma rule file or directory of rules
+    #[arg(short, long)]
+    pub rules: PathBuf,
+
+    /// A single event as a JSON string, or @path to read from a file.
+    /// Supports NDJSON files and .evtx (Windows Event Log) files.
+    /// If omitted, reads NDJSON from stdin.
+    #[arg(short, long)]
+    pub event: Option<String>,
+
+    /// Pretty-print JSON output
+    #[arg(long)]
+    pub pretty: bool,
+
+    /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
+    #[arg(short = 'p', long = "pipeline")]
+    pub pipelines: Vec<PathBuf>,
+
+    /// jq filter to extract the event payload from each JSON object.
+    /// Example: --jq '.event' or --jq '.records[]'
+    #[arg(long = "jq", conflicts_with = "jsonpath")]
+    pub jq: Option<String>,
+
+    /// JSONPath (RFC 9535) query to extract the event payload.
+    /// Example: --jsonpath '$.event' or --jsonpath '$.records[*]'
+    #[arg(long = "jsonpath", conflicts_with = "jq")]
+    pub jsonpath: Option<String>,
+
+    /// Suppression window for correlation alerts.
+    /// After a correlation fires for a group key, suppress re-alerts
+    /// for this duration. Examples: 5m, 1h, 30s.
+    #[arg(long = "suppress")]
+    pub suppress: Option<String>,
+
+    /// Action to take after a correlation fires.
+    /// 'alert' (default): keep state, re-alert on next match.
+    /// 'reset': clear window state, require threshold from scratch.
+    #[arg(long = "action", value_parser = ["alert", "reset"])]
+    pub action: Option<String>,
+
+    /// Suppress detection-level output for rules that are only
+    /// referenced by correlations (where generate=false).
+    #[arg(long = "no-detections")]
+    pub no_detections: bool,
+
+    /// Include the full event JSON in each detection match output.
+    /// Equivalent to the `rsigma.include_event` custom attribute.
+    #[arg(long = "include-event")]
+    pub include_event: bool,
+
+    /// Correlation event inclusion mode:
+    ///   none  — don't include events (default, zero overhead)
+    ///   full  — include full event bodies (deflate compressed in memory)
+    ///   refs  — include lightweight references (timestamp + event ID)
+    /// Use --max-correlation-events to cap storage per window.
+    #[arg(long = "correlation-event-mode", default_value = "none")]
+    pub correlation_event_mode: String,
+
+    /// Maximum events to store per correlation window group when
+    /// --correlation-event-mode is not 'none'. Oldest events are
+    /// evicted when the cap is reached.
+    #[arg(long = "max-correlation-events", default_value = "10")]
+    pub max_correlation_events: usize,
+
+    /// Event field name(s) to use for timestamp extraction in correlations.
+    /// Can be specified multiple times; tried in order before built-in
+    /// defaults (@timestamp, timestamp, EventTime, …).
+    /// Equivalent to the `rsigma.timestamp_field` custom attribute.
+    #[arg(long = "timestamp-field")]
+    pub timestamp_fields: Vec<String>,
+
+    /// Input log format for event parsing.
+    /// auto: try JSON → syslog → plain (default).
+    /// Explicit: json, syslog, plain, logfmt (requires logfmt feature),
+    /// cef (requires cef feature).
+    #[arg(long = "input-format", default_value = "auto")]
+    pub input_format: String,
+
+    /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
+    /// Only used when --input-format is syslog or auto. Defaults to UTC.
+    #[arg(long = "syslog-tz", default_value = "+00:00")]
+    pub syslog_tz: String,
+
+    /// Exit with code 1 when any detection or correlation fires.
+    /// Useful in CI/CD pipelines to fail a build on detection.
+    #[arg(long = "fail-on-detection")]
+    pub fail_on_detection: bool,
+
+    /// Enable bloom-filter pre-filtering of positive substring matchers.
+    /// See `rsigma engine daemon --help` for the trade-off.
+    #[arg(long = "bloom-prefilter")]
+    pub bloom_prefilter: bool,
+
+    /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB.
+    /// No effect unless `--bloom-prefilter` is set.
+    #[arg(long = "bloom-max-bytes")]
+    pub bloom_max_bytes: Option<usize>,
+
+    /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
+    /// See `rsigma engine daemon --help` for the trade-off. Available when
+    /// compiled with the `daachorse-index` Cargo feature.
+    #[cfg(feature = "daachorse-index")]
+    #[arg(long = "cross-rule-ac")]
+    pub cross_rule_ac: bool,
+}
 
 /// Resolved event source from the `--event` flag.
 enum EventSource {
@@ -47,34 +157,37 @@ fn resolve_event_source(event_json: Option<String>) -> EventSource {
 }
 
 /// Returns `true` if any detection or correlation matched.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn cmd_eval(
-    rules_path: PathBuf,
-    event_json: Option<String>,
-    pretty: bool,
-    pipeline_paths: Vec<PathBuf>,
-    jq: Option<String>,
-    jsonpath: Option<String>,
-    suppress: Option<String>,
-    action: Option<String>,
-    no_detections: bool,
-    include_event: bool,
-    correlation_event_mode: String,
-    max_correlation_events: usize,
-    timestamp_fields: Vec<String>,
-    input_format: String,
-    syslog_tz: String,
-    bloom_prefilter: bool,
-    bloom_max_bytes: Option<usize>,
-    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
-) -> bool {
+pub(crate) fn cmd_eval(args: EvalArgs) -> bool {
+    let EvalArgs {
+        rules: rules_path,
+        event: event_json,
+        pretty,
+        pipelines: pipeline_paths,
+        jq,
+        jsonpath,
+        suppress,
+        action,
+        no_detections,
+        include_event,
+        correlation_event_mode,
+        max_correlation_events,
+        timestamp_fields,
+        input_format,
+        syslog_tz,
+        fail_on_detection: _,
+        bloom_prefilter,
+        bloom_max_bytes,
+        #[cfg(feature = "daachorse-index")]
+        cross_rule_ac,
+    } = args;
+
     let collection = crate::load_collection(&rules_path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
     if pipelines.iter().any(|p| p.is_dynamic()) {
         eprintln!(
-            "  note: dynamic sources are not resolved by `rsigma eval`. \
-             Use `rsigma resolve` to inspect sources or `rsigma daemon` to evaluate \
+            "  note: dynamic sources are not resolved by `rsigma engine eval`. \
+             Use `rsigma pipeline resolve` to inspect sources or `rsigma engine daemon` to evaluate \
              events with dynamic pipelines."
         );
     }
@@ -269,7 +382,7 @@ fn eval_stream_corr(
     let mut corr_count = 0u64;
 
     #[cfg(feature = "daemon")]
-    let format = crate::parse_input_format(input_format_str, syslog_tz_str);
+    let format = crate::commands::parse_input_format(input_format_str, syslog_tz_str);
     #[cfg(not(feature = "daemon"))]
     let _ = (input_format_str, syslog_tz_str);
 
@@ -521,7 +634,7 @@ fn eval_stream_detect(
     let mut match_count = 0u64;
 
     #[cfg(feature = "daemon")]
-    let format = crate::parse_input_format(input_format_str, syslog_tz_str);
+    let format = crate::commands::parse_input_format(input_format_str, syslog_tz_str);
     #[cfg(not(feature = "daemon"))]
     let _ = (input_format_str, syslog_tz_str);
 

--- a/crates/rsigma-cli/src/commands/fields.rs
+++ b/crates/rsigma-cli/src/commands/fields.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
+use clap::Args;
 use rsigma_eval::{Pipeline, apply_pipelines};
 use rsigma_parser::{
     CorrelationCondition, CorrelationRule, Detection, DetectionItem, Detections, FilterRule,
@@ -12,19 +13,41 @@ use serde::Serialize;
 // Public entry point
 // ---------------------------------------------------------------------------
 
-pub(crate) fn cmd_fields(
-    path: PathBuf,
-    pipeline_paths: Vec<PathBuf>,
-    no_filters: bool,
-    json: bool,
-) {
+/// Arguments for `rsigma rule fields` (and the deprecated `rsigma fields`).
+#[derive(Args, Debug)]
+pub(crate) struct FieldsArgs {
+    /// Path to a Sigma rule file or directory of rules
+    #[arg(short, long)]
+    pub rules: PathBuf,
+
+    /// Processing pipeline(s) to apply (repeatable). Accepts builtin names (ecs_windows, sysmon) or YAML file paths.
+    /// When provided, fields are shown after pipeline transformations.
+    #[arg(short = 'p', long = "pipeline")]
+    pub pipelines: Vec<PathBuf>,
+
+    /// Exclude fields from filter rules
+    #[arg(long)]
+    pub no_filters: bool,
+
+    /// Output as JSON instead of a table
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(crate) fn cmd_fields(args: FieldsArgs) {
+    let FieldsArgs {
+        rules: path,
+        pipelines: pipeline_paths,
+        no_filters,
+        json,
+    } = args;
     let collection = crate::load_collection(&path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
     if pipelines.iter().any(|p| p.is_dynamic()) {
         eprintln!(
-            "  note: dynamic sources are not resolved by `rsigma fields`. \
-             Use `rsigma resolve` to inspect sources or `rsigma daemon` to evaluate \
+            "  note: dynamic sources are not resolved by `rsigma rule fields`. \
+             Use `rsigma pipeline resolve` to inspect sources or `rsigma engine daemon` to evaluate \
              events with dynamic pipelines."
         );
     }

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::process;
 use std::time::SystemTime;
 
+use clap::Args;
 use rsigma_parser::lint::{self, FileLintResult, LintConfig};
 use serde::Deserialize;
 
@@ -13,18 +14,69 @@ pub(crate) struct LintCounts {
     pub infos: usize,
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn cmd_lint(
-    path: PathBuf,
-    schema: Option<String>,
-    verbose: bool,
-    color: &str,
-    disable: Vec<String>,
-    lint_config_path: Option<PathBuf>,
-    exclude: Vec<String>,
-    apply_fix: bool,
-) -> LintCounts {
-    let p = Painter::new(color);
+/// Arguments for `rsigma rule lint` (and the deprecated `rsigma lint`).
+#[derive(Args, Debug)]
+pub(crate) struct LintArgs {
+    /// Path to a Sigma rule file or directory of rules
+    pub path: PathBuf,
+
+    /// JSON schema for additional validation.
+    /// Use "default" to download the official Sigma schema (cached for 7 days),
+    /// or provide a path to a local schema file.
+    #[arg(short, long)]
+    pub schema: Option<String>,
+
+    /// Show details for all files, including those that pass
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    /// Color output: auto (default), always, never
+    #[arg(long, default_value = "auto", value_parser = ["auto", "always", "never"])]
+    pub color: String,
+
+    /// Disable specific lint rules (comma-separated).
+    /// Example: --disable missing_description,missing_author
+    #[arg(long, value_delimiter = ',')]
+    pub disable: Vec<String>,
+
+    /// Path to a .rsigma-lint.yml config file.
+    /// If omitted, searches for .rsigma-lint.yml in ancestor directories.
+    #[arg(long = "config")]
+    pub lint_config: Option<PathBuf>,
+
+    /// Exclude paths matching glob patterns (can be repeated).
+    /// Patterns are matched against paths relative to the lint root.
+    /// Example: --exclude "config/**" --exclude "**/unsupported/**"
+    #[arg(long)]
+    pub exclude: Vec<String>,
+
+    /// Auto-fix safe lint issues in-place.
+    /// Applies format-preserving fixes to files on disk.
+    #[arg(long)]
+    pub fix: bool,
+
+    /// Minimum severity that causes a non-zero exit code.
+    /// 'error' (default): exit 1 only when errors are found.
+    /// 'warning': exit 1 when warnings or errors are found.
+    /// 'info': exit 1 when any findings (info, warning, error) are found.
+    #[arg(long = "fail-level", default_value = "error",
+           value_parser = ["error", "warning", "info"])]
+    pub fail_level: String,
+}
+
+pub(crate) fn cmd_lint(args: LintArgs) -> LintCounts {
+    let LintArgs {
+        path,
+        schema,
+        verbose,
+        color,
+        disable,
+        lint_config: lint_config_path,
+        exclude,
+        fix: apply_fix,
+        fail_level: _,
+    } = args;
+    let p = Painter::new(&color);
 
     // 0. Build lint config from file + CLI flags
     let config = build_lint_config(&path, disable, lint_config_path, exclude);

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -1,4 +1,6 @@
 mod convert;
+#[cfg(feature = "daemon")]
+mod daemon;
 mod eval;
 mod fields;
 mod lint;
@@ -6,10 +8,14 @@ mod parse;
 mod resolve;
 mod validate;
 
-pub(crate) use convert::{cmd_convert, cmd_list_formats, cmd_list_targets};
-pub(crate) use eval::cmd_eval;
-pub(crate) use fields::cmd_fields;
-pub(crate) use lint::cmd_lint;
-pub(crate) use parse::{cmd_condition, cmd_parse, cmd_stdin};
-pub(crate) use resolve::cmd_resolve;
-pub(crate) use validate::cmd_validate;
+pub(crate) use convert::{
+    ConvertArgs, ListFormatsArgs, cmd_convert, cmd_list_formats, cmd_list_targets,
+};
+#[cfg(feature = "daemon")]
+pub(crate) use daemon::{DaemonArgs, cmd_daemon, parse_input_format};
+pub(crate) use eval::{EvalArgs, cmd_eval};
+pub(crate) use fields::{FieldsArgs, cmd_fields};
+pub(crate) use lint::{LintArgs, LintCounts, cmd_lint};
+pub(crate) use parse::{ConditionArgs, ParseArgs, StdinArgs, cmd_condition, cmd_parse, cmd_stdin};
+pub(crate) use resolve::{ResolveArgs, cmd_resolve};
+pub(crate) use validate::{ValidateArgs, cmd_validate};

--- a/crates/rsigma-cli/src/commands/parse.rs
+++ b/crates/rsigma-cli/src/commands/parse.rs
@@ -2,9 +2,37 @@ use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process;
 
+use clap::Args;
 use rsigma_parser::{parse_sigma_file, parse_sigma_yaml};
 
-pub(crate) fn cmd_parse(path: PathBuf, pretty: bool) {
+/// Arguments for `rsigma rule parse` (and the deprecated `rsigma parse`).
+#[derive(Args, Debug)]
+pub(crate) struct ParseArgs {
+    /// Path to a Sigma YAML file
+    pub path: PathBuf,
+
+    /// Pretty-print JSON output
+    #[arg(short, long, default_value_t = true)]
+    pub pretty: bool,
+}
+
+/// Arguments for `rsigma rule condition` (and the deprecated `rsigma condition`).
+#[derive(Args, Debug)]
+pub(crate) struct ConditionArgs {
+    /// The condition expression to parse
+    pub expr: String,
+}
+
+/// Arguments for `rsigma rule stdin` (and the deprecated `rsigma stdin`).
+#[derive(Args, Debug)]
+pub(crate) struct StdinArgs {
+    /// Pretty-print JSON output
+    #[arg(short, long, default_value_t = true)]
+    pub pretty: bool,
+}
+
+pub(crate) fn cmd_parse(args: ParseArgs) {
+    let ParseArgs { path, pretty } = args;
     match parse_sigma_file(&path) {
         Ok(collection) => {
             crate::print_warnings(&collection.errors);
@@ -17,7 +45,8 @@ pub(crate) fn cmd_parse(path: PathBuf, pretty: bool) {
     }
 }
 
-pub(crate) fn cmd_condition(expr: String) {
+pub(crate) fn cmd_condition(args: ConditionArgs) {
+    let ConditionArgs { expr } = args;
     match rsigma_parser::parse_condition(&expr) {
         Ok(ast) => crate::print_json(&ast, true),
         Err(e) => {
@@ -27,7 +56,8 @@ pub(crate) fn cmd_condition(expr: String) {
     }
 }
 
-pub(crate) fn cmd_stdin(pretty: bool) {
+pub(crate) fn cmd_stdin(args: StdinArgs) {
+    let StdinArgs { pretty } = args;
     let mut input = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut input) {
         eprintln!("Error reading stdin: {e}");

--- a/crates/rsigma-cli/src/commands/resolve.rs
+++ b/crates/rsigma-cli/src/commands/resolve.rs
@@ -3,16 +3,39 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use clap::Args;
 use rsigma_eval::parse_pipeline_file;
 use rsigma_runtime::DefaultSourceResolver;
 use rsigma_runtime::sources::SourceResolver;
 
-pub fn cmd_resolve(
-    pipeline_paths: Vec<PathBuf>,
-    source_filter: Option<String>,
-    pretty: bool,
-    dry_run: bool,
-) {
+/// Arguments for `rsigma pipeline resolve` (and the deprecated `rsigma resolve`).
+#[derive(Args, Debug)]
+pub struct ResolveArgs {
+    /// Processing pipeline(s) containing dynamic sources
+    #[arg(short = 'p', long = "pipeline", required = true)]
+    pub pipelines: Vec<PathBuf>,
+
+    /// Resolve only a specific source by ID
+    #[arg(short, long)]
+    pub source: Option<String>,
+
+    /// Pretty-print JSON output
+    #[arg(long)]
+    pub pretty: bool,
+
+    /// Show what would be resolved without performing resolution
+    #[arg(long = "dry-run")]
+    pub dry_run: bool,
+}
+
+pub fn cmd_resolve(args: ResolveArgs) {
+    let ResolveArgs {
+        pipelines: pipeline_paths,
+        source: source_filter,
+        pretty,
+        dry_run,
+    } = args;
+
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/crates/rsigma-cli/src/commands/validate.rs
+++ b/crates/rsigma-cli/src/commands/validate.rs
@@ -1,15 +1,37 @@
 use std::path::PathBuf;
 use std::process;
 
+use clap::Args;
 use rsigma_eval::Engine;
 use rsigma_parser::parse_sigma_directory;
 
-pub(crate) fn cmd_validate(
-    path: PathBuf,
-    verbose: bool,
-    pipeline_paths: Vec<PathBuf>,
-    resolve_sources: bool,
-) {
+/// Arguments for `rsigma rule validate` (and the deprecated `rsigma validate`).
+#[derive(Args, Debug)]
+pub(crate) struct ValidateArgs {
+    /// Path to a directory containing Sigma YAML files
+    pub path: PathBuf,
+
+    /// Show details for each file (not just summary)
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
+    #[arg(short = 'p', long = "pipeline")]
+    pub pipelines: Vec<PathBuf>,
+
+    /// Also resolve dynamic pipeline sources during validation.
+    /// Sources must be reachable (file/command/HTTP) for validation to pass.
+    #[arg(long = "resolve-sources")]
+    pub resolve_sources: bool,
+}
+
+pub(crate) fn cmd_validate(args: ValidateArgs) {
+    let ValidateArgs {
+        path,
+        verbose,
+        pipelines: pipeline_paths,
+        resolve_sources,
+    } = args;
     let mut pipelines = crate::load_pipelines(&pipeline_paths);
 
     if resolve_sources {

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -8,6 +8,12 @@ use std::path::PathBuf;
 use std::process;
 
 use clap::{Parser, Subcommand};
+use commands::{
+    ConditionArgs, ConvertArgs, EvalArgs, FieldsArgs, LintArgs, LintCounts, ListFormatsArgs,
+    ParseArgs, ResolveArgs, StdinArgs, ValidateArgs,
+};
+#[cfg(feature = "daemon")]
+use commands::{DaemonArgs, cmd_daemon};
 use jaq_interpret::{Ctx, FilterT, ParseCtx, RcIter, Val};
 use rsigma_eval::{
     CorrelationAction, CorrelationConfig, CorrelationEventMode, Pipeline, parse_pipeline_file,
@@ -28,7 +34,7 @@ struct Cli {
     /// (default: info). Human-readable stdout/stderr output is unchanged;
     /// this flag only adds machine-readable diagnostic logs alongside it.
     ///
-    /// Has no effect on the `daemon` subcommand, which always logs JSON.
+    /// Has no effect on the `engine daemon` subcommand, which always logs JSON.
     #[arg(long = "log-format", value_enum, global = true)]
     log_format: Option<LogFormat>,
 
@@ -44,546 +50,147 @@ enum LogFormat {
     Text,
 }
 
+// The new noun-led command groups (`engine`, `rule`, `backend`, `pipeline`,
+// `attack`) are the source of truth. The flat top-level variants that follow
+// are deprecated aliases kept for one release; each carries `[deprecated]` in
+// its `about` text and prints a stderr warning before forwarding to the same
+// `cmd_*` helper.
+//
+// We deliberately use a `//` comment (not `///`) so clap does not promote it
+// to the top-level `--help` `about` text and override the explicit
+// `#[command(about = ...)]` on `Cli`.
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Parse a single Sigma YAML file and print the AST as JSON
-    Parse {
-        /// Path to a Sigma YAML file
-        path: PathBuf,
-
-        /// Pretty-print JSON output
-        #[arg(short, long, default_value_t = true)]
-        pretty: bool,
+    /// Run rules against events (eval / daemon)
+    Engine {
+        #[command(subcommand)]
+        cmd: EngineCommands,
     },
 
-    /// Parse all Sigma rules in a directory (recursive) and report results
-    Validate {
-        /// Path to a directory containing Sigma YAML files
-        path: PathBuf,
-
-        /// Show details for each file (not just summary)
-        #[arg(short, long)]
-        verbose: bool,
-
-        /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
-        #[arg(short = 'p', long = "pipeline")]
-        pipelines: Vec<PathBuf>,
-
-        /// Also resolve dynamic pipeline sources during validation.
-        /// Sources must be reachable (file/command/HTTP) for validation to pass.
-        #[arg(long = "resolve-sources")]
-        resolve_sources: bool,
-    },
-
-    /// Parse a condition expression and print the AST
-    Condition {
-        /// The condition expression to parse
-        expr: String,
-    },
-
-    /// Read Sigma YAML from stdin and print parsed AST as JSON
-    Stdin {
-        /// Pretty-print JSON output
-        #[arg(short, long, default_value_t = true)]
-        pretty: bool,
-    },
-
-    /// Lint Sigma rules against the specification
-    ///
-    /// Runs built-in lint checks derived from the Sigma v2.1.0 specification.
-    /// Optionally also validates against a JSON schema (use --schema default
-    /// to download the official schema, or --schema <path> for a local file).
-    Lint {
-        /// Path to a Sigma rule file or directory of rules
-        path: PathBuf,
-
-        /// JSON schema for additional validation.
-        /// Use "default" to download the official Sigma schema (cached for 7 days),
-        /// or provide a path to a local schema file.
-        #[arg(short, long)]
-        schema: Option<String>,
-
-        /// Show details for all files, including those that pass
-        #[arg(short, long)]
-        verbose: bool,
-
-        /// Color output: auto (default), always, never
-        #[arg(long, default_value = "auto", value_parser = ["auto", "always", "never"])]
-        color: String,
-
-        /// Disable specific lint rules (comma-separated).
-        /// Example: --disable missing_description,missing_author
-        #[arg(long, value_delimiter = ',')]
-        disable: Vec<String>,
-
-        /// Path to a .rsigma-lint.yml config file.
-        /// If omitted, searches for .rsigma-lint.yml in ancestor directories.
-        #[arg(long = "config")]
-        lint_config: Option<PathBuf>,
-
-        /// Exclude paths matching glob patterns (can be repeated).
-        /// Patterns are matched against paths relative to the lint root.
-        /// Example: --exclude "config/**" --exclude "**/unsupported/**"
-        #[arg(long)]
-        exclude: Vec<String>,
-
-        /// Auto-fix safe lint issues in-place.
-        /// Applies format-preserving fixes to files on disk.
-        #[arg(long)]
-        fix: bool,
-
-        /// Minimum severity that causes a non-zero exit code.
-        /// 'error' (default): exit 1 only when errors are found.
-        /// 'warning': exit 1 when warnings or errors are found.
-        /// 'info': exit 1 when any findings (info, warning, error) are found.
-        #[arg(long = "fail-level", default_value = "error",
-               value_parser = ["error", "warning", "info"])]
-        fail_level: String,
-    },
-
-    /// Run as a long-running daemon with hot-reload, health checks, and metrics
-    ///
-    /// Reads NDJSON events from stdin, evaluates against rules, and writes
-    /// matches to stdout. Exposes health endpoints, Prometheus metrics,
-    /// and a management API on the configured address.
-    #[cfg(feature = "daemon")]
-    Daemon {
-        /// Path to a Sigma rule file or directory of rules
-        #[arg(short, long)]
-        rules: PathBuf,
-
-        /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
-        #[arg(short = 'p', long = "pipeline")]
-        pipelines: Vec<PathBuf>,
-
-        /// jq filter to extract the event payload from each JSON object
-        #[arg(long = "jq", conflicts_with = "jsonpath")]
-        jq: Option<String>,
-
-        /// JSONPath (RFC 9535) query to extract the event payload
-        #[arg(long = "jsonpath", conflicts_with = "jq")]
-        jsonpath: Option<String>,
-
-        /// Include the full event JSON in each detection match output
-        #[arg(long = "include-event")]
-        include_event: bool,
-
-        /// Pretty-print JSON output
-        #[arg(long)]
-        pretty: bool,
-
-        /// Address for health, metrics, and API server (default: 0.0.0.0:9090)
-        #[arg(long = "api-addr", default_value = "0.0.0.0:9090")]
-        api_addr: String,
-
-        /// Suppression window for correlation alerts (e.g. 5m, 1h, 30s)
-        #[arg(long = "suppress")]
-        suppress: Option<String>,
-
-        /// Action after correlation fires: 'alert' (default) or 'reset'
-        #[arg(long = "action", value_parser = ["alert", "reset"])]
-        action: Option<String>,
-
-        /// Suppress detection output for correlation-only rules
-        #[arg(long = "no-detections")]
-        no_detections: bool,
-
-        /// Correlation event mode: none, full, or refs
-        #[arg(long = "correlation-event-mode", default_value = "none")]
-        correlation_event_mode: String,
-
-        /// Max events per correlation window group
-        #[arg(long = "max-correlation-events", default_value = "10")]
-        max_correlation_events: usize,
-
-        /// Event field name(s) for timestamp extraction in correlations
-        #[arg(long = "timestamp-field")]
-        timestamp_fields: Vec<String>,
-
-        /// Path to SQLite database for persisting correlation state across restarts.
-        /// When set, state is loaded on startup and saved periodically + on shutdown.
-        #[arg(long = "state-db")]
-        state_db: Option<PathBuf>,
-
-        /// Interval in seconds between periodic state snapshots (default: 30).
-        /// Only meaningful when --state-db is set.
-        #[arg(long = "state-save-interval", default_value = "30", value_parser = clap::value_parser!(u64).range(1..))]
-        state_save_interval: u64,
-
-        /// Event input source. Supported schemes: stdin, http, nats://<host>:<port>/<subject>
-        #[arg(long = "input", default_value = "stdin")]
-        input: String,
-
-        /// Detection output sink (can be repeated for fan-out).
-        /// Supported schemes: stdout, file://<path>, nats://<host>:<port>/<subject>
-        #[arg(long = "output", default_value = "stdout")]
-        output: Vec<String>,
-
-        /// Bounded channel capacity for source→engine and engine→sink queues.
-        /// Higher values absorb bursts; lower values apply back-pressure sooner.
-        #[arg(long = "buffer-size", default_value = "10000")]
-        buffer_size: usize,
-
-        /// Maximum events to process per engine lock acquisition.
-        /// Reduces mutex overhead under load. 1 = process one at a time (default).
-        #[arg(long = "batch-size", default_value = "1")]
-        batch_size: usize,
-
-        /// Seconds to wait for in-flight events to drain on shutdown (default: 5).
-        #[arg(long = "drain-timeout", default_value = "5")]
-        drain_timeout: u64,
-
-        /// Dead-letter queue target for events that fail processing.
-        /// Accepts same schemes as --output: stdout, file://<path>, nats://<host>:<port>/<subject>.
-        /// When not set, failed events are logged and discarded.
-        #[arg(long = "dlq")]
-        dlq: Option<String>,
-
-        /// Input log format for event parsing.
-        /// auto: try JSON → syslog → plain (default).
-        /// Explicit: json, syslog, plain, logfmt (requires logfmt feature),
-        /// cef (requires cef feature).
-        #[arg(long = "input-format", default_value = "auto")]
-        input_format: String,
-
-        /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
-        /// Only used when --input-format is syslog or auto. Defaults to UTC.
-        #[arg(long = "syslog-tz", default_value = "+00:00")]
-        syslog_tz: String,
-
-        /// NATS credentials file (.creds) for JWT + NKey authentication.
-        /// Also reads from NATS_CREDS environment variable.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-creds", env = "NATS_CREDS")]
-        nats_creds: Option<PathBuf>,
-
-        /// NATS authentication token. Also reads from NATS_TOKEN.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-token", env = "NATS_TOKEN", conflicts_with = "nats_creds")]
-        nats_token: Option<String>,
-
-        /// NATS username (requires --nats-password). Also reads from NATS_USER.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-user", env = "NATS_USER", requires = "nats_password", conflicts_with_all = ["nats_creds", "nats_token"])]
-        nats_user: Option<String>,
-
-        /// NATS password (requires --nats-user). Also reads from NATS_PASSWORD.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-password", env = "NATS_PASSWORD", requires = "nats_user")]
-        nats_password: Option<String>,
-
-        /// NATS NKey seed for authentication. Also reads from NATS_NKEY.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-nkey", env = "NATS_NKEY", conflicts_with_all = ["nats_creds", "nats_token", "nats_user"])]
-        nats_nkey: Option<String>,
-
-        /// TLS client certificate for mutual TLS with NATS.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-tls-cert", requires = "nats_tls_key")]
-        nats_tls_cert: Option<PathBuf>,
-
-        /// TLS client private key for mutual TLS with NATS.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-tls-key", requires = "nats_tls_cert")]
-        nats_tls_key: Option<PathBuf>,
-
-        /// Require TLS for NATS connections.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "nats-require-tls")]
-        nats_require_tls: bool,
-
-        /// Replay from a specific JetStream sequence number.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "replay-from-sequence", conflicts_with_all = ["replay_from_time", "replay_from_latest"])]
-        replay_from_sequence: Option<u64>,
-
-        /// Replay from a specific timestamp (ISO 8601, e.g. 2024-01-15T10:00:00Z).
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "replay-from-time", conflicts_with_all = ["replay_from_sequence", "replay_from_latest"])]
-        replay_from_time: Option<String>,
-
-        /// Start from the latest message, skipping stream history.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "replay-from-latest", conflicts_with_all = ["replay_from_sequence", "replay_from_time"])]
-        replay_from_latest: bool,
-
-        /// Clear correlation state on startup. When used with --replay-from-*,
-        /// forces a clean slate even if the replay starts after the stored position.
-        #[arg(long = "clear-state", conflicts_with = "keep_state")]
-        clear_state: bool,
-
-        /// Force restore correlation state even during replay. Use when you know
-        /// the replay starts after the last processed position (forward catch-up)
-        /// and want to preserve cross-boundary correlation windows.
-        #[arg(long = "keep-state", conflicts_with = "clear_state")]
-        keep_state: bool,
-
-        /// Behavior when no timestamp field is found in an event.
-        /// 'wallclock' (default): use wall-clock time for correlation windows.
-        /// 'skip': run detections but skip correlation state updates for that
-        /// event. Recommended for forensic replay of logs without timestamps.
-        #[arg(long = "timestamp-fallback", default_value = "wallclock",
-               value_parser = ["wallclock", "skip"])]
-        timestamp_fallback: String,
-
-        /// Consumer group name for NATS JetStream load balancing.
-        /// Multiple daemon instances using the same group name share the
-        /// workload via a single durable pull consumer.
-        #[cfg(feature = "daemon-nats")]
-        #[arg(long = "consumer-group", env = "RSIGMA_CONSUMER_GROUP")]
-        consumer_group: Option<String>,
-
-        /// Allow include directives to reference remote (HTTP/NATS) sources.
-        /// By default, includes are restricted to local sources (file/command)
-        /// for security. Use this flag to opt in to remote include resolution.
-        #[arg(long = "allow-remote-include")]
-        allow_remote_include: bool,
-
-        /// Enable bloom-filter pre-filtering of positive substring matchers.
-        ///
-        /// Off by default. When enabled, the engine builds a per-field bloom
-        /// over every rule's `|contains` / `|startswith` / `|endswith`
-        /// needles and short-circuits items whose field value cannot
-        /// possibly contain a needle trigram. The probe costs ~1 µs per
-        /// event, so this only pays off on rule sets where most events do
-        /// NOT match any pattern (e.g. high-volume telemetry against
-        /// substring-heavy threat-intel rules). Run the
-        /// `eval_bloom_rejection` benchmark on representative data before
-        /// flipping this on in production.
-        #[arg(long = "bloom-prefilter")]
-        bloom_prefilter: bool,
-
-        /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB
-        /// (1048576). Lower the cap on memory-constrained deployments;
-        /// raise it for very large rule sets where the default starts
-        /// evicting useful filters. Has no effect unless
-        /// `--bloom-prefilter` is set.
-        #[arg(long = "bloom-max-bytes")]
-        bloom_max_bytes: Option<usize>,
-
-        /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
-        ///
-        /// Off by default. When enabled, the engine builds a single
-        /// per-field `DoubleArrayAhoCorasick` over every rule's positive
-        /// substring needles and drops AC-prunable rules (pure positive
-        /// substring detections, no negation) from the candidate set when
-        /// none of their patterns match the event. Pays off only on rule
-        /// sets > ~5K rules with many shared substring patterns
-        /// (threat-intel feeds, IOC packs). For smaller rule sets the
-        /// per-rule Aho-Corasick matcher is already optimal. Build time
-        /// scales linearly with total pattern count; pattern count per
-        /// field is capped at 100K. Available when compiled with the
-        /// `daachorse-index` Cargo feature.
-        #[cfg(feature = "daachorse-index")]
-        #[arg(long = "cross-rule-ac")]
-        cross_rule_ac: bool,
-    },
-
-    /// Evaluate events against Sigma rules
-    ///
-    /// Load rules from a file or directory, then evaluate JSON events.
-    /// Events can be provided as a single JSON string (--event) or as
-    /// NDJSON (newline-delimited JSON) from stdin. Files with a .evtx
-    /// extension are parsed as Windows Event Log files (requires the
-    /// evtx feature).
-    Eval {
-        /// Path to a Sigma rule file or directory of rules
-        #[arg(short, long)]
-        rules: PathBuf,
-
-        /// A single event as a JSON string, or @path to read from a file.
-        /// Supports NDJSON files and .evtx (Windows Event Log) files.
-        /// If omitted, reads NDJSON from stdin.
-        #[arg(short, long)]
-        event: Option<String>,
-
-        /// Pretty-print JSON output
-        #[arg(long)]
-        pretty: bool,
-
-        /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows, sysmon) or YAML file paths
-        #[arg(short = 'p', long = "pipeline")]
-        pipelines: Vec<PathBuf>,
-
-        /// jq filter to extract the event payload from each JSON object.
-        /// Example: --jq '.event' or --jq '.records[]'
-        #[arg(long = "jq", conflicts_with = "jsonpath")]
-        jq: Option<String>,
-
-        /// JSONPath (RFC 9535) query to extract the event payload.
-        /// Example: --jsonpath '$.event' or --jsonpath '$.records[*]'
-        #[arg(long = "jsonpath", conflicts_with = "jq")]
-        jsonpath: Option<String>,
-
-        /// Suppression window for correlation alerts.
-        /// After a correlation fires for a group key, suppress re-alerts
-        /// for this duration. Examples: 5m, 1h, 30s.
-        #[arg(long = "suppress")]
-        suppress: Option<String>,
-
-        /// Action to take after a correlation fires.
-        /// 'alert' (default): keep state, re-alert on next match.
-        /// 'reset': clear window state, require threshold from scratch.
-        #[arg(long = "action", value_parser = ["alert", "reset"])]
-        action: Option<String>,
-
-        /// Suppress detection-level output for rules that are only
-        /// referenced by correlations (where generate=false).
-        #[arg(long = "no-detections")]
-        no_detections: bool,
-
-        /// Include the full event JSON in each detection match output.
-        /// Equivalent to the `rsigma.include_event` custom attribute.
-        #[arg(long = "include-event")]
-        include_event: bool,
-
-        /// Correlation event inclusion mode:
-        ///   none  — don't include events (default, zero overhead)
-        ///   full  — include full event bodies (deflate compressed in memory)
-        ///   refs  — include lightweight references (timestamp + event ID)
-        /// Use --max-correlation-events to cap storage per window.
-        #[arg(long = "correlation-event-mode", default_value = "none")]
-        correlation_event_mode: String,
-
-        /// Maximum events to store per correlation window group when
-        /// --correlation-event-mode is not 'none'. Oldest events are
-        /// evicted when the cap is reached.
-        #[arg(long = "max-correlation-events", default_value = "10")]
-        max_correlation_events: usize,
-
-        /// Event field name(s) to use for timestamp extraction in correlations.
-        /// Can be specified multiple times; tried in order before built-in
-        /// defaults (@timestamp, timestamp, EventTime, …).
-        /// Equivalent to the `rsigma.timestamp_field` custom attribute.
-        #[arg(long = "timestamp-field")]
-        timestamp_fields: Vec<String>,
-
-        /// Input log format for event parsing.
-        /// auto: try JSON → syslog → plain (default).
-        /// Explicit: json, syslog, plain, logfmt (requires logfmt feature),
-        /// cef (requires cef feature).
-        #[arg(long = "input-format", default_value = "auto")]
-        input_format: String,
-
-        /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
-        /// Only used when --input-format is syslog or auto. Defaults to UTC.
-        #[arg(long = "syslog-tz", default_value = "+00:00")]
-        syslog_tz: String,
-
-        /// Exit with code 1 when any detection or correlation fires.
-        /// Useful in CI/CD pipelines to fail a build on detection.
-        #[arg(long = "fail-on-detection")]
-        fail_on_detection: bool,
-
-        /// Enable bloom-filter pre-filtering of positive substring matchers.
-        /// See `rsigma daemon --help` for the trade-off.
-        #[arg(long = "bloom-prefilter")]
-        bloom_prefilter: bool,
-
-        /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB.
-        /// No effect unless `--bloom-prefilter` is set.
-        #[arg(long = "bloom-max-bytes")]
-        bloom_max_bytes: Option<usize>,
-
-        /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
-        /// See `rsigma daemon --help` for the trade-off. Available when
-        /// compiled with the `daachorse-index` Cargo feature.
-        #[cfg(feature = "daachorse-index")]
-        #[arg(long = "cross-rule-ac")]
-        cross_rule_ac: bool,
+    /// Inspect and operate on Sigma rule files
+    Rule {
+        #[command(subcommand)]
+        cmd: RuleCommands,
     },
 
     /// Convert Sigma rules to backend-native queries
-    Convert {
-        /// Path(s) to Sigma rule file(s) or directory
-        rules: Vec<PathBuf>,
-
-        /// Target backend (e.g. test)
-        #[arg(short, long)]
-        target: String,
-
-        /// Output format (backend-specific, default: "default")
-        #[arg(short, long, default_value = "default")]
-        format: String,
-
-        /// Processing pipeline(s) (repeatable). Accepts builtin names (ecs_windows, sysmon) or YAML file paths
-        #[arg(short = 'p', long = "pipeline")]
-        pipeline: Vec<PathBuf>,
-
-        /// Skip pipeline requirement check
-        #[arg(long)]
-        without_pipeline: bool,
-
-        /// Skip unsupported rules instead of failing
-        #[arg(short, long)]
-        skip_unsupported: bool,
-
-        /// Output file (default: stdout)
-        #[arg(short, long)]
-        output: Option<PathBuf>,
-
-        /// Backend options as key=value pairs (repeatable)
-        #[arg(short = 'O', long = "option")]
-        backend_options: Vec<String>,
+    Backend {
+        #[command(subcommand)]
+        cmd: BackendCommands,
     },
 
-    /// List available conversion targets (backends)
+    /// Pipeline tooling (resolve dynamic sources, …)
+    Pipeline {
+        #[command(subcommand)]
+        cmd: PipelineCommands,
+    },
+
+    /// MITRE ATT&CK tooling (reserved; populated by the ATT&CK contributor PR)
+    Attack {
+        #[command(subcommand)]
+        cmd: AttackCommands,
+    },
+
+    // ---- Deprecated flat aliases (visible this release, hidden next) ----
+    /// [deprecated] Use `rsigma engine eval` instead
+    Eval(EvalArgs),
+
+    /// [deprecated] Use `rsigma engine daemon` instead
+    #[cfg(feature = "daemon")]
+    Daemon(DaemonArgs),
+
+    /// [deprecated] Use `rsigma rule parse` instead
+    Parse(ParseArgs),
+
+    /// [deprecated] Use `rsigma rule validate` instead
+    Validate(ValidateArgs),
+
+    /// [deprecated] Use `rsigma rule lint` instead
+    Lint(LintArgs),
+
+    /// [deprecated] Use `rsigma rule fields` instead
+    Fields(FieldsArgs),
+
+    /// [deprecated] Use `rsigma rule condition` instead
+    Condition(ConditionArgs),
+
+    /// [deprecated] Use `rsigma rule stdin` instead
+    Stdin(StdinArgs),
+
+    /// [deprecated] Use `rsigma backend convert` instead
+    Convert(ConvertArgs),
+
+    /// [deprecated] Use `rsigma backend targets` instead
+    #[command(name = "list-targets")]
     ListTargets,
 
-    /// List available output formats for a target
-    ListFormats {
-        /// Target backend name
-        target: String,
-    },
+    /// [deprecated] Use `rsigma backend formats` instead
+    #[command(name = "list-formats")]
+    ListFormats(ListFormatsArgs),
 
-    /// Resolve dynamic pipeline sources and display their data
-    ///
-    /// Test source resolution without running the daemon. Resolves all
-    /// dynamic sources declared in the given pipeline(s) and prints
-    /// the resulting data as JSON.
-    Resolve {
-        /// Processing pipeline(s) containing dynamic sources
-        #[arg(short = 'p', long = "pipeline", required = true)]
-        pipelines: Vec<PathBuf>,
+    /// [deprecated] Use `rsigma pipeline resolve` instead
+    Resolve(ResolveArgs),
+}
 
-        /// Resolve only a specific source by ID
-        #[arg(short, long)]
-        source: Option<String>,
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
+enum EngineCommands {
+    /// Evaluate events against Sigma rules
+    Eval(EvalArgs),
 
-        /// Pretty-print JSON output
-        #[arg(long)]
-        pretty: bool,
+    /// Run as a long-running daemon with hot-reload, health checks, and metrics
+    #[cfg(feature = "daemon")]
+    Daemon(DaemonArgs),
+}
 
-        /// Show what would be resolved without performing resolution
-        #[arg(long = "dry-run")]
-        dry_run: bool,
-    },
+#[derive(Subcommand)]
+enum RuleCommands {
+    /// Parse a single Sigma YAML file and print the AST as JSON
+    Parse(ParseArgs),
+
+    /// Parse all Sigma rules in a directory (recursive) and report results
+    Validate(ValidateArgs),
+
+    /// Lint Sigma rules against the specification
+    Lint(LintArgs),
 
     /// List all fields referenced by Sigma rules
-    ///
-    /// Extracts field names from detection blocks, correlation group-by/condition
-    /// fields, filter detections, and rule metadata. Optionally applies pipelines
-    /// to show post-mapping field names.
-    Fields {
-        /// Path to a Sigma rule file or directory of rules
-        #[arg(short, long)]
-        rules: PathBuf,
+    Fields(FieldsArgs),
 
-        /// Processing pipeline(s) to apply (repeatable). Accepts builtin names (ecs_windows, sysmon) or YAML file paths.
-        /// When provided, fields are shown after pipeline transformations.
-        #[arg(short = 'p', long = "pipeline")]
-        pipelines: Vec<PathBuf>,
+    /// Parse a condition expression and print the AST
+    Condition(ConditionArgs),
 
-        /// Exclude fields from filter rules
-        #[arg(long)]
-        no_filters: bool,
-
-        /// Output as JSON instead of a table
-        #[arg(long)]
-        json: bool,
-    },
+    /// Read Sigma YAML from stdin and print parsed AST as JSON
+    Stdin(StdinArgs),
 }
+
+#[derive(Subcommand)]
+enum BackendCommands {
+    /// Convert Sigma rules to backend-native queries
+    Convert(ConvertArgs),
+
+    /// List available conversion targets (backends)
+    Targets,
+
+    /// List available output formats for a target
+    Formats(ListFormatsArgs),
+}
+
+#[derive(Subcommand)]
+enum PipelineCommands {
+    /// Resolve dynamic pipeline sources and display their data
+    Resolve(ResolveArgs),
+}
+
+/// Reserved for the MITRE ATT&CK contributor work in
+/// [post-evaluation_enrichment_f3efb7b4.plan.md].
+///
+/// Concrete variants (`Coverage`, `Update`) land in that PR behind
+/// `#[cfg(feature = "attack-mapping")]`. Until then this enum is empty and
+/// `rsigma attack` reports "no available subcommands" via clap.
+#[derive(Subcommand)]
+enum AttackCommands {}
 
 fn main() {
     let cli = Cli::parse();
@@ -591,266 +198,161 @@ fn main() {
     // Daemon installs its own JSON subscriber unconditionally; only init for
     // other subcommands when the user opts in via --log-format.
     #[cfg(feature = "daemon")]
-    let is_daemon = matches!(cli.command, Commands::Daemon { .. });
+    let is_daemon = matches!(
+        cli.command,
+        Commands::Engine {
+            cmd: EngineCommands::Daemon(_),
+            ..
+        } | Commands::Daemon(_)
+    );
     #[cfg(not(feature = "daemon"))]
     let is_daemon = false;
     if !is_daemon && let Some(format) = cli.log_format {
         init_cli_log_subscriber(format);
     }
 
-    match cli.command {
+    dispatch(cli.command);
+}
+
+/// Forward a deprecated flat invocation to its new home and print a stderr
+/// migration hint. The warning text follows a single template so operators
+/// see a consistent message regardless of which alias they hit.
+fn deprecation_warn(old: &str, new: &str) {
+    eprintln!(
+        "warning: `rsigma {old}` is deprecated; use `rsigma {new}` instead. \
+         This alias will be hidden in the next release and removed in v1.0."
+    );
+}
+
+fn dispatch(command: Commands) {
+    match command {
+        // -- Grouped commands ------------------------------------------------
+        Commands::Engine { cmd } => dispatch_engine(cmd),
+        Commands::Rule { cmd } => dispatch_rule(cmd),
+        Commands::Backend { cmd } => dispatch_backend(cmd),
+        Commands::Pipeline { cmd } => dispatch_pipeline(cmd),
+        Commands::Attack { cmd } => dispatch_attack(cmd),
+
+        // -- Deprecated flat aliases ----------------------------------------
+        Commands::Eval(args) => {
+            deprecation_warn("eval", "engine eval");
+            run_eval(args);
+        }
         #[cfg(feature = "daemon")]
-        Commands::Daemon {
-            rules,
-            pipelines,
-            jq,
-            jsonpath,
-            include_event,
-            pretty,
-            api_addr,
-            suppress,
-            action,
-            no_detections,
-            correlation_event_mode,
-            max_correlation_events,
-            timestamp_fields,
-            state_db,
-            state_save_interval,
-            input,
-            output,
-            buffer_size,
-            batch_size,
-            drain_timeout,
-            dlq,
-            input_format,
-            syslog_tz,
-            #[cfg(feature = "daemon-nats")]
-            nats_creds,
-            #[cfg(feature = "daemon-nats")]
-            nats_token,
-            #[cfg(feature = "daemon-nats")]
-            nats_user,
-            #[cfg(feature = "daemon-nats")]
-            nats_password,
-            #[cfg(feature = "daemon-nats")]
-            nats_nkey,
-            #[cfg(feature = "daemon-nats")]
-            nats_tls_cert,
-            #[cfg(feature = "daemon-nats")]
-            nats_tls_key,
-            #[cfg(feature = "daemon-nats")]
-            nats_require_tls,
-            #[cfg(feature = "daemon-nats")]
-            replay_from_sequence,
-            #[cfg(feature = "daemon-nats")]
-            replay_from_time,
-            #[cfg(feature = "daemon-nats")]
-            replay_from_latest,
-            clear_state,
-            keep_state,
-            timestamp_fallback,
-            #[cfg(feature = "daemon-nats")]
-            consumer_group,
-            allow_remote_include,
-            bloom_prefilter,
-            bloom_max_bytes,
-            #[cfg(feature = "daachorse-index")]
-            cross_rule_ac,
-        } => {
-            #[cfg(feature = "daemon-nats")]
-            let nats_auth = NatsAuthArgs {
-                nats_creds,
-                nats_token,
-                nats_user,
-                nats_password,
-                nats_nkey,
-                nats_tls_cert,
-                nats_tls_key,
-                nats_require_tls,
-            };
-            #[cfg(feature = "daemon-nats")]
-            let replay_policy = if let Some(seq) = replay_from_sequence {
-                rsigma_runtime::ReplayPolicy::FromSequence(seq)
-            } else if let Some(ref ts) = replay_from_time {
-                let t =
-                    time::OffsetDateTime::parse(ts, &time::format_description::well_known::Rfc3339)
-                        .unwrap_or_else(|e| {
-                            eprintln!("Invalid --replay-from-time '{ts}': {e}");
-                            process::exit(exit_code::CONFIG_ERROR);
-                        });
-                rsigma_runtime::ReplayPolicy::FromTime(t)
-            } else if replay_from_latest {
-                rsigma_runtime::ReplayPolicy::Latest
-            } else {
-                rsigma_runtime::ReplayPolicy::Resume
-            };
+        Commands::Daemon(args) => {
+            deprecation_warn("daemon", "engine daemon");
+            cmd_daemon(args);
+        }
+        Commands::Parse(args) => {
+            deprecation_warn("parse", "rule parse");
+            commands::cmd_parse(args);
+        }
+        Commands::Validate(args) => {
+            deprecation_warn("validate", "rule validate");
+            commands::cmd_validate(args);
+        }
+        Commands::Lint(args) => {
+            deprecation_warn("lint", "rule lint");
+            run_lint(args);
+        }
+        Commands::Fields(args) => {
+            deprecation_warn("fields", "rule fields");
+            commands::cmd_fields(args);
+        }
+        Commands::Condition(args) => {
+            deprecation_warn("condition", "rule condition");
+            commands::cmd_condition(args);
+        }
+        Commands::Stdin(args) => {
+            deprecation_warn("stdin", "rule stdin");
+            commands::cmd_stdin(args);
+        }
+        Commands::Convert(args) => {
+            deprecation_warn("convert", "backend convert");
+            commands::cmd_convert(args);
+        }
+        Commands::ListTargets => {
+            deprecation_warn("list-targets", "backend targets");
+            commands::cmd_list_targets();
+        }
+        Commands::ListFormats(ListFormatsArgs { target }) => {
+            deprecation_warn("list-formats", "backend formats");
+            commands::cmd_list_formats(target);
+        }
+        Commands::Resolve(args) => {
+            deprecation_warn("resolve", "pipeline resolve");
+            commands::cmd_resolve(args);
+        }
+    }
+}
 
-            let state_restore_mode = if clear_state {
-                daemon::server::StateRestoreMode::ForceClear
-            } else if keep_state {
-                daemon::server::StateRestoreMode::ForceKeep
-            } else {
-                daemon::server::StateRestoreMode::Auto
-            };
+fn dispatch_engine(cmd: EngineCommands) {
+    match cmd {
+        EngineCommands::Eval(args) => run_eval(args),
+        #[cfg(feature = "daemon")]
+        EngineCommands::Daemon(args) => cmd_daemon(args),
+    }
+}
 
-            cmd_daemon(
-                rules,
-                pipelines,
-                jq,
-                jsonpath,
-                include_event,
-                pretty,
-                api_addr,
-                suppress,
-                action,
-                no_detections,
-                correlation_event_mode,
-                max_correlation_events,
-                timestamp_fields,
-                timestamp_fallback,
-                state_db,
-                state_save_interval,
-                input,
-                output,
-                buffer_size,
-                batch_size,
-                drain_timeout,
-                dlq,
-                input_format,
-                syslog_tz,
-                state_restore_mode,
-                #[cfg(feature = "daemon-nats")]
-                nats_auth,
-                #[cfg(feature = "daemon-nats")]
-                replay_policy,
-                #[cfg(feature = "daemon-nats")]
-                consumer_group,
-                allow_remote_include,
-                bloom_prefilter,
-                bloom_max_bytes,
-                #[cfg(feature = "daachorse-index")]
-                cross_rule_ac,
-            )
-        }
-        Commands::Parse { path, pretty } => commands::cmd_parse(path, pretty),
-        Commands::Validate {
-            path,
-            verbose,
-            pipelines,
-            resolve_sources,
-        } => commands::cmd_validate(path, verbose, pipelines, resolve_sources),
-        Commands::Lint {
-            path,
-            schema,
-            verbose,
-            color,
-            disable,
-            lint_config,
-            exclude,
-            fix: apply_fix,
-            fail_level,
-        } => {
-            let counts = commands::cmd_lint(
-                path,
-                schema,
-                verbose,
-                &color,
-                disable,
-                lint_config,
-                exclude,
-                apply_fix,
-            );
-            let should_fail = match fail_level.as_str() {
-                "info" => counts.errors > 0 || counts.warnings > 0 || counts.infos > 0,
-                "warning" => counts.errors > 0 || counts.warnings > 0,
-                _ => counts.errors > 0,
-            };
-            if should_fail {
-                process::exit(exit_code::FINDINGS);
-            }
-        }
-        Commands::Condition { expr } => commands::cmd_condition(expr),
-        Commands::Stdin { pretty } => commands::cmd_stdin(pretty),
-        Commands::Eval {
-            rules,
-            event,
-            pretty,
-            pipelines,
-            jq,
-            jsonpath,
-            suppress,
-            action,
-            no_detections,
-            include_event,
-            correlation_event_mode,
-            max_correlation_events,
-            timestamp_fields,
-            input_format,
-            syslog_tz,
-            fail_on_detection,
-            bloom_prefilter,
-            bloom_max_bytes,
-            #[cfg(feature = "daachorse-index")]
-            cross_rule_ac,
-        } => {
-            let had_matches = commands::cmd_eval(
-                rules,
-                event,
-                pretty,
-                pipelines,
-                jq,
-                jsonpath,
-                suppress,
-                action,
-                no_detections,
-                include_event,
-                correlation_event_mode,
-                max_correlation_events,
-                timestamp_fields,
-                input_format,
-                syslog_tz,
-                bloom_prefilter,
-                bloom_max_bytes,
-                #[cfg(feature = "daachorse-index")]
-                cross_rule_ac,
-            );
-            if fail_on_detection && had_matches {
-                process::exit(exit_code::FINDINGS);
-            }
-        }
-        Commands::Convert {
-            rules,
-            target,
-            format,
-            pipeline,
-            without_pipeline,
-            skip_unsupported,
-            output,
-            backend_options,
-        } => commands::cmd_convert(
-            rules,
-            target,
-            format,
-            pipeline,
-            without_pipeline,
-            skip_unsupported,
-            output,
-            backend_options,
-        ),
-        Commands::ListTargets => commands::cmd_list_targets(),
-        Commands::ListFormats { target } => commands::cmd_list_formats(target),
-        Commands::Fields {
-            rules,
-            pipelines,
-            no_filters,
-            json,
-        } => commands::cmd_fields(rules, pipelines, no_filters, json),
-        Commands::Resolve {
-            pipelines,
-            source,
-            pretty,
-            dry_run,
-        } => commands::cmd_resolve(pipelines, source, pretty, dry_run),
+fn dispatch_rule(cmd: RuleCommands) {
+    match cmd {
+        RuleCommands::Parse(args) => commands::cmd_parse(args),
+        RuleCommands::Validate(args) => commands::cmd_validate(args),
+        RuleCommands::Lint(args) => run_lint(args),
+        RuleCommands::Fields(args) => commands::cmd_fields(args),
+        RuleCommands::Condition(args) => commands::cmd_condition(args),
+        RuleCommands::Stdin(args) => commands::cmd_stdin(args),
+    }
+}
+
+fn dispatch_backend(cmd: BackendCommands) {
+    match cmd {
+        BackendCommands::Convert(args) => commands::cmd_convert(args),
+        BackendCommands::Targets => commands::cmd_list_targets(),
+        BackendCommands::Formats(ListFormatsArgs { target }) => commands::cmd_list_formats(target),
+    }
+}
+
+fn dispatch_pipeline(cmd: PipelineCommands) {
+    match cmd {
+        PipelineCommands::Resolve(args) => commands::cmd_resolve(args),
+    }
+}
+
+fn dispatch_attack(cmd: AttackCommands) {
+    // `AttackCommands` is intentionally empty until the ATT&CK contributor PR
+    // populates it. The exhaustive `match` keeps it impossible to add a
+    // variant without wiring a handler. Once `Coverage` and `Update` land,
+    // they slot in here.
+    match cmd {}
+}
+
+/// Shared eval entry point used by both `engine eval` and the deprecated
+/// `eval` alias. Centralizes the `--fail-on-detection` exit-code handling.
+fn run_eval(args: EvalArgs) {
+    let fail_on_detection = args.fail_on_detection;
+    let had_matches = commands::cmd_eval(args);
+    if fail_on_detection && had_matches {
+        process::exit(exit_code::FINDINGS);
+    }
+}
+
+/// Shared lint entry point used by both `rule lint` and the deprecated `lint`
+/// alias. Centralizes the `--fail-level` exit-code handling.
+fn run_lint(args: LintArgs) {
+    let fail_level = args.fail_level.clone();
+    let LintCounts {
+        errors,
+        warnings,
+        infos,
+    } = commands::cmd_lint(args);
+    let should_fail = match fail_level.as_str() {
+        "info" => errors > 0 || warnings > 0 || infos > 0,
+        "warning" => errors > 0 || warnings > 0,
+        _ => errors > 0,
+    };
+    if should_fail {
+        process::exit(exit_code::FINDINGS);
     }
 }
 
@@ -877,149 +379,7 @@ fn init_cli_log_subscriber(format: LogFormat) {
 }
 
 // ---------------------------------------------------------------------------
-// Daemon subcommand
-// ---------------------------------------------------------------------------
-
-#[cfg(feature = "daemon-nats")]
-struct NatsAuthArgs {
-    nats_creds: Option<PathBuf>,
-    nats_token: Option<String>,
-    nats_user: Option<String>,
-    nats_password: Option<String>,
-    nats_nkey: Option<String>,
-    nats_tls_cert: Option<PathBuf>,
-    nats_tls_key: Option<PathBuf>,
-    nats_require_tls: bool,
-}
-
-#[cfg(feature = "daemon")]
-#[allow(clippy::too_many_arguments)]
-fn cmd_daemon(
-    rules_path: PathBuf,
-    pipeline_paths: Vec<PathBuf>,
-    jq: Option<String>,
-    jsonpath: Option<String>,
-    include_event: bool,
-    pretty: bool,
-    api_addr: String,
-    suppress: Option<String>,
-    action: Option<String>,
-    no_detections: bool,
-    correlation_event_mode: String,
-    max_correlation_events: usize,
-    timestamp_fields: Vec<String>,
-    timestamp_fallback: String,
-    state_db: Option<PathBuf>,
-    state_save_interval: u64,
-    input: String,
-    output: Vec<String>,
-    buffer_size: usize,
-    batch_size: usize,
-    drain_timeout: u64,
-    dlq: Option<String>,
-    input_format: String,
-    syslog_tz: String,
-    state_restore_mode: daemon::server::StateRestoreMode,
-    #[cfg(feature = "daemon-nats")] nats_auth: NatsAuthArgs,
-    #[cfg(feature = "daemon-nats")] replay_policy: rsigma_runtime::ReplayPolicy,
-    #[cfg(feature = "daemon-nats")] consumer_group: Option<String>,
-    allow_remote_include: bool,
-    bloom_prefilter: bool,
-    bloom_max_bytes: Option<usize>,
-    #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
-) {
-    // Set up structured logging
-    tracing_subscriber::fmt()
-        .json()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .with_writer(std::io::stderr)
-        .init();
-
-    let pipelines = load_pipelines(&pipeline_paths);
-    let event_filter = std::sync::Arc::new(build_event_filter(jq, jsonpath));
-    let parsed_input_format = parse_input_format(&input_format, &syslog_tz);
-
-    let corr_config = build_correlation_config(
-        suppress,
-        action,
-        no_detections,
-        correlation_event_mode,
-        max_correlation_events,
-        timestamp_fields,
-        &timestamp_fallback,
-    );
-
-    let addr: std::net::SocketAddr = api_addr.parse().unwrap_or_else(|e| {
-        eprintln!("Invalid API address '{api_addr}': {e}");
-        process::exit(exit_code::CONFIG_ERROR);
-    });
-
-    #[cfg(feature = "daemon-nats")]
-    let nats_config = rsigma_runtime::NatsConnectConfig {
-        credentials_file: nats_auth.nats_creds,
-        token: nats_auth.nats_token,
-        username: nats_auth.nats_user,
-        password: nats_auth.nats_password,
-        nkey: nats_auth.nats_nkey,
-        tls_client_cert: nats_auth.nats_tls_cert,
-        tls_client_key: nats_auth.nats_tls_key,
-        require_tls: nats_auth.nats_require_tls,
-        ..Default::default()
-    };
-
-    let file_pipeline_paths: Vec<PathBuf> = pipeline_paths
-        .into_iter()
-        .filter(|p| resolve_builtin_pipeline(p.to_str().unwrap_or("")).is_none())
-        .collect();
-
-    let config = daemon::server::DaemonConfig {
-        rules_path,
-        pipelines,
-        pipeline_paths: file_pipeline_paths,
-        corr_config,
-        include_event,
-        pretty,
-        api_addr: addr,
-        event_filter,
-        state_db,
-        state_save_interval,
-        input,
-        output,
-        buffer_size,
-        batch_size,
-        drain_timeout,
-        dlq,
-        input_format: parsed_input_format,
-        #[cfg(feature = "daemon-nats")]
-        nats_config,
-        #[cfg(feature = "daemon-nats")]
-        replay_policy,
-        #[cfg(feature = "daemon-nats")]
-        consumer_group,
-        state_restore_mode,
-        allow_remote_include,
-        bloom_prefilter,
-        bloom_max_bytes,
-        #[cfg(feature = "daachorse-index")]
-        cross_rule_ac,
-    };
-
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to create Tokio runtime: {e}");
-            process::exit(exit_code::CONFIG_ERROR);
-        });
-
-    rt.block_on(daemon::run_daemon(config));
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
+// Shared helpers (used across commands)
 // ---------------------------------------------------------------------------
 
 pub(crate) fn load_pipelines(paths: &[PathBuf]) -> Vec<Pipeline> {
@@ -1113,77 +473,6 @@ pub(crate) fn print_json(value: &impl serde::Serialize, pretty: bool) {
             process::exit(exit_code::CONFIG_ERROR);
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Input format parsing
-// ---------------------------------------------------------------------------
-
-#[cfg(feature = "daemon")]
-pub(crate) fn parse_input_format(format_str: &str, syslog_tz: &str) -> rsigma_runtime::InputFormat {
-    use rsigma_runtime::InputFormat;
-    use rsigma_runtime::input::SyslogConfig;
-
-    let tz_secs = parse_tz_offset(syslog_tz);
-
-    match format_str {
-        "auto" => InputFormat::Auto(SyslogConfig {
-            default_tz_offset_secs: tz_secs,
-        }),
-        "json" => InputFormat::Json,
-        "syslog" => InputFormat::Syslog(SyslogConfig {
-            default_tz_offset_secs: tz_secs,
-        }),
-        "plain" => InputFormat::Plain,
-        #[cfg(feature = "logfmt")]
-        "logfmt" => InputFormat::Logfmt,
-        #[cfg(feature = "cef")]
-        "cef" => InputFormat::Cef,
-        other => {
-            eprintln!("Unknown input format: '{other}'");
-            eprintln!("Supported formats: auto, json, syslog, plain");
-            #[cfg(feature = "logfmt")]
-            eprintln!("  (with logfmt feature): logfmt");
-            #[cfg(feature = "cef")]
-            eprintln!("  (with cef feature): cef");
-            process::exit(exit_code::CONFIG_ERROR);
-        }
-    }
-}
-
-/// Parse a timezone offset string like "+05:00" or "-08:00" into seconds east of UTC.
-#[cfg(feature = "daemon")]
-fn parse_tz_offset(s: &str) -> i32 {
-    let s = s.trim();
-    if s == "UTC" || s == "utc" || s == "Z" || s == "+00:00" {
-        return 0;
-    }
-
-    let (sign, rest) = if let Some(rest) = s.strip_prefix('+') {
-        (1i32, rest)
-    } else if let Some(rest) = s.strip_prefix('-') {
-        (-1i32, rest)
-    } else {
-        eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
-        process::exit(exit_code::CONFIG_ERROR);
-    };
-
-    let parts: Vec<&str> = rest.split(':').collect();
-    if parts.len() != 2 {
-        eprintln!("Invalid timezone offset: '{s}' (expected +HH:MM or -HH:MM)");
-        process::exit(exit_code::CONFIG_ERROR);
-    }
-
-    let hours: i32 = parts[0].parse().unwrap_or_else(|_| {
-        eprintln!("Invalid timezone offset hours: '{}'", parts[0]);
-        process::exit(exit_code::CONFIG_ERROR);
-    });
-    let minutes: i32 = parts[1].parse().unwrap_or_else(|_| {
-        eprintln!("Invalid timezone offset minutes: '{}'", parts[1]);
-        process::exit(exit_code::CONFIG_ERROR);
-    });
-
-    sign * (hours * 3600 + minutes * 60)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-cli/tests/cli_convert.rs
+++ b/crates/rsigma-cli/tests/cli_convert.rs
@@ -58,6 +58,7 @@ fn convert_simple_rule_to_postgres() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -74,6 +75,7 @@ fn convert_with_format_view() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -92,6 +94,7 @@ fn convert_with_format_timescaledb() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -127,6 +130,7 @@ level: low
 
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             dir.path().to_str().unwrap(),
             "--target",
@@ -157,6 +161,7 @@ transformations:
 
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -175,6 +180,7 @@ fn convert_skip_unsupported() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -192,6 +198,7 @@ fn convert_requires_pipeline_error() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -207,6 +214,7 @@ fn convert_invalid_target() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -226,6 +234,7 @@ fn convert_invalid_format() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -247,6 +256,7 @@ fn convert_correlation_rule() {
     let rule = temp_file(".yml", CORRELATION_RULES);
     let output = rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -269,6 +279,7 @@ fn convert_to_file_output() {
 
     rsigma()
         .args([
+            "backend",
             "convert",
             rule.path().to_str().unwrap(),
             "--target",
@@ -289,7 +300,7 @@ fn convert_to_file_output() {
 
 #[test]
 fn list_targets() {
-    let output = rsigma().args(["list-targets"]).output().unwrap();
+    let output = rsigma().args(["backend", "targets"]).output().unwrap();
     assert!(output.status.success());
     assert_snapshot!(String::from_utf8_lossy(&output.stdout), @"
     Available conversion targets:
@@ -302,7 +313,7 @@ fn list_targets() {
 #[test]
 fn list_formats_postgres() {
     let output = rsigma()
-        .args(["list-formats", "postgres"])
+        .args(["backend", "formats", "postgres"])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -319,7 +330,7 @@ fn list_formats_postgres() {
 #[test]
 fn list_formats_invalid_target() {
     let output = rsigma()
-        .args(["list-formats", "nonexistent"])
+        .args(["backend", "formats", "nonexistent"])
         .output()
         .unwrap();
     assert!(!output.status.success());

--- a/crates/rsigma-cli/tests/cli_daemon.rs
+++ b/crates/rsigma-cli/tests/cli_daemon.rs
@@ -41,6 +41,7 @@ fn daemon_state_db_created_on_first_run() {
 
     rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -69,6 +70,7 @@ fn daemon_state_persists_across_restarts() {
                         {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     let output1 = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -93,6 +95,7 @@ fn daemon_state_persists_across_restarts() {
     let events_run2 = "{\"EventType\":\"login\",\"User\":\"admin\"}\n";
     let output2 = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -131,6 +134,7 @@ fn daemon_state_db_multiple_groups() {
                         {\"EventType\":\"login\",\"User\":\"bob\"}\n";
     rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -149,6 +153,7 @@ fn daemon_state_db_multiple_groups() {
                         {\"EventType\":\"login\",\"User\":\"bob\"}\n";
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -182,6 +187,7 @@ fn daemon_without_state_db_works() {
                    {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -220,6 +226,7 @@ level: medium
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -252,6 +259,7 @@ fn daemon_streaming_stdin_stdout() {
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -284,6 +292,7 @@ fn daemon_streaming_file_output() {
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -320,6 +329,7 @@ fn daemon_streaming_fanout_stdout_and_file() {
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -356,6 +366,7 @@ fn daemon_streaming_no_match_produces_no_output() {
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -386,6 +397,7 @@ fn daemon_streaming_batch_size() {
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -417,6 +429,7 @@ fn daemon_streaming_custom_buffer_size() {
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -462,6 +475,7 @@ level: low
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -499,6 +513,7 @@ level: low
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -534,6 +549,7 @@ level: high
 
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rule.path().to_str().unwrap(),
@@ -566,6 +582,7 @@ fn daemon_clear_state_prevents_restore() {
                         {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -582,6 +599,7 @@ fn daemon_clear_state_prevents_restore() {
     // Run 2: send 1 event with --clear-state. State is wiped, so total is 1, not 3.
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -616,6 +634,7 @@ fn daemon_keep_state_forces_restore() {
                         {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -632,6 +651,7 @@ fn daemon_keep_state_forces_restore() {
     // Run 2: send 1 event with --keep-state. Restored 2 + 1 = 3, should fire.
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -661,6 +681,7 @@ fn daemon_clear_state_and_keep_state_conflict() {
 
     rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -690,6 +711,7 @@ fn daemon_timestamp_fallback_skip() {
                    {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -727,6 +749,7 @@ fn daemon_timestamp_fallback_wallclock_default() {
                    {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -765,6 +788,7 @@ fn daemon_state_db_migration_from_old_schema() {
                    {\"EventType\":\"login\",\"User\":\"admin\"}\n";
     rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),
@@ -830,6 +854,7 @@ fn daemon_state_db_migration_from_old_schema() {
     // It should auto-migrate and restore the snapshot.
     let output = rsigma()
         .args([
+            "engine",
             "daemon",
             "-r",
             rules.path().to_str().unwrap(),

--- a/crates/rsigma-cli/tests/cli_daemon_dynamic.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_dynamic.rs
@@ -264,6 +264,7 @@ fn daemon_with_dynamic_pipeline_detects_via_var_expansion() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -310,6 +311,7 @@ fn daemon_dynamic_pipeline_no_false_positive() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -353,6 +355,7 @@ fn daemon_reload_preserves_dynamic_detection() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -414,6 +417,7 @@ fn daemon_source_refresh_on_file_change() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -477,6 +481,7 @@ fn daemon_error_policy_use_cached() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -537,6 +542,7 @@ fn daemon_required_source_fail_exits() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let status = DaemonProcess::spawn_expect_exit(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -571,6 +577,7 @@ fn daemon_api_sources_resolve_triggers_re_resolution() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -632,6 +639,7 @@ fn daemon_status_includes_dynamic_sources() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -671,6 +679,7 @@ fn daemon_metrics_include_source_resolution() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -713,6 +722,7 @@ fn daemon_cache_invalidation_endpoint() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -743,6 +753,7 @@ fn daemon_sources_list_endpoint() {
     let pipeline_file = temp_file(".yml", &pipeline_yaml);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),
@@ -779,6 +790,7 @@ fn cli_resolve_command_resolves_sources() {
 
     let output = Command::new(rsigma_bin())
         .args([
+            "pipeline",
             "resolve",
             "-p",
             pipeline_file.path().to_str().unwrap(),
@@ -820,6 +832,7 @@ fn cli_resolve_dry_run_shows_metadata() {
 
     let output = Command::new(rsigma_bin())
         .args([
+            "pipeline",
             "resolve",
             "-p",
             pipeline_file.path().to_str().unwrap(),
@@ -861,6 +874,7 @@ fn cli_validate_resolve_sources_passes() {
 
     let output = Command::new(rsigma_bin())
         .args([
+            "rule",
             "validate",
             rule_dir.path().to_str().unwrap(),
             "-p",
@@ -893,6 +907,7 @@ fn cli_validate_resolve_sources_fails_unreachable() {
 
     let output = Command::new(rsigma_bin())
         .args([
+            "rule",
             "validate",
             rule_dir.path().to_str().unwrap(),
             "-p",
@@ -962,6 +977,7 @@ level: high
     let rule_file = temp_file(".yml", rule);
 
     let daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule_file.path().to_str().unwrap(),

--- a/crates/rsigma-cli/tests/cli_daemon_nats.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_nats.rs
@@ -174,6 +174,7 @@ async fn daemon_nats_single_detection() {
         .unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -221,6 +222,7 @@ async fn daemon_nats_no_match_no_output() {
         .unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -269,6 +271,7 @@ async fn daemon_nats_correlation() {
         .unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -318,6 +321,7 @@ async fn daemon_nats_fanout() {
         .unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -401,6 +405,7 @@ async fn daemon_nats_state_persists_source_position() {
         .unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -474,6 +479,7 @@ async fn daemon_nats_forward_replay_restores_state() {
     let mut output_sub = client.subscribe("e2e.fwd.out".to_string()).await.unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -513,6 +519,7 @@ async fn daemon_nats_forward_replay_restores_state() {
     let mut output_sub2 = client.subscribe("e2e.fwd.out".to_string()).await.unwrap();
 
     let mut daemon2 = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -579,6 +586,7 @@ async fn daemon_nats_backward_replay_clears_state() {
     let mut output_sub = client.subscribe("e2e.bwd.out".to_string()).await.unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -617,6 +625,7 @@ async fn daemon_nats_backward_replay_clears_state() {
     let mut output_sub2 = client.subscribe("e2e.bwd.out".to_string()).await.unwrap();
 
     let mut daemon2 = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),
@@ -712,6 +721,7 @@ async fn daemon_nats_state_db_migration_stores_position() {
     let mut output_sub = client.subscribe("e2e.mig.out".to_string()).await.unwrap();
 
     let mut daemon = DaemonProcess::spawn(&[
+        "engine",
         "daemon",
         "-r",
         rule.path().to_str().unwrap(),

--- a/crates/rsigma-cli/tests/cli_deprecation.rs
+++ b/crates/rsigma-cli/tests/cli_deprecation.rs
@@ -1,0 +1,316 @@
+//! Smoke tests for the deprecated flat-form CLI aliases.
+//!
+//! Each deprecated alias (`eval`, `daemon`, `parse`, `validate`, `lint`,
+//! `fields`, `condition`, `stdin`, `convert`, `list-targets`, `list-formats`,
+//! `resolve`) must keep working for one release before it is hidden in the
+//! next and removed in v1.0. This file asserts that:
+//!
+//! 1. The flat invocation still succeeds (or fails with the same exit code
+//!    as the new grouped form for error paths).
+//! 2. The flat invocation prints the `warning: \`rsigma <old>\` is deprecated`
+//!    message on stderr.
+//! 3. Where it makes sense (cheap stateless commands), the flat form
+//!    produces the same stdout as the new grouped form.
+//! 4. `rsigma --help` lists every deprecated alias with `[deprecated]` in
+//!    its about text, plus the five new groups.
+//! 5. Each new group's own `--help` lists the leaf subcommands.
+
+mod common;
+
+use common::{SIMPLE_RULE, rsigma, temp_file};
+use predicates::prelude::*;
+
+const DEPRECATION_PREFIX: &str = "warning: `rsigma ";
+
+// ---------------------------------------------------------------------------
+// Help output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn root_help_lists_all_groups_and_deprecated_aliases() {
+    let assert = rsigma()
+        .args(["--help"])
+        .assert()
+        .success()
+        // New groups appear with their short description.
+        .stdout(predicate::str::contains("engine"))
+        .stdout(predicate::str::contains("rule"))
+        .stdout(predicate::str::contains("backend"))
+        .stdout(predicate::str::contains("pipeline"))
+        .stdout(predicate::str::contains("attack"))
+        // Every deprecated alias keeps its row and is tagged `[deprecated]`.
+        .stdout(predicate::str::contains("[deprecated]"));
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for alias in [
+        "eval",
+        "daemon",
+        "parse",
+        "validate",
+        "lint",
+        "fields",
+        "condition",
+        "stdin",
+        "convert",
+        "list-targets",
+        "list-formats",
+        "resolve",
+    ] {
+        assert!(
+            stdout.contains(alias),
+            "`{alias}` should appear in `rsigma --help`, got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn engine_group_help_lists_eval_and_daemon() {
+    rsigma()
+        .args(["engine", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("eval"))
+        .stdout(predicate::str::contains("daemon"));
+}
+
+#[test]
+fn rule_group_help_lists_all_six_leafs() {
+    let assert = rsigma().args(["rule", "--help"]).assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    for leaf in ["parse", "validate", "lint", "fields", "condition", "stdin"] {
+        assert!(
+            stdout.contains(leaf),
+            "`rsigma rule --help` should list `{leaf}`, got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn backend_group_help_lists_convert_targets_formats() {
+    let assert = rsigma().args(["backend", "--help"]).assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    for leaf in ["convert", "targets", "formats"] {
+        assert!(
+            stdout.contains(leaf),
+            "`rsigma backend --help` should list `{leaf}`, got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn pipeline_group_help_lists_resolve() {
+    rsigma()
+        .args(["pipeline", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("resolve"));
+}
+
+// ---------------------------------------------------------------------------
+// Per-alias deprecation warning + behavior parity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deprecated_parse_warns_and_succeeds() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let assert = rsigma()
+        .args(["parse", rule.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("rule parse"))
+        .stdout(predicate::str::contains("Test Rule"));
+
+    // Same stdout as the new form.
+    let new_stdout = rsigma()
+        .args(["rule", "parse", rule.path().to_str().unwrap()])
+        .output()
+        .unwrap()
+        .stdout;
+    let old_stdout = assert.get_output().stdout.clone();
+    assert_eq!(
+        String::from_utf8_lossy(&old_stdout),
+        String::from_utf8_lossy(&new_stdout),
+        "deprecated `parse` should produce identical stdout to `rule parse`",
+    );
+}
+
+#[test]
+fn deprecated_validate_warns_and_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("rule.yml"), SIMPLE_RULE).unwrap();
+    rsigma()
+        .args(["validate", dir.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("rule validate"))
+        .stdout(predicate::str::contains("Detection rules:"));
+}
+
+#[test]
+fn deprecated_lint_warns_and_succeeds() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args(["lint", rule.path().to_str().unwrap()])
+        .assert()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("rule lint"));
+}
+
+#[test]
+fn deprecated_fields_warns_and_succeeds() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("rule fields"));
+}
+
+#[test]
+fn deprecated_condition_warns_and_succeeds() {
+    let assert = rsigma()
+        .args(["condition", "sel and not filter"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("rule condition"));
+
+    let new_stdout = rsigma()
+        .args(["rule", "condition", "sel and not filter"])
+        .output()
+        .unwrap()
+        .stdout;
+    assert_eq!(
+        String::from_utf8_lossy(&assert.get_output().stdout),
+        String::from_utf8_lossy(&new_stdout),
+        "deprecated `condition` should produce identical stdout to `rule condition`",
+    );
+}
+
+#[test]
+fn deprecated_stdin_warns_and_succeeds() {
+    rsigma()
+        .args(["stdin"])
+        .write_stdin(SIMPLE_RULE)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("rule stdin"))
+        .stdout(predicate::str::contains("Test Rule"));
+}
+
+#[test]
+fn deprecated_eval_warns_and_succeeds() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args([
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine":"benign"}"#,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("engine eval"));
+}
+
+#[test]
+fn deprecated_convert_warns_and_succeeds() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args(["convert", rule.path().to_str().unwrap(), "-t", "test"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("backend convert"));
+}
+
+#[test]
+fn deprecated_list_targets_warns_and_matches_backend_targets() {
+    let assert = rsigma()
+        .args(["list-targets"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("backend targets"));
+
+    let new_stdout = rsigma()
+        .args(["backend", "targets"])
+        .output()
+        .unwrap()
+        .stdout;
+    assert_eq!(
+        String::from_utf8_lossy(&assert.get_output().stdout),
+        String::from_utf8_lossy(&new_stdout),
+        "deprecated `list-targets` should produce identical stdout to `backend targets`",
+    );
+}
+
+#[test]
+fn deprecated_list_formats_warns_and_matches_backend_formats() {
+    let assert = rsigma()
+        .args(["list-formats", "test"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("backend formats"));
+
+    let new_stdout = rsigma()
+        .args(["backend", "formats", "test"])
+        .output()
+        .unwrap()
+        .stdout;
+    assert_eq!(
+        String::from_utf8_lossy(&assert.get_output().stdout),
+        String::from_utf8_lossy(&new_stdout),
+        "deprecated `list-formats test` should produce identical stdout to `backend formats test`",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Daemon and resolve deprecation
+// ---------------------------------------------------------------------------
+
+/// `rsigma daemon` is the heaviest deprecated alias. We only assert that
+/// `--help` on the alias prints the deprecation warning and the same flag
+/// list as `engine daemon --help`. Spawning a real daemon is covered by
+/// `cli_daemon.rs` (which already uses the new path).
+#[cfg(feature = "daemon")]
+#[test]
+fn deprecated_daemon_help_lists_new_path() {
+    rsigma()
+        .args(["daemon", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--rules"))
+        .stdout(predicate::str::contains("--input"));
+
+    // The about line tags the flat form as deprecated.
+    rsigma()
+        .args(["--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "daemon        [deprecated] Use `rsigma engine daemon` instead",
+        ));
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn deprecated_resolve_warns_on_invalid_pipeline() {
+    // Don't need a real dynamic source — empty pipeline list is a parse error
+    // and exits non-zero. We're only checking the deprecation warning fires
+    // before the failure.
+    rsigma()
+        .args(["resolve", "-p", "/tmp/nonexistent_rsigma_pipeline.yml"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(DEPRECATION_PREFIX))
+        .stderr(predicate::str::contains("pipeline resolve"));
+}

--- a/crates/rsigma-cli/tests/cli_eval.rs
+++ b/crates/rsigma-cli/tests/cli_eval.rs
@@ -67,6 +67,7 @@ fn eval_single_event_match() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -86,6 +87,7 @@ fn eval_bloom_prefilter_flag_is_accepted() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -104,6 +106,7 @@ fn eval_bloom_prefilter_with_max_bytes() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -126,6 +129,7 @@ fn eval_bloom_prefilter_rejects_non_matching_event() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -143,6 +147,7 @@ fn eval_single_event_no_match() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -160,6 +165,7 @@ fn eval_invalid_json_event() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -179,7 +185,7 @@ fn eval_ndjson_stdin() {
 {"CommandLine": "inject malware payload"}
 "#;
     rsigma()
-        .args(["eval", "--rules", rule.path().to_str().unwrap()])
+        .args(["engine", "eval", "--rules", rule.path().to_str().unwrap()])
         .write_stdin(events)
         .assert()
         .success()
@@ -195,7 +201,7 @@ fn eval_ndjson_skips_blank_lines() {
 
 "#;
     rsigma()
-        .args(["eval", "--rules", rule.path().to_str().unwrap()])
+        .args(["engine", "eval", "--rules", rule.path().to_str().unwrap()])
         .write_stdin(events)
         .assert()
         .success()
@@ -209,6 +215,7 @@ fn eval_at_file_single_event() {
     let at_path = format!("@{}", events.path().to_str().unwrap());
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -234,6 +241,7 @@ fn eval_at_file_ndjson() {
     let at_path = format!("@{}", events.path().to_str().unwrap());
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -250,6 +258,7 @@ fn eval_at_file_not_found() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -266,6 +275,7 @@ fn eval_pretty_output() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -283,6 +293,7 @@ fn eval_include_event() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -306,6 +317,7 @@ fn eval_with_pipeline() {
 
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -329,6 +341,7 @@ fn eval_jq_filter() {
     let event = r#"{"wrapper": {"CommandLine": "malware"}}"#;
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -348,6 +361,7 @@ fn eval_jsonpath_filter() {
     let event = r#"{"data": {"CommandLine": "malware"}}"#;
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -366,6 +380,7 @@ fn eval_jq_and_jsonpath_conflict() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -393,7 +408,7 @@ fn eval_correlation_fires() {
 {"EventType": "login_failure", "User": "admin", "@timestamp": "2025-01-01T00:00:03Z"}
 "#;
     rsigma()
-        .args(["eval", "--rules", rule.path().to_str().unwrap()])
+        .args(["engine", "eval", "--rules", rule.path().to_str().unwrap()])
         .write_stdin(events)
         .assert()
         .success()
@@ -408,7 +423,7 @@ fn eval_correlation_below_threshold() {
 {"EventType": "login_failure", "User": "admin", "@timestamp": "2025-01-01T00:00:02Z"}
 "#;
     rsigma()
-        .args(["eval", "--rules", rule.path().to_str().unwrap()])
+        .args(["engine", "eval", "--rules", rule.path().to_str().unwrap()])
         .write_stdin(events)
         .assert()
         .success()
@@ -427,6 +442,7 @@ fn eval_correlation_with_suppress() {
 "#;
     let output = rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -460,6 +476,7 @@ fn eval_correlation_action_reset() {
 "#;
     let output = rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -490,6 +507,7 @@ fn eval_no_detections_flag() {
 "#;
     let output = rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -522,6 +540,7 @@ fn eval_filter_excludes_match() {
     let rule = temp_file(".yml", FILTER_RULES);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -539,6 +558,7 @@ fn eval_filter_allows_match() {
     let rule = temp_file(".yml", FILTER_RULES);
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -563,6 +583,7 @@ fn eval_custom_timestamp_field() {
 "#;
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             rule.path().to_str().unwrap(),
@@ -600,6 +621,7 @@ level: low
     let events = "<38>Apr 25 14:30:00 web01 sudo: admin : TTY=pts/0 ; COMMAND=/bin/bash\n";
     let output = rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             syslog_rule.path().to_str().unwrap(),
@@ -632,6 +654,7 @@ level: high
     );
     let output = rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             plain_rule.path().to_str().unwrap(),
@@ -660,7 +683,7 @@ fn no_subcommand_shows_help() {
 #[test]
 fn eval_missing_rules_arg() {
     rsigma()
-        .args(["eval", "--event", "{}"])
+        .args(["engine", "eval", "--event", "{}"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--rules"));
@@ -670,6 +693,7 @@ fn eval_missing_rules_arg() {
 fn eval_nonexistent_rules_path() {
     rsigma()
         .args([
+            "engine",
             "eval",
             "--rules",
             "/tmp/nonexistent_rsigma_rules.yml",

--- a/crates/rsigma-cli/tests/cli_fields.rs
+++ b/crates/rsigma-cli/tests/cli_fields.rs
@@ -205,7 +205,7 @@ level: high
 fn fields_simple_detection() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -225,7 +225,7 @@ fn fields_simple_detection() {
 fn fields_with_metadata_fields() {
     let rule = temp_file(".yml", RULE_WITH_FIELDS_METADATA);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -243,7 +243,7 @@ fn fields_with_metadata_fields() {
 fn fields_correlation_adds_group_by() {
     let rule = temp_file(".yml", CORRELATION_RULES);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -265,7 +265,7 @@ fn fields_correlation_adds_group_by() {
 fn fields_value_count_condition_field() {
     let rule = temp_file(".yml", VALUE_COUNT_CORRELATION);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -282,7 +282,7 @@ fn fields_value_count_condition_field() {
 fn fields_alias_mapping_values() {
     let rule = temp_file(".yml", FIELD_ALIAS_CORRELATION);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -301,7 +301,7 @@ fn fields_alias_mapping_values() {
 fn fields_keywords_only_rule_has_no_fields() {
     let rule = temp_file(".yml", KEYWORDS_ONLY);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -318,7 +318,7 @@ fn fields_keywords_only_rule_has_no_fields() {
 fn fields_includes_filters_by_default() {
     let rule = temp_file(".yml", WITH_FILTER);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", rule.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -341,6 +341,7 @@ fn fields_no_filters_excludes_filter_fields() {
     let rule = temp_file(".yml", WITH_FILTER);
     let output = rsigma()
         .args([
+            "rule",
             "fields",
             "-r",
             rule.path().to_str().unwrap(),
@@ -369,6 +370,7 @@ fn fields_with_pipeline_transforms_names() {
     let pipeline = temp_file(".yml", PIPELINE_YAML);
     let output = rsigma()
         .args([
+            "rule",
             "fields",
             "-r",
             rule.path().to_str().unwrap(),
@@ -399,7 +401,13 @@ fn fields_with_pipeline_transforms_names() {
 fn fields_json_output() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap(), "--json"])
+        .args([
+            "rule",
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--json",
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -420,6 +428,7 @@ fn fields_json_with_pipeline_includes_mappings() {
     let pipeline = temp_file(".yml", PIPELINE_YAML);
     let output = rsigma()
         .args([
+            "rule",
             "fields",
             "-r",
             rule.path().to_str().unwrap(),
@@ -447,7 +456,13 @@ fn fields_json_with_pipeline_includes_mappings() {
 fn fields_json_with_filter() {
     let rule = temp_file(".yml", WITH_FILTER);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap(), "--json"])
+        .args([
+            "rule",
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--json",
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -469,7 +484,13 @@ fn fields_json_with_filter() {
 fn fields_json_snapshot() {
     let rule = temp_file(".yml", CORRELATION_RULES);
     let output = rsigma()
-        .args(["fields", "-r", rule.path().to_str().unwrap(), "--json"])
+        .args([
+            "rule",
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--json",
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -529,7 +550,7 @@ fn fields_directory_of_rules() {
     std::fs::write(dir.path().join("rule_b.yml"), RULE_WITH_FIELDS_METADATA).unwrap();
 
     let output = rsigma()
-        .args(["fields", "-r", dir.path().to_str().unwrap()])
+        .args(["rule", "fields", "-r", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -554,7 +575,7 @@ fn fields_directory_of_rules() {
 #[test]
 fn fields_nonexistent_path() {
     rsigma()
-        .args(["fields", "-r", "/nonexistent/path"])
+        .args(["rule", "fields", "-r", "/nonexistent/path"])
         .assert()
         .failure();
 }
@@ -562,7 +583,7 @@ fn fields_nonexistent_path() {
 #[test]
 fn fields_missing_rules_arg() {
     rsigma()
-        .args(["fields"])
+        .args(["rule", "fields"])
         .assert()
         .failure()
         .stderr(predicates::str::contains("--rules"));

--- a/crates/rsigma-cli/tests/cli_lint.rs
+++ b/crates/rsigma-cli/tests/cli_lint.rs
@@ -167,7 +167,7 @@ level: invalid_level
 fn lint_valid_rule_passes() {
     let rule = temp_file(".yml", LINT_VALID_RULE);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("0 failed"));
@@ -177,7 +177,7 @@ fn lint_valid_rule_passes() {
 fn lint_valid_rule_verbose() {
     let rule = temp_file(".yml", LINT_VALID_RULE);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap(), "--verbose"])
+        .args(["rule", "lint", rule.path().to_str().unwrap(), "--verbose"])
         .assert()
         .success()
         .stdout(predicate::str::contains("OK"));
@@ -187,7 +187,7 @@ fn lint_valid_rule_verbose() {
 fn lint_invalid_level() {
     let rule = temp_file(".yml", LINT_INVALID_LEVEL);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("invalid_level"))
@@ -198,7 +198,7 @@ fn lint_invalid_level() {
 fn lint_invalid_status() {
     let rule = temp_file(".yml", LINT_INVALID_STATUS);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("invalid_status"));
@@ -208,7 +208,7 @@ fn lint_invalid_status() {
 fn lint_invalid_date() {
     let rule = temp_file(".yml", LINT_INVALID_DATE);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("invalid_date"));
@@ -218,7 +218,7 @@ fn lint_invalid_date() {
 fn lint_invalid_tags() {
     let rule = temp_file(".yml", LINT_INVALID_TAGS);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .stdout(predicate::str::contains("invalid_tag"))
         .stdout(predicate::str::contains("duplicate_tags"));
@@ -228,7 +228,7 @@ fn lint_invalid_tags() {
 fn lint_missing_detection() {
     let rule = temp_file(".yml", LINT_MISSING_DETECTION);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("missing_detection"));
@@ -238,7 +238,7 @@ fn lint_missing_detection() {
 fn lint_deprecated_without_related() {
     let rule = temp_file(".yml", LINT_DEPRECATED_NO_RELATED);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .stdout(predicate::str::contains("deprecated_without_related"));
 }
@@ -247,7 +247,7 @@ fn lint_deprecated_without_related() {
 fn lint_valid_correlation() {
     let rule = temp_file(".yml", LINT_VALID_CORRELATION);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("0 failed"));
@@ -257,7 +257,7 @@ fn lint_valid_correlation() {
 fn lint_invalid_correlation() {
     let rule = temp_file(".yml", LINT_INVALID_CORRELATION);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("invalid_correlation_type"))
@@ -268,7 +268,7 @@ fn lint_invalid_correlation() {
 fn lint_valid_filter() {
     let rule = temp_file(".yml", LINT_VALID_FILTER);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("0 failed"));
@@ -278,7 +278,7 @@ fn lint_valid_filter() {
 fn lint_filter_has_level() {
     let rule = temp_file(".yml", LINT_FILTER_WITH_LEVEL);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .stdout(predicate::str::contains("filter_has_level"));
 }
@@ -287,7 +287,7 @@ fn lint_filter_has_level() {
 fn lint_multi_doc_yaml() {
     let rule = temp_file(".yml", LINT_MULTI_DOC);
     rsigma()
-        .args(["lint", rule.path().to_str().unwrap()])
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("invalid_level"))
@@ -301,7 +301,7 @@ fn lint_directory() {
     std::fs::write(dir.path().join("bad.yml"), LINT_INVALID_LEVEL).unwrap();
 
     rsigma()
-        .args(["lint", dir.path().to_str().unwrap()])
+        .args(["rule", "lint", dir.path().to_str().unwrap()])
         .assert()
         .failure()
         .stdout(predicate::str::contains("1 failed"))
@@ -311,7 +311,7 @@ fn lint_directory() {
 #[test]
 fn lint_nonexistent_path() {
     rsigma()
-        .args(["lint", "/tmp/nonexistent_rsigma_lint_path.yml"])
+        .args(["rule", "lint", "/tmp/nonexistent_rsigma_lint_path.yml"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("Error"));
@@ -342,6 +342,7 @@ detection:
 
     rsigma()
         .args([
+            "rule",
             "lint",
             rule.path().to_str().unwrap(),
             "--schema",
@@ -375,7 +376,7 @@ detection:
     .unwrap();
 
     rsigma()
-        .args(["lint", path.to_str().unwrap(), "--fix"])
+        .args(["rule", "lint", path.to_str().unwrap(), "--fix"])
         .assert()
         .stdout(predicate::str::contains("Applied"));
 
@@ -406,7 +407,7 @@ detection:
     .unwrap();
 
     rsigma()
-        .args(["lint", path.to_str().unwrap(), "--fix"])
+        .args(["rule", "lint", path.to_str().unwrap(), "--fix"])
         .assert()
         .stdout(predicate::str::contains("Applied"));
 
@@ -439,7 +440,7 @@ detection:
     .unwrap();
 
     rsigma()
-        .args(["lint", path.to_str().unwrap(), "--fix"])
+        .args(["rule", "lint", path.to_str().unwrap(), "--fix"])
         .assert()
         .stdout(predicate::str::contains("Applied"));
 
@@ -464,7 +465,7 @@ detection:
     std::fs::write(&path, original).unwrap();
 
     rsigma()
-        .args(["lint", path.to_str().unwrap(), "--fix"])
+        .args(["rule", "lint", path.to_str().unwrap(), "--fix"])
         .assert()
         .success();
 
@@ -494,7 +495,7 @@ detection:
     .unwrap();
 
     rsigma()
-        .args(["lint", path.to_str().unwrap(), "--fix"])
+        .args(["rule", "lint", path.to_str().unwrap(), "--fix"])
         .assert()
         .stdout(predicate::str::contains("Applied"));
 

--- a/crates/rsigma-cli/tests/cli_parse.rs
+++ b/crates/rsigma-cli/tests/cli_parse.rs
@@ -13,7 +13,7 @@ use predicates::prelude::*;
 fn parse_valid_rule() {
     let rule = temp_file(".yml", SIMPLE_RULE);
     rsigma()
-        .args(["parse", rule.path().to_str().unwrap()])
+        .args(["rule", "parse", rule.path().to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("Test Rule"))
@@ -23,7 +23,7 @@ fn parse_valid_rule() {
 #[test]
 fn parse_nonexistent_file() {
     rsigma()
-        .args(["parse", "/tmp/nonexistent_rsigma_test.yml"])
+        .args(["rule", "parse", "/tmp/nonexistent_rsigma_test.yml"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("Error"));
@@ -33,7 +33,7 @@ fn parse_nonexistent_file() {
 fn parse_invalid_yaml() {
     let bad = temp_file(".yml", "42");
     rsigma()
-        .args(["parse", bad.path().to_str().unwrap()])
+        .args(["rule", "parse", bad.path().to_str().unwrap()])
         .assert()
         .success()
         .stderr(predicate::str::contains("Warning"));
@@ -46,7 +46,7 @@ fn parse_invalid_yaml() {
 #[test]
 fn condition_valid() {
     rsigma()
-        .args(["condition", "selection1 and not filter"])
+        .args(["rule", "condition", "selection1 and not filter"])
         .assert()
         .success()
         .stdout(predicate::str::contains("And"))
@@ -57,7 +57,11 @@ fn condition_valid() {
 #[test]
 fn condition_complex() {
     rsigma()
-        .args(["condition", "1 of selection* or (filter1 and filter2)"])
+        .args([
+            "rule",
+            "condition",
+            "1 of selection* or (filter1 and filter2)",
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("selection*"));
@@ -66,7 +70,7 @@ fn condition_complex() {
 #[test]
 fn condition_invalid() {
     rsigma()
-        .args(["condition", "invalid !!! syntax"])
+        .args(["rule", "condition", "invalid !!! syntax"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("error"));
@@ -79,7 +83,7 @@ fn condition_invalid() {
 #[test]
 fn stdin_valid_rule() {
     rsigma()
-        .args(["stdin"])
+        .args(["rule", "stdin"])
         .write_stdin(SIMPLE_RULE)
         .assert()
         .success()
@@ -89,7 +93,7 @@ fn stdin_valid_rule() {
 #[test]
 fn stdin_invalid_yaml() {
     rsigma()
-        .args(["stdin"])
+        .args(["rule", "stdin"])
         .write_stdin("12345")
         .assert()
         .success()

--- a/crates/rsigma-cli/tests/cli_validate.rs
+++ b/crates/rsigma-cli/tests/cli_validate.rs
@@ -26,7 +26,7 @@ fn validate_directory_with_valid_rules() {
     std::fs::write(dir.path().join("rule2.yml"), SIMPLE_RULE_WINDASH).unwrap();
 
     rsigma()
-        .args(["validate", dir.path().to_str().unwrap()])
+        .args(["rule", "validate", dir.path().to_str().unwrap()])
         .assert()
         .success()
         .stdout(predicate::str::contains("Detection rules:"))
@@ -39,7 +39,12 @@ fn validate_directory_with_errors() {
     std::fs::write(dir.path().join("bad.yml"), "42").unwrap();
 
     rsigma()
-        .args(["validate", dir.path().to_str().unwrap(), "--verbose"])
+        .args([
+            "rule",
+            "validate",
+            dir.path().to_str().unwrap(),
+            "--verbose",
+        ])
         .assert()
         .stdout(predicate::str::contains("Parsed"));
 }
@@ -47,7 +52,7 @@ fn validate_directory_with_errors() {
 #[test]
 fn validate_nonexistent_directory() {
     rsigma()
-        .args(["validate", "/tmp/nonexistent_rsigma_dir"])
+        .args(["rule", "validate", "/tmp/nonexistent_rsigma_dir"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("Error"));
@@ -61,6 +66,7 @@ fn validate_with_pipeline() {
 
     rsigma()
         .args([
+            "rule",
             "validate",
             dir.path().to_str().unwrap(),
             "-p",

--- a/crates/rsigma-cli/tests/common/mod.rs
+++ b/crates/rsigma-cli/tests/common/mod.rs
@@ -156,9 +156,10 @@ impl DaemonProcess {
         }
     }
 
-    /// Spawn `rsigma daemon -r RULE --input http --api-addr 127.0.0.1:0`.
+    /// Spawn `rsigma engine daemon -r RULE --input http --api-addr 127.0.0.1:0`.
     pub fn spawn_http(rule_path: &str) -> Self {
         Self::spawn(&[
+            "engine",
             "daemon",
             "-r",
             rule_path,

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -142,7 +142,7 @@ transformations:
 ```
 
 ```bash
-rsigma convert -r rules/ -t lynxdb -p pipeline.yml
+rsigma backend convert -r rules/ -t lynxdb -p pipeline.yml
 # Output: FROM security_logs | search ...
 ```
 
@@ -165,7 +165,7 @@ When a Sigma rule specifies `fields:`, the backend emits `SELECT field1, field2,
 Backend configuration can be set via `-O key=value` flags on the CLI, which are wired through to `PostgresBackend::from_options`. Recognized keys: `table`, `schema`, `database`, `timestamp_field`, `json_field`, `case_sensitive_re`.
 
 ```bash
-rsigma convert -r rules/ -t postgres -O table=security_logs -O schema=public -O timestamp_field=created_at
+rsigma backend convert -r rules/ -t postgres -O table=security_logs -O schema=public -O timestamp_field=created_at
 ```
 
 ### Custom table, schema, and database
@@ -203,14 +203,14 @@ Two OCSF processing pipelines are included:
 
 ```bash
 # Single-table pipeline
-rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
+rsigma backend convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml
 
 # Multi-table pipeline (per-logsource routing)
-rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
+rsigma backend convert -r rules/ -t postgres -p pipelines/ocsf_postgres_multi_table.yml
 
 # With output format
-rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f view
-rsigma convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f continuous_aggregate
+rsigma backend convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f view
+rsigma backend convert -r rules/ -t postgres -p pipelines/ocsf_postgres.yml -f continuous_aggregate
 ```
 
 ### Multi-table temporal correlations
@@ -362,7 +362,7 @@ This matches the nested traversal behavior of the evaluation engine (`rsigma-eva
 
 ```bash
 # Convert rules with JSONB field access against a "data" column
-rsigma convert -r rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
+rsigma backend convert -r rules/ -t postgres -O table=okta_events -O json_field=data -O timestamp_field=time
 ```
 
 ## LynxDB Backend Details

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -390,7 +390,7 @@ engine.set_bloom_max_bytes(2 * 1024 * 1024);
 engine.add_collection(&collection)?;
 ```
 
-CLI equivalents on `rsigma eval` and `rsigma daemon`:
+CLI equivalents on `rsigma engine eval` and `rsigma engine daemon`:
 
 ```
 --bloom-prefilter              # enable
@@ -425,7 +425,7 @@ engine.set_cross_rule_ac(true);
 engine.add_collection(&collection)?;
 ```
 
-CLI equivalents on `rsigma eval` and `rsigma daemon` (when the CLI is compiled with the feature):
+CLI equivalents on `rsigma engine eval` and `rsigma engine daemon` (when the CLI is compiled with the feature):
 
 ```
 --cross-rule-ac


### PR DESCRIPTION
## Summary

Reorganize the 12 flat top-level `rsigma` subcommands into five noun-led command groups (`engine`, `rule`, `backend`, `pipeline`, `attack`) so the CLI scales as more subcommands arrive. The flat aliases keep working as visible-deprecated forwarders for one release, will be hidden in the next, and removed in v1.0. No breaking change in this release.

### Migration map

| Old (flat, deprecated) | New (grouped) |
|------------------------|---------------|
| `rsigma eval ...` | `rsigma engine eval ...` |
| `rsigma daemon ...` | `rsigma engine daemon ...` |
| `rsigma parse ...` | `rsigma rule parse ...` |
| `rsigma validate ...` | `rsigma rule validate ...` |
| `rsigma lint ...` | `rsigma rule lint ...` |
| `rsigma fields ...` | `rsigma rule fields ...` |
| `rsigma condition ...` | `rsigma rule condition ...` |
| `rsigma stdin ...` | `rsigma rule stdin ...` |
| `rsigma convert RULES ...` | `rsigma backend convert RULES ...` |
| `rsigma list-targets` | `rsigma backend targets` |
| `rsigma list-formats TARGET` | `rsigma backend formats TARGET` |
| `rsigma resolve ...` | `rsigma pipeline resolve ...` |

### What you'll see

Invoking any flat alias prints one stderr line:

```
warning: `rsigma <old>` is deprecated; use `rsigma <new>` instead. This alias will be hidden in the next release and removed in v1.0.
```

stdout is unchanged. Exit codes are unchanged. Every flag accepted by the old form is accepted by the new form with identical defaults and semantics.

### Why noun-led groups

Every group is a noun (`engine`, `rule`, `backend`, `pipeline`, `attack`), so command paths read as "rsigma's X tooling: do Y" rather than the awkward verb-on-verb chains a `run`/`convert` group would produce (`rsigma convert run RULES` vs the chosen `rsigma backend convert RULES`). The five groups are deliberately stable and small so future commands have an obvious home rather than landing as more top-level sprawl.

### `attack` group reserved

`rsigma attack --help` lists no subcommands in this release. The `AttackCommands` enum is intentionally empty and is reserved for MITRE ATT&CK tooling that will land in a separate change. No new top-level `attack-coverage` or `attack-update` commands will ever ship; both will land as `attack` subcommands.

### Deprecation timeline

- **This release**: flat aliases visible in `rsigma --help` with `[deprecated]` tag, stderr warning on invocation.
- **Next release**: `#[command(hide = true)]` removes them from `--help` but invocations still work.
- **v1.0**: flat aliases removed.

## Internal refactor

- Each subcommand's clap arguments now live in `crates/rsigma-cli/src/commands/<name>.rs` as a `pub struct <Name>Args` deriving `clap::Args`.
- The daemon's 35-field arg set + `cmd_daemon` body + `parse_input_format` + `parse_tz_offset` moved out of `main.rs` into a new `crates/rsigma-cli/src/commands/daemon.rs` (mirroring the existing `commands/eval.rs` pattern).
- `main.rs` dropped from ~1360 lines to ~520, with the dispatch becoming a thin two-layer match (group → leaf). No behavior change.

## Test plan

- [x] `cargo build -p rsigma` (default features) — clean
- [x] `cargo build -p rsigma --all-features --tests` — clean
- [x] `cargo test -p rsigma --features daemon` — **182 passed across 13 suites, 0 failed**
- [x] `cargo clippy -p rsigma --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New `tests/cli_deprecation.rs` (17 tests) covers each deprecated alias: still succeeds, prints stderr warning, identical stdout to the new form where comparable; plus `--help` lists every group + every deprecated alias with `[deprecated]`.
- [x] Every existing CLI integration test invocation migrated to the new grouped paths (~150 sites).
- [x] Pre-existing `--no-default-features` build errors in `commands/resolve.rs` and `commands/validate.rs` (unconditional `rsigma_runtime`/`tokio` use that should be daemon-gated) are unchanged. Out of scope here.

## Docs

- [crates/rsigma-cli/README.md](crates/rsigma-cli/README.md): subcommand headings restructured (`engine eval`, `rule lint`, etc.); Migrating from flat commands table at the top; ~100 example invocations rewritten.
- Root [README.md](README.md), [BENCHMARKS.md](BENCHMARKS.md), [crates/rsigma-eval/README.md](crates/rsigma-eval/README.md), [crates/rsigma-convert/README.md](crates/rsigma-convert/README.md): example invocations updated.
- [CHANGELOG.md](CHANGELOG.md): new `## [Unreleased]` section with the full alias map, deprecation timeline, rationale for noun-led naming, and `attack` reservation note. Historical release notes preserved verbatim.

## Follow-ups

- #125
- #126
