### PR TITLE
docs(cli): missed command refs + Unreleased CHANGELOG draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,17 +152,17 @@ jobs:
       - name: Clone SigmaHQ rules
         run: git clone --depth 1 https://github.com/SigmaHQ/sigma.git /tmp/sigma
       - name: Validate and compile all Sigma rules
-        run: ./target/release/rsigma validate /tmp/sigma/rules/ --verbose
+        run: ./target/release/rsigma rule validate /tmp/sigma/rules/ --verbose
       - name: Validate SigmaHQ corpus with dynamic pipelines
         run: |
-          ./target/release/rsigma validate /tmp/sigma/rules/ \
+          ./target/release/rsigma rule validate /tmp/sigma/rules/ \
             --pipeline tests/fixtures/dynamic-pipelines/pipelines/field_mapping.yml \
             --pipeline tests/fixtures/dynamic-pipelines/pipelines/allowlist.yml \
             --pipeline tests/fixtures/dynamic-pipelines/pipelines/multi_format.yml \
             --pipeline tests/fixtures/dynamic-pipelines/pipelines/extract_languages.yml \
             --pipeline tests/fixtures/dynamic-pipelines/pipelines/include_expansion.yml \
             --resolve-sources --verbose
-      - name: Golden file comparison for rsigma resolve
+      - name: Golden file comparison for rsigma pipeline resolve
         run: |
           failed=0
           for pipeline in tests/fixtures/dynamic-pipelines/pipelines/*.yml; do
@@ -172,7 +172,7 @@ jobs:
               echo "SKIP: no golden file for ${name}"
               continue
             fi
-            actual=$(./target/release/rsigma resolve --pipeline "$pipeline" --pretty)
+            actual=$(./target/release/rsigma pipeline resolve --pipeline "$pipeline" --pretty)
             if ! diff -u "$golden" <(echo "$actual") > /tmp/diff_${name}.txt 2>&1; then
               echo "FAIL: ${name} resolve output differs from golden file"
               cat /tmp/diff_${name}.txt
@@ -182,6 +182,6 @@ jobs:
             fi
           done
           if [ "$failed" -ne 0 ]; then
-            echo "::error::Golden file comparison failed. Run 'rsigma resolve' locally and update golden files."
+            echo "::error::Golden file comparison failed. Run 'rsigma pipeline resolve' locally and update golden files."
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,70 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### CLI
+**TL;DR**
+The next RSigma release is the "operations and load performance" release:
+* Comprehensive daemon and CLI observability: tower-http API access logs, per-request OTLP tracing, batch processing spans, source resolution spans, DLQ visibility, NATS and sink lifecycle events, correlation state eviction warnings, rule load diagnostics, daemon lifecycle logs, and a global `--log-format` flag for non-daemon subcommands.
+* Eval rule loading is no longer O(N²): `Engine::add_rule` is amortized O(1), and bulk loaders (`Engine::add_rules`, `extend_compiled_rules`, `add_collection`) rebuild indexes exactly once per batch. The full 3,120-rule SigmaHQ corpus that previously appeared to hang now loads in ~120 ms.
+* CLI subcommands reorganized into five noun-led groups (`engine`, `rule`, `backend`, `pipeline`). Flat aliases continue to work as deprecated forwarders for one release.
+* Test reliability: `cli_daemon_http` and `cli_daemon_otlp` E2E suites are now flake-free on macOS under load.
+* Dependency bumps: opentelemetry-proto 0.31.0 to 0.32.0, async-nats 0.47 to 0.48, yamlpath/yamlpatch 1.25.2 (with the `serde_yaml` cargo rename replaced by `yaml_serde` directly), tokio 1.52.3, jsonschema 0.46.4, tower-http 0.6.10, tonic 0.14.6.
 
-The 12 flat top-level subcommands are reorganized into five noun-led command groups so the CLI scales as more subcommands arrive (most immediately, `attack coverage` and `attack update` from the upcoming MITRE ATT&CK contributor PR). The flat aliases continue to work for one release as visible-deprecated forwarders, are hidden in the next release, and are removed in v1.0. Every existing invocation keeps working, so there is no breaking change in this release.
+### Daemon and CLI observability (PR #107)
+
+The daemon and CLI ship with structured logs, distributed tracing spans, and profiling hooks across the three observability pillars. All new instrumentation flows through the existing `tracing-subscriber` (JSON, env-filter) and is controlled via `RUST_LOG`. Spans are designed to be consumable by future `tokio-console` or `tracing-opentelemetry` exporters without code changes.
+
+**Phases.** One commit per phase, in landing order:
+
+| Phase | Scope |
+|-------|-------|
+| HTTP API access logs | `tower-http::TraceLayer::new_for_http()` on the Axum router; each request produces a span with method, URI, status, and latency |
+| Event pipeline | Per-batch debug span (`batch_size`, `input_format`, `match` count, `elapsed_ms`); DLQ parse-failure debug events; checked DLQ channel send with warn-on-closed; DLQ task lifecycle logging |
+| Source resolution | `InstrumentedResolver` debug span (`source_id`, `source_type`); cache hit / fetch boundary events; refresh scheduler cycle completion logs (`sources`, `duration_ms`) |
+| Correlation memory pressure | Warn on hard-cap eviction (current count, max, evicted, target capacity) so high-cardinality traffic causing data loss is no longer silent |
+| NATS, sinks, backpressure | NATS source/sink publish and ack events; `spawn_source` backpressure warn alongside the existing metric; `Sink::FanOut` per-sink labels (`sink_index`, `sink_type`, error) |
+| Rule load diagnostics | `load_rules` info span (`rules_path`, `duration_ms`); first three parse error details when bad rules fail to compile |
+| OTLP per-request tracing | `otlp_ingest` debug span on both HTTP and gRPC handlers; `record_count` event after decoding `ExportLogsServiceRequest` |
+| Daemon lifecycle | Health state transitions; file watcher errors; reload-channel coalesce vs closed events; periodic state snapshot duration and serialized size; SQLite migration column events; per-task shutdown-join logs |
+| `--log-format` for CLI | Global `--log-format <json\|text>` initializes a stderr subscriber on non-daemon subcommands. `engine eval`, `rule validate`, and `rule lint` emit info events on completion (rules loaded, validation totals, lint summary) when a subscriber is installed. The daemon always logs JSON, so the flag is a no-op there. |
+
+**Verbosity targets.**
+
+| `RUST_LOG` filter | Surfaces |
+|-------------------|----------|
+| `info,tower_http=debug` | HTTP API access logs |
+| `info,rsigma=debug` | Batch processing spans, DLQ routing, OTLP per-request fields, snapshot save duration |
+| `info,rsigma_runtime::sources=debug` | Dynamic source resolution and refresh scheduler |
+| `info,rsigma_eval=debug` | Correlation engine internals |
+
+**Span correctness fix.** Holding an `EnteredSpan` guard from `Span::enter()` across `.await` is an anti-pattern on the multi-threaded tokio runtime: when the task is suspended, the thread-local span context can leak into other tasks scheduled on the same thread, producing incorrect span nesting. `InstrumentedResolver::resolve`, the OTLP HTTP and gRPC handlers, and the engine batch loop now use `.instrument()` on async blocks instead. Span fields, event payloads, and runtime behavior are unchanged.
+
+**Documentation.** A new Observability section in the root README and an updated Logging paragraph in the CLI README list the supported `RUST_LOG` filter targets and document the new `--log-format` flag.
+
+### Eval rule loading performance (PRs #119, #121, #122, #123)
+
+Loading rules into an engine is no longer O(N²) in the rule count.
+
+**Batched loaders rebuild indexes exactly once.** New `Engine::add_rules` (compiles each rule with the configured pipelines and collects per-rule compile errors without aborting the batch) and `Engine::extend_compiled_rules` (pre-compiled equivalent) rebuild the inverted index and per-field bloom exactly once at the end of the batch. `Engine::add_collection`, the `rsigma rule validate` path, and the `rsigma engine eval` rule load path now route through these APIs so the daemon and every `RuntimeEngine` caller share the one-rebuild fast path. Loading the SigmaHQ corpus (~3,120 rules) used to pay around 3K full index rebuilds and appeared to hang; it now completes in roughly 120 ms.
+
+**Single-rule add path is amortized O(1).** `Engine::add_rule` and `Engine::add_compiled_rule` no longer rebuild the indexes from scratch on every push. They fold the new rule into the inverted index incrementally via the new `RuleIndex::append_rule(rule_idx, rule)` primitive, and into the per-field bloom via `FieldBloomIndex::append_rule(rule)`. The bloom uses a doubling watermark with a 64-rule floor to schedule full rebuilds when the rule count has at least doubled past the last rebuild, capping false-positive-rate drift while keeping the amortized per-rule cost O(1). Rules that introduce a brand-new indexed field get a fresh bloom on the fly.
+
+| Rules   | `add_collection` | `add_rules` | `add_rule` loop |
+|--------:|-----------------:|------------:|----------------:|
+| 1,000   |          1.15 ms |     1.17 ms |         1.64 ms |
+| 10,000  |         11.82 ms |    11.85 ms |        17.23 ms |
+| 100,000 |        121.65 ms |   122.13 ms |       166.07 ms |
+
+(M4 Pro, release build. Run via `cargo bench -p rsigma-eval --bench eval -- rule_load`.)
+
+When `cross_rule_ac_enabled` is on, the daachorse cross-rule index has no incremental update story, so the single-rule add path falls back to a full `Engine::rebuild_index`. Bulk loaders are unaffected.
+
+**Correctness.** Between bloom rebuilds, probes may answer `MaybeMatch` where the batched-rebuild path would answer `DefinitelyNoMatch`. Both verdicts are correct (`MaybeMatch` is always safe); the engine just evaluates the rule directly instead of short-circuiting. The new differential test `append_rule_matches_build_verdicts` pins this property by checking that positive verdicts match exactly and that disjoint haystacks are still rejected at >= 90% under incremental builds.
+
+**Benchmarks.** A new `rule_load` Criterion group compares the three load entry points at 1K / 10K / 100K rules. Numbers recorded in `BENCHMARKS.md` under the Rule Load Paths (0.11.x) subsection.
+
+### CLI command groups (PR #124)
+
+The 12 flat top-level subcommands are reorganized into five noun-led command groups so the CLI scales as more subcommands arrive. The flat aliases continue to work for one release as visible-deprecated forwarders, are hidden in the next release, and are removed in v1.0. Every existing invocation keeps working, so there is no breaking change in this release.
 
 **Migration:**
 
@@ -34,19 +95,37 @@ warning: `rsigma <old>` is deprecated; use `rsigma <new>` instead. This alias wi
 
 stdout is unchanged. Exit codes are unchanged. Every flag accepted by the old form is accepted by the new form, with identical defaults and semantics.
 
-**Why noun-led groups.** Every group is a noun (`engine`, `rule`, `backend`, `pipeline`, `attack`), so command paths read as "rsigma's X tooling: do Y" rather than the awkward verb-on-verb chains a `run` or `convert` group would produce (`rsigma convert run RULES` vs the chosen `rsigma backend convert RULES`). The five groups are deliberately stable and small so future commands have an obvious home rather than landing as more top-level sprawl.
-
-**`attack` group reserved.** `rsigma attack --help` lists no subcommands in this release. The `AttackCommands` enum is intentionally empty and is populated by the separate MITRE ATT&CK contributor PR (see `idea-proposals/MITRE ATT&CK/`) with `attack coverage` and `attack update`. No new top-level `attack-coverage` or `attack-update` commands will ever ship; both land as `attack` subcommands.
+**Why noun-led groups.** Every group is a noun (`engine`, `rule`, `backend`, `pipeline`), so command paths read as "rsigma's X tooling: do Y" rather than the awkward verb-on-verb chains a `run` or `convert` group would produce (`rsigma convert run RULES` vs the chosen `rsigma backend convert RULES`). The five groups are deliberately stable and small so future commands have an obvious home rather than landing as more top-level sprawl.
 
 **Deprecation timeline.**
 
 - **This release**: flat aliases visible in `rsigma --help` with a `[deprecated]` tag, stderr warning on invocation. Every test, script, and pipeline keeps working.
-- **Next release**: `#[command(hide = true)]` removes the aliases from `--help` but the invocations still work.
-- **v1.0**: flat aliases removed.
+- **Next release** ([issue #125](https://github.com/timescale/rsigma/issues/125)): `#[command(hide = true)]` removes the aliases from `--help` but the invocations still work.
+- **v1.0** ([issue #126](https://github.com/timescale/rsigma/issues/126)): flat aliases removed.
 
-### Internal
+**Internal refactor.** The CLI dispatch layer is collapsed: each subcommand's clap arguments now live in `crates/rsigma-cli/src/commands/<name>.rs` as a `pub struct <Name>Args` deriving `clap::Args`, and the daemon's 35-field arg set + `cmd_daemon` body moved out of `main.rs` into a new `crates/rsigma-cli/src/commands/daemon.rs`. `main.rs` dropped from ~1360 lines to ~520 with no behavior change; the dispatch becomes a thin two-layer match (group -> leaf).
 
-- The CLI dispatch layer is collapsed: each subcommand's clap arguments now live in `crates/rsigma-cli/src/commands/<name>.rs` as a `pub struct <Name>Args` deriving `clap::Args`, and the daemon's 35-field arg set + `cmd_daemon` body moved out of `main.rs` into a new `crates/rsigma-cli/src/commands/daemon.rs`. `main.rs` dropped from ~1360 lines to ~600 with no behavior change.
+### Test reliability (PRs #115, #123)
+
+The `cli_daemon_http` and `cli_daemon_otlp` E2E suites are no longer flaky on macOS under load. Three real issues caused intermittent `ConnectionRefused`:
+
+1. The daemon's stdout was piped but never drained, so a chatty detection-match sink could fill the ~64 KiB pipe buffer and stall the daemon mid-write.
+2. The spawn handshake stopped reading stderr after seeing "Sink started", so any subsequent log line could fill the stderr buffer too.
+3. "Sink started" is emitted before `axum::serve` enters its accept loop; tests that fired requests immediately after the handshake sometimes hit the kernel before the listener was wired up.
+
+The shared `DaemonProcess` helper (now in `tests/common/mod.rs`) drains stdout in a background thread, forwards interesting stderr lines to the main thread via `mpsc`, probes the actual TCP socket with `TcpStream::connect_timeout` before returning, and wraps the `Child` in a `ChildGuard` RAII type. Fixed `std::thread::sleep` waits in three OTLP tests and two HTTP tests are replaced with a `poll_until` helper that retries every 50 ms up to a 5 s deadline against the specific observable condition (metric labels present, status counters incremented). Each test now finishes in around 1.0 s, with the suite passing consistently across many consecutive macOS runs.
+
+PR #123 also de-flaked an eval bloom test (`append_rule_matches_build_verdicts`) by replacing brittle three-needle assertions with a 1000-trigram aggregate sweep, since `BuildHasherDefault<ahash::AHasher>` uses a runtime-randomized seed by default and bit positions shift between process invocations.
+
+### Other changes
+
+* **Dependencies (PRs #111, #113, #114, #120):** opentelemetry-proto 0.31.0 -> 0.32.0 with handling for the new `StringValueStrindex` and `key_strindex` schema fields; async-nats 0.47 -> 0.48 (JetStream 2.14 features, panic fix); jsonschema 0.46.3 -> 0.46.4 (regex panic fix); tower-http 0.6.9 -> 0.6.10; tonic 0.14.5 -> 0.14.6; tokio 1.52.2 -> 1.52.3. yamlpath and yamlpatch bumped to 1.25.2, and the `serde_yaml` cargo rename was replaced with the real `yaml_serde` crate name across all six member manifests (~199 source references), so the manifest, source code, and compiler errors agree about which crate is in use.
+* **GitHub Actions (PRs #111, #120):** taiki-e/install-action 2.75.28 -> 2.77.3, github/codeql-action 4.35.2 -> 4.35.4, sigstore/cosign-installer 4.1.1 -> 4.1.2.
+* **Dependabot config (PR #114):** added a second cargo ecosystem entry pointed at `/fuzz` with the same weekly schedule and patch group as the root entry, so the fuzz workspace's lockfile no longer drifts and bleeds into unrelated PRs.
+* **Architecture diagrams:** the ASCII diagram in `README.md` and the Mermaid diagram in `assets/architecture.mmd` were refreshed to reflect Dynamic Sigma Pipelines (v0.10.0), the matcher optimizer and prefilters (v0.11.0), DLQ as a sink target, broadened hot-reload over rules + pipelines, builtin pipelines (`ecs_windows`, `sysmon`), and the directory-style modules from the v0.9.0 modularization. A legend now explains feature-gated components (`*` for feature-gated and `**` for `daachorse-index`).
+* **README:** install and build instructions corrected; eval prefilters mentioned in the prose; fifth blog article and BlackNoise newsletter mention added.
+
+[v0.11.0...HEAD](https://github.com/timescale/rsigma/compare/v0.11.0...HEAD)
 
 ## [0.11.0] - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker run --rm \
   --cap-drop=ALL \
   --security-opt=no-new-privileges:true \
   -v /path/to/rules:/rules:ro \
-  ghcr.io/timescale/rsigma:latest validate /rules/
+  ghcr.io/timescale/rsigma:latest rule validate /rules/
 ```
 
 Verify the image signature:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,5 +43,5 @@ When running the daemon in production, we recommend the following Docker flags:
 
 ```bash
 docker run --read-only --cap-drop=ALL --security-opt=no-new-privileges \
-  ghcr.io/timescale/rsigma:latest daemon ...
+  ghcr.io/timescale/rsigma:latest engine daemon ...
 ```

--- a/crates/rsigma-cli/tests/cli_daemon_dynamic.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_dynamic.rs
@@ -1,4 +1,4 @@
-//! E2E tests for the `rsigma daemon` with dynamic pipelines.
+//! E2E tests for the `rsigma engine daemon` with dynamic pipelines.
 //!
 //! Tests exercise the full lifecycle: source resolution at startup,
 //! detection with dynamically-resolved pipelines, source refresh on
@@ -41,7 +41,7 @@ impl DaemonProcess {
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
-            .expect("failed to spawn rsigma daemon");
+            .expect("failed to spawn rsigma engine daemon");
 
         let stderr = child.stderr.take().unwrap();
         let stderr_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -100,7 +100,7 @@ impl DaemonProcess {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .expect("failed to spawn rsigma daemon");
+            .expect("failed to spawn rsigma engine daemon");
 
         let timeout = Duration::from_secs(10);
         let start = std::time::Instant::now();
@@ -776,7 +776,7 @@ fn daemon_sources_list_endpoint() {
 }
 
 // ---------------------------------------------------------------------------
-// Test: rsigma resolve command (CLI) works with dynamic pipeline
+// Test: rsigma pipeline resolve command (CLI) works with dynamic pipeline
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -797,7 +797,7 @@ fn cli_resolve_command_resolves_sources() {
             "--pretty",
         ])
         .output()
-        .expect("failed to run rsigma resolve");
+        .expect("failed to run rsigma pipeline resolve");
 
     assert!(
         output.status.success(),
@@ -818,7 +818,7 @@ fn cli_resolve_command_resolves_sources() {
 }
 
 // ---------------------------------------------------------------------------
-// Test: rsigma resolve --dry-run shows metadata without resolving
+// Test: rsigma pipeline resolve --dry-run shows metadata without resolving
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -840,7 +840,7 @@ fn cli_resolve_dry_run_shows_metadata() {
             "--pretty",
         ])
         .output()
-        .expect("failed to run rsigma resolve --dry-run");
+        .expect("failed to run rsigma pipeline resolve --dry-run");
 
     assert!(
         output.status.success(),
@@ -856,7 +856,7 @@ fn cli_resolve_dry_run_shows_metadata() {
 }
 
 // ---------------------------------------------------------------------------
-// Test: rsigma validate --resolve-sources checks source reachability
+// Test: rsigma rule validate --resolve-sources checks source reachability
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -882,7 +882,7 @@ fn cli_validate_resolve_sources_passes() {
             "--resolve-sources",
         ])
         .output()
-        .expect("failed to run rsigma validate");
+        .expect("failed to run rsigma rule validate");
 
     assert!(
         output.status.success(),
@@ -892,7 +892,7 @@ fn cli_validate_resolve_sources_passes() {
 }
 
 // ---------------------------------------------------------------------------
-// Test: rsigma validate --resolve-sources fails for unreachable source
+// Test: rsigma rule validate --resolve-sources fails for unreachable source
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -915,7 +915,7 @@ fn cli_validate_resolve_sources_fails_unreachable() {
             "--resolve-sources",
         ])
         .output()
-        .expect("failed to run rsigma validate");
+        .expect("failed to run rsigma rule validate");
 
     assert!(
         !output.status.success(),

--- a/crates/rsigma-cli/tests/cli_daemon_http.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_http.rs
@@ -1,4 +1,4 @@
-//! E2E tests for the `rsigma daemon` HTTP input mode and REST API.
+//! E2E tests for the `rsigma engine daemon` HTTP input mode and REST API.
 //!
 //! Each test spawns the daemon with `--input http`, discovers the actual
 //! API port from the structured log output, and exercises the endpoints.

--- a/crates/rsigma-cli/tests/cli_daemon_nats.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_nats.rs
@@ -1,4 +1,4 @@
-//! E2E tests for the `rsigma daemon` binary with NATS source/sink.
+//! E2E tests for the `rsigma engine daemon` binary with NATS source/sink.
 //!
 //! Each test starts a NATS JetStream container via testcontainers, spawns
 //! the daemon binary with `--input nats://... --output nats://...`, publishes
@@ -75,7 +75,7 @@ impl DaemonProcess {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .expect("failed to spawn rsigma daemon");
+            .expect("failed to spawn rsigma engine daemon");
         Self { child }
     }
 

--- a/crates/rsigma-cli/tests/common/mod.rs
+++ b/crates/rsigma-cli/tests/common/mod.rs
@@ -64,7 +64,7 @@ impl Drop for ChildGuard {
     }
 }
 
-/// A live `rsigma daemon` subprocess with a known API address. Killed and
+/// A live `rsigma engine daemon` subprocess with a known API address. Killed and
 /// reaped on drop.
 pub struct DaemonProcess {
     child: std::process::Child,
@@ -96,7 +96,7 @@ impl DaemonProcess {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .expect("failed to spawn rsigma daemon");
+            .expect("failed to spawn rsigma engine daemon");
         let mut guard = ChildGuard(Some(child));
 
         if let Some(stdout) = guard.as_child_mut().stdout.take() {

--- a/crates/rsigma-convert/pipelines/ocsf_postgres.yml
+++ b/crates/rsigma-convert/pipelines/ocsf_postgres.yml
@@ -5,7 +5,7 @@
 # in the reference TimescaleDB `security_events` schema.
 #
 # Usage:
-#   rsigma convert -t postgres -p pipelines/ocsf_postgres.yml rules/
+#   rsigma backend convert -t postgres -p pipelines/ocsf_postgres.yml rules/
 
 name: ocsf_postgres
 priority: 10

--- a/crates/rsigma-convert/pipelines/ocsf_postgres_multi_table.yml
+++ b/crates/rsigma-convert/pipelines/ocsf_postgres_multi_table.yml
@@ -6,7 +6,7 @@
 # event type for better partition pruning and compression ratios.
 #
 # Usage:
-#   rsigma convert -t postgres -p pipelines/ocsf_postgres_multi_table.yml rules/
+#   rsigma backend convert -t postgres -p pipelines/ocsf_postgres_multi_table.yml rules/
 #
 # When used with temporal correlation rules that reference detection rules from
 # different categories, the PostgreSQL backend automatically generates UNION ALL

--- a/crates/rsigma-eval/pipelines/ecs_windows.yml
+++ b/crates/rsigma-eval/pipelines/ecs_windows.yml
@@ -7,8 +7,8 @@
 # Derived from pySigma-backend-elasticsearch ecs_windows pipeline.
 #
 # Usage:
-#   rsigma eval -r rules/ -p ecs_windows -e '{"process.command_line": "whoami"}'
-#   rsigma daemon -r rules/ -p ecs_windows
+#   rsigma engine eval -r rules/ -p ecs_windows -e '{"process.command_line": "whoami"}'
+#   rsigma engine daemon -r rules/ -p ecs_windows
 
 name: ecs_windows
 priority: 20

--- a/crates/rsigma-eval/pipelines/sysmon.yml
+++ b/crates/rsigma-eval/pipelines/sysmon.yml
@@ -12,8 +12,8 @@
 # Derived from pySigma-pipeline-sysmon.
 #
 # Usage:
-#   rsigma eval -r rules/ -p sysmon -e '{"EventID": 1, "Image": "cmd.exe", ...}'
-#   rsigma daemon -r rules/ -p sysmon
+#   rsigma engine eval -r rules/ -p sysmon -e '{"EventID": 1, "Image": "cmd.exe", ...}'
+#   rsigma engine daemon -r rules/ -p sysmon
 
 name: sysmon
 priority: 10


### PR DESCRIPTION
## Summary

Follow-up to #124 covering two threads:

### 1. Missed command references

The initial migration covered every direct `rsigma <cmd>` invocation in markdown, but missed paths where the binary name is implicit or path-qualified. Net result: scripts, CI runs, and bundled docs were still teaching users (and our own CI) the deprecated flat shape.

| Where | Old | New |
|-------|-----|-----|
| [README.md](README.md) docker hardening example | `ghcr.io/timescale/rsigma:latest validate /rules/` | `... rule validate /rules/` |
| [SECURITY.md](SECURITY.md) production docker recipe | `... daemon ...` | `... engine daemon ...` |
| [.github/workflows/ci.yml](.github/workflows/ci.yml) | `./target/release/rsigma validate` and `... resolve ...` | `rule validate` and `pipeline resolve` |
| [crates/rsigma-eval/pipelines/sysmon.yml](crates/rsigma-eval/pipelines/sysmon.yml), [ecs_windows.yml](crates/rsigma-eval/pipelines/ecs_windows.yml) header comments | `rsigma eval ...`, `rsigma daemon ...` | `rsigma engine eval ...`, `rsigma engine daemon ...` |
| [crates/rsigma-convert/pipelines/ocsf_postgres.yml](crates/rsigma-convert/pipelines/ocsf_postgres.yml), [ocsf_postgres_multi_table.yml](crates/rsigma-convert/pipelines/ocsf_postgres_multi_table.yml) header comments | `rsigma convert ...` | `rsigma backend convert ...` |
| [crates/rsigma-cli/tests/common/mod.rs](crates/rsigma-cli/tests/common/mod.rs), [cli_daemon*.rs](crates/rsigma-cli/tests/) module headers and `.expect()` strings | "rsigma daemon", "rsigma resolve", "rsigma validate" | "rsigma engine daemon", "rsigma pipeline resolve", "rsigma rule validate" |

The CI fix matters most: without it, every workflow run was emitting the deprecation warning at us (and would be a fresh broken-build risk once #125 hides the aliases).

No behavior change — deprecated aliases still work, this just stops the project itself from teaching the old shape.

### 2. Unreleased CHANGELOG draft

Replaces the placeholder Unreleased section with full release notes following the v0.11.0 / v0.10.0 / v0.9.0 format. Covers every PR merged to main since v0.11.0:

- **Daemon and CLI observability** (PR #107) - tower-http access logs, per-request OTLP tracing, batch spans, source resolution spans, DLQ visibility, NATS/sink lifecycle, correlation eviction warnings, rule load diagnostics, daemon lifecycle, global `--log-format` flag.
- **Eval rule loading performance** (PRs #119, #121, #122, #123) - batched loaders rebuild indexes once per batch; single-rule path amortized O(1) via `RuleIndex::append_rule` and a doubling-watermark `FieldBloomIndex`. SigmaHQ corpus (~3,120 rules) now loads in ~120 ms.
- **CLI command groups** (PR #124) - the noun-led `engine` / `rule` / `backend` / `pipeline` / `attack` grouping. Deprecation timeline now links the followup issues: #125 (hide in next release) and #126 (remove at v1.0).
- **Test reliability** (PRs #115, #123) - cli_daemon_http and cli_daemon_otlp E2E suites de-flaked on macOS under load; eval bloom test made deterministic against random AHash seeds.
- **Dependency and CI bumps.**

All command-name references inside the draft already use the new noun-led paths, so the next release ships with consistent terminology throughout the notes.

## Commits

- `ef9d169 docs(cli): migrate missed command references to noun-led paths` (11 files, +29 / -29)
- `02c444e docs: draft Unreleased release notes for next version` (1 file, +86 / -7)

## Test plan

- [x] `cargo test -p rsigma --features daemon --test cli_daemon --test cli_daemon_dynamic --test cli_daemon_http --test cli_deprecation` - 63 passed across 4 suites, 0 failed
- [x] `cargo clippy -p rsigma --all-features --all-targets -- -D warnings` - clean
- [x] `cargo fmt --all -- --check` - clean
- [x] YAML pipelines still parse (loaded as part of test runs)
- [x] CI workflow YAML syntax valid (no schema change, only command-text inside `run:` blocks)