### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to RSigma are documented in this file.
 Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
-## [0.12.0] - 2026-05-19
+## [0.12.0] - 2026-05-20
 
 **TL;DR**
 RSigma v0.12.0 is the "operability, performance, and documentation" release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 All notable changes to RSigma are documented in this file.
 Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
-## [Unreleased]
+## [0.12.0] - 2026-05-19
 
 **TL;DR**
-The next RSigma release is the "operations and load performance" release:
+RSigma v0.12.0 is the "operability, performance, and documentation" release:
 * Comprehensive daemon and CLI observability: tower-http API access logs, per-request OTLP tracing, batch processing spans, source resolution spans, DLQ visibility, NATS and sink lifecycle events, correlation state eviction warnings, rule load diagnostics, daemon lifecycle logs, and a global `--log-format` flag for non-daemon subcommands.
 * Eval rule loading is no longer O(N²): `Engine::add_rule` is amortized O(1), and bulk loaders (`Engine::add_rules`, `extend_compiled_rules`, `add_collection`) rebuild indexes exactly once per batch. The full 3,120-rule SigmaHQ corpus that previously appeared to hang now loads in ~120 ms.
 * CLI subcommands reorganized into five noun-led groups (`engine`, `rule`, `backend`, `pipeline`). Flat aliases continue to work as deprecated forwarders for one release.
+* Full documentation site live at <https://timescale.github.io/rsigma/>: 47 pages spanning Getting Started, User Guide, CLI Reference, Library API, Developers, Reference (including a 66-rule lint catalogue and a 27-metric Prometheus catalogue), Deployment, Editors, and Ecosystem. Built from `docs/` on every merge to `main` via the new `.github/workflows/docs.yml`.
 * Test reliability: `cli_daemon_http` and `cli_daemon_otlp` E2E suites are now flake-free on macOS under load.
 * Dependency bumps: opentelemetry-proto 0.31.0 to 0.32.0, async-nats 0.47 to 0.48, yamlpath/yamlpatch 1.25.2 (with the `serde_yaml` cargo rename replaced by `yaml_serde` directly), tokio 1.52.3, jsonschema 0.46.4, tower-http 0.6.10, tonic 0.14.6.
 
@@ -137,6 +138,33 @@ stdout is unchanged. Exit codes are unchanged. Every flag accepted by the old fo
 
 **Internal refactor.** The CLI dispatch layer is collapsed: each subcommand's clap arguments now live in `crates/rsigma-cli/src/commands/<name>.rs` as a `pub struct <Name>Args` deriving `clap::Args`, and the daemon's 35-field arg set + `cmd_daemon` body moved out of `main.rs` into a new `crates/rsigma-cli/src/commands/daemon.rs`. `main.rs` dropped from ~1360 lines to ~520 with no behavior change; the dispatch becomes a thin two-layer match (group -> leaf).
 
