### PR TITLE
docs: post-v0.12.0 cleanup (version refs, perf docs, lint count)

### DIFF
--- a/crates/rsigma-parser/README.md
+++ b/crates/rsigma-parser/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/rsigma/actions/workflows/ci.yml)
 
-`rsigma-parser` is a parser for [Sigma](https://github.com/SigmaHQ/sigma) detection rules, correlations, and filters. It parses Sigma YAML into a strongly-typed AST covering the full Sigma 2.0 specification, and includes a 65-rule linter derived from the Sigma v2.1.0 spec.
+`rsigma-parser` is a parser for [Sigma](https://github.com/SigmaHQ/sigma) detection rules, correlations, and filters. It parses Sigma YAML into a strongly-typed AST covering the full Sigma 2.0 specification, and includes a 66-rule linter derived from the Sigma v2.1.0 spec.
 
 This library is part of [rsigma].
 

--- a/docs/_data/vars.yml
+++ b/docs/_data/vars.yml
@@ -1,7 +1,7 @@
 # Variables exposed to MkDocs pages via mkdocs-macros-plugin.
 # Update these in lockstep with the workspace Cargo.toml on release.
 rsigma:
-  version: "0.11.0"
+  version: "0.12.0"
   msrv: "1.88.0"
   edition: "2024"
   license: "MIT"

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -7,7 +7,7 @@
 | Property | Value |
 |----------|-------|
 | Registry | `ghcr.io/timescale/rsigma` |
-| Tags | `latest`, `v0.11.0`, ... (every release) |
+| Tags | `latest`, `v0.12.0`, `v0.11.0`, ... (every release) |
 | Architectures | `linux/amd64`, `linux/arm64` |
 | Base image | `FROM scratch` (no shell, no package manager) |
 | User | `65534:65534` (`nobody:nogroup`) |
@@ -34,13 +34,13 @@ docker run --rm -v "$PWD/rules:/rules:ro" \
 Production deployments should pin to a specific version, not `latest`:
 
 ```bash
-docker run --rm ghcr.io/timescale/rsigma:0.11.0 --version
+docker run --rm ghcr.io/timescale/rsigma:0.12.0 --version
 ```
 
 For full immutability, pin by image digest. Pull `inspect` to find the digest, then reference it directly:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/timescale/rsigma:0.11.0
+docker buildx imagetools inspect ghcr.io/timescale/rsigma:0.12.0
 # Note the Digest line, then:
 docker run --rm ghcr.io/timescale/rsigma@sha256:<digest> --version
 ```
@@ -117,7 +117,7 @@ A self-contained compose file for the streaming daemon with file-based persisten
 ```yaml
 services:
   rsigma:
-    image: ghcr.io/timescale/rsigma:0.11.0
+    image: ghcr.io/timescale/rsigma:0.12.0
     read_only: true
     cap_drop:
       - ALL
@@ -167,7 +167,7 @@ docker run --rm \
     -e NATS_CREDS_FILE=/etc/rsigma/nats.creds \
     -v "$PWD/rules:/rules:ro" \
     -v "$PWD/nats.creds:/etc/rsigma/nats.creds:ro" \
-    ghcr.io/timescale/rsigma:0.11.0 \
+    ghcr.io/timescale/rsigma:0.12.0 \
     engine daemon -r /rules/ \
     --input "nats://nats.internal:4222/events.>" \
     --nats-creds /etc/rsigma/nats.creds

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -39,7 +39,7 @@ For the runtime data flow and how the crates talk to each other, see [Architectu
 ## Conventions
 
 - **Single workspace version.** Every crate bumps together. Do not bump individually; the release pipeline expects a single `vX.Y.Z` tag.
-- **Edition 2024.** Rust 1.85+; MSRV is enforced by the `msrv` CI job.
+- **Edition 2024.** MSRV is `{{ rsigma.msrv }}` (the workspace's `rust-version` in `Cargo.toml`), enforced by the `msrv` CI job. Edition 2024 itself compiles on Rust 1.85+, but features and tests are written against the MSRV.
 - **No warnings.** `RUSTFLAGS=-Dwarnings` is set globally in CI.
 - **`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings`** must pass.
 - **All features for testing.** CI runs `cargo test --workspace --all-features --locked`; if your change is feature-gated, make sure the gate works in isolation too.

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -109,7 +109,7 @@ on:
 permissions: {}
 
 env:
-  RSIGMA_VERSION: "0.11.0"
+  RSIGMA_VERSION: "0.12.0"
 
 jobs:
   lint:
@@ -194,7 +194,7 @@ For a faster CI loop, install from the precompiled archives instead of `cargo in
 stages: [check, eval, build]
 
 variables:
-  RSIGMA_VERSION: "0.11.0"
+  RSIGMA_VERSION: "0.12.0"
 
 default:
   image: debian:bookworm-slim
@@ -305,7 +305,7 @@ done
 ## Tips and gotchas
 
 - **Cache the rsigma binary** between CI runs. The `cargo install` form compiles rsigma from source and typically takes several minutes on a GitHub-hosted runner; the precompiled archive download completes in under 5 seconds. The release page ships archives for `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, and `aarch64-pc-windows-msvc`.
-- **Pin the rsigma version** in CI. Detection-as-code repos test specific behaviour; a silent rsigma upgrade can flip a previously-fixed bug. Use `cargo install --locked rsigma --version 0.11.0` or pin the precompiled archive URL.
+- **Pin the rsigma version** in CI. Detection-as-code repos test specific behaviour; a silent rsigma upgrade can flip a previously-fixed bug. Use `cargo install --locked rsigma --version 0.12.0` or pin the precompiled archive URL.
 - **Separate lint and validate jobs**. They fail for different reasons. A combined job hides which check broke.
 - **Avoid `set +e` around rsigma**. Structured exit codes are the API. Wrapping commands in `|| true` or `set +e` defeats the whole model.
 - **JSON output for diagnostic logs**. Pass `--log-format json` so CI log aggregators (Datadog CI Visibility, Buildkite test analytics) can parse run metadata without regex. Stdout/stderr are unchanged; only structured diagnostic logs flip to JSON. See [Observability](observability.md).

--- a/docs/guide/performance-tuning.md
+++ b/docs/guide/performance-tuning.md
@@ -18,6 +18,32 @@ Threshold choices come from a Criterion sweep documented in the [Benchmarks](../
 
 Because the optimizer is part of compilation, a rule reload picks up any new pattern groupings automatically.
 
+## Rule loading at scale
+
+Loading a large rule corpus is no longer the bottleneck it was in v0.11.x. As of v0.12.0, `Engine::add_rule` and `Engine::add_compiled_rule` are amortized O(1) per call, and the bulk loaders (`Engine::add_rules`, `Engine::extend_compiled_rules`, `Engine::add_collection`) rebuild the inverted index and the per-field bloom filter exactly once per batch instead of once per rule.
+
+| Loader | Single-rule cost | Batched cost | When you use it |
+|--------|------------------|--------------|-----------------|
+| `Engine::add_rule(rule)` | Amortized O(1) | n/a | Streaming rule ingestion (e.g. a control-plane that adds one rule at a time). |
+| `Engine::add_compiled_rule(rule)` | Amortized O(1) | n/a | Same, but for pre-compiled rules. |
+| `Engine::add_rules(iter)` | n/a | One index rebuild at the end | Library callers loading a batch with per-rule compile-error tolerance. |
+| `Engine::add_collection(collection)` | n/a | One index rebuild at the end | `rsigma engine eval` and `rsigma engine daemon`'s rule load. |
+| `Engine::extend_compiled_rules(iter)` | n/a | One index rebuild at the end | Hot-reload of a fully pre-compiled snapshot. |
+
+Concrete numbers from the `rule_load` Criterion group on an Apple M4 Pro (release build):
+
+| Rules   | `add_collection` | `add_rules` | `add_rule` loop |
+|--------:|-----------------:|------------:|----------------:|
+| 1,000   |          1.15 ms |     1.17 ms |         1.64 ms |
+| 10,000  |         11.82 ms |    11.85 ms |        17.23 ms |
+| 100,000 |        121.65 ms |   122.13 ms |       166.07 ms |
+
+Reproduce with `cargo bench -p rsigma-eval --bench eval -- rule_load`. The full SigmaHQ corpus (~3,120 rules) loads in ~120 ms.
+
+**How the bloom rebuild is amortized.** The per-field bloom uses a doubling watermark with a 64-rule floor. A full bloom rebuild only fires when the rule count has at least doubled past the last rebuild, capping false-positive-rate drift while keeping the amortized per-rule cost flat. Rules that introduce a brand-new indexed field get a fresh bloom on the fly. The differential test `append_rule_matches_build_verdicts` pins the property that incremental and batched indexes accept the same haystacks (with the documented MaybeMatch tolerance between rebuilds).
+
+**Caveat: the cross-rule Aho-Corasick index falls back to a full rebuild on `add_rule`.** The daachorse automaton has no incremental update story, so if you enable `--cross-rule-ac` and then call `add_rule` in a loop, each call rebuilds the cross-rule AC. The batched loaders (`add_collection`, `add_rules`, `extend_compiled_rules`) keep the single-rebuild-at-end fast path. For very large rule sets with cross-rule AC on, always batch.
+
 ## Bloom pre-filter for substring-heavy rule sets
 
 The bloom pre-filter is the right knob when:

--- a/docs/library/eval.md
+++ b/docs/library/eval.md
@@ -140,6 +140,8 @@ Pipeline transformations can write `rsigma.*` attributes that the engine consume
 | `Engine::set_cross_rule_ac(bool)` | Toggle the cross-rule Aho-Corasick pre-filter. Requires the `daachorse-index` feature. Pays off only on very large pure-substring rule sets. |
 | `Engine::evaluate_batch(&[events])` (with `parallel`) | Batch evaluation. With the `parallel` feature, rayon parallelizes across events internally. |
 
+`Engine::add_rule` and `add_compiled_rule` are amortized O(1) per call (v0.12.0+), so a control-plane that ingests rules one at a time no longer pays an O(N) cost on every push. The bulk loaders (`add_rules`, `extend_compiled_rules`, `add_collection`) rebuild indexes exactly once per batch. If you enable `set_cross_rule_ac(true)`, prefer the bulk loaders since the daachorse automaton has no incremental update.
+
 Decision matrix in [Performance Tuning](../guide/performance-tuning.md). Verified Criterion numbers in [Benchmarks](../benchmarks.md).
 
 ## Error handling


### PR DESCRIPTION
Three thematic post-v0.12.0 cleanups, all small.

## Version references

Bumps the three places that hard-code an rsigma version, now that the v0.12.0 tag and the GHCR image exist:

- `docs/_data/vars.yml`: `rsigma.version` macro `0.11.0` -> `0.12.0`.
- `docs/guide/ci-cd.md`: `RSIGMA_VERSION` in GitHub Actions and GitLab CI examples + the pin-your-version tip.
- `docs/deployment/docker.md`: four `ghcr.io/timescale/rsigma:0.11.0` snippets bumped to `0.12.0`; the Tags table row now lists both v0.12.0 and v0.11.0.

## Rule-loading perf documentation

The CHANGELOG calls out amortized O(1) `Engine::add_rule` and single-rebuild batched loaders as a top-line v0.12.0 deliverable; no user-facing guide page mentioned it. Adds:

- A `## Rule loading at scale` section to `docs/guide/performance-tuning.md` with the five-loader table, verified Criterion numbers at 1K/10K/100K rules, the doubling-watermark bloom explanation, and the cross-rule-AC caveat.
- A short paragraph in `docs/library/eval.md` for embedders driving `add_rule` directly.
- Fixes a small MSRV-statement drift in `docs/developers/index.md` (was "Rust 1.85+" conflating edition 2024's compiler floor with the workspace MSRV 1.88.0; now uses the `{{ rsigma.msrv }}` macro).

## Parser README lint count

Pre-existing v0.11.0 drift: the rsigma-parser README's intro paragraph said "65-rule linter" while the rest of the same file (and the LSP README, and the lint-rules reference) already said 66. Caught during the post-release audit; flipped to 66.

## Verification

- `mkdocs build --strict` clean.
- `rg -n '0\.11\.0' docs/` returns only the intentional historical-tag-list line in `docs/deployment/docker.md`.
- `rg -n '65 rules\|65-rule' crates/*/README.md` returns nothing.