+### Documentation site (PR #129)
+
+A full documentation site now lives at <https://timescale.github.io/rsigma/>, built from `docs/` with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and deployed by `.github/workflows/docs.yml`. 47 pages were written from scratch or migrated out of the README sprawl, structured so a detection engineer can get from "what is rsigma" to a running daemon in five minutes and to backend conversion or correlation in fifteen.
+
+**Sections.**
+
+| Section | Pages | What it covers |
+|---------|-------|----------------|
+| Getting Started | 3 | Installation (cargo, Docker, signed binary archives), quick-start (first eval, first daemon, first convert in five minutes), core concepts (Sigma primer, rule kinds, eval-vs-daemon, noun-led CLI). |
+| User Guide | 11 | Evaluating rules, streaming detection, rule conversion, linting, processing pipelines (static + dynamic), input formats (incl EVTX), NATS streaming, OTLP integration with copy-paste recipes for Grafana Alloy / Vector / Fluent Bit / OTel Collector, CI/CD, performance tuning (matcher optimizer, bloom, cross-rule AC), observability (`--log-format`, `RUST_LOG` filter targets). |
+| CLI Reference | 13 | One page per grouped subcommand (`engine eval`, `engine daemon`, `rule parse/validate/lint/fields/condition/stdin`, `backend convert/targets/formats`, `pipeline resolve`) plus an overview with the migration table from the deprecated flat aliases. |
+| Library | 5 | Per-crate overviews of `rsigma-parser`, `rsigma-eval`, `rsigma-convert`, `rsigma-runtime`, each with a verified minimum working example and the public API surface that matters for embedders. |
+| Developers | 6 | Orientation, testing (the five-tier CI shape), fuzzing (all 15 cargo-fuzz harnesses), walkthroughs for adding a new backend, adding a new input format, and adding a new lint rule (the linter and LSP). |
+| Reference | 13 | 66-rule lint catalogue with worked examples for the trickier rules; PostgreSQL and LynxDB backend references; 27-metric Prometheus catalogue with verified labels; HTTP API; exit codes; environment variables; feature flags; custom attributes; builtin pipelines (`ecs_windows`, `sysmon`); dynamic-pipeline source spec; security hardening (input caps, resource limits, parser robustness, SQL injection prevention, network exposure, filesystem footprint, dependency policy); architecture diagram with the full crate map. |
+| Deployment | 1 | Docker deployment with all hardening flags verified end-to-end against a `rsigma:local` build, including cosign signature verification and SLSA Build L3 attestation lookup via `gh attestation`. |
+| Editors | 2 | VS Code / Cursor extension (wrapping `rsigma-lsp`); Neovim, Helix, Zed, Emacs `eglot`, and Sublime LSP wiring for the same server. |
+| Ecosystem | 1 | Helr companion page with a full docker-compose stack pairing Helr's HTTP-API log collection with the rsigma daemon over NATS. |
+| Top-level | 5 | Home (with a `Built with RSigma` section featuring [detection.studio](https://detection.studio/), a browser-based Sigma rule playground compiled from rsigma to WASM), Release Notes (mirrors this CHANGELOG), Contributing, Security Policy, Benchmarks (mirror of the root-level `BENCHMARKS.md`). |
+
+**Verification.** Every documented CLI flag, exit code, metric label, HTTP endpoint, environment variable, feature flag, and Docker hardening flag was checked against the live binary or the workspace source rather than transcribed from memory. The Docker page was tested end-to-end against a local `rsigma:local` build from `main` (compose stacks, bind-mount permissions, `--state-db` persistence, signature verification with cosign, SLSA attestation lookup via `gh attestation`).
+
+**CI.** `.github/workflows/docs.yml` has a `build` job that runs `mkdocs build --strict` on every PR touching `docs/`, `mkdocs.yml`, or `docs/requirements.txt`, and a `deploy` job that runs only on `main` and publishes via `actions/deploy-pages`. Every action is SHA-pinned with a version comment; top-level `permissions: {}` with least-privilege per-job overrides (`contents: read` for build, `pages: write` + `id-token: write` for deploy); `persist-credentials: false` on checkout; `concurrency` group with cancel-in-progress; `workflow_dispatch` for manual dry-runs. `zizmor --pedantic` reports zero findings.
+
+**One-time setup.** GitHub Pages source must be set to "GitHub Actions" under `Settings -> Pages`. The first push to `main` after the v0.12.0 release does the first deploy; subsequent docs-only changes redeploy automatically.
+
+**Deferred.** The Kubernetes deployment page is staged under `docs-drafts/` until the Helm Chart (#1a roadmap item) lands. The `attack` CLI subcommand group has a reserved enum but no docs yet; documentation will arrive with the MITRE ATT&CK contributor PR.
+
 ### Test reliability (PRs #115, #123)
 
 The `cli_daemon_http` and `cli_daemon_otlp` E2E suites are no longer flaky on macOS under load. Three real issues caused intermittent `ConnectionRefused`:
@@ -157,7 +185,7 @@ PR #123 also de-flaked an eval bloom test (`append_rule_matches_build_verdicts`)
 * **Architecture diagrams:** the ASCII diagram in `README.md` and the Mermaid diagram in `assets/architecture.mmd` were refreshed to reflect Dynamic Sigma Pipelines (v0.10.0), the matcher optimizer and prefilters (v0.11.0), DLQ as a sink target, broadened hot-reload over rules + pipelines, builtin pipelines (`ecs_windows`, `sysmon`), and the directory-style modules from the v0.9.0 modularization. A legend now explains feature-gated components (`*` for feature-gated and `**` for `daachorse-index`).
 * **README:** install and build instructions corrected; eval prefilters mentioned in the prose; fifth blog article and BlackNoise newsletter mention added.
 
-[v0.11.0...HEAD](https://github.com/timescale/rsigma/compare/v0.11.0...HEAD)
+[v0.11.0...v0.12.0](https://github.com/timescale/rsigma/compare/v0.11.0...v0.12.0)
 
 ## [0.11.0] - 2026-05-14
 
@@ -1194,6 +1222,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.12.0]: https://github.com/timescale/rsigma/releases/tag/v0.12.0
 [0.11.0]: https://github.com/timescale/rsigma/releases/tag/v0.11.0
 [0.10.0]: https://github.com/timescale/rsigma/releases/tag/v0.10.0
 [0.9.0]: https://github.com/timescale/rsigma/releases/tag/v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1065,7 +1065,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1245,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2172,7 +2172,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2616,7 +2616,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3875,7 +3875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3934,7 +3934,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4371,7 +4371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4566,7 +4566,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5515,7 +5515,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "async-nats",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "insta",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "globset",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -20,10 +20,10 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.11.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.11.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.11.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.12.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.12.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.12.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.11.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.12.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.11.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.12.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -19,8 +19,8 @@ evtx = ["dep:evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.11.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.11.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.12.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -1,14 +1,15 @@
 # Testing
 
-The workspace runs five tiers of tests, all gated in CI. PRs are expected to pass every tier.
+The workspace runs six tiers of tests, all gated in CI. PRs are expected to pass every tier.
 
 ## At a glance
 
 | Tier | Where it lives | How to run | Gated by |
 |------|----------------|------------|----------|
 | Unit | `src/` modules with `#[cfg(test)] mod tests` | `cargo test --workspace --all-features --locked` | `test` job on Linux, macOS, Windows. |
-| Integration | `crates/<crate>/tests/*.rs` | Same. | Same. |
-| Snapshot / golden | `crates/rsigma-eval/tests/state_snapshot.rs`, `tests/fixtures/dynamic-pipelines/golden/` | `cargo test` plus the SigmaHQ-corpus job for the dynamic-pipelines goldens. | `test` and `sigma-corpus` jobs. |
+| Integration (in-process) | `crates/{rsigma-parser,rsigma-eval,rsigma-convert,rsigma-runtime}/tests/*.rs` | Same. | Same. |
+| End-to-end (binary + containers) | `crates/rsigma-cli/tests/cli_*.rs`, `crates/rsigma-runtime/tests/nats_e2e.rs`, `crates/rsigma-convert/tests/postgres_integration.rs` | Same; testcontainers-based tests skip when Docker is unavailable. | Same. |
+| Snapshot / golden | `crates/rsigma-{parser,eval,convert}/tests/snapshots/`, `tests/fixtures/dynamic-pipelines/golden/` | `cargo test` plus the SigmaHQ-corpus job for the dynamic-pipelines goldens. | `test` and `sigma-corpus` jobs. |
 | SigmaHQ corpus | `.github/workflows/ci.yml` -> `sigma-corpus` | `cargo build --release --all-features --locked -p rsigma` then `target/release/rsigma rule validate /tmp/sigma/rules/ --verbose` | `sigma-corpus` job, on every PR. |
 | Coverage | `cargo-llvm-cov` (Linux) | `cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info` | `coverage` job (advisory, not gating). |
 
@@ -31,19 +32,77 @@ mod tests {
 
 Bias toward unit tests for pure-functional logic (parsers, matchers, formatters). Bias toward integration tests for end-to-end shapes (CLI invocations, daemon HTTP round-trips, dynamic source resolution).
 
-## Integration tests
+## Integration tests (in-process)
 
-| Crate | File(s) | What they cover |
-|-------|---------|-----------------|
-| `rsigma-parser` | `tests/*.rs` (2 files) | Multi-document parsing, malformed YAML, directory parsing. |
-| `rsigma-eval` | `tests/integration.rs`, `correlation_edge.rs`, `error_paths.rs`, `pipeline_errors.rs`, `regression_eval.rs`, `state_snapshot.rs` (and a shared `helpers/`) | Full rule-eval pipelines, correlation edge cases, snapshot replay, pipeline error semantics. |
-| `rsigma-convert` | `tests/*.rs` (3 files) | Backend output for each `--format` (`default`, `view`, `timescaledb`, …). |
-| `rsigma-runtime` | `tests/integration.rs`, `nats_integration.rs`, `evtx_integration.rs`, `nats_e2e.rs`, `sources_integration.rs` | Streaming runtime, NATS round-trips (gated on a local NATS server in CI), EVTX file parsing, dynamic source resolution. |
-| `rsigma-cli` | `tests/cli_*.rs` (13 files) | The full CLI surface: `convert`, `daemon` (stdin / HTTP / NATS / OTLP / dynamic sources), `eval`, `lint`, `parse`, `validate`, `fields`, deprecation warnings. |
+These tests link directly against the crate as a library and exercise multi-component flows without spawning the compiled binary.
+
+| Crate | Files | Tests | What they cover |
+|-------|-------|------:|-----------------|
+| `rsigma-parser` | `ast_snapshots.rs`, `parse_errors.rs` (+ `snapshots/` for `insta`) | ~30 | Multi-document parsing, malformed YAML, directory parsing; insta-locked AST snapshots. |
+| `rsigma-eval` | `integration.rs`, `correlation_edge.rs`, `error_paths.rs`, `pipeline_errors.rs`, `regression_eval.rs`, `state_snapshot.rs` (+ shared `helpers/`) | ~56 | Full rule-eval pipelines, correlation edge cases, snapshot replay, pipeline error semantics. |
+| `rsigma-convert` | `golden_postgres.rs`, `golden_lynxdb.rs` (+ `golden/` for committed expected outputs) | (golden) | Backend query generation for every `--format` (`default`, `view`, `timescaledb`, `continuous_aggregate`, `sliding_window`, `minimal`). |
+| `rsigma-runtime` | `integration.rs`, `evtx_integration.rs`, `sources_integration.rs` (the `nats_*.rs` files live in the E2E section below) | ~40 | Streaming runtime; EVTX file parsing against the committed `security.evtx` fixture; dynamic source resolution (HTTP, file, command, in-process mocks) with TTL, refresh, and template expansion. |
 
 Helpers (test rule fixtures, common test pipelines) live in `crates/<crate>/tests/helpers/mod.rs` or `crates/<crate>/tests/common/mod.rs`. Reuse them; do not duplicate.
 
 Do not duplicate unit-level assertions in integration tests. Integration tests own the boundaries, the multi-component chains, and the error paths.
+
+## End-to-end tests
+
+E2E tests cross the binary boundary or stand up real external services through containers. They are the highest-confidence layer and the longest to run.
+
+### CLI E2E (`crates/rsigma-cli/tests/cli_*.rs`)
+
+The 12 `cli_*.rs` files contain **167 tests** that invoke the freshly built `rsigma` binary via [`assert_cmd`](https://docs.rs/assert_cmd). They exercise stdin, stdout, stderr, exit codes, and (for the daemon tests) the full HTTP, NATS, and OTLP wire surface.
+
+| File | Tests | What it covers |
+|------|------:|----------------|
+| `cli_convert.rs` | 14 | `backend convert` against every shipped backend and output format. |
+| `cli_daemon.rs` | 20 | Long-running daemon (stdin input), hot-reload, health, shutdown. |
+| `cli_daemon_dynamic.rs` | 16 | Dynamic-pipeline source resolution end-to-end via the daemon's `POST /api/v1/sources/resolve`. |
+| `cli_daemon_http.rs` | 10 | HTTP input mode, `POST /api/v1/events`, OTLP HTTP. |
+| `cli_daemon_nats.rs` | 8 | NATS input + sink over an in-process NATS server. |
+| `cli_daemon_otlp.rs` | 9 | OTLP HTTP and gRPC ingest, with the metric-label assertions added in PR #115. |
+| `cli_deprecation.rs` | 17 | Every deprecated flat alias still works and prints the correct stderr migration warning. |
+| `cli_eval.rs` | 32 | `engine eval`: inline events, `@file`, stdin, `jq` / JSONPath, fail-on-detection, exit codes. |
+| `cli_fields.rs` | 16 | `rule fields` extraction across detection items, correlation, filters; `--no-filters`, `--json`. |
+| `cli_lint.rs` | 21 | `rule lint`, `.rsigma-lint.yml`, `# rsigma-disable` suppressions, `--fix`. |
+| `cli_parse.rs` | 8 | `rule parse` exit-code and structured-error contract. |
+| `cli_validate.rs` | 4 | `rule validate` against good and bad rule sets. |
+
+The shared harness in `crates/rsigma-cli/tests/common/mod.rs` is the canonical reference for spawning a long-running daemon under test: it drains stdout in a background thread to prevent pipe stalls, forwards stderr lines via `mpsc`, probes the actual TCP socket with `TcpStream::connect_timeout` before returning a handle, and wraps the `Child` in a `ChildGuard` RAII type that kills it on drop. PR #115 hardened this against macOS-under-load flakes by replacing every `std::thread::sleep` wait with a `poll_until` retry loop that polls the actual observable condition (HTTP status, metric counter) every 50 ms up to a 5 s deadline. Use it for any new daemon-level test; do not roll your own.
+
+### Container E2E (NATS and Postgres via testcontainers)
+
+Four files spin up real services in Docker containers via [`testcontainers`](https://docs.rs/testcontainers). Together they cover **29 tests**, all guarded by a `can_run_linux_containers()` probe that shells out to `docker info` and checks that the daemon reports a Linux OS type. If Docker is missing or only provides Windows containers, the tests print "Skipping" and return successfully.
+
+| File | Tests | Container | What it covers |
+|------|------:|-----------|----------------|
+| `crates/rsigma-runtime/tests/nats_e2e.rs` | 6 | NATS JetStream | Replay-from-offset, replay-from-timestamp, JetStream-based DLQ, consumer groups (the highest-rigor NATS surface). |
+| `crates/rsigma-runtime/tests/nats_integration.rs` | 7 | NATS JetStream | Connection auth (token, NKey, JWT), TLS round-trips, ack semantics, source / sink fan-out. |
+| `crates/rsigma-cli/tests/cli_daemon_nats.rs` | 8 | NATS JetStream | The full `rsigma engine daemon --input nats ...` shape: spawn the binary, point it at the container, assert against published detection matches. |
+| `crates/rsigma-convert/tests/postgres_integration.rs` | 8 | PostgreSQL | Convert real Sigma rules to SQL with `convert_collection`, execute the generated queries against a live PostgreSQL container, assert match counts against the Okta cross-tenant impersonation chain from [the detection-layer-on-postgres companion project](https://github.com/mostafa/detection-layer-on-postgres). This is the only place where the documented PostgreSQL backend output formats (`default`, `view`, `timescaledb`, `continuous_aggregate`, `sliding_window`) are tested *as SQL the database actually accepts*, rather than just as text matching a golden file. |
+
+The `skip_without_docker!()` macro pattern is identical in all four:
+
+```rust
+macro_rules! skip_without_docker {
+    () => {
+        if !can_run_linux_containers() {
+            eprintln!("Skipping: Docker with Linux container support is not available");
+            return;
+        }
+    };
+}
+```
+
+Use the same `skip_without_docker!()` pattern for any new test that requires an external service via testcontainers. CI runs these on the Linux matrix entry; macOS and Windows entries skip them.
+
+### What "e2e" means here
+
+- **Goal**: cross every internal boundary the binary has, so a regression in the dispatch / IO / metric / exit-code surface fails CI rather than escaping to a user.
+- **Scope**: the compiled binary; the HTTP API; NATS JetStream wiring (via testcontainers, 21 tests across three files); the OTLP HTTP and gRPC handlers; and the PostgreSQL backend's generated SQL (via testcontainers, 8 tests).
+- **Out of scope (today)**: LynxDB, Splunk, Elastic, and KQL backends only have golden-text coverage, not live-query e2e. The Kubernetes deployment path has no e2e coverage yet (covered by the [Helm Chart roadmap item](https://github.com/timescale/rsigma/issues) when it lands).
 
 ## Golden tests
 
@@ -129,7 +188,8 @@ Benchmarks are not gated in CI. The numbers in [Benchmarks](../benchmarks.md) co
 
 - **Run only the failing test first.** `cargo test -p rsigma-runtime nats_e2e::test_replay_from_offset -- --nocapture` is much faster than `--workspace`.
 - **Run feature-gated tests once with the feature off.** A `#[cfg(feature = "nats")] fn test_x()` is silently skipped if you forget; CI catches that. Locally, `cargo test --no-default-features -p rsigma-runtime` is a useful smoke test.
-- **NATS / OTLP integration tests** spawn a local server in-process; they do not need external infrastructure.
-- **CLI tests use `assert_cmd`.** They invoke the compiled `rsigma` binary, so first time they run is slow because they trigger a full build.
+- **In-process NATS and OTLP** servers are spawned by the integration tests in `crates/rsigma-runtime/tests/nats_integration.rs` and `crates/rsigma-cli/tests/cli_daemon_otlp.rs`; they do not need external infrastructure.
+- **Container-backed NATS e2e** in `crates/rsigma-runtime/tests/nats_e2e.rs` needs Docker. On a Mac, `colima start` or Docker Desktop is the easiest local setup.
+- **CLI tests use `assert_cmd`.** They invoke the compiled `rsigma` binary, so the first run is slow because it triggers a full build. Subsequent runs reuse the cache.
 
 See also: [Fuzzing](fuzzing.md), [Benchmarks](../benchmarks.md), [Contributing](../contributing.md).

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -183,7 +183,7 @@ A correlation that fires produces a `CorrelationResult`:
 }
 ```
 
-Both types are stable JSON suitable for downstream consumers (Loki, Slack webhooks, SOAR playbooks, Fenrir response engines, custom alerting). The [output formats reference](../reference/http-api.md#output-payloads) defines every field.
+Both types are stable JSON suitable for downstream consumers (Loki, Slack webhooks, SOAR playbooks, Fenrir response engines, custom alerting). The [HTTP API reference](../reference/http-api.md) shows the response shape for every endpoint that emits these payloads.
 
 ## Where to go next
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -238,7 +238,7 @@ From here, pick the path that matches your work:
 
 - **Detection engineers**: [linting rules](../guide/linting-rules.md), [CI/CD](../guide/ci-cd.md), [processing pipelines](../guide/processing-pipelines.md).
 - **Platform engineers**: [streaming detection](../guide/streaming-detection.md), [NATS](../guide/nats-streaming.md), [OTLP integration](../guide/otlp-integration.md).
-- **Threat hunters**: [evaluating rules](../guide/evaluating-rules.md), [input formats](../guide/input-formats.md), [EVTX files](../guide/input-formats.md#evtx-windows-event-log).
+- **Threat hunters**: [evaluating rules](../guide/evaluating-rules.md), [input formats](../guide/input-formats.md), [EVTX files](../guide/input-formats.md#evtx-windows-event-log-feature-gated).
 - **Library users**: [embedding the crates](../library/index.md).
 
-If anything in this quick start did not work, check the [troubleshooting tips](../guide/observability.md#troubleshooting) or [open an issue](https://{{ rsigma.repo_url | replace("https://", "") }}/issues).
+If anything in this quick start did not work, run the [quick-verification checklist](../guide/observability.md#quick-verification) (log filter targets, `/healthz` / `/readyz`, `/metrics` smoke check) or [open an issue](https://{{ rsigma.repo_url | replace("https://", "") }}/issues).

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -128,5 +128,5 @@ groups:
 
 - [Observability](../guide/observability.md) for the broader observability story, including the `tracing` event targets that complement these metrics.
 - [Performance Tuning](../guide/performance-tuning.md) for which metric to watch when sizing `--buffer-size`, `--batch-size`, or correlation `max_state_entries`.
-- [Streaming Detection](../guide/streaming-detection.md#prometheus-and-the-http-api) for how the `/metrics` endpoint fits into the broader daemon API.
+- [Streaming Detection](../guide/streaming-detection.md#http-api) for how the `/metrics` endpoint fits into the broader daemon API.
 - [`daemon/metrics` source](https://github.com/timescale/rsigma/blob/main/crates/rsigma-cli/src/daemon/metrics.rs) for the registry implementation.


### PR DESCRIPTION
Cuts RSigma v0.12.0. After this PR merges, create a GitHub Release with tag `v0.12.0` against `main` and paste the v0.12.0 section of [`CHANGELOG.md`](https://github.com/timescale/rsigma/blob/chore/release-v0.12.0/CHANGELOG.md) as the body. That tag fires `publish.yml` (crates.io), `release-binaries.yml` (six target archives), and `docker.yml` (multi-arch GHCR image).

## What changed

- Workspace `version = "0.11.0"` → `"0.12.0"` in `Cargo.toml`.
- All 10 inter-crate dep pins refreshed in the five member manifests that pin a version (`rsigma-eval`, `rsigma-convert`, `rsigma-runtime`, `rsigma-cli`, `rsigma-lsp`). `rsigma-parser` has no rsigma deps. `fuzz/Cargo.toml` uses `path`-only deps and does not need a bump.
- `Cargo.lock` regenerated with `cargo check --workspace --all-features --locked` so the lockfile is reproducible from CI.
- `CHANGELOG.md` `[Unreleased]` flipped to `[0.12.0] - 2026-05-19`; the comparison link at the bottom of the section moved from `v0.11.0...HEAD` to `v0.11.0...v0.12.0`; a `[0.12.0]: …/releases/tag/v0.12.0` tag-reference line was added to the bottom-of-file link block alongside the existing entries for 0.11.0 → 0.1.0.
- The CHANGELOG also gained a new `### Documentation site (PR #129)` section under the existing TL;DR sections, and the release theme moved from "operations and load performance" to "operability, performance, and documentation" to reflect the new docs site as a top-line deliverable.
- Security advisory fix: `cargo audit` flagged `RUSTSEC-2026-0145` (PAX header desync in `astral-tokio-tar 0.6.1`, published 2026-05-18) on the first CI run. A targeted `cargo update -p astral-tokio-tar` bumps the lockfile to 0.6.2 in isolation; no other crate moved. The crate is a transitive dev-dep via `testcontainers 0.27.3` so production builds were unaffected, but `cargo audit` gates the release pipeline. `cargo check --workspace --all-features --locked` clean afterwards.
- E2E tests documented: `docs/developers/testing.md` was missing an end-to-end test tier. The page now calls out 167 binary-spawning CLI tests via `assert_cmd` (12 `cli_*.rs` files with the shared `DaemonProcess` harness from PR #115), plus 29 testcontainers-backed tests (NATS in three files: 6+7+8; Postgres: 8). The "Integration tests" table was corrected accordingly (`nats_integration.rs` and `cli_daemon_nats.rs` use containers, so they moved to the e2e section). Added the `skip_without_docker!()` macro pattern and an explicit "What 'e2e' means here" callout (PostgreSQL has live-SQL coverage; LynxDB / Splunk / Elastic / KQL only have golden-text).
- Anchor fixes: Four `INFO`-level anchor warnings in the strict mkdocs build are gone: `concepts.md` no longer points at the never-written `http-api.md#output-payloads`; `quick-start.md` uses the correct `#evtx-windows-event-log-feature-gated` slug and now redirects "troubleshooting" to `observability.md#quick-verification`; `metrics.md` retargets to `streaming-detection.md#http-api`. `mkdocs build --strict` now reports zero warnings.

## Release scope

All 13 PRs merged since v0.11.0 (2026-05-14):

| Section | PRs |
|---------|-----|
| Daemon and CLI observability | #107 |
| Eval rule loading performance | #119, #121, #122, #123 |
| CLI command groups | #124, with doc followups in #127 |
| Documentation site | #129 |
| Test reliability | #115, #123 |
| Dependencies and CI | #111, #113, #114, #120 |

## Verification before merging

- [x] `cargo check --workspace --all-features --locked` clean (run locally on this branch).
- [x] `cargo audit` clean (one RustSec finding fixed in 4ec55f3; surviving `encoding` unmaintained warning is already on the `deny.toml` allowlist via `RUSTSEC-2021-0153`).
- [x] `mkdocs build --strict` clean (anchor fixes in 2f1046b).
- [x] Reviewer checks the CHANGELOG section reads cleanly end-to-end.
- [x] CI passes across the full matrix (Check, Clippy, Format, MSRV, Test ubuntu/macos/windows, Coverage, Sigma Corpus Regression, Build docs, cargo audit, cargo deny, zizmor).

## After merge

1. Create a GitHub Release with tag `v0.12.0` against `main`. Title `v0.12.0`. Body = the v0.12.0 section of `CHANGELOG.md` verbatim.
2. Watch `publish.yml` step through the six crates on crates.io with the 30-second waits.
3. Watch `release-binaries.yml` upload six archives (linux/macos/windows × amd64/arm64).
4. Watch `docker.yml` push `ghcr.io/timescale/rsigma:0.12.0` and `:latest` and verify the cosign signature plus SLSA Build L3 attestation are queryable.
5. Verify `https://timescale.github.io/rsigma/release-notes/` reflects the new entry once the next `docs.yml` deploy runs.