### PR TITLE
feat(enrichment): post-evaluation enrichment pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ editors/vscode/*.vsix
 
 # MkDocs build output
 /site/
+/docs/.venv/
+/docs/__pycache__/
 
 # Secrets and credentials
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Post-evaluation enrichment (#134)
+
+The daemon now runs a configurable enrichment pipeline between `engine.evaluate()` and the sinks. Each detection or correlation gets context (asset owner, IP reputation, identity, GeoIP, KEV flag, runbook URL, ...) injected into its `RuleHeader::enrichments` map before serialization, so every downstream consumer sees the same structured data without re-fetching it.
+
+**New flag.** `rsigma engine daemon --enrichers <PATH>` points at a YAML file with `max_concurrent_enrichments: <N>` (default `16`) plus a list of enricher entries. The file is hot-reloaded on `SIGHUP`, file-watcher events, and `POST /api/v1/reload`; a reload that fails validation logs the error and keeps the previous pipeline active, so a typo never silently degrades production to "no enrichment".
+
+**Four primitives.** Every entry declares a `type:` from a fixed set, modeled on what Splunk (`lookup` + `rest`), Cribl Stream (`Lookup` + `HTTP` + `Code` + `Eval`), and Vector (`enrichment_tables` + `remap`) all converged on:
+
+| `type` | Surface |
+|--------|---------|
+| `template` | Pure string interpolation. No I/O. Used for runbook URLs and synthetic identifiers. |
+| `lookup` | Reads a dynamic source (as declared today via pipeline `sources:`) from the existing `Arc<SourceCache>` by `source_id`, with an optional jq / JSONPath / CEL `extract` to slice the cached value and an optional `default` for cache miss or no extract match. Zero-network-cost. |
+| `http` | Per-result `reqwest` request with template-expanded URL, headers, and optional body. Optional response cache keyed on `(method, url, body_hash)` with configurable TTL is mandatory in practice for any rate-limited API. |
+| `command` | Per-result `tokio::process::Command` invocation with template-expanded argv and environment. Stdout capped at 10 MiB; output parsed as JSON (default) or raw string. |
+
+The IRQL-style catalog (`enrich_ip_employee`, `enrich_ip_geoip`, `enrich_hash_virustotal`, `enrich_cve_kev`, `enrich_url_runbook`, `enrich_ip_passive_dns`) ships as field-parametric YAML recipes in `docs/guide/enrichers.md`, not Rust code. External crates that need a Rust-coded named enricher (bundled data, complex parser, stable contract, non-obvious algorithm) register one via the public `register_builtin(name, factory)` API.
+
+**Strict kind separation.** Every enricher declares `kind: detection | correlation`. The kind drives two checks. At config load time, a `kind: detection` enricher may only reference `${detection.*}` template variables and a `kind: correlation` enricher may only reference `${correlation.*}`; cross-namespace references are rejected with a clear error pointing at the offending field. At runtime, the pipeline skips enrichers whose declared kind does not match the current `EvaluationResult` body variant before invoking `enrich()`, so a detection-kind enricher pays no cost on correlation results and vice versa. Available variables are documented in the Kind and template namespaces section of `docs/guide/enrichers.md`.
+
+**`scope` filtering and `on_error` policies.** Within its declared kind, an enricher can be limited via `scope.rules` (rule ID or title glob), `scope.tags` (tag-set intersection with `prefix.*` wildcards), and `scope.levels` (severity membership). Axes are AND-ed; an empty axis is not a filter. On failure, `on_error` selects between `skip` (drop the enrichment, keep the result), `null` (inject `null`), and `drop` (drop the entire result). The default is `skip`, so an enrichment outage never silently swallows detections.
+
+**Six new Prometheus metrics.** All six are pre-registered at startup, so every label triple renders with `# HELP` and `# TYPE` lines and zero counts on the first scrape, before any event has fired:
+
+| Metric | Labels |
+|--------|--------|
+| `rsigma_enrichment_total` | `enricher_id`, `kind`, `status` (`success`/`skip`/`error`/`timeout`/`drop`) |
+| `rsigma_enrichment_duration_seconds` | `enricher_id`, `kind` |
+| `rsigma_enrichment_queue_depth` | -- |
+| `rsigma_enrichment_http_cache_hits_total` | `enricher_id` |
+| `rsigma_enrichment_http_cache_misses_total` | `enricher_id` |
+| `rsigma_enrichment_http_cache_expirations_total` | `enricher_id` |
+
+Filtered (kind- or scope-mismatched) enricher calls do not increment any counter, so cardinality stays bounded by the number of configured enrichers.
+
+**Library API.** `rsigma-runtime` exports the `Enricher` async trait, `EnrichmentPipeline`, `EnricherKind`, `OnError`, `Scope`, the four primitive types (`TemplateEnricher`, `LookupEnricher`, `HttpEnricher`, `CommandEnricher`), `HttpEnricherClient`, `HttpResponseCache`, `OutputFormat`, the `MetricsHook` trait, and the `register_builtin(name, factory)` registry. Reserved names (`template`, `lookup`, `http`, `command`) are rejected at registration time; duplicate registrations of the same name are rejected to keep the registry append-only.
+
+**Documentation.** New `docs/guide/enrichers.md` (config schema, the four primitives, recipes catalog, promotion criteria, output shape, metrics) and `docs/developers/adding-enrichers.md` (testing pattern, metrics wiring, naming conventions). `docs/cli/engine/daemon.md`, `docs/library/runtime.md`, and `docs/reference/metrics.md` updated. The `crates/rsigma-cli/README.md` gains a full enrichment surface section that mirrors the docs-site guide.
+
+**New dependencies.** `humantime` and `arc-swap` in `rsigma-cli` (humantime for `5s` / `1h` duration parsing in the YAML; arc-swap for the hot-reload swap), `globset` and `jaq-core` / `jaq-std` in `rsigma-runtime` (globset for `scope.rules` / `scope.tags` patterns; the jaq additions wire the existing `jaq-interpret` / `jaq-parse` into the enrichment `extract` flow). `wiremock` added as a dev-dependency in both crates for HTTP enricher integration tests.
+
 ### Unified evaluation result type (#132)
 
 `MatchResult` and `CorrelationResult` are collapsed into a single `EvaluationResult` via composition. The five fields shared between detection and correlation today (`rule_title`, `rule_id`, `level`, `tags`, `custom_attributes`) move into a new `RuleHeader` struct along with a new optional `enrichments` map. Kind-specific fields live in `DetectionBody` and `CorrelationBody`, behind a `#[serde(untagged)]` `ResultBody` enum.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,17 @@ Internally, the three duplicated `for m in &result.detections / for m in &result
 
 A new Criterion bench (`crates/rsigma-eval/benches/result_serialize.rs`) pins serialize throughput of the new design against a byte-for-byte copy of the old types across four representative inputs; the derived `#[serde(flatten)]` path is within ±4% of the baseline on every sample.
 
+### Drop reserved `attack` subcommand
+
+The empty `attack` command group that v0.12.0 reserved as a forward declaration for MITRE ATT&CK tooling is removed. The corresponding `Commands::Attack` clap variant, the `AttackCommands` enum, the dispatcher branch, the help-text test assertion, and the "reserved; populated by the upcoming MITRE ATT&CK contributor PR" README line are gone. The CLI now exposes four groups instead of five (`engine`, `rule`, `backend`, `pipeline`); the `attack` namespace remains available for a future contributor PR to populate but is no longer reserved ahead of time.
+
+### Other changes
+
+* **Documentation (PR #131):** version references no longer hardcode the current release in the docs site -- `rsigma.version` now reads from `Cargo.toml` at build time via the macros plugin, so the docs auto-bump on every release rather than drifting behind. `docs/guide/performance-tuning.md` gains a "Rule loading at scale" section covering the v0.12.0 single-rebuild batched loaders and amortized O(1) `add_rule` with verified Criterion numbers at 1K / 10K / 100K rules. The `rsigma-parser` README intro paragraph's stale lint count (65) was bumped to 66 to match every other authoritative location.
+* **Enrichment wording:** the `lookup` enricher's startup error message and `docs/guide/enrichers.md` describe sources as "configured on the daemon" rather than "declared in your pipeline `sources:` block" so the copy stays accurate after a forthcoming release lets sources be declared independently of pipelines.
+* **README and home page:** [Detection Engineering Weekly #157](https://www.detectionengineering.net/p/dew-157-shai-hulud-goes-open-source) added to the "featured in" list (`README.md` and `docs/index.md`) with a quote calling out RSigma's dynamic-pipelines model.
+* **Contributing guidelines:** the `docs/` MkDocs site is now listed as a release deliverable in `CONTRIBUTING.md` alongside the crate READMEs, with a page-to-change matrix that maps each kind of change (new CLI flag, new daemon config key, new library API, new metric, new feature flag) to the page that must stay in sync.
+
 ## [0.12.0] - 2026-05-20
 
 **TL;DR**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
 name = "rsigma"
 version = "0.12.0"
 dependencies = [
+ "arc-swap",
  "assert_cmd",
  "async-nats",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,6 +3790,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "wiremock",
  "yaml_serde",
  "yamlpatch",
  "yamlpath",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,6 +141,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -999,6 +1009,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,7 +1093,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1245,7 +1273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1700,6 +1728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1807,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
@@ -2127,6 +2167,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jaq-core"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6fda09ee08c84c81293fdf811d9ebaa87b327557b5391f290c926d728c2ddd4"
+dependencies = [
+ "aho-corasick",
+ "base64",
+ "chrono",
+ "hifijson",
+ "jaq-interpret",
+ "libm",
+ "log",
+ "regex",
+ "urlencoding",
+]
+
+[[package]]
 name = "jaq-interpret"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jaq-std"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfbaa55578fd3b70433b594a370741e0c364e4afff92cc0099623fce87311bc1"
+dependencies = [
+ "jaq-syn",
+]
+
+[[package]]
 name = "jaq-syn"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,7 +2238,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2351,6 +2417,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2616,7 +2688,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2722,6 +2794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3678,6 +3760,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
+ "humantime",
  "insta",
  "jaq-interpret",
  "jaq-parse",
@@ -3799,8 +3882,11 @@ dependencies = [
  "csv",
  "evtx",
  "futures",
+ "globset",
+ "jaq-core",
  "jaq-interpret",
  "jaq-parse",
+ "jaq-std",
  "jsonpath-rust",
  "notify",
  "opentelemetry-proto",
@@ -3822,6 +3908,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "wiremock",
  "yaml_serde",
 ]
 
@@ -3875,7 +3962,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3934,7 +4021,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4371,7 +4458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4566,7 +4653,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5204,6 +5291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf16-simd"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5515,7 +5608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5754,6 +5847,29 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For rule quality and editor integration, a built-in linter validates rules again
 * Accept JSON, syslog (RFC 3164/5424), logfmt, CEF, EVTX (Windows Event Log), plain text, and OTLP logs with format auto-detection
 * pySigma-compatible processing pipelines for field mapping, transformations, conditions, and finalizers
 * Dynamic pipelines: populate any pipeline value from external sources (HTTP, files, commands, NATS) with template expansion, auto-refresh, and data extraction via jq, JSONPath, or CEL
+* Post-evaluation enrichment: inject contextual data (asset info, IP reputation, identity, GeoIP, runbook URLs, ...) into detection and correlation results via four primitives (`template`, `lookup`, `http`, `command`) with kind-aware template namespaces, response cache, scope filtering, and hot-reload
 * Convert rules into backend-native query strings via a pluggable backend trait (PostgreSQL/TimescaleDB SQL, LynxDB)
 * Optional eval prefilters for large rule sets: bloom filter for substring matchers (`--bloom-prefilter`) and cross-rule Aho-Corasick index for whole-rule pruning (`--cross-rule-ac`, requires `daachorse-index` feature)
 * Run as a streaming detection daemon with hot-reload, Prometheus metrics, and HTTP/NATS/OTLP input

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -40,6 +40,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
 humantime = "2"
+arc-swap = "1"
 
 # daemon mode dependencies
 tokio = { version = "1", features = ["full"], optional = true }

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -72,4 +72,5 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 serde_json = "1"
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic", "logs", "with-serde"] }
 prost = "0.14"
+wiremock = "0.6"
 flate2 = "1"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -39,6 +39,7 @@ yamlpatch = "1.25"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
+humantime = "2"
 
 # daemon mode dependencies
 tokio = { version = "1", features = ["full"], optional = true }

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -1031,14 +1031,14 @@ Cheapest primitive. No I/O. Cannot fail past config-load-time template parse err
 
 ### `lookup`: read from the dynamic-pipelines source cache
 
-Reads a value from the dynamic-pipelines `SourceCache` by `source_id` and applies an `extract` expression (jq/JSONPath/CEL) with template-expanded variables to slice it. Zero-network-cost for anything already loaded as a pipeline source.
+Reads a value from the dynamic-pipelines `SourceCache` by `source_id` and applies an `extract` expression (jq/JSONPath/CEL) with template-expanded variables to slice it. Zero-network-cost for anything already loaded as a dynamic source.
 
 ```yaml
 - id: asset_context_corr
   kind: correlation
   type: lookup
   inject_field: asset_context
-  source: asset_inventory          # source_id from the pipeline `sources:` block
+  source: asset_inventory          # id of a dynamic source configured on the daemon
   extract: '.assets[] | select(.hostname == "${correlation.group_key.HostName}")'
   extract_type: jq                 # jq | jsonpath | cel; defaults to jq
   default: "unknown"               # injected on cache miss / no extract match
@@ -1052,7 +1052,7 @@ The decision matrix:
 - **Cache miss** → if `default` is configured, inject it; otherwise apply `on_error`
 - **Extract evaluation error** (invalid jq, type mismatch) → always applies `on_error`, even with `default` set
 
-`lookup` requires the daemon's pipelines to declare at least one dynamic source. The loader surfaces a clear error at startup if a `lookup` enricher is configured without a source cache.
+`lookup` requires at least one dynamic source to be configured on the daemon. The loader surfaces a clear error at startup if a `lookup` enricher is configured without a source cache.
 
 ### `http`: per-result HTTP fetch with optional response cache
 

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -1296,7 +1296,7 @@ The enrichment pipeline reports six Prometheus metrics:
 | `rsigma_enrichment_http_cache_misses_total` | `enricher_id` | HTTP enricher response-cache misses |
 | `rsigma_enrichment_http_cache_expirations_total` | `enricher_id` | HTTP enricher response-cache entries evicted on expiry |
 
-The `kind` label is carried even though `enricher_id` typically already encodes it (`asset_lookup_det` vs `asset_lookup_corr`), so dashboards can compute `sum by (kind)` without depending on a naming convention. Filtered (kind- or scope-mismatched) calls do not increment any counters.
+The `kind` label is carried even though `enricher_id` typically already encodes it (`asset_lookup_det` vs `asset_lookup_corr`), so dashboards can compute `sum by (kind)` without depending on a naming convention. Every label combination is pre-registered at startup, so all six families render at zero on the first `/metrics` scrape, before any event has fired. Filtered (kind- or scope-mismatched) calls do not increment any counters.
 
 ## Environment Variables
 

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -943,6 +943,361 @@ The source must resolve to a JSON array of transformation objects. Nested includ
 
 Resolved values are cached in memory (and optionally SQLite). The cache supports TTL-based expiration. The `use_cached` error policy serves stale data from the cache when a fresh fetch fails. Cache entries can be invalidated per-source via `DELETE /api/v1/sources/cache/{source_id}`.
 
+## Enrichers
+
+Post-evaluation enrichers run after `engine.evaluate()` produces a `ProcessResult` and before each result is serialized to a sink. They inject contextual data (asset info, IP reputation, identity, GeoIP, runbook URLs, ...) into `enrichments.<field>` on each detection or correlation.
+
+Enrichers are configured in a YAML file passed via `--enrichers <path>` to `engine daemon`:
+
+```bash
+rsigma engine daemon -r rules/ --enrichers /etc/rsigma/enrichers.yml
+```
+
+The config is hot-reloaded on `SIGHUP`, on file-watcher changes, and on `POST /api/v1/reload`. A reload that fails validation logs the error and keeps the previous pipeline active; the daemon never silently degrades to "no enrichment" because of a typo.
+
+### Config schema
+
+```yaml
+# Bound on concurrent enrichment chains across all results in a batch.
+# Defaults to 16 if omitted.
+max_concurrent_enrichments: 16
+
+enrichers:
+  - id: <unique-string>            # required, used as a Prometheus label
+    kind: detection | correlation  # required, see "Kind and template namespaces"
+    type: template | lookup | http | command  # required, the primitive
+    inject_field: <field-name>     # required, key under enrichments.<...>
+    timeout: 5s                    # optional, humantime; default 5s
+    on_error: skip | null | drop   # optional; default skip
+    scope:                         # optional; see "Scope filtering"
+      rules: [<rule-id-or-glob>, ...]
+      tags:  [<tag-or-prefix.*>, ...]
+      levels: [low, medium, high, critical, informational]
+    # ... primitive-specific fields below ...
+```
+
+### Kind and template namespaces
+
+Every enricher declares a `kind: detection | correlation`. The kind drives two checks:
+
+1. **Config-load-time template validation.** A `kind: detection` enricher may only reference `${detection.*}` variables in its templated fields (`url`, `template`, `headers`, `body`, `command`, `env`, `extract`); a `kind: correlation` enricher may only reference `${correlation.*}`. Cross-namespace references are rejected at startup with a clear error pointing at the offending field. `${ENV_VAR}` is allowed in both namespaces.
+2. **Runtime body matching.** The pipeline skips enrichers whose declared kind does not match the current `EvaluationResult` body variant before invoking `enrich()`, so a detection-kind enricher pays no cost on correlation results and vice versa.
+
+Detection variables (`${detection.*}`):
+
+| Variable | Resolves to |
+|---|---|
+| `${detection.rule.title}` / `.id` / `.level` | Rule metadata from `RuleHeader` |
+| `${detection.tags}` | Comma-joined `tags` |
+| `${detection.fields.<name>}` | The matched value of `<name>` from `matched_fields` |
+| `${detection.event.<dotted.path>}` | JSON path into the original event (when `rsigma.include_event: "true"` on the rule) |
+
+Correlation variables (`${correlation.*}`):
+
+| Variable | Resolves to |
+|---|---|
+| `${correlation.rule.title}` / `.id` / `.level` | Rule metadata from `RuleHeader` |
+| `${correlation.tags}` | Comma-joined `tags` |
+| `${correlation.type}` | `event_count`, `temporal`, `value_sum`, ... |
+| `${correlation.aggregated_value}` | The value that crossed the condition threshold |
+| `${correlation.timespan_secs}` | Window size in seconds |
+| `${correlation.group_key.<field>}` | Look up a group-by field by name |
+| `${correlation.group_key}` | Joined `field=value,field=value` string |
+
+For enrichers that conceptually apply to both kinds (identity lookups, runbook URLs, any tag-based enricher), declare two YAML entries. The plan below shows the YAML-anchor pattern for cutting duplication.
+
+### Scope filtering
+
+`scope` limits when an enricher fires within its declared `kind`:
+
+- `scope.rules`: list of rule IDs (exact match) or rule-title globs (`Suspicious *`)
+- `scope.tags`: tag-set intersection with prefix wildcards (`attack.*` matches `attack.t1059.001`)
+- `scope.levels`: severity membership against `RuleHeader::level`
+- No scope = fires for every result of the enricher's declared kind (use for cheap enrichers like `template`)
+
+There is no `scope.kinds` axis: the top-level `kind` already gates which result variant the enricher sees. Axes are AND-ed; an empty axis is not a filter.
+
+### `template`: pure string interpolation
+
+Cheapest primitive. No I/O. Cannot fail past config-load-time template parse errors.
+
+```yaml
+- id: runbook_det
+  kind: detection
+  type: template
+  inject_field: runbook_url
+  template: "https://wiki.internal/runbooks/${detection.rule.id}"
+```
+
+### `lookup`: read from the dynamic-pipelines source cache
+
+Reads a value from the dynamic-pipelines `SourceCache` by `source_id` and applies an `extract` expression (jq/JSONPath/CEL) with template-expanded variables to slice it. Zero-network-cost for anything already loaded as a pipeline source.
+
+```yaml
+- id: asset_context_corr
+  kind: correlation
+  type: lookup
+  inject_field: asset_context
+  source: asset_inventory          # source_id from the pipeline `sources:` block
+  extract: '.assets[] | select(.hostname == "${correlation.group_key.HostName}")'
+  extract_type: jq                 # jq | jsonpath | cel; defaults to jq
+  default: "unknown"               # injected on cache miss / no extract match
+  on_error: skip                   # applied only when default is not configured
+```
+
+The decision matrix:
+
+- **Cache hit + extract matches** → inject the extracted value
+- **Cache hit + no extract match** → if `default` is configured, inject it; otherwise apply `on_error`
+- **Cache miss** → if `default` is configured, inject it; otherwise apply `on_error`
+- **Extract evaluation error** (invalid jq, type mismatch) → always applies `on_error`, even with `default` set
+
+`lookup` requires the daemon's pipelines to declare at least one dynamic source. The loader surfaces a clear error at startup if a `lookup` enricher is configured without a source cache.
+
+### `http`: per-result HTTP fetch with optional response cache
+
+Per-result `reqwest` request with template-expanded URL, headers, and optional body. Parses the response as JSON, optionally sliced by an `extract` expression. The optional response cache is keyed on `(method, url, body_hash)` with a configurable TTL; mandatory in practice for any rate-limited API.
+
+```yaml
+- id: hash_virustotal
+  kind: detection
+  type: http
+  inject_field: file_reputation
+  url: "https://www.virustotal.com/api/v3/files/${detection.fields.SHA256}"
+  method: GET                      # default GET
+  headers:
+    x-apikey: "${VIRUSTOTAL_API_KEY}"
+  cache_ttl: 1h                    # mandatory for the 4 req/min free tier
+  extract: ".data.attributes.last_analysis_stats"
+  extract_type: jq
+  on_error: skip
+  scope:
+    tags: ["attack.execution", "attack.defense_evasion"]
+```
+
+Each enricher instance owns its own response cache: two enrichers hitting the same URL with different `Authorization` headers do not share entries.
+
+### `command`: per-result local-process execution
+
+Per-result `tokio::process::Command` invocation with template-expanded argv and environment. Stdout is captured (capped at 10 MB) and parsed as JSON or as a raw string. Non-zero exit codes map to `EnrichErrorKind::Fetch` with a snippet of stderr attached to the error message.
+
+```yaml
+- id: ip_reputation
+  kind: detection
+  type: command
+  inject_field: ip_reputation
+  command:
+    - "/usr/local/bin/check-ip-rep"
+    - "${detection.fields.SourceIp}"
+  env:
+    REP_LOCAL_DB: "/var/lib/iprep.db"
+  output: json                     # json (default) | raw
+  timeout: 3s
+  on_error: skip
+```
+
+### YAML-anchor pattern for kind-agnostic enrichers
+
+Some enrichers conceptually apply to both kinds (identity lookups, runbook URLs, any tag-based enricher). Declare two entries with the same `type` and `inject_field` but different `kind` and template namespaces; YAML anchors cut the duplication where the loader allows them, but the safest portable form is two explicit entries:
+
+```yaml
+enrichers:
+  - id: runbook_det
+    kind: detection
+    type: template
+    inject_field: runbook_url
+    template: "https://wiki.internal/runbooks/${detection.rule.id}"
+
+  - id: runbook_corr
+    kind: correlation
+    type: template
+    inject_field: runbook_url
+    template: "https://wiki.internal/runbooks/${correlation.rule.id}"
+```
+
+### Output shape
+
+The pipeline writes into `RuleHeader::enrichments` lazily, so detections and correlations that no enricher touched still serialize without an empty `enrichments` object. A typical NDJSON line looks like:
+
+```json
+{"rule_title":"Suspicious PowerShell encoded command","rule_id":"rule-pwsh-enc","level":"high","tags":["attack.t1059.001"],"matched_selections":["selection"],"matched_fields":[{"field":"CommandLine","value":"powershell -enc ..."}],"enrichments":{"asset_info":{"hostname":"dc01","owner":"IT-Ops"},"runbook_url":"https://wiki.internal/runbooks/rule-pwsh-enc"}}
+```
+
+### Composing enrichers (recipe catalog)
+
+Operators rarely need new Rust code. Every recipe below composes one of the four primitives against a dynamic-pipelines source or a remote API. Field names like `${detection.fields.SourceIp}` are illustrative; substitute the names your pipeline actually produces.
+
+#### `enrich_ip_employee`: identity lookup by source IP
+
+```yaml
+sources:
+  employee_directory:
+    type: file
+    path: /etc/rsigma/employees.json
+    format: json
+    extract:
+      expr: 'with_entries(.value |= {user: .user, team: .team})'
+      type: jq
+
+enrichers:
+  - id: enrich_ip_employee
+    kind: detection
+    type: lookup
+    inject_field: employee
+    source: employee_directory
+    extract: '."${detection.fields.SourceIp}"'
+    extract_type: jq
+    default: "unknown"
+    scope:
+      levels: [high, critical]
+```
+
+Expected `enrichments.employee` shape: `{"user": "alice", "team": "Platform"}` or `"unknown"` on miss.
+
+#### `enrich_username_employee`: identity lookup by username
+
+Same source as above, key by username instead:
+
+```yaml
+- id: enrich_username_employee
+  kind: detection
+  type: lookup
+  inject_field: employee
+  source: employee_directory_by_user
+  extract: '."${detection.fields.User}"'
+  extract_type: jq
+  default: null
+```
+
+#### `enrich_ip_geoip`: country/city/ASN by IP
+
+Prefer `lookup` if a GeoIP dump fits in memory; fall back to `http` for vendor APIs:
+
+```yaml
+sources:
+  geoip_db:
+    type: file
+    path: /var/lib/geoip/cidr-to-country.json
+    format: json
+    refresh: { interval: 86400s }
+
+enrichers:
+  - id: enrich_ip_geoip
+    kind: detection
+    type: lookup
+    inject_field: geoip
+    source: geoip_db
+    extract: '.[] | select(.cidr | test("${detection.fields.SourceIp}"))'
+    extract_type: jq
+    default: { country: "unknown" }
+```
+
+#### `enrich_hash_virustotal`: hash reputation with cache
+
+`cache_ttl` is mandatory for the 4 req/min free tier and a major win for duplicate-detection bursts on any tier:
+
+```yaml
+- id: enrich_hash_virustotal
+  kind: detection
+  type: http
+  inject_field: file_reputation
+  url: "https://www.virustotal.com/api/v3/files/${detection.fields.SHA256}"
+  headers:
+    x-apikey: "${VIRUSTOTAL_API_KEY}"
+  cache_ttl: 1h
+  extract: ".data.attributes.last_analysis_stats"
+  extract_type: jq
+  on_error: skip
+  scope:
+    tags: ["attack.execution"]
+```
+
+#### `enrich_cve_kev`: known-exploited-vulnerability flag
+
+Pulls the CISA KEV catalog as a dynamic-pipelines source, then flags CVEs that appear in it:
+
+```yaml
+sources:
+  kev_catalog:
+    type: http
+    url: https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+    format: json
+    refresh: { interval: 3600s }
+
+enrichers:
+  - id: enrich_cve_kev
+    kind: detection
+    type: lookup
+    inject_field: kev
+    source: kev_catalog
+    extract: '.vulnerabilities[] | select(.cveID == "${detection.fields.CveId}")'
+    extract_type: jq
+    default: null
+```
+
+#### `enrich_url_runbook`: synthesized runbook URL
+
+Pure string interpolation, no I/O. Use this any time a downstream consumer (Slack, PagerDuty, RSoar) needs a per-detection link:
+
+```yaml
+- id: enrich_url_runbook
+  kind: detection
+  type: template
+  inject_field: runbook_url
+  template: "https://wiki.internal/runbooks/${detection.rule.id}"
+```
+
+#### When to pick which primitive
+
+- Prefer `lookup` if the data is bounded and refreshes infrequently (employee directory, KEV catalog, GeoIP dump).
+- Prefer `http` only when the data is genuinely per-result or too large to cache. Always set `cache_ttl` for rate-limited APIs.
+- Prefer `command` only when no other primitive will do (a binary parser, a vendored CLI tool, anything that already exists as a script).
+- Never use `template` for anything that could be a YAML literal.
+
+### Bespoke (Rust-coded) enrichers
+
+The four primitives cover almost every use case via composition. A bespoke Rust-coded enricher is justified only when at least one of these holds:
+
+1. **It bundles non-trivial data** (e.g. a dataset committed to the repo and `include_bytes!`-ed at compile time). Recipes can't express vendored data.
+2. **It needs a parser the YAML primitives don't expose** (e.g. MaxMind's binary GeoLite2 format, the STIX 2.1 graph with parent/child resolution). Adding the parser as a generic source might cost more than just shipping the enricher.
+3. **It provides a stable named contract**: downstream consumers reference a specific `enrichments.<field>` shape directly. A recipe-driven approach lets every operator choose their own `inject_field`, which is fine for ad-hoc enrichment but bad for a contract that crosses team or organisational boundaries.
+4. **It implements a non-obvious algorithm** (e.g. coalescing per-result hash lookups into one batched-GET request). This is implementable as a recipe but the implementation is fragile.
+
+Otherwise, ship a recipe and only promote when one of the criteria above bites.
+
+#### `register_builtin(name, factory)`
+
+External crates register a bespoke enricher type via:
+
+```rust
+use rsigma_runtime::{Enricher, register_builtin};
+
+register_builtin(
+    "enrich_my_thing",
+    std::sync::Arc::new(|raw_config: &serde_json::Value| -> Result<Box<dyn Enricher>, String> {
+        let cfg: MyConfig = serde_json::from_value(raw_config.clone()).map_err(|e| e.to_string())?;
+        Ok(Box::new(MyEnricher::new(cfg)))
+    }),
+).unwrap();
+```
+
+Reserved names (`template`, `lookup`, `http`, `command`) are rejected at registration time; duplicate registrations of the same name are rejected to keep the global registry append-only. Bespoke types follow the same `kind` / `scope` / template rules as the four primitives; promotion does not change the YAML shape, only the `type:` value.
+
+### Metrics
+
+The enrichment pipeline reports six Prometheus metrics:
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rsigma_enrichment_total` | `enricher_id`, `kind`, `status` | Per-call outcome counter; `status` is `success` / `skip` / `error` / `timeout` / `drop` |
+| `rsigma_enrichment_duration_seconds` | `enricher_id`, `kind` | Per-enricher latency histogram |
+| `rsigma_enrichment_queue_depth` | – | Pending enrichment calls (sum across both kinds) |
+| `rsigma_enrichment_http_cache_hits_total` | `enricher_id` | HTTP enricher response-cache hits |
+| `rsigma_enrichment_http_cache_misses_total` | `enricher_id` | HTTP enricher response-cache misses |
+| `rsigma_enrichment_http_cache_expirations_total` | `enricher_id` | HTTP enricher response-cache entries evicted on expiry |
+
+The `kind` label is carried even though `enricher_id` typically already encodes it (`asset_lookup_det` vs `asset_lookup_corr`), so dashboards can compute `sum by (kind)` without depending on a naming convention. Filtered (kind- or scope-mismatched) calls do not increment any counters.
+
 ## Environment Variables
 
 | Variable | Scope | Behavior |

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -499,19 +499,6 @@ fn run_daemon(
         .filter(|p| resolve_builtin_pipeline(p.to_str().unwrap_or("")).is_none())
         .collect();
 
-    // Parse the enrichers config now so a malformed YAML or
-    // cross-namespace template reference fails at startup rather than
-    // when the first event arrives. The actual `EnrichmentPipeline`
-    // construction happens inside `run_daemon` once the `Metrics`
-    // struct (which owns the Prometheus registry) exists, so
-    // `rsigma_enrichment_*` counters can be wired into Prometheus.
-    let enrichers_file = enrichers_path.as_ref().map(|path| {
-        daemon::enrichment::load_enrichers_file(path).unwrap_or_else(|e| {
-            eprintln!("Failed to load enrichers config: {e}");
-            process::exit(exit_code::CONFIG_ERROR);
-        })
-    });
-
     let config = daemon::server::DaemonConfig {
         rules_path,
         pipelines,
@@ -542,7 +529,7 @@ fn run_daemon(
         bloom_max_bytes,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
-        enrichers_file,
+        enrichers_path,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -499,22 +499,18 @@ fn run_daemon(
         .filter(|p| resolve_builtin_pipeline(p.to_str().unwrap_or("")).is_none())
         .collect();
 
-    // Load post-evaluation enrichers from --enrichers, if set. Failures
-    // here exit with CONFIG_ERROR before the daemon spawns any tokio
-    // tasks, so operators see one clear error per missing field.
-    let enrichment_pipeline = if let Some(path) = enrichers_path.as_ref() {
-        let file = daemon::enrichment::load_enrichers_file(path).unwrap_or_else(|e| {
+    // Parse the enrichers config now so a malformed YAML or
+    // cross-namespace template reference fails at startup rather than
+    // when the first event arrives. The actual `EnrichmentPipeline`
+    // construction happens inside `run_daemon` once the `Metrics`
+    // struct (which owns the Prometheus registry) exists, so
+    // `rsigma_enrichment_*` counters can be wired into Prometheus.
+    let enrichers_file = enrichers_path.as_ref().map(|path| {
+        daemon::enrichment::load_enrichers_file(path).unwrap_or_else(|e| {
             eprintln!("Failed to load enrichers config: {e}");
             process::exit(exit_code::CONFIG_ERROR);
-        });
-        let pipeline = daemon::enrichment::build_enrichers(file).unwrap_or_else(|e| {
-            eprintln!("Failed to build enrichment pipeline: {e}");
-            process::exit(exit_code::CONFIG_ERROR);
-        });
-        Some(std::sync::Arc::new(pipeline))
-    } else {
-        None
-    };
+        })
+    });
 
     let config = daemon::server::DaemonConfig {
         rules_path,
@@ -546,7 +542,7 @@ fn run_daemon(
         bloom_max_bytes,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
-        enrichment: enrichment_pipeline,
+        enrichers_file,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -243,6 +243,22 @@ pub(crate) struct DaemonArgs {
     #[cfg(feature = "daachorse-index")]
     #[arg(long = "cross-rule-ac")]
     pub cross_rule_ac: bool,
+
+    /// Path to a YAML file declaring post-evaluation enrichers.
+    ///
+    /// When set, every `EvaluationResult` produced by the engine flows
+    /// through the configured enrichment pipeline (one or more of
+    /// `template` / `lookup` / `http` / `command` primitives, plus any
+    /// bespoke types registered via `register_builtin`) before being
+    /// written to the sink. See the `Enrichers` section in the
+    /// `rsigma-cli` README for the YAML schema and recipes.
+    ///
+    /// The validator runs at startup: a config that references the
+    /// wrong template namespace (e.g. `${correlation.*}` inside a
+    /// `kind: detection` enricher), declares an unknown `type:`, or
+    /// has a malformed `scope:` rejects the daemon with a clear error.
+    #[arg(long = "enrichers", value_name = "PATH")]
+    pub enrichers: Option<PathBuf>,
 }
 
 /// Helper struct grouping NATS connection / auth flags so `cmd_daemon` does
@@ -317,6 +333,7 @@ pub(crate) fn cmd_daemon(args: DaemonArgs) {
         bloom_max_bytes,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
+        enrichers,
     } = args;
 
     #[cfg(feature = "daemon-nats")]
@@ -392,6 +409,7 @@ pub(crate) fn cmd_daemon(args: DaemonArgs) {
         bloom_max_bytes,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
+        enrichers,
     );
 }
 
@@ -429,6 +447,7 @@ fn run_daemon(
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
     #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
+    enrichers_path: Option<PathBuf>,
 ) {
     use rsigma_eval::resolve_builtin_pipeline;
 
@@ -480,6 +499,23 @@ fn run_daemon(
         .filter(|p| resolve_builtin_pipeline(p.to_str().unwrap_or("")).is_none())
         .collect();
 
+    // Load post-evaluation enrichers from --enrichers, if set. Failures
+    // here exit with CONFIG_ERROR before the daemon spawns any tokio
+    // tasks, so operators see one clear error per missing field.
+    let enrichment_pipeline = if let Some(path) = enrichers_path.as_ref() {
+        let file = daemon::enrichment::load_enrichers_file(path).unwrap_or_else(|e| {
+            eprintln!("Failed to load enrichers config: {e}");
+            process::exit(exit_code::CONFIG_ERROR);
+        });
+        let pipeline = daemon::enrichment::build_enrichers(file).unwrap_or_else(|e| {
+            eprintln!("Failed to build enrichment pipeline: {e}");
+            process::exit(exit_code::CONFIG_ERROR);
+        });
+        Some(std::sync::Arc::new(pipeline))
+    } else {
+        None
+    };
+
     let config = daemon::server::DaemonConfig {
         rules_path,
         pipelines,
@@ -510,6 +546,7 @@ fn run_daemon(
         bloom_max_bytes,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
+        enrichment: enrichment_pipeline,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/rsigma-cli/src/daemon/enrichment/config.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/config.rs
@@ -125,7 +125,7 @@ pub struct EnricherConfig {
     /// `command`: how to interpret stdout. `json` (default) or `raw`.
     #[serde(default)]
     pub output: OutputFormatLabel,
-    /// `lookup`: source ID from the dynamic-pipelines `sources:` block.
+    /// `lookup`: source ID of a dynamic source configured on the daemon.
     #[serde(default)]
     pub source: Option<String>,
     /// `lookup`: default value injected on cache miss / no extract match.
@@ -452,9 +452,13 @@ fn build_one(
             let cache = source_cache.ok_or(EnrichersConfigError::MissingField {
                 enricher_id: cfg.id.clone(),
                 type_name: cfg.type_name.clone(),
-                // Surfaced when the daemon has no dynamic-sources block
-                // but an operator declared a lookup enricher anyway.
-                field: "<source_cache: declare a `sources:` block in your pipeline>",
+                // Surfaced when the daemon has no dynamic sources
+                // configured but an operator declared a lookup enricher
+                // anyway. Intentionally declaration-site-neutral so the
+                // error reads correctly regardless of whether the
+                // operator declares sources inline in a pipeline file or
+                // via the daemon-level source registry.
+                field: "<source_cache: no dynamic sources configured>",
             })?;
             let extract = build_extract_expr(&cfg)?;
             Ok(Box::new(LookupEnricher::new(

--- a/crates/rsigma-cli/src/daemon/enrichment/config.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/config.rs
@@ -1,0 +1,799 @@
+//! YAML schema and loader for the daemon's enrichers config file.
+//!
+//! Loaded at daemon startup (and again on hot-reload). Validates that:
+//! - every enricher declares a `kind: detection | correlation`,
+//! - templated fields reference only the declared kind's namespace
+//!   (`${detection.*}` or `${correlation.*}`) plus `${ENV_VAR}`,
+//! - `scope.rules`, `scope.tags`, and `scope.levels` parse correctly,
+//! - bespoke `type:` values map to a registered factory.
+//!
+//! Failures abort daemon startup with a clear error pointing at the
+//! offending enricher id and field.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+
+use rsigma_runtime::{
+    CommandEnricher, EnricherKind, EnrichmentPipeline, HttpEnricher, HttpEnricherClient,
+    HttpResponseCache, LookupEnricher, OnError, OutputFormat, Scope, SourceCache, TemplateEnricher,
+    build_default_http_client, lookup_builtin, validate_template_namespace,
+};
+use serde::Deserialize;
+
+/// Default per-enricher timeout when YAML omits `timeout:`.
+const DEFAULT_ENRICHER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default global concurrency cap when YAML omits `max_concurrent_enrichments`.
+const DEFAULT_MAX_CONCURRENT_ENRICHMENTS: usize = 16;
+
+/// Top-level enrichers config file.
+///
+/// ```yaml
+/// max_concurrent_enrichments: 16
+/// enrichers:
+///   - id: runbook_det
+///     kind: detection
+///     type: template
+///     template: "https://wiki/${detection.rule.id}"
+///     inject_field: runbook_url
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct EnrichersFile {
+    /// Global concurrency cap shared across both kinds. Defaults to 16
+    /// if omitted; values of 0 are treated as the default to keep the
+    /// pipeline functional even on a malformed config.
+    #[serde(default)]
+    pub max_concurrent_enrichments: Option<usize>,
+
+    /// Per-enricher configurations. Empty list / missing key is allowed
+    /// (no enrichment is configured) so an operator can keep an
+    /// enrichers file with an empty list during a rollout.
+    #[serde(default)]
+    pub enrichers: Vec<EnricherConfig>,
+}
+
+/// One enricher's YAML config block.
+#[derive(Debug, Deserialize)]
+pub struct EnricherConfig {
+    /// Stable identifier for this enricher instance. Required.
+    pub id: String,
+    /// Required kind (`detection` or `correlation`).
+    pub kind: KindLabel,
+    /// Primitive type name (`template`, `lookup`, `http`, `command`) or
+    /// the `type:` of a bespoke enricher registered via
+    /// [`register_builtin`](rsigma_runtime::register_builtin).
+    #[serde(rename = "type")]
+    pub type_name: String,
+    /// Field under `enrichments` to write the result into.
+    pub inject_field: String,
+    /// Per-enricher timeout. Accepts humantime strings (`5s`, `200ms`).
+    #[serde(default, with = "humantime_opt")]
+    pub timeout: Option<Duration>,
+    /// Behavior when this enricher fails. Defaults to `skip`.
+    #[serde(default)]
+    pub on_error: OnErrorLabel,
+    /// Optional scope filter.
+    #[serde(default)]
+    pub scope: Option<ScopeConfig>,
+
+    // Primitive-specific fields. Captured here as `Option`s so a single
+    // serde struct covers all four primitives without separate
+    // deserializer types per `type_name`.
+    /// `template`: template string to render.
+    #[serde(default)]
+    pub template: Option<String>,
+
+    // The remaining fields are reserved for the http / command / lookup
+    // primitives shipped in Phases 2 and 3. They live on the same
+    // struct so YAML files round-trip with the loader without needing
+    // per-phase reparse logic; missing values produce a clear error
+    // when the matching primitive is selected.
+    /// `http`: target URL.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// `http`: HTTP method (GET / POST / …). Defaults to GET inside
+    /// the primitive when omitted.
+    #[serde(default)]
+    pub method: Option<String>,
+    /// `http`: optional headers.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// `http`: optional request body.
+    #[serde(default)]
+    pub body: Option<String>,
+    /// `http`: response cache TTL. Off by default.
+    #[serde(default, with = "humantime_opt")]
+    pub cache_ttl: Option<Duration>,
+    /// `http` / `lookup`: optional extract expression applied to the
+    /// fetched value before injection.
+    #[serde(default)]
+    pub extract: Option<String>,
+    /// `http` / `lookup`: extract language (`jq` / `jsonpath` / `cel`).
+    /// Defaults to `jq` inside the primitive.
+    #[serde(default)]
+    pub extract_type: Option<String>,
+    /// `command`: argv. The first element is the program; remaining
+    /// elements are arguments. Each is template-expanded.
+    #[serde(default)]
+    pub command: Vec<String>,
+    /// `command`: optional environment overrides.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// `command`: how to interpret stdout. `json` (default) or `raw`.
+    #[serde(default)]
+    pub output: OutputFormatLabel,
+    /// `lookup`: source ID from the dynamic-pipelines `sources:` block.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// `lookup`: default value injected on cache miss / no extract match.
+    /// Overrides `on_error` when configured.
+    #[serde(default)]
+    pub default: Option<serde_json::Value>,
+}
+
+/// `kind:` discriminator. Lower-case in YAML, parses to
+/// [`EnricherKind`].
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KindLabel {
+    Detection,
+    Correlation,
+}
+
+impl From<KindLabel> for EnricherKind {
+    fn from(k: KindLabel) -> Self {
+        match k {
+            KindLabel::Detection => EnricherKind::Detection,
+            KindLabel::Correlation => EnricherKind::Correlation,
+        }
+    }
+}
+
+/// `on_error:` discriminator.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OnErrorLabel {
+    #[default]
+    Skip,
+    Null,
+    Drop,
+}
+
+impl From<OnErrorLabel> for OnError {
+    fn from(o: OnErrorLabel) -> Self {
+        match o {
+            OnErrorLabel::Skip => OnError::Skip,
+            OnErrorLabel::Null => OnError::Null,
+            OnErrorLabel::Drop => OnError::Drop,
+        }
+    }
+}
+
+/// `output:` discriminator for the `command` primitive.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormatLabel {
+    /// Parse stdout as JSON.
+    #[default]
+    Json,
+    /// Inject stdout verbatim as a string.
+    Raw,
+}
+
+impl From<OutputFormatLabel> for OutputFormat {
+    fn from(o: OutputFormatLabel) -> Self {
+        match o {
+            OutputFormatLabel::Json => OutputFormat::Json,
+            OutputFormatLabel::Raw => OutputFormat::Raw,
+        }
+    }
+}
+
+/// `scope:` block.
+#[derive(Debug, Default, Deserialize)]
+pub struct ScopeConfig {
+    #[serde(default)]
+    pub rules: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub levels: Vec<String>,
+}
+
+/// Errors produced while loading or validating an enrichers config.
+#[derive(Debug)]
+pub enum EnrichersConfigError {
+    /// File could not be read.
+    Io(std::io::Error, std::path::PathBuf),
+    /// YAML failed to deserialize.
+    Yaml(yaml_serde::Error),
+    /// An enricher referenced an unknown `type:` value.
+    UnknownType {
+        enricher_id: String,
+        type_name: String,
+    },
+    /// A primitive was missing a required field (e.g. `template:` for a
+    /// `template` enricher).
+    MissingField {
+        enricher_id: String,
+        type_name: String,
+        field: &'static str,
+    },
+    /// Template-namespace validator rejected a reference.
+    Template(rsigma_runtime::TemplateError),
+    /// Scope construction failed.
+    Scope {
+        enricher_id: String,
+        message: String,
+    },
+    /// Bespoke enricher factory rejected the config.
+    BespokeFactory {
+        enricher_id: String,
+        message: String,
+    },
+}
+
+impl std::fmt::Display for EnrichersConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EnrichersConfigError::Io(e, p) => {
+                write!(f, "failed to read enrichers config '{}': {e}", p.display())
+            }
+            EnrichersConfigError::Yaml(e) => write!(f, "invalid enrichers YAML: {e}"),
+            EnrichersConfigError::UnknownType {
+                enricher_id,
+                type_name,
+            } => write!(
+                f,
+                "enricher '{enricher_id}': unknown type '{type_name}' (built-ins: template, lookup, http, command; bespoke types must register_builtin() before daemon start)"
+            ),
+            EnrichersConfigError::MissingField {
+                enricher_id,
+                type_name,
+                field,
+            } => write!(
+                f,
+                "enricher '{enricher_id}' (type: {type_name}): missing required field '{field}'"
+            ),
+            EnrichersConfigError::Template(e) => write!(f, "{e}"),
+            EnrichersConfigError::Scope {
+                enricher_id,
+                message,
+            } => write!(f, "enricher '{enricher_id}': {message}"),
+            EnrichersConfigError::BespokeFactory {
+                enricher_id,
+                message,
+            } => write!(
+                f,
+                "enricher '{enricher_id}': bespoke factory rejected config: {message}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EnrichersConfigError {}
+
+/// Read and deserialize an enrichers config file.
+pub fn load_enrichers_file(path: &Path) -> Result<EnrichersFile, EnrichersConfigError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| EnrichersConfigError::Io(e, path.to_path_buf()))?;
+    let parsed: EnrichersFile = yaml_serde::from_str(&text).map_err(EnrichersConfigError::Yaml)?;
+    Ok(parsed)
+}
+
+/// Construct an [`EnrichmentPipeline`] from a parsed config.
+///
+/// This is split from [`load_enrichers_file`] so unit tests and the
+/// hot-reload path can build a pipeline from a programmatically
+/// constructed [`EnrichersFile`] without going through the disk.
+///
+/// `source_cache` is the dynamic-pipelines source cache shared across
+/// the daemon. Pass `None` if no `lookup` enrichers will be configured;
+/// the loader returns a clear error if a `lookup` enricher is encountered
+/// without a cache.
+///
+/// All HTTP enrichers in the resulting pipeline share a single
+/// `reqwest::Client` (wrapped in [`HttpEnricherClient`]) so connection
+/// pooling works at the daemon level.
+pub fn build_enrichers(file: EnrichersFile) -> Result<EnrichmentPipeline, EnrichersConfigError> {
+    build_enrichers_with_cache(file, None)
+}
+
+/// Like [`build_enrichers`] but accepts an optional shared
+/// [`SourceCache`] for `lookup` enrichers. The daemon path constructs
+/// this cache when at least one pipeline declares dynamic sources, and
+/// passes it through here so `lookup` enrichers can read pre-resolved
+/// source data without going through the network.
+pub fn build_enrichers_with_cache(
+    file: EnrichersFile,
+    source_cache: Option<std::sync::Arc<SourceCache>>,
+) -> Result<EnrichmentPipeline, EnrichersConfigError> {
+    let http_client =
+        build_default_http_client().map_err(|message| EnrichersConfigError::BespokeFactory {
+            enricher_id: "<global>".to_string(),
+            message,
+        })?;
+    let mut enrichers: Vec<Box<dyn rsigma_runtime::Enricher>> =
+        Vec::with_capacity(file.enrichers.len());
+    for cfg in file.enrichers {
+        enrichers.push(build_one(cfg, http_client.clone(), source_cache.clone())?);
+    }
+    let cap = file
+        .max_concurrent_enrichments
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_ENRICHMENTS);
+    Ok(EnrichmentPipeline::new(enrichers, cap))
+}
+
+/// Build a single [`Enricher`](rsigma_runtime::Enricher) from one YAML
+/// config block.
+///
+/// Pulled out of [`build_enrichers`] so the loader's match on
+/// `type_name` stays linear and so future primitives can be added by
+/// extending one match arm.
+fn build_one(
+    cfg: EnricherConfig,
+    http_client: HttpEnricherClient,
+    source_cache: Option<std::sync::Arc<SourceCache>>,
+) -> Result<Box<dyn rsigma_runtime::Enricher>, EnrichersConfigError> {
+    let kind: EnricherKind = cfg.kind.into();
+    let on_error: OnError = cfg.on_error.into();
+    let timeout = cfg.timeout.unwrap_or(DEFAULT_ENRICHER_TIMEOUT);
+
+    let scope =
+        match &cfg.scope {
+            Some(s) => Scope::new(s.rules.clone(), s.tags.clone(), s.levels.clone()).map_err(
+                |message| EnrichersConfigError::Scope {
+                    enricher_id: cfg.id.clone(),
+                    message,
+                },
+            )?,
+            None => Scope::default(),
+        };
+
+    // Validate template-namespace references on every templated field.
+    // The full set of templated fields is type-dependent, but every
+    // primitive shares the same namespace rules, so we run the
+    // validator once per field that the chosen primitive touches.
+    validate_templated_fields(&cfg, kind)?;
+
+    match cfg.type_name.as_str() {
+        "template" => {
+            let template = cfg
+                .template
+                .clone()
+                .ok_or(EnrichersConfigError::MissingField {
+                    enricher_id: cfg.id.clone(),
+                    type_name: cfg.type_name.clone(),
+                    field: "template",
+                })?;
+            Ok(Box::new(TemplateEnricher::new(
+                cfg.id,
+                kind,
+                cfg.inject_field,
+                template,
+                timeout,
+                on_error,
+                scope,
+            )))
+        }
+        "http" => {
+            let url = cfg.url.clone().ok_or(EnrichersConfigError::MissingField {
+                enricher_id: cfg.id.clone(),
+                type_name: cfg.type_name.clone(),
+                field: "url",
+            })?;
+            let method = cfg.method.clone().unwrap_or_else(|| "GET".to_string());
+            let headers: Vec<(String, String)> = cfg
+                .headers
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            let extract = build_extract_expr(&cfg)?;
+            let cache_ttl = cfg.cache_ttl.unwrap_or_default();
+            let cache = HttpResponseCache::new(cache_ttl);
+            Ok(Box::new(HttpEnricher::new(
+                cfg.id,
+                kind,
+                cfg.inject_field,
+                method,
+                url,
+                headers,
+                cfg.body.clone(),
+                timeout,
+                on_error,
+                scope,
+                extract,
+                http_client,
+                cache,
+            )))
+        }
+        "command" => {
+            if cfg.command.is_empty() {
+                return Err(EnrichersConfigError::MissingField {
+                    enricher_id: cfg.id.clone(),
+                    type_name: cfg.type_name.clone(),
+                    field: "command",
+                });
+            }
+            Ok(Box::new(CommandEnricher::new(
+                cfg.id,
+                kind,
+                cfg.inject_field,
+                cfg.command,
+                cfg.env,
+                timeout,
+                on_error,
+                scope,
+                cfg.output.into(),
+            )))
+        }
+        "lookup" => {
+            let source = cfg
+                .source
+                .clone()
+                .ok_or(EnrichersConfigError::MissingField {
+                    enricher_id: cfg.id.clone(),
+                    type_name: cfg.type_name.clone(),
+                    field: "source",
+                })?;
+            let cache = source_cache.ok_or(EnrichersConfigError::MissingField {
+                enricher_id: cfg.id.clone(),
+                type_name: cfg.type_name.clone(),
+                // Surfaced when the daemon has no dynamic-sources block
+                // but an operator declared a lookup enricher anyway.
+                field: "<source_cache: declare a `sources:` block in your pipeline>",
+            })?;
+            let extract = build_extract_expr(&cfg)?;
+            Ok(Box::new(LookupEnricher::new(
+                cfg.id,
+                kind,
+                cfg.inject_field,
+                source,
+                extract,
+                cfg.default,
+                timeout,
+                on_error,
+                scope,
+                cache,
+            )))
+        }
+        other => {
+            // Bespoke type: look up factory and pass the raw config block.
+            let factory = lookup_builtin(other).ok_or(EnrichersConfigError::UnknownType {
+                enricher_id: cfg.id.clone(),
+                type_name: other.to_string(),
+            })?;
+            // Re-serialize the entire config block as JSON so the
+            // factory can deserialize whatever schema it needs.
+            let raw =
+                serde_json::to_value(&cfg).map_err(|e| EnrichersConfigError::BespokeFactory {
+                    enricher_id: cfg.id.clone(),
+                    message: format!("internal: re-serialize failed: {e}"),
+                })?;
+            factory(&raw).map_err(|message| EnrichersConfigError::BespokeFactory {
+                enricher_id: cfg.id.clone(),
+                message,
+            })
+        }
+    }
+}
+
+/// Build an [`ExtractExpr`] from `cfg.extract` + `cfg.extract_type`.
+/// `None` when no extract is configured. Defaults to `jq` when an
+/// extract expression is set without an explicit type, matching the
+/// pipeline-source convention.
+fn build_extract_expr(
+    cfg: &EnricherConfig,
+) -> Result<Option<rsigma_eval::pipeline::sources::ExtractExpr>, EnrichersConfigError> {
+    use rsigma_eval::pipeline::sources::ExtractExpr;
+    let Some(expr) = cfg.extract.clone() else {
+        return Ok(None);
+    };
+    let kind = cfg.extract_type.as_deref().unwrap_or("jq");
+    Ok(Some(match kind {
+        "jq" => ExtractExpr::Jq(expr),
+        "jsonpath" => ExtractExpr::JsonPath(expr),
+        "cel" => ExtractExpr::Cel(expr),
+        other => {
+            return Err(EnrichersConfigError::Scope {
+                enricher_id: cfg.id.clone(),
+                message: format!("unknown extract_type '{other}' (expected jq | jsonpath | cel)"),
+            });
+        }
+    }))
+}
+
+/// Walk every templated field on `cfg` and validate that its `${...}`
+/// references match the enricher's declared kind.
+fn validate_templated_fields(
+    cfg: &EnricherConfig,
+    kind: EnricherKind,
+) -> Result<(), EnrichersConfigError> {
+    let id = cfg.id.as_str();
+    let check = |s: &str, field: &'static str| -> Result<(), EnrichersConfigError> {
+        validate_template_namespace(s, kind, id, field).map_err(EnrichersConfigError::Template)
+    };
+    if let Some(t) = &cfg.template {
+        check(t, "template")?;
+    }
+    if let Some(u) = &cfg.url {
+        check(u, "url")?;
+    }
+    for (k, v) in &cfg.headers {
+        // Headers are key/value; we only template the value (the
+        // typical case is `Authorization: Bearer ${TOKEN}`). We still
+        // surface the header name in the error context for clarity.
+        let static_field: &'static str = Box::leak(format!("headers.{k}").into_boxed_str());
+        check(v, static_field)?;
+    }
+    if let Some(b) = &cfg.body {
+        check(b, "body")?;
+    }
+    for (i, c) in cfg.command.iter().enumerate() {
+        let static_field: &'static str = Box::leak(format!("command[{i}]").into_boxed_str());
+        check(c, static_field)?;
+    }
+    for (k, v) in &cfg.env {
+        let static_field: &'static str = Box::leak(format!("env.{k}").into_boxed_str());
+        check(v, static_field)?;
+    }
+    if let Some(e) = &cfg.extract {
+        check(e, "extract")?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// EnricherConfig must Serialize too so bespoke factories see the same
+// shape via `serde_json::to_value(&cfg)`.
+// ---------------------------------------------------------------------------
+
+impl serde::Serialize for EnricherConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut m = serializer.serialize_map(None)?;
+        m.serialize_entry("id", &self.id)?;
+        m.serialize_entry(
+            "kind",
+            match self.kind {
+                KindLabel::Detection => "detection",
+                KindLabel::Correlation => "correlation",
+            },
+        )?;
+        m.serialize_entry("type", &self.type_name)?;
+        m.serialize_entry("inject_field", &self.inject_field)?;
+        if let Some(t) = &self.timeout {
+            m.serialize_entry("timeout_ms", &(t.as_millis() as u64))?;
+        }
+        m.serialize_entry(
+            "on_error",
+            match self.on_error {
+                OnErrorLabel::Skip => "skip",
+                OnErrorLabel::Null => "null",
+                OnErrorLabel::Drop => "drop",
+            },
+        )?;
+        if let Some(s) = &self.scope {
+            m.serialize_entry("scope", s)?;
+        }
+        if let Some(t) = &self.template {
+            m.serialize_entry("template", t)?;
+        }
+        if let Some(u) = &self.url {
+            m.serialize_entry("url", u)?;
+        }
+        if let Some(meth) = &self.method {
+            m.serialize_entry("method", meth)?;
+        }
+        if !self.headers.is_empty() {
+            m.serialize_entry("headers", &self.headers)?;
+        }
+        if let Some(b) = &self.body {
+            m.serialize_entry("body", b)?;
+        }
+        if let Some(c) = &self.cache_ttl {
+            m.serialize_entry("cache_ttl_ms", &(c.as_millis() as u64))?;
+        }
+        if let Some(e) = &self.extract {
+            m.serialize_entry("extract", e)?;
+        }
+        if let Some(et) = &self.extract_type {
+            m.serialize_entry("extract_type", et)?;
+        }
+        if !self.command.is_empty() {
+            m.serialize_entry("command", &self.command)?;
+        }
+        if !self.env.is_empty() {
+            m.serialize_entry("env", &self.env)?;
+        }
+        if let Some(s) = &self.source {
+            m.serialize_entry("source", s)?;
+        }
+        if let Some(d) = &self.default {
+            m.serialize_entry("default", d)?;
+        }
+        m.end()
+    }
+}
+
+impl serde::Serialize for ScopeConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut m = serializer.serialize_map(None)?;
+        if !self.rules.is_empty() {
+            m.serialize_entry("rules", &self.rules)?;
+        }
+        if !self.tags.is_empty() {
+            m.serialize_entry("tags", &self.tags)?;
+        }
+        if !self.levels.is_empty() {
+            m.serialize_entry("levels", &self.levels)?;
+        }
+        m.end()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// humantime_opt: serde adapter that parses humantime strings into
+// `Option<Duration>` while accepting `null` / missing entries as `None`.
+// ---------------------------------------------------------------------------
+
+mod humantime_opt {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Option<Duration>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw: Option<String> = Option::deserialize(d)?;
+        match raw {
+            Some(s) => humantime::parse_duration(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_template_yaml() -> &'static str {
+        r#"
+max_concurrent_enrichments: 8
+enrichers:
+  - id: runbook_det
+    kind: detection
+    type: template
+    template: "https://wiki/runbooks/${detection.rule.id}"
+    inject_field: runbook_url
+
+  - id: runbook_corr
+    kind: correlation
+    type: template
+    template: "https://wiki/runbooks/${correlation.rule.id}"
+    inject_field: runbook_url
+"#
+    }
+
+    #[test]
+    fn loads_minimal_template_config() {
+        let parsed: EnrichersFile = yaml_serde::from_str(cfg_template_yaml()).unwrap();
+        let pipeline = build_enrichers(parsed).unwrap();
+        assert_eq!(pipeline.len(), 2);
+    }
+
+    #[test]
+    fn rejects_cross_namespace_in_detection_enricher() {
+        let yaml = r#"
+enrichers:
+  - id: bad
+    kind: detection
+    type: template
+    inject_field: out
+    template: "https://wiki/${correlation.rule.id}"
+"#;
+        let parsed: EnrichersFile = yaml_serde::from_str(yaml).unwrap();
+        let err = build_enrichers(parsed).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("wrong namespace"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        let yaml = r#"
+enrichers:
+  - id: weird
+    kind: detection
+    type: something_unknown
+    inject_field: out
+"#;
+        let parsed: EnrichersFile = yaml_serde::from_str(yaml).unwrap();
+        let err = build_enrichers(parsed).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unknown type"), "got: {msg}");
+    }
+
+    #[test]
+    fn two_kind_aware_entries_for_one_logical_enricher() {
+        // The plan documents a "YAML anchor pattern" for kind-agnostic
+        // enrichers: declare two YAML entries that share everything
+        // except `kind` and the namespace of their template. We verify
+        // here that two such entries (regardless of how the operator
+        // reduces duplication via YAML anchors / merge keys, which is a
+        // YAML-loader concern) build into two valid enrichers, one per
+        // kind, with no cross-namespace leakage.
+        let yaml = r#"
+enrichers:
+  - id: runbook_det
+    kind: detection
+    type: template
+    inject_field: runbook_url
+    template: "https://wiki/${detection.rule.id}"
+
+  - id: runbook_corr
+    kind: correlation
+    type: template
+    inject_field: runbook_url
+    template: "https://wiki/${correlation.rule.id}"
+"#;
+        let parsed: EnrichersFile = yaml_serde::from_str(yaml).unwrap();
+        let pipeline = build_enrichers(parsed).unwrap();
+        assert_eq!(pipeline.len(), 2);
+    }
+
+    #[test]
+    fn rejects_missing_template_field() {
+        let yaml = r#"
+enrichers:
+  - id: t
+    kind: detection
+    type: template
+    inject_field: out
+"#;
+        let parsed: EnrichersFile = yaml_serde::from_str(yaml).unwrap();
+        let err = build_enrichers(parsed).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("missing required field 'template'"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn defaults_max_concurrent_when_unset_or_zero() {
+        let yaml = r#"
+enrichers: []
+"#;
+        let parsed: EnrichersFile = yaml_serde::from_str(yaml).unwrap();
+        let pipeline = build_enrichers(parsed).unwrap();
+        assert!(pipeline.is_empty());
+    }
+
+    #[test]
+    fn timeout_string_parses_humantime() {
+        let yaml = r#"
+enrichers:
+  - id: t
+    kind: detection
+    type: template
+    inject_field: out
+    template: "x"
+    timeout: 2500ms
+"#;
+        let parsed: EnrichersFile = yaml_serde::from_str(yaml).unwrap();
+        // We don't have a direct getter for the internal timeout; the
+        // round-trip building succeeds when humantime parses it.
+        build_enrichers(parsed).unwrap();
+    }
+}

--- a/crates/rsigma-cli/src/daemon/enrichment/config.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/config.rs
@@ -14,10 +14,12 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
+#[cfg(test)]
+use rsigma_runtime::NoopMetrics;
 use rsigma_runtime::{
     CommandEnricher, EnricherKind, EnrichmentPipeline, HttpEnricher, HttpEnricherClient,
-    HttpResponseCache, LookupEnricher, OnError, OutputFormat, Scope, SourceCache, TemplateEnricher,
-    build_default_http_client, lookup_builtin, validate_template_namespace,
+    HttpResponseCache, LookupEnricher, MetricsHook, OnError, OutputFormat, Scope, SourceCache,
+    TemplateEnricher, build_default_http_client, lookup_builtin, validate_template_namespace,
 };
 use serde::Deserialize;
 
@@ -38,7 +40,7 @@ const DEFAULT_MAX_CONCURRENT_ENRICHMENTS: usize = 16;
 ///     template: "https://wiki/${detection.rule.id}"
 ///     inject_field: runbook_url
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct EnrichersFile {
     /// Global concurrency cap shared across both kinds. Defaults to 16
     /// if omitted; values of 0 are treated as the default to keep the
@@ -54,7 +56,7 @@ pub struct EnrichersFile {
 }
 
 /// One enricher's YAML config block.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct EnricherConfig {
     /// Stable identifier for this enricher instance. Required.
     pub id: String,
@@ -191,7 +193,7 @@ impl From<OutputFormatLabel> for OutputFormat {
 }
 
 /// `scope:` block.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ScopeConfig {
     #[serde(default)]
     pub rules: Vec<String>,
@@ -296,18 +298,19 @@ pub fn load_enrichers_file(path: &Path) -> Result<EnrichersFile, EnrichersConfig
 /// All HTTP enrichers in the resulting pipeline share a single
 /// `reqwest::Client` (wrapped in [`HttpEnricherClient`]) so connection
 /// pooling works at the daemon level.
+#[cfg(test)]
 pub fn build_enrichers(file: EnrichersFile) -> Result<EnrichmentPipeline, EnrichersConfigError> {
-    build_enrichers_with_cache(file, None)
+    build_enrichers_full(file, None, std::sync::Arc::new(NoopMetrics))
 }
 
 /// Like [`build_enrichers`] but accepts an optional shared
-/// [`SourceCache`] for `lookup` enrichers. The daemon path constructs
-/// this cache when at least one pipeline declares dynamic sources, and
-/// passes it through here so `lookup` enrichers can read pre-resolved
-/// source data without going through the network.
-pub fn build_enrichers_with_cache(
+/// [`SourceCache`] for `lookup` enrichers and a metrics hook the
+/// pipeline (and per-enricher cache lookups) report into. The daemon
+/// passes its Prometheus-backed `Metrics` here.
+pub fn build_enrichers_full(
     file: EnrichersFile,
     source_cache: Option<std::sync::Arc<SourceCache>>,
+    metrics: std::sync::Arc<dyn MetricsHook>,
 ) -> Result<EnrichmentPipeline, EnrichersConfigError> {
     let http_client =
         build_default_http_client().map_err(|message| EnrichersConfigError::BespokeFactory {
@@ -317,12 +320,17 @@ pub fn build_enrichers_with_cache(
     let mut enrichers: Vec<Box<dyn rsigma_runtime::Enricher>> =
         Vec::with_capacity(file.enrichers.len());
     for cfg in file.enrichers {
-        enrichers.push(build_one(cfg, http_client.clone(), source_cache.clone())?);
+        enrichers.push(build_one(
+            cfg,
+            http_client.clone(),
+            source_cache.clone(),
+            metrics.clone(),
+        )?);
     }
     let cap = file
         .max_concurrent_enrichments
         .unwrap_or(DEFAULT_MAX_CONCURRENT_ENRICHMENTS);
-    Ok(EnrichmentPipeline::new(enrichers, cap))
+    Ok(EnrichmentPipeline::new(enrichers, cap).with_metrics(metrics))
 }
 
 /// Build a single [`Enricher`](rsigma_runtime::Enricher) from one YAML
@@ -335,6 +343,7 @@ fn build_one(
     cfg: EnricherConfig,
     http_client: HttpEnricherClient,
     source_cache: Option<std::sync::Arc<SourceCache>>,
+    metrics: std::sync::Arc<dyn MetricsHook>,
 ) -> Result<Box<dyn rsigma_runtime::Enricher>, EnrichersConfigError> {
     let kind: EnricherKind = cfg.kind.into();
     let on_error: OnError = cfg.on_error.into();
@@ -392,21 +401,24 @@ fn build_one(
             let extract = build_extract_expr(&cfg)?;
             let cache_ttl = cfg.cache_ttl.unwrap_or_default();
             let cache = HttpResponseCache::new(cache_ttl);
-            Ok(Box::new(HttpEnricher::new(
-                cfg.id,
-                kind,
-                cfg.inject_field,
-                method,
-                url,
-                headers,
-                cfg.body.clone(),
-                timeout,
-                on_error,
-                scope,
-                extract,
-                http_client,
-                cache,
-            )))
+            Ok(Box::new(
+                HttpEnricher::new(
+                    cfg.id,
+                    kind,
+                    cfg.inject_field,
+                    method,
+                    url,
+                    headers,
+                    cfg.body.clone(),
+                    timeout,
+                    on_error,
+                    scope,
+                    extract,
+                    http_client,
+                    cache,
+                )
+                .with_metrics(metrics),
+            ))
         }
         "command" => {
             if cfg.command.is_empty() {

--- a/crates/rsigma-cli/src/daemon/enrichment/mod.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/mod.rs
@@ -13,4 +13,4 @@
 
 pub mod config;
 
-pub use config::{EnrichersFile, build_enrichers_full, load_enrichers_file};
+pub use config::{build_enrichers_full, load_enrichers_file};

--- a/crates/rsigma-cli/src/daemon/enrichment/mod.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/mod.rs
@@ -13,4 +13,4 @@
 
 pub mod config;
 
-pub use config::{build_enrichers, load_enrichers_file};
+pub use config::{EnrichersFile, build_enrichers_full, load_enrichers_file};

--- a/crates/rsigma-cli/src/daemon/enrichment/mod.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/mod.rs
@@ -1,0 +1,16 @@
+//! Daemon-side enrichment configuration loader.
+//!
+//! Parses the `enrichers:` block from the daemon's enrichers config file
+//! (loaded via `--enrichers <path>`), validates template-namespace
+//! references at load time, and produces an
+//! [`EnrichmentPipeline`](rsigma_runtime::EnrichmentPipeline) that the
+//! daemon's sink task uses to enrich each result before sink delivery.
+//!
+//! Splitting this module out from `enrichment` in `rsigma-runtime` keeps
+//! YAML parsing (a CLI-shaped concern) out of the runtime crate, which
+//! must stay deserialization-agnostic so library consumers can build
+//! enrichers programmatically.
+
+pub mod config;
+
+pub use config::{build_enrichers, load_enrichers_file};

--- a/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
+++ b/crates/rsigma-cli/src/daemon/instrumented_resolver.rs
@@ -28,6 +28,13 @@ impl InstrumentedResolver {
     pub fn cache(&self) -> &rsigma_runtime::sources::cache::SourceCache {
         self.inner.cache()
     }
+
+    /// Borrow the shared `Arc<SourceCache>` so other consumers (the
+    /// enrichment pipeline's `lookup` enrichers) can read from the
+    /// same cache the resolver writes into.
+    pub fn arc_cache(&self) -> std::sync::Arc<rsigma_runtime::sources::cache::SourceCache> {
+        self.inner.arc_cache()
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/rsigma-cli/src/daemon/metrics.rs
+++ b/crates/rsigma-cli/src/daemon/metrics.rs
@@ -519,6 +519,38 @@ impl MetricsHook for Metrics {
             .with_label_values(&[enricher_id])
             .inc();
     }
+
+    fn register_enricher(&self, enricher_id: &str, kind: &str) {
+        // Pre-create label sets so `# HELP` / `# TYPE` lines for the
+        // per-enricher metrics show up on the first /metrics scrape,
+        // even before the enricher has fired. `inc_by(0)` and a
+        // bare `with_label_values` both materialise the entry; the
+        // former is more explicit about the intent.
+        for status in ["success", "skip", "error", "timeout", "drop"] {
+            self.enrichment_total
+                .with_label_values(&[enricher_id, kind, status])
+                .inc_by(0);
+        }
+        // HistogramVec materialises its buckets in `with_label_values`
+        // without observing, so this is side-effect-free: the metric
+        // appears with all-zero buckets and `_count == 0` until the
+        // first `observe(...)` call.
+        let _ = self
+            .enrichment_duration_seconds
+            .with_label_values(&[enricher_id, kind]);
+    }
+
+    fn register_http_enricher_cache(&self, enricher_id: &str) {
+        self.enrichment_http_cache_hits_total
+            .with_label_values(&[enricher_id])
+            .inc_by(0);
+        self.enrichment_http_cache_misses_total
+            .with_label_values(&[enricher_id])
+            .inc_by(0);
+        self.enrichment_http_cache_expirations_total
+            .with_label_values(&[enricher_id])
+            .inc_by(0);
+    }
 }
 
 #[cfg(test)]

--- a/crates/rsigma-cli/src/daemon/metrics.rs
+++ b/crates/rsigma-cli/src/daemon/metrics.rs
@@ -31,6 +31,12 @@ pub struct Metrics {
     pub source_resolve_latency: Histogram,
     pub source_cache_hits: IntCounter,
     pub source_last_resolved: GaugeVec,
+    pub enrichment_total: IntCounterVec,
+    pub enrichment_duration_seconds: prometheus::HistogramVec,
+    pub enrichment_queue_depth: IntGauge,
+    pub enrichment_http_cache_hits_total: IntCounterVec,
+    pub enrichment_http_cache_misses_total: IntCounterVec,
+    pub enrichment_http_cache_expirations_total: IntCounterVec,
     #[cfg(feature = "daemon-otlp")]
     pub otlp_requests: IntCounterVec,
     #[cfg(feature = "daemon-otlp")]
@@ -261,6 +267,71 @@ impl Metrics {
             .register(Box::new(source_last_resolved.clone()))
             .unwrap();
 
+        let enrichment_total = IntCounterVec::new(
+            Opts::new(
+                "rsigma_enrichment_total",
+                "Total per-result enrichment calls, labeled by enricher and outcome",
+            ),
+            &["enricher_id", "kind", "status"],
+        )
+        .unwrap();
+        let enrichment_duration_seconds = prometheus::HistogramVec::new(
+            HistogramOpts::new("rsigma_enrichment_duration_seconds", "Per-enricher latency")
+                .buckets(vec![
+                    0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+                ]),
+            &["enricher_id", "kind"],
+        )
+        .unwrap();
+        let enrichment_queue_depth = IntGauge::with_opts(Opts::new(
+            "rsigma_enrichment_queue_depth",
+            "Pending enrichment calls (sum across both kinds)",
+        ))
+        .unwrap();
+        let enrichment_http_cache_hits_total = IntCounterVec::new(
+            Opts::new(
+                "rsigma_enrichment_http_cache_hits_total",
+                "HTTP enricher response-cache hits",
+            ),
+            &["enricher_id"],
+        )
+        .unwrap();
+        let enrichment_http_cache_misses_total = IntCounterVec::new(
+            Opts::new(
+                "rsigma_enrichment_http_cache_misses_total",
+                "HTTP enricher response-cache misses",
+            ),
+            &["enricher_id"],
+        )
+        .unwrap();
+        let enrichment_http_cache_expirations_total = IntCounterVec::new(
+            Opts::new(
+                "rsigma_enrichment_http_cache_expirations_total",
+                "HTTP enricher response-cache entries evicted on expiry",
+            ),
+            &["enricher_id"],
+        )
+        .unwrap();
+
+        registry
+            .register(Box::new(enrichment_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(enrichment_duration_seconds.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(enrichment_queue_depth.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(enrichment_http_cache_hits_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(enrichment_http_cache_misses_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(enrichment_http_cache_expirations_total.clone()))
+            .unwrap();
+
         #[cfg(feature = "daemon-otlp")]
         let otlp_requests = IntCounterVec::new(
             Opts::new(
@@ -318,6 +389,12 @@ impl Metrics {
             source_resolve_latency,
             source_cache_hits,
             source_last_resolved,
+            enrichment_total,
+            enrichment_duration_seconds,
+            enrichment_queue_depth,
+            enrichment_http_cache_hits_total,
+            enrichment_http_cache_misses_total,
+            enrichment_http_cache_expirations_total,
             #[cfg(feature = "daemon-otlp")]
             otlp_requests,
             #[cfg(feature = "daemon-otlp")]
@@ -399,6 +476,47 @@ impl MetricsHook for Metrics {
     fn on_correlation_match_detail(&self, rule_title: &str, level: &str, correlation_type: &str) {
         self.correlation_matches_by_rule
             .with_label_values(&[rule_title, level, correlation_type])
+            .inc();
+    }
+
+    fn on_enrichment_completed(
+        &self,
+        enricher_id: &str,
+        kind: &str,
+        status: &str,
+        duration_seconds: f64,
+    ) {
+        self.enrichment_total
+            .with_label_values(&[enricher_id, kind, status])
+            .inc();
+        self.enrichment_duration_seconds
+            .with_label_values(&[enricher_id, kind])
+            .observe(duration_seconds);
+    }
+
+    fn on_enrichment_queue_depth_change(&self, delta: i64) {
+        if delta > 0 {
+            self.enrichment_queue_depth.add(delta);
+        } else {
+            self.enrichment_queue_depth.sub(-delta);
+        }
+    }
+
+    fn on_enrichment_http_cache_hit(&self, enricher_id: &str) {
+        self.enrichment_http_cache_hits_total
+            .with_label_values(&[enricher_id])
+            .inc();
+    }
+
+    fn on_enrichment_http_cache_miss(&self, enricher_id: &str) {
+        self.enrichment_http_cache_misses_total
+            .with_label_values(&[enricher_id])
+            .inc();
+    }
+
+    fn on_enrichment_http_cache_expiration(&self, enricher_id: &str) {
+        self.enrichment_http_cache_expirations_total
+            .with_label_values(&[enricher_id])
             .inc();
     }
 }

--- a/crates/rsigma-cli/src/daemon/mod.rs
+++ b/crates/rsigma-cli/src/daemon/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod enrichment;
 mod health;
 mod instrumented_resolver;
 mod metrics;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::time::Instant;
 
+use arc_swap::ArcSwap;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -11,11 +12,9 @@ use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
 use rsigma_runtime::{
-    AckToken, FileSink, InputFormat, LogProcessor, MetricsHook, RawEvent, RuntimeEngine, Sink,
-    StdinSource, StdoutSink, spawn_source,
+    AckToken, EnrichmentPipeline, FileSink, InputFormat, LogProcessor, MetricsHook, RawEvent,
+    RuntimeEngine, Sink, StdinSource, StdoutSink, spawn_source,
 };
-
-use super::enrichment::EnrichersFile;
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tower_http::trace::TraceLayer;
@@ -106,34 +105,44 @@ pub struct DaemonConfig {
     /// Cargo feature.
     #[cfg(feature = "daachorse-index")]
     pub cross_rule_ac: bool,
-    /// Optional parsed enrichers config (from `--enrichers`). The
-    /// daemon constructs the `EnrichmentPipeline` from this once its
-    /// `Metrics` struct exists, so per-call counters can be wired into
-    /// Prometheus.
-    pub enrichers_file: Option<EnrichersFile>,
+    /// Optional path to the enrichers config (from `--enrichers`). Read
+    /// at daemon startup and again on hot-reload (SIGHUP / file watcher
+    /// / `POST /api/v1/reload`); failures during reload are logged and
+    /// the previous pipeline stays active.
+    pub enrichers_path: Option<PathBuf>,
 }
 
-pub async fn run_daemon(mut config: DaemonConfig) {
+pub async fn run_daemon(config: DaemonConfig) {
     let metrics = Arc::new(Metrics::new());
     let health = HealthState::new();
 
     // Build the post-evaluation enrichment pipeline now that the
     // metrics struct (which owns the Prometheus registry) exists.
     // Failures here exit cleanly because no I/O has started yet.
-    let enrichment_pipeline = match config.enrichers_file.take() {
-        Some(file) => match super::enrichment::build_enrichers_full(
-            file,
-            None,
-            metrics.clone() as Arc<dyn rsigma_runtime::MetricsHook>,
-        ) {
-            Ok(p) => Some(Arc::new(p)),
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to build enrichment pipeline");
-                std::process::exit(crate::exit_code::CONFIG_ERROR);
-            }
-        },
-        None => None,
-    };
+    // The pipeline is wrapped in an `ArcSwap` so the SIGHUP / reload
+    // path (below) can swap a new build in place atomically.
+    let enrichment_metrics = metrics.clone() as Arc<dyn rsigma_runtime::MetricsHook>;
+    let enrichment_swap: Arc<ArcSwap<Option<Arc<EnrichmentPipeline>>>> = Arc::new(ArcSwap::new(
+        Arc::new(match config.enrichers_path.as_deref() {
+            Some(path) => match super::enrichment::load_enrichers_file(path).and_then(|file| {
+                super::enrichment::build_enrichers_full(file, None, enrichment_metrics.clone())
+            }) {
+                Ok(p) => {
+                    tracing::info!(
+                        enrichers = p.len(),
+                        path = %path.display(),
+                        "Enrichment pipeline loaded"
+                    );
+                    Some(Arc::new(p))
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to build enrichment pipeline");
+                    std::process::exit(crate::exit_code::CONFIG_ERROR);
+                }
+            },
+            None => None,
+        }),
+    ));
 
     // Open SQLite state store if configured
     let state_store = config.state_db.as_ref().map(|path| {
@@ -414,6 +423,9 @@ pub async fn run_daemon(mut config: DaemonConfig) {
     let reload_processor = processor.clone();
     let reload_metrics = metrics.clone();
     let reload_health = health.clone();
+    let reload_enrichment_swap = enrichment_swap.clone();
+    let reload_enrichers_path = config.enrichers_path.clone();
+    let reload_enrichment_metrics = enrichment_metrics.clone();
     tokio::spawn(async move {
         while reload_rx.recv().await.is_some() {
             // Debounce: batch rapid file changes
@@ -442,6 +454,45 @@ pub async fn run_daemon(mut config: DaemonConfig) {
                 Err(e) => {
                     tracing::error!(error = %e, "Failed to reload rules");
                     reload_metrics.reloads_failed.inc();
+                }
+            }
+
+            // Reload enrichers. Failures here log + bump
+            // `reloads_failed` and leave the previous pipeline in place
+            // so a typo in the enrichers config doesn't take down
+            // detection enrichment in production.
+            if let Some(path) = reload_enrichers_path.as_deref() {
+                match super::enrichment::load_enrichers_file(path).and_then(|file| {
+                    super::enrichment::build_enrichers_full(
+                        file,
+                        None,
+                        reload_enrichment_metrics.clone(),
+                    )
+                }) {
+                    Ok(new_pipeline) => {
+                        let prev_count = reload_enrichment_swap
+                            .load()
+                            .as_ref()
+                            .as_ref()
+                            .map(|p| p.len())
+                            .unwrap_or(0);
+                        let new_count = new_pipeline.len();
+                        reload_enrichment_swap.store(Arc::new(Some(Arc::new(new_pipeline))));
+                        tracing::info!(
+                            previous = prev_count,
+                            current = new_count,
+                            path = %path.display(),
+                            "Enrichment pipeline reloaded"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            error = %e,
+                            path = %path.display(),
+                            "Failed to reload enrichers config; keeping previous pipeline"
+                        );
+                        reload_metrics.reloads_failed.inc();
+                    }
                 }
             }
         }
@@ -754,7 +805,7 @@ pub async fn run_daemon(mut config: DaemonConfig) {
     // enabled, routes the failed result to the DLQ.
     let sink_metrics = metrics.clone();
     let sink_dlq_tx = dlq_tx;
-    let enrichment = enrichment_pipeline.clone();
+    let enrichment_swap_for_sink = enrichment_swap.clone();
     let sink_handle = tokio::spawn(async move {
         let mut sink = sink;
         while let Some((mut result, ack_tokens)) = sink_rx.recv().await {
@@ -765,7 +816,12 @@ pub async fn run_daemon(mut config: DaemonConfig) {
             // declared `kind` against the `body` variant and may
             // suppress entries via `on_error: drop`. If every entry is
             // dropped, skip sink delivery but still ack the events.
-            if let Some(pipeline) = enrichment.as_ref()
+            //
+            // We `load_full` so the pipeline's lifetime extends across
+            // the await without holding an `ArcSwap` guard; the
+            // reload path swaps in a new value without blocking.
+            let pipeline_snapshot = enrichment_swap_for_sink.load_full();
+            if let Some(pipeline) = pipeline_snapshot.as_ref()
                 && !pipeline.is_empty()
             {
                 pipeline.run(&mut result).await;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -116,33 +116,13 @@ pub async fn run_daemon(config: DaemonConfig) {
     let metrics = Arc::new(Metrics::new());
     let health = HealthState::new();
 
-    // Build the post-evaluation enrichment pipeline now that the
-    // metrics struct (which owns the Prometheus registry) exists.
-    // Failures here exit cleanly because no I/O has started yet.
-    // The pipeline is wrapped in an `ArcSwap` so the SIGHUP / reload
-    // path (below) can swap a new build in place atomically.
+    // The enrichment pipeline is constructed below, after the dynamic
+    // source resolver exists, so `lookup` enrichers can share the
+    // resolver's `Arc<SourceCache>`. We hoist the `ArcSwap` here so
+    // the sink task closure can capture it directly.
     let enrichment_metrics = metrics.clone() as Arc<dyn rsigma_runtime::MetricsHook>;
-    let enrichment_swap: Arc<ArcSwap<Option<Arc<EnrichmentPipeline>>>> = Arc::new(ArcSwap::new(
-        Arc::new(match config.enrichers_path.as_deref() {
-            Some(path) => match super::enrichment::load_enrichers_file(path).and_then(|file| {
-                super::enrichment::build_enrichers_full(file, None, enrichment_metrics.clone())
-            }) {
-                Ok(p) => {
-                    tracing::info!(
-                        enrichers = p.len(),
-                        path = %path.display(),
-                        "Enrichment pipeline loaded"
-                    );
-                    Some(Arc::new(p))
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "Failed to build enrichment pipeline");
-                    std::process::exit(crate::exit_code::CONFIG_ERROR);
-                }
-            },
-            None => None,
-        }),
-    ));
+    let enrichment_swap: Arc<ArcSwap<Option<Arc<EnrichmentPipeline>>>> =
+        Arc::new(ArcSwap::new(Arc::new(None)));
 
     // Open SQLite state store if configured
     let state_store = config.state_db.as_ref().map(|path| {
@@ -317,6 +297,35 @@ pub async fn run_daemon(config: DaemonConfig) {
         }
     }
 
+    // Build the post-evaluation enrichment pipeline now that the
+    // dynamic source resolver (if any) has been constructed; `lookup`
+    // enrichers share the resolver's `Arc<SourceCache>` so they read
+    // from the same cache the resolver writes into. Failures here exit
+    // cleanly because no I/O has started yet.
+    let initial_source_cache = source_resolver_val.as_ref().map(|r| r.arc_cache());
+    if let Some(path) = config.enrichers_path.as_ref() {
+        match super::enrichment::load_enrichers_file(path).and_then(|file| {
+            super::enrichment::build_enrichers_full(
+                file,
+                initial_source_cache.clone(),
+                enrichment_metrics.clone(),
+            )
+        }) {
+            Ok(p) => {
+                tracing::info!(
+                    enrichers = p.len(),
+                    path = %path.display(),
+                    "Enrichment pipeline loaded"
+                );
+                enrichment_swap.store(Arc::new(Some(Arc::new(p))));
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to build enrichment pipeline");
+                std::process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+        }
+    }
+
     // Bounded channel acts as backpressure for reload requests. Capacity 4
     // allows the file watcher, SIGHUP handler, and HTTP endpoint to queue
     // reloads without blocking, while the consumer debounces with a 500ms
@@ -426,6 +435,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     let reload_enrichment_swap = enrichment_swap.clone();
     let reload_enrichers_path = config.enrichers_path.clone();
     let reload_enrichment_metrics = enrichment_metrics.clone();
+    let reload_source_cache = initial_source_cache.clone();
     tokio::spawn(async move {
         while reload_rx.recv().await.is_some() {
             // Debounce: batch rapid file changes
@@ -465,7 +475,7 @@ pub async fn run_daemon(config: DaemonConfig) {
                 match super::enrichment::load_enrichers_file(path).and_then(|file| {
                     super::enrichment::build_enrichers_full(
                         file,
-                        None,
+                        reload_source_cache.clone(),
                         reload_enrichment_metrics.clone(),
                     )
                 }) {

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -11,9 +11,11 @@ use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
 use rsigma_runtime::{
-    AckToken, EnrichmentPipeline, FileSink, InputFormat, LogProcessor, MetricsHook, RawEvent,
-    RuntimeEngine, Sink, StdinSource, StdoutSink, spawn_source,
+    AckToken, FileSink, InputFormat, LogProcessor, MetricsHook, RawEvent, RuntimeEngine, Sink,
+    StdinSource, StdoutSink, spawn_source,
 };
+
+use super::enrichment::EnrichersFile;
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tower_http::trace::TraceLayer;
@@ -104,16 +106,34 @@ pub struct DaemonConfig {
     /// Cargo feature.
     #[cfg(feature = "daachorse-index")]
     pub cross_rule_ac: bool,
-    /// Optional post-evaluation enrichment pipeline. When `Some`, every
-    /// `EvaluationResult` flows through the pipeline before being sent to
-    /// the sink; the pipeline itself decides per-result whether each
-    /// enricher fires (kind / scope filtering inside the pipeline).
-    pub enrichment: Option<Arc<EnrichmentPipeline>>,
+    /// Optional parsed enrichers config (from `--enrichers`). The
+    /// daemon constructs the `EnrichmentPipeline` from this once its
+    /// `Metrics` struct exists, so per-call counters can be wired into
+    /// Prometheus.
+    pub enrichers_file: Option<EnrichersFile>,
 }
 
-pub async fn run_daemon(config: DaemonConfig) {
+pub async fn run_daemon(mut config: DaemonConfig) {
     let metrics = Arc::new(Metrics::new());
     let health = HealthState::new();
+
+    // Build the post-evaluation enrichment pipeline now that the
+    // metrics struct (which owns the Prometheus registry) exists.
+    // Failures here exit cleanly because no I/O has started yet.
+    let enrichment_pipeline = match config.enrichers_file.take() {
+        Some(file) => match super::enrichment::build_enrichers_full(
+            file,
+            None,
+            metrics.clone() as Arc<dyn rsigma_runtime::MetricsHook>,
+        ) {
+            Ok(p) => Some(Arc::new(p)),
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to build enrichment pipeline");
+                std::process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+        },
+        None => None,
+    };
 
     // Open SQLite state store if configured
     let state_store = config.state_db.as_ref().map(|path| {
@@ -734,7 +754,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     // enabled, routes the failed result to the DLQ.
     let sink_metrics = metrics.clone();
     let sink_dlq_tx = dlq_tx;
-    let enrichment = config.enrichment.clone();
+    let enrichment = enrichment_pipeline.clone();
     let sink_handle = tokio::spawn(async move {
         let mut sink = sink;
         while let Some((mut result, ack_tokens)) = sink_rx.recv().await {

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -11,8 +11,8 @@ use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
 use rsigma_runtime::{
-    AckToken, FileSink, InputFormat, LogProcessor, MetricsHook, RawEvent, RuntimeEngine, Sink,
-    StdinSource, StdoutSink, spawn_source,
+    AckToken, EnrichmentPipeline, FileSink, InputFormat, LogProcessor, MetricsHook, RawEvent,
+    RuntimeEngine, Sink, StdinSource, StdoutSink, spawn_source,
 };
 use serde::Serialize;
 use tokio::sync::mpsc;
@@ -104,6 +104,11 @@ pub struct DaemonConfig {
     /// Cargo feature.
     #[cfg(feature = "daachorse-index")]
     pub cross_rule_ac: bool,
+    /// Optional post-evaluation enrichment pipeline. When `Some`, every
+    /// `EvaluationResult` flows through the pipeline before being sent to
+    /// the sink; the pipeline itself decides per-result whether each
+    /// enricher fires (kind / scope filtering inside the pipeline).
+    pub enrichment: Option<Arc<EnrichmentPipeline>>,
 }
 
 pub async fn run_daemon(config: DaemonConfig) {
@@ -723,15 +728,38 @@ pub async fn run_daemon(config: DaemonConfig) {
     };
     tracing::info!(output = ?output_specs, "Sink started");
 
-    // Sink task: reads (ProcessResult, Vec<AckToken>) from channel, writes via
-    // Sink dispatch, then forwards ack tokens to the ack task.
-    // On sink failure with DLQ enabled, routes the failed result to the DLQ.
+    // Sink task: reads (ProcessResult, Vec<AckToken>) from channel, runs
+    // any configured post-evaluation enrichment, writes via Sink dispatch,
+    // then forwards ack tokens to the ack task. On sink failure with DLQ
+    // enabled, routes the failed result to the DLQ.
     let sink_metrics = metrics.clone();
     let sink_dlq_tx = dlq_tx;
+    let enrichment = config.enrichment.clone();
     let sink_handle = tokio::spawn(async move {
         let mut sink = sink;
-        while let Some((result, ack_tokens)) = sink_rx.recv().await {
+        while let Some((mut result, ack_tokens)) = sink_rx.recv().await {
             sink_metrics.on_output_queue_depth_change(-1);
+
+            // Post-evaluation enrichment: one loop over the flat
+            // `Vec<EvaluationResult>`. The pipeline filters per-result by
+            // declared `kind` against the `body` variant and may
+            // suppress entries via `on_error: drop`. If every entry is
+            // dropped, skip sink delivery but still ack the events.
+            if let Some(pipeline) = enrichment.as_ref()
+                && !pipeline.is_empty()
+            {
+                pipeline.run(&mut result).await;
+                if result.is_empty() {
+                    for token in ack_tokens {
+                        if ack_tx.send(token).await.is_err() {
+                            tracing::debug!("Ack channel closed");
+                            return;
+                        }
+                    }
+                    continue;
+                }
+            }
+
             if let Err(e) = sink.send(&result).await {
                 tracing::warn!(error = %e, "Error writing to sink");
                 let serialized = serde_json::to_string(&result).unwrap_or_default();

--- a/crates/rsigma-cli/tests/cli_daemon_enrichment.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_enrichment.rs
@@ -1,0 +1,307 @@
+//! E2E tests for the daemon's `--enrichers` flag.
+//!
+//! Spawns `rsigma engine daemon` with an enrichers config covering all
+//! four primitives (`template`, `lookup`, `http`, `command`) plus a
+//! file sink, sends a detection-triggering event over `--input http`,
+//! and asserts that the resulting NDJSON line carries an `enrichments`
+//! object with each primitive's contribution. Also covers:
+//!
+//! - cross-namespace template references rejected at startup,
+//! - the HTTP response cache eliminating the second upstream call.
+
+#![cfg(feature = "daemon")]
+
+mod common;
+
+use common::{DaemonProcess, http_post, poll_until, rsigma_bin, temp_file};
+use std::process::Stdio;
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// The rule selection covers `CommandLine`, `SourceIp`, and `SHA256` so
+// every templated field landing in `matched_fields` is available to the
+// enrichers (the `${detection.fields.X}` resolver reads from
+// `matched_fields`, not from the original event).
+const ENRICH_RULE: &str = r#"
+title: Encoded PowerShell
+id: 00000000-0000-0000-0000-0000000000aa
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: "powershell -enc"
+        SourceIp|contains: "."
+        SHA256|contains: ""
+    condition: selection
+level: high
+tags:
+    - attack.t1059.001
+"#;
+
+/// Pipeline declaring an `employee_directory` dynamic source so the
+/// `lookup` enricher has something to read from.
+fn pipeline_yaml(employees_path: &str) -> String {
+    format!(
+        r#"
+name: enrich-test
+priority: 10
+sources:
+  - id: employee_directory
+    type: file
+    path: {employees_path}
+    format: json
+"#
+    )
+}
+
+const EMPLOYEES_JSON: &str = r#"{
+  "10.0.0.5": {"user": "alice", "team": "Platform"},
+  "10.0.0.7": {"user": "bob", "team": "IT-Ops"}
+}"#;
+
+/// Enrichers config covering all four primitives.
+fn enrichers_yaml(http_base: &str) -> String {
+    format!(
+        r#"
+max_concurrent_enrichments: 4
+
+enrichers:
+  - id: runbook
+    kind: detection
+    type: template
+    inject_field: runbook_url
+    template: "https://wiki/runbooks/${{detection.rule.id}}"
+
+  - id: employee
+    kind: detection
+    type: lookup
+    inject_field: employee
+    source: employee_directory
+    extract: '."${{detection.fields.SourceIp}}"'
+    extract_type: jq
+    default: "unknown"
+
+  - id: hash_rep
+    kind: detection
+    type: http
+    inject_field: file_reputation
+    url: "{http_base}/files/${{detection.fields.SHA256}}"
+    method: GET
+    cache_ttl: 1h
+    on_error: skip
+
+  - id: who_am_i
+    kind: detection
+    type: command
+    inject_field: probe_output
+    command: ["/bin/sh", "-c", "echo '{{\"who\": \"daemon\"}}'"]
+    output: json
+"#
+    )
+}
+
+const CROSS_NAMESPACE_ENRICHERS_YAML: &str = r#"
+enrichers:
+  - id: bad
+    kind: detection
+    type: template
+    inject_field: out
+    template: "https://wiki/${correlation.rule.id}"
+"#;
+
+fn detect_event() -> serde_json::Value {
+    // The rule matches `CommandLine|contains "powershell -enc"`. We
+    // include `SourceIp` (consumed by the `lookup` enricher) and
+    // `SHA256` (consumed by the `http` enricher) so every primitive
+    // has data to act on.
+    serde_json::json!({
+        "CommandLine": "powershell -enc QQA=",
+        "SourceIp": "10.0.0.5",
+        "SHA256": "abc123"
+    })
+}
+
+#[test]
+fn enrichers_inject_into_detection_output_via_all_four_primitives() {
+    // Stand up a wiremock server for the `http` enricher. The mock
+    // returns a fixed JSON payload regardless of body so the test does
+    // not depend on `${detection.fields.SHA256}` resolving to any
+    // particular value.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let server = rt.block_on(async {
+        let s = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/files/abc123"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"score": 12})),
+            )
+            // Strict: the cache should keep us at exactly one upstream call
+            // across the two events sent below.
+            .expect(1)
+            .mount(&s)
+            .await;
+        s
+    });
+
+    // Pipeline + employees + enrichers config files.
+    let employees = temp_file(".json", EMPLOYEES_JSON);
+    let pipeline = temp_file(".yml", &pipeline_yaml(employees.path().to_str().unwrap()));
+    let rule = temp_file(".yml", ENRICH_RULE);
+    let enrichers = temp_file(".yml", &enrichers_yaml(server.uri().as_str()));
+
+    // File sink for reading enriched detections back.
+    let output_file = tempfile::NamedTempFile::new().unwrap();
+    let output_path = output_file.path().to_str().unwrap().to_string();
+
+    let daemon = DaemonProcess::spawn(&[
+        "engine",
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "-p",
+        pipeline.path().to_str().unwrap(),
+        "--enrichers",
+        enrichers.path().to_str().unwrap(),
+        "--input",
+        "http",
+        "--api-addr",
+        "127.0.0.1:0",
+        "--output",
+        &format!("file://{output_path}"),
+    ]);
+
+    // Send the same event twice; the second call must hit the HTTP
+    // cache (`expect(1)` on the mock above asserts this).
+    let body = serde_json::to_string(&detect_event()).unwrap();
+    for _ in 0..2 {
+        let (status, _) = http_post(&daemon.url("/api/v1/events"), &body);
+        assert_eq!(status, 200, "POST /api/v1/events did not accept the event");
+    }
+
+    // Wait for the two enriched lines to land in the file sink.
+    let lines = poll_until(Duration::from_secs(5), || {
+        let bytes = std::fs::read_to_string(&output_path).ok()?;
+        let lines: Vec<&str> = bytes.lines().filter(|l| !l.is_empty()).collect();
+        if lines.len() >= 2 {
+            Some(lines.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+        } else {
+            None
+        }
+    })
+    .expect("two enriched detections never landed in the file sink within 5s");
+
+    // Assertions on the first enriched detection.
+    let parsed: serde_json::Value = serde_json::from_str(&lines[0]).expect("invalid NDJSON");
+    let enr = parsed
+        .get("enrichments")
+        .expect("detection must carry an `enrichments` object");
+
+    assert_eq!(
+        enr.get("runbook_url"),
+        Some(&serde_json::json!(format!(
+            "https://wiki/runbooks/{}",
+            "00000000-0000-0000-0000-0000000000aa"
+        ))),
+        "template enricher should have synthesised the runbook URL"
+    );
+    assert_eq!(
+        enr.get("employee"),
+        Some(&serde_json::json!({"user": "alice", "team": "Platform"})),
+        "lookup enricher should have resolved the source IP to alice"
+    );
+    assert_eq!(
+        enr.get("file_reputation"),
+        Some(&serde_json::json!({"score": 12})),
+        "http enricher should have written the wiremock response"
+    );
+    assert_eq!(
+        enr.get("probe_output"),
+        Some(&serde_json::json!({"who": "daemon"})),
+        "command enricher should have parsed the JSON stdout"
+    );
+
+    // Sanity check: the second enriched line carries the same fields
+    // (the cache hit served the same `file_reputation` value).
+    let parsed_2: serde_json::Value = serde_json::from_str(&lines[1]).expect("invalid NDJSON");
+    assert_eq!(
+        parsed_2.get("enrichments").unwrap().get("file_reputation"),
+        Some(&serde_json::json!({"score": 12}))
+    );
+
+    // Verify cache stats via /metrics. We expect at least one cache hit
+    // (the second call hit the cache) and at least one miss (the first).
+    let (_, metrics_body) = common::http_get(&daemon.url("/metrics"));
+    assert!(
+        metrics_body.contains("rsigma_enrichment_total{"),
+        "/metrics should expose rsigma_enrichment_total"
+    );
+    assert!(
+        metrics_body.contains("rsigma_enrichment_http_cache_hits_total{"),
+        "/metrics should expose the HTTP cache hits counter"
+    );
+
+    // The wiremock `expect(1)` assertion runs on Drop. If the cache
+    // failed and we made two upstream calls, dropping `server` would
+    // panic.
+    drop(server);
+}
+
+#[test]
+fn cross_namespace_enrichers_config_is_rejected_at_startup() {
+    // Spawning the daemon with a `kind: detection` enricher that
+    // references `${correlation.rule.id}` must exit with the
+    // configuration-error code (3) and never bind to a port.
+    let rule = temp_file(".yml", ENRICH_RULE);
+    let enrichers = temp_file(".yml", CROSS_NAMESPACE_ENRICHERS_YAML);
+
+    let mut child = std::process::Command::new(rsigma_bin())
+        .args([
+            "engine",
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--enrichers",
+            enrichers.path().to_str().unwrap(),
+            "--input",
+            "http",
+            "--api-addr",
+            "127.0.0.1:0",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn rsigma engine daemon");
+
+    // Drain stderr in the background so a slow log consumer cannot
+    // block the daemon from exiting.
+    let stderr = child.stderr.take().unwrap();
+    let stderr_handle = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut s = String::new();
+        let mut r = stderr;
+        let _ = r.read_to_string(&mut s);
+        s
+    });
+
+    let exit = poll_until(Duration::from_secs(10), || child.try_wait().ok().flatten())
+        .expect("daemon did not exit within 10s on a malformed enrichers config");
+    let stderr_output = stderr_handle.join().unwrap_or_default();
+
+    assert_eq!(
+        exit.code(),
+        Some(3),
+        "expected exit code 3 (CONFIG_ERROR), got {:?}; stderr was:\n{stderr_output}",
+        exit.code()
+    );
+    assert!(
+        stderr_output.contains("wrong namespace") || stderr_output.contains("malformed"),
+        "stderr should explain the cross-namespace error; got:\n{stderr_output}"
+    );
+}

--- a/crates/rsigma-cli/tests/cli_daemon_enrichment.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_enrichment.rs
@@ -64,11 +64,21 @@ const EMPLOYEES_JSON: &str = r#"{
 
 /// Build the platform-portable `command:` argv for the test's `command`
 /// enricher. On Unix, runs `cat <fixture>`; on Windows, runs
-/// `cmd.exe /C type "<fixture>"`. Returns a YAML inline list literal
-/// ready to splice into the config.
+/// `cmd.exe /D /C type <fixture>` as four separate argv elements.
+/// Returns a YAML inline list literal ready to splice into the config.
 ///
 /// The fixture file holds the JSON body the enricher should produce,
 /// avoiding cross-shell quote-escaping headaches.
+///
+/// **Windows note:** the path goes in its own argv element rather than
+/// being baked into a `type "..."` blob. That avoids cmd.exe's `/C`
+/// quote-stripping pathology, which otherwise leaves cmd trying to
+/// open a file with literal `\"...\"` characters at both ends after
+/// Rust's `CreateProcess` quoting and cmd's outer-quote-stripping
+/// rule interact. With separate args, Rust quotes only the path
+/// element (when it contains spaces), cmd's `type` receives a single
+/// clean path argument, and the file is read normally. `/D` disables
+/// AutoRun for hermeticity.
 fn command_argv_yaml(probe_path: &str) -> String {
     #[cfg(unix)]
     {
@@ -76,11 +86,10 @@ fn command_argv_yaml(probe_path: &str) -> String {
     }
     #[cfg(windows)]
     {
-        // Forward slashes work fine inside `type "..."` on cmd.exe and
-        // make the YAML escaping simple. The JSON-like quoting around
-        // the YAML element handles spaces in temp paths.
-        let win_path = probe_path.replace('\\', "/");
-        format!(r#"["cmd.exe", "/C", "type \"{win_path}\""]"#)
+        // Escape backslashes for the YAML double-quoted string so each
+        // `\\` decodes back to a single `\` in the parsed path.
+        let yaml_escaped = probe_path.replace('\\', "\\\\");
+        format!(r#"["cmd.exe", "/D", "/C", "type", "{yaml_escaped}"]"#)
     }
 }
 

--- a/crates/rsigma-cli/tests/cli_daemon_enrichment.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_enrichment.rs
@@ -62,8 +62,30 @@ const EMPLOYEES_JSON: &str = r#"{
   "10.0.0.7": {"user": "bob", "team": "IT-Ops"}
 }"#;
 
+/// Build the platform-portable `command:` argv for the test's `command`
+/// enricher. On Unix, runs `cat <fixture>`; on Windows, runs
+/// `cmd.exe /C type "<fixture>"`. Returns a YAML inline list literal
+/// ready to splice into the config.
+///
+/// The fixture file holds the JSON body the enricher should produce,
+/// avoiding cross-shell quote-escaping headaches.
+fn command_argv_yaml(probe_path: &str) -> String {
+    #[cfg(unix)]
+    {
+        format!(r#"["/bin/cat", "{probe_path}"]"#)
+    }
+    #[cfg(windows)]
+    {
+        // Forward slashes work fine inside `type "..."` on cmd.exe and
+        // make the YAML escaping simple. The JSON-like quoting around
+        // the YAML element handles spaces in temp paths.
+        let win_path = probe_path.replace('\\', "/");
+        format!(r#"["cmd.exe", "/C", "type \"{win_path}\""]"#)
+    }
+}
+
 /// Enrichers config covering all four primitives.
-fn enrichers_yaml(http_base: &str) -> String {
+fn enrichers_yaml(http_base: &str, command_argv: &str) -> String {
     format!(
         r#"
 max_concurrent_enrichments: 4
@@ -97,7 +119,7 @@ enrichers:
     kind: detection
     type: command
     inject_field: probe_output
-    command: ["/bin/sh", "-c", "echo '{{\"who\": \"daemon\"}}'"]
+    command: {command_argv}
     output: json
 "#
     )
@@ -149,11 +171,21 @@ fn enrichers_inject_into_detection_output_via_all_four_primitives() {
         s
     });
 
-    // Pipeline + employees + enrichers config files.
+    // Pipeline + employees + enrichers config files. The `command`
+    // enricher reads its JSON body from a fixture file via `cat`
+    // (Unix) / `type` (Windows) so the test doesn't have to deal with
+    // cross-shell quote escaping.
     let employees = temp_file(".json", EMPLOYEES_JSON);
+    let probe_payload = temp_file(".json", r#"{"who": "daemon"}"#);
     let pipeline = temp_file(".yml", &pipeline_yaml(employees.path().to_str().unwrap()));
     let rule = temp_file(".yml", ENRICH_RULE);
-    let enrichers = temp_file(".yml", &enrichers_yaml(server.uri().as_str()));
+    let enrichers = temp_file(
+        ".yml",
+        &enrichers_yaml(
+            server.uri().as_str(),
+            &command_argv_yaml(probe_payload.path().to_str().unwrap()),
+        ),
+    );
 
     // File sink for reading enriched detections back.
     let output_file = tempfile::NamedTempFile::new().unwrap();

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -31,10 +31,13 @@ parking_lot = "0.12"
 syslog_loose = "0.23"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 async-trait = "0.1"
+globset = "0.4"
 regex = "1"
 csv = "1"
+jaq-core = "1.5.0"
 jaq-interpret = "1.5.0"
 jaq-parse = "1.0.3"
+jaq-std = "1.5.0"
 jsonpath-rust = "1"
 cel = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
@@ -57,6 +60,7 @@ criterion = "0.8"
 rand = "0.10"
 testcontainers = "0.27"
 testcontainers-modules = { version = "0.15", features = ["nats"] }
+wiremock = "0.6"
 
 [[bench]]
 name = "runtime_throughput"

--- a/crates/rsigma-runtime/src/enrichment/command.rs
+++ b/crates/rsigma-runtime/src/enrichment/command.rs
@@ -171,8 +171,14 @@ impl Enricher for CommandEnricher {
                     kind: EnrichErrorKind::Parse(format!("JSON: {e}")),
                 })?,
             OutputFormat::Raw => {
+                // Strip trailing CR and LF in any combination so that the
+                // Windows CRLF line ending from `cmd /C echo ...` produces
+                // the same captured value as the Unix LF from `sh -c
+                // echo ...`. We do not call `.trim_end()` because that
+                // would also strip trailing spaces, which a `Raw` capture
+                // is otherwise expected to preserve verbatim.
                 let s = String::from_utf8_lossy(&output.stdout);
-                serde_json::Value::String(s.trim_end_matches('\n').to_string())
+                serde_json::Value::String(s.trim_end_matches(['\r', '\n']).to_string())
             }
         };
         inject_enrichment(result, &self.inject_field, value);

--- a/crates/rsigma-runtime/src/enrichment/command.rs
+++ b/crates/rsigma-runtime/src/enrichment/command.rs
@@ -1,0 +1,181 @@
+//! `CommandEnricher`: per-result local-process execution.
+//!
+//! Runs a local command via [`tokio::process::Command`] with a
+//! template-expanded argv and an optional template-expanded environment.
+//! Stdout is captured (capped at 10 MB to mirror the existing
+//! dynamic-source command resolver) and parsed as either a JSON value or
+//! a raw string (the [`OutputFormat`] knob).
+//!
+//! Non-zero exit codes map to [`EnrichErrorKind::Fetch`]. Stderr is read
+//! into the error message (truncated at 4 KB) so operators can see what
+//! went wrong without grepping the daemon's tracing output.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rsigma_eval::EvaluationResult;
+use tokio::process::Command;
+
+use super::{
+    EnrichError, EnrichErrorKind, Enricher, EnricherKind, OnError, Scope, inject_enrichment,
+    template::render_template,
+};
+
+/// Maximum stdout bytes captured per invocation. Mirrors
+/// [`crate::sources::MAX_SOURCE_RESPONSE_BYTES`] so the two surfaces
+/// share the same hard limit.
+const MAX_COMMAND_STDOUT: usize = 10 * 1024 * 1024;
+/// Maximum stderr bytes attached to error messages.
+const MAX_COMMAND_STDERR_IN_ERROR: usize = 4 * 1024;
+
+/// How to interpret captured stdout.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Parse stdout as JSON. Non-JSON stdout produces a `Parse` error.
+    /// Default — matches the dynamic-pipelines command source behaviour.
+    #[default]
+    Json,
+    /// Inject stdout as a raw `serde_json::Value::String`. Trailing
+    /// newlines are stripped.
+    Raw,
+}
+
+/// One command enricher instance.
+pub struct CommandEnricher {
+    id: String,
+    kind: EnricherKind,
+    inject_field: String,
+    argv: Vec<String>,
+    env: HashMap<String, String>,
+    timeout: Duration,
+    on_error: OnError,
+    scope: Scope,
+    output: OutputFormat,
+}
+
+impl CommandEnricher {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        kind: EnricherKind,
+        inject_field: String,
+        argv: Vec<String>,
+        env: HashMap<String, String>,
+        timeout: Duration,
+        on_error: OnError,
+        scope: Scope,
+        output: OutputFormat,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            inject_field,
+            argv,
+            env,
+            timeout,
+            on_error,
+            scope,
+            output,
+        }
+    }
+}
+
+#[async_trait]
+impl Enricher for CommandEnricher {
+    fn kind(&self) -> EnricherKind {
+        self.kind
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn inject_field(&self) -> &str {
+        &self.inject_field
+    }
+    fn timeout(&self) -> Duration {
+        self.timeout
+    }
+    fn scope(&self) -> &Scope {
+        &self.scope
+    }
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+
+    async fn enrich(&self, result: &mut EvaluationResult) -> Result<(), EnrichError> {
+        if self.argv.is_empty() {
+            return Err(EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch("empty argv".to_string()),
+            });
+        }
+
+        let rendered: Vec<String> = self
+            .argv
+            .iter()
+            .map(|a| render_template(a, result))
+            .collect();
+
+        let mut cmd = Command::new(&rendered[0]);
+        cmd.args(&rendered[1..]);
+        // Replace the inherited env wholesale with the configured env
+        // when the operator supplies any entries; otherwise inherit the
+        // daemon's env (so e.g. `PATH` resolves binary names normally).
+        if !self.env.is_empty() {
+            for (k, v) in &self.env {
+                cmd.env(k, render_template(v, result));
+            }
+        }
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.kill_on_drop(true);
+
+        let output = cmd.output().await.map_err(|e| EnrichError {
+            enricher_id: self.id.clone(),
+            kind: EnrichErrorKind::Fetch(format!("spawn: {e}")),
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let mut snippet = stderr
+                .chars()
+                .take(MAX_COMMAND_STDERR_IN_ERROR)
+                .collect::<String>();
+            if stderr.len() > MAX_COMMAND_STDERR_IN_ERROR {
+                snippet.push_str("…[truncated]");
+            }
+            return Err(EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!(
+                    "exit {:?}: {}",
+                    output.status.code(),
+                    snippet.trim()
+                )),
+            });
+        }
+
+        if output.stdout.len() > MAX_COMMAND_STDOUT {
+            return Err(EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!(
+                    "stdout exceeded {} bytes",
+                    MAX_COMMAND_STDOUT
+                )),
+            });
+        }
+
+        let value = match self.output {
+            OutputFormat::Json => serde_json::from_slice::<serde_json::Value>(&output.stdout)
+                .map_err(|e| EnrichError {
+                    enricher_id: self.id.clone(),
+                    kind: EnrichErrorKind::Parse(format!("JSON: {e}")),
+                })?,
+            OutputFormat::Raw => {
+                let s = String::from_utf8_lossy(&output.stdout);
+                serde_json::Value::String(s.trim_end_matches('\n').to_string())
+            }
+        };
+        inject_enrichment(result, &self.inject_field, value);
+        Ok(())
+    }
+}

--- a/crates/rsigma-runtime/src/enrichment/http.rs
+++ b/crates/rsigma-runtime/src/enrichment/http.rs
@@ -125,7 +125,13 @@ impl HttpEnricher {
     }
 
     /// Replace the metrics hook this enricher reports cache events into.
+    ///
+    /// Pre-registers the three HTTP-cache counter label sets for this
+    /// enricher's `id` so `rsigma_enrichment_http_cache_{hits,misses,
+    /// expirations}_total{...}` are emitted on `/metrics` from the
+    /// first scrape, even before the enricher has run.
     pub fn with_metrics(mut self, metrics: Arc<dyn MetricsHook>) -> Self {
+        metrics.register_http_enricher_cache(&self.id);
         self.metrics = metrics;
         self
     }

--- a/crates/rsigma-runtime/src/enrichment/http.rs
+++ b/crates/rsigma-runtime/src/enrichment/http.rs
@@ -1,0 +1,243 @@
+//! `HttpEnricher`: per-result HTTP fetch with optional response cache.
+//!
+//! Builds a [`reqwest::Request`] from a template-expanded URL, optional
+//! template-expanded headers, and an optional template-expanded body.
+//! The response is parsed as JSON; if an `extract` expression is set,
+//! it is applied via [`crate::sources::extract::apply_extract`] using
+//! the existing dynamic-pipelines extractor stack (jq / jsonpath / cel)
+//! so operators learn one mental model, not two.
+//!
+//! Optional in-memory response cache via [`super::http_cache::HttpResponseCache`]
+//! keyed on `(method, url, body_hash)` with configurable TTL. Mandatory
+//! in practice for rate-limited APIs (VirusTotal: 4 req/min free tier).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use rsigma_eval::EvaluationResult;
+use rsigma_eval::pipeline::sources::ExtractExpr;
+use serde_json::Value;
+
+use super::{
+    EnrichError, EnrichErrorKind, Enricher, EnricherKind, OnError, Scope,
+    http_cache::{CacheKey, HttpResponseCache},
+    inject_enrichment,
+    template::render_template,
+};
+
+/// One HTTP enricher instance.
+///
+/// Constructed by the daemon config loader. The `Arc<reqwest::Client>`
+/// is shared across all HTTP enrichers in the same daemon process so
+/// connection pooling works at the process level rather than per-config-block.
+pub struct HttpEnricher {
+    id: String,
+    kind: EnricherKind,
+    inject_field: String,
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+    body: Option<String>,
+    timeout: Duration,
+    on_error: OnError,
+    scope: Scope,
+    extract: Option<ExtractExpr>,
+    client: HttpEnricherClient,
+    cache: HttpResponseCache,
+}
+
+/// Opaque handle around a process-wide `reqwest::Client`. Constructed by
+/// [`build_default_http_client`] and passed by [`Arc`] to every
+/// [`HttpEnricher`] so connection pooling works at the daemon level.
+///
+/// Wrapping the `reqwest::Client` keeps `reqwest` an internal dependency
+/// of `rsigma-runtime` so consumer crates (e.g. `rsigma-cli`) do not
+/// need a direct dep just to wire enrichers together.
+#[derive(Clone)]
+pub struct HttpEnricherClient(Arc<reqwest::Client>);
+
+impl HttpEnricherClient {
+    /// Wrap an existing `reqwest::Client`. Useful for tests that want to
+    /// stub out the client (e.g. a `wiremock`-backed tower stack).
+    pub fn from_reqwest(client: Arc<reqwest::Client>) -> Self {
+        Self(client)
+    }
+    /// Access the inner client. Crate-private so external code goes
+    /// through the wrapper.
+    fn inner(&self) -> &reqwest::Client {
+        &self.0
+    }
+}
+
+/// Build the default shared HTTP client used by the daemon's enrichment
+/// pipeline. All HTTP enrichers in the same daemon process share one
+/// client to amortize TLS handshakes and DNS resolution.
+pub fn build_default_http_client() -> Result<HttpEnricherClient, String> {
+    reqwest::Client::builder()
+        .build()
+        .map(|c| HttpEnricherClient(Arc::new(c)))
+        .map_err(|e| format!("reqwest client build failed: {e}"))
+}
+
+impl HttpEnricher {
+    /// Build a new enricher.
+    ///
+    /// `client` is shared at the process level. `cache` may be a
+    /// disabled cache ([`HttpResponseCache::new(Duration::from_secs(0))`])
+    /// when `cache_ttl` is unset; the lookup path treats that as "always
+    /// miss".
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        kind: EnricherKind,
+        inject_field: String,
+        method: String,
+        url: String,
+        headers: Vec<(String, String)>,
+        body: Option<String>,
+        timeout: Duration,
+        on_error: OnError,
+        scope: Scope,
+        extract: Option<ExtractExpr>,
+        client: HttpEnricherClient,
+        cache: HttpResponseCache,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            inject_field,
+            method: method.to_ascii_uppercase(),
+            url,
+            headers,
+            body,
+            timeout,
+            on_error,
+            scope,
+            extract,
+            client,
+            cache,
+        }
+    }
+
+    /// Read-only view of the response cache. Used by the metrics layer
+    /// to expose cache hit/miss/expiration counters.
+    pub fn cache(&self) -> &HttpResponseCache {
+        &self.cache
+    }
+}
+
+#[async_trait]
+impl Enricher for HttpEnricher {
+    fn kind(&self) -> EnricherKind {
+        self.kind
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn inject_field(&self) -> &str {
+        &self.inject_field
+    }
+    fn timeout(&self) -> Duration {
+        self.timeout
+    }
+    fn scope(&self) -> &Scope {
+        &self.scope
+    }
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+
+    async fn enrich(&self, result: &mut EvaluationResult) -> Result<(), EnrichError> {
+        let url = render_template(&self.url, result);
+        let body = self.body.as_ref().map(|b| render_template(b, result));
+
+        let cache_key = CacheKey::new(&self.method, &url, body.as_deref().map(str::as_bytes));
+        let (_outcome, cached) = self.cache.lookup(&cache_key);
+        if let Some(cached_value) = cached {
+            let extracted = self.maybe_extract(&cached_value)?;
+            inject_enrichment(result, &self.inject_field, extracted);
+            return Ok(());
+        }
+
+        let mut header_map = HeaderMap::with_capacity(self.headers.len());
+        for (name, value_template) in &self.headers {
+            let rendered = render_template(value_template, result);
+            let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|e| EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!("invalid header name '{name}': {e}")),
+            })?;
+            let header_value = HeaderValue::from_str(&rendered).map_err(|e| EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!("invalid header value for '{name}': {e}")),
+            })?;
+            header_map.insert(header_name, header_value);
+        }
+
+        let method =
+            reqwest::Method::from_bytes(self.method.as_bytes()).map_err(|e| EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!("invalid method '{}': {e}", self.method)),
+            })?;
+
+        let mut req = self
+            .client
+            .inner()
+            .request(method, &url)
+            .headers(header_map);
+        if let Some(b) = &body {
+            req = req.body(b.clone());
+        }
+        let resp = req.send().await.map_err(|e| EnrichError {
+            enricher_id: self.id.clone(),
+            kind: if e.is_timeout() {
+                EnrichErrorKind::Timeout
+            } else {
+                EnrichErrorKind::Fetch(format!("{e}"))
+            },
+        })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!("HTTP {status}")),
+            });
+        }
+
+        let bytes = resp.bytes().await.map_err(|e| EnrichError {
+            enricher_id: self.id.clone(),
+            kind: EnrichErrorKind::Fetch(format!("body read: {e}")),
+        })?;
+        let parsed: Value = serde_json::from_slice(&bytes).map_err(|e| EnrichError {
+            enricher_id: self.id.clone(),
+            kind: EnrichErrorKind::Parse(format!("JSON: {e}")),
+        })?;
+
+        // Cache the parsed value before extract: a different enricher
+        // sharing the same URL with a different `extract` benefits from
+        // the cached upstream JSON.
+        self.cache.insert(cache_key, parsed.clone());
+
+        let extracted = self.maybe_extract(&parsed)?;
+        inject_enrichment(result, &self.inject_field, extracted);
+        Ok(())
+    }
+}
+
+impl HttpEnricher {
+    /// Apply the configured `extract` expression to `value`. Returns the
+    /// raw value untouched when no extract is configured.
+    fn maybe_extract(&self, value: &Value) -> Result<Value, EnrichError> {
+        match &self.extract {
+            None => Ok(value.clone()),
+            Some(expr) => {
+                crate::sources::extract::apply_extract(value, expr).map_err(|e| EnrichError {
+                    enricher_id: self.id.clone(),
+                    kind: EnrichErrorKind::Extract(format!("{}", e.kind)),
+                })
+            }
+        }
+    }
+}

--- a/crates/rsigma-runtime/src/enrichment/http.rs
+++ b/crates/rsigma-runtime/src/enrichment/http.rs
@@ -22,10 +22,11 @@ use serde_json::Value;
 
 use super::{
     EnrichError, EnrichErrorKind, Enricher, EnricherKind, OnError, Scope,
-    http_cache::{CacheKey, HttpResponseCache},
+    http_cache::{CacheKey, CacheOutcome, HttpResponseCache},
     inject_enrichment,
     template::render_template,
 };
+use crate::metrics::{MetricsHook, NoopMetrics};
 
 /// One HTTP enricher instance.
 ///
@@ -46,6 +47,7 @@ pub struct HttpEnricher {
     extract: Option<ExtractExpr>,
     client: HttpEnricherClient,
     cache: HttpResponseCache,
+    metrics: Arc<dyn MetricsHook>,
 }
 
 /// Opaque handle around a process-wide `reqwest::Client`. Constructed by
@@ -118,7 +120,14 @@ impl HttpEnricher {
             extract,
             client,
             cache,
+            metrics: Arc::new(NoopMetrics),
         }
+    }
+
+    /// Replace the metrics hook this enricher reports cache events into.
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsHook>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     /// Read-only view of the response cache. Used by the metrics layer
@@ -154,7 +163,15 @@ impl Enricher for HttpEnricher {
         let body = self.body.as_ref().map(|b| render_template(b, result));
 
         let cache_key = CacheKey::new(&self.method, &url, body.as_deref().map(str::as_bytes));
-        let (_outcome, cached) = self.cache.lookup(&cache_key);
+        let (outcome, cached) = self.cache.lookup(&cache_key);
+        match outcome {
+            CacheOutcome::Hit => self.metrics.on_enrichment_http_cache_hit(&self.id),
+            CacheOutcome::Miss => self.metrics.on_enrichment_http_cache_miss(&self.id),
+            CacheOutcome::Expired => {
+                self.metrics.on_enrichment_http_cache_expiration(&self.id);
+                self.metrics.on_enrichment_http_cache_miss(&self.id);
+            }
+        }
         if let Some(cached_value) = cached {
             let extracted = self.maybe_extract(&cached_value)?;
             inject_enrichment(result, &self.inject_field, extracted);

--- a/crates/rsigma-runtime/src/enrichment/http_cache.rs
+++ b/crates/rsigma-runtime/src/enrichment/http_cache.rs
@@ -1,0 +1,301 @@
+//! In-memory response cache for [`HttpEnricher`](super::http::HttpEnricher).
+//!
+//! Keyed on `(method, url, body_hash)` with a configurable TTL. Each
+//! `HttpEnricher` instance owns its own cache so two recipes that hit
+//! the same URL with different API keys (different `Authorization`
+//! headers) cannot accidentally share each other's cached responses.
+//!
+//! Mandatory in practice for any rate-limited API (VirusTotal: 4 req/min
+//! on the free tier) and a major win for any duplicate-detection burst.
+//! Off by default; `cache_ttl: <duration>` on the enricher config flips
+//! it on.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+
+/// Composite cache key for one cached HTTP response.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CacheKey {
+    /// Request method, normalized to upper case (`GET`, `POST`, …).
+    pub method: String,
+    /// Full request URL.
+    pub url: String,
+    /// 64-bit hash of the request body (zero when no body).
+    pub body_hash: u64,
+}
+
+impl CacheKey {
+    /// Build a cache key from raw components. Hashes the body once at
+    /// insert time so subsequent lookups are O(key-size).
+    pub fn new(method: &str, url: &str, body: Option<&[u8]>) -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        body.unwrap_or(&[]).hash(&mut hasher);
+        Self {
+            method: method.to_ascii_uppercase(),
+            url: url.to_string(),
+            body_hash: hasher.finish(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    value: serde_json::Value,
+    stored_at: Instant,
+}
+
+/// Outcome of a cache lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheOutcome {
+    /// Entry was present and within TTL; the cached value was returned.
+    Hit,
+    /// No entry for this key.
+    Miss,
+    /// Entry was present but past its TTL; lazily evicted on read.
+    Expired,
+}
+
+/// Stats counters that survive across [`HttpResponseCache::lookup`] /
+/// [`HttpResponseCache::insert`] calls. Wired into Prometheus metrics
+/// in Phase 4 (`rsigma_enrichment_http_cache_{hits,misses,expirations}_total`).
+#[derive(Default)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub expirations: u64,
+}
+
+impl std::fmt::Debug for CacheStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CacheStats")
+            .field("hits", &self.hits)
+            .field("misses", &self.misses)
+            .field("expirations", &self.expirations)
+            .finish()
+    }
+}
+
+/// In-memory `(method, url, body_hash) → JSON value` cache with TTL.
+///
+/// Cheap to clone (`Arc`-wrapped internals); each enricher instance keeps
+/// its own clone in its hot path, and the daemon may share instances
+/// across enricher reload cycles when the config has not changed.
+#[derive(Clone)]
+pub struct HttpResponseCache {
+    inner: Arc<HttpResponseCacheInner>,
+}
+
+struct HttpResponseCacheInner {
+    entries: RwLock<HashMap<CacheKey, CacheEntry>>,
+    stats: RwLock<CacheStats>,
+    ttl: Duration,
+}
+
+impl HttpResponseCache {
+    /// Build a new cache with the given TTL.
+    ///
+    /// A `ttl` of zero is treated as "disabled" — every lookup returns
+    /// [`CacheOutcome::Miss`] and inserts are no-ops, so call sites can
+    /// always go through the cache without checking `cache_ttl > 0`.
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(HttpResponseCacheInner {
+                entries: RwLock::new(HashMap::new()),
+                stats: RwLock::new(CacheStats::default()),
+                ttl,
+            }),
+        }
+    }
+
+    /// Returns true when this cache is "off" (TTL is zero).
+    pub fn is_disabled(&self) -> bool {
+        self.inner.ttl.is_zero()
+    }
+
+    /// Configured TTL.
+    pub fn ttl(&self) -> Duration {
+        self.inner.ttl
+    }
+
+    /// Look up `key`. Returns the cached value if it is present and
+    /// within TTL; expires it lazily otherwise.
+    pub fn lookup(&self, key: &CacheKey) -> (CacheOutcome, Option<serde_json::Value>) {
+        if self.is_disabled() {
+            self.inner.stats.write().misses += 1;
+            return (CacheOutcome::Miss, None);
+        }
+
+        // Fast path: read lock for the common hit / miss case.
+        {
+            let map = self.inner.entries.read();
+            if let Some(entry) = map.get(key) {
+                if entry.stored_at.elapsed() <= self.inner.ttl {
+                    self.inner.stats.write().hits += 1;
+                    return (CacheOutcome::Hit, Some(entry.value.clone()));
+                }
+                // Expired — fall through to write-locked eviction.
+            } else {
+                self.inner.stats.write().misses += 1;
+                return (CacheOutcome::Miss, None);
+            }
+        }
+
+        // Slow path: take write lock to evict expired entry.
+        let mut map = self.inner.entries.write();
+        if let Some(entry) = map.get(key) {
+            if entry.stored_at.elapsed() > self.inner.ttl {
+                map.remove(key);
+                self.inner.stats.write().expirations += 1;
+                return (CacheOutcome::Expired, None);
+            }
+            // Race: re-validated by another thread.
+            self.inner.stats.write().hits += 1;
+            return (CacheOutcome::Hit, Some(entry.value.clone()));
+        }
+        // Race: removed by another thread.
+        self.inner.stats.write().misses += 1;
+        (CacheOutcome::Miss, None)
+    }
+
+    /// Insert `value` under `key`. No-op when the cache is disabled.
+    pub fn insert(&self, key: CacheKey, value: serde_json::Value) {
+        if self.is_disabled() {
+            return;
+        }
+        self.inner.entries.write().insert(
+            key,
+            CacheEntry {
+                value,
+                stored_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Remove every entry whose stored_at + TTL is in the past. Called
+    /// periodically by a background sweep when the daemon's enrichment
+    /// pipeline has at least one cache configured.
+    pub fn evict_expired(&self) -> usize {
+        if self.is_disabled() {
+            return 0;
+        }
+        let mut map = self.inner.entries.write();
+        let before = map.len();
+        let ttl = self.inner.ttl;
+        map.retain(|_, e| e.stored_at.elapsed() <= ttl);
+        let removed = before - map.len();
+        if removed > 0 {
+            self.inner.stats.write().expirations += removed as u64;
+        }
+        removed
+    }
+
+    /// Snapshot the cumulative cache stats since construction.
+    pub fn stats(&self) -> (u64, u64, u64) {
+        let s = self.inner.stats.read();
+        (s.hits, s.misses, s.expirations)
+    }
+
+    /// Number of entries currently held.
+    pub fn len(&self) -> usize {
+        self.inner.entries.read().len()
+    }
+
+    /// True when no entries are held.
+    pub fn is_empty(&self) -> bool {
+        self.inner.entries.read().is_empty()
+    }
+}
+
+impl std::fmt::Debug for HttpResponseCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (h, m, x) = self.stats();
+        f.debug_struct("HttpResponseCache")
+            .field("ttl", &self.inner.ttl)
+            .field("len", &self.len())
+            .field("hits", &h)
+            .field("misses", &m)
+            .field("expirations", &x)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_cache_always_misses() {
+        let cache = HttpResponseCache::new(Duration::from_secs(0));
+        assert!(cache.is_disabled());
+        let key = CacheKey::new("GET", "https://x", None);
+        cache.insert(key.clone(), serde_json::json!("v"));
+        let (out, val) = cache.lookup(&key);
+        assert_eq!(out, CacheOutcome::Miss);
+        assert!(val.is_none());
+    }
+
+    #[test]
+    fn hit_then_miss_after_ttl() {
+        let cache = HttpResponseCache::new(Duration::from_millis(50));
+        let key = CacheKey::new("GET", "https://x", None);
+        cache.insert(key.clone(), serde_json::json!("v"));
+        let (out, val) = cache.lookup(&key);
+        assert_eq!(out, CacheOutcome::Hit);
+        assert_eq!(val, Some(serde_json::json!("v")));
+
+        std::thread::sleep(Duration::from_millis(80));
+        let (out, val) = cache.lookup(&key);
+        assert_eq!(out, CacheOutcome::Expired);
+        assert!(val.is_none());
+    }
+
+    #[test]
+    fn body_hash_separates_keys() {
+        let a = CacheKey::new("POST", "https://x", Some(b"a"));
+        let b = CacheKey::new("POST", "https://x", Some(b"b"));
+        assert_ne!(a, b);
+        let cache = HttpResponseCache::new(Duration::from_secs(60));
+        cache.insert(a.clone(), serde_json::json!(1));
+        let (out, _) = cache.lookup(&b);
+        assert_eq!(out, CacheOutcome::Miss);
+    }
+
+    #[test]
+    fn method_difference_separates_keys() {
+        let a = CacheKey::new("GET", "https://x", None);
+        let b = CacheKey::new("POST", "https://x", None);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn evict_expired_drops_old_entries() {
+        let cache = HttpResponseCache::new(Duration::from_millis(20));
+        for i in 0..5 {
+            cache.insert(
+                CacheKey::new("GET", &format!("https://x/{i}"), None),
+                serde_json::json!(i),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(40));
+        let evicted = cache.evict_expired();
+        assert_eq!(evicted, 5);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn stats_counters_increment() {
+        let cache = HttpResponseCache::new(Duration::from_secs(60));
+        let key = CacheKey::new("GET", "https://x", None);
+        let (_, _) = cache.lookup(&key);
+        cache.insert(key.clone(), serde_json::json!("v"));
+        let (_, _) = cache.lookup(&key);
+        let (_, _) = cache.lookup(&key);
+        let (hits, misses, _exp) = cache.stats();
+        assert_eq!(hits, 2);
+        assert_eq!(misses, 1);
+    }
+}

--- a/crates/rsigma-runtime/src/enrichment/lookup.rs
+++ b/crates/rsigma-runtime/src/enrichment/lookup.rs
@@ -2,7 +2,7 @@
 //! [`SourceCache`](crate::sources::SourceCache) and inject it (optionally
 //! after applying an [`ExtractExpr`] for slicing).
 //!
-//! Zero-network-cost path for anything already loaded as a pipeline
+//! Zero-network-cost path for anything already loaded as a dynamic
 //! source. The enricher takes a `source_id`, an optional extract
 //! expression, and an optional `default` value. The flow is:
 //!

--- a/crates/rsigma-runtime/src/enrichment/lookup.rs
+++ b/crates/rsigma-runtime/src/enrichment/lookup.rs
@@ -1,0 +1,173 @@
+//! `LookupEnricher`: pull a value from the dynamic-pipelines
+//! [`SourceCache`](crate::sources::SourceCache) and inject it (optionally
+//! after applying an [`ExtractExpr`] for slicing).
+//!
+//! Zero-network-cost path for anything already loaded as a pipeline
+//! source. The enricher takes a `source_id`, an optional extract
+//! expression, and an optional `default` value. The flow is:
+//!
+//! 1. Look up `source_id` in the shared `Arc<SourceCache>`.
+//! 2. **Cache miss** → if `default` is configured, inject it and return
+//!    `Ok`; otherwise return `EnrichErrorKind::Fetch("cache miss")` so
+//!    the pipeline applies the configured `on_error` policy.
+//! 3. **Cache hit** + no extract → inject the cached value verbatim.
+//! 4. **Cache hit** + extract:
+//!     - `null` extract result → same as "no extract match"; if
+//!       `default` is set, inject it; otherwise apply `on_error`.
+//!     - extract evaluation failed → return
+//!       `EnrichErrorKind::Extract(...)`; the pipeline applies
+//!       `on_error`.
+//!     - non-null extract result → inject the extracted value.
+//!
+//! `default` therefore overrides `on_error` for the cache-miss /
+//! no-extract-match cases only; outright extractor failures still apply
+//! `on_error` (so a malformed extract expression doesn't silently mask
+//! data quality issues behind the default value).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rsigma_eval::EvaluationResult;
+use rsigma_eval::pipeline::sources::ExtractExpr;
+use serde_json::Value;
+
+use super::{
+    EnrichError, EnrichErrorKind, Enricher, EnricherKind, OnError, Scope, inject_enrichment,
+    template::render_template,
+};
+use crate::sources::SourceCache;
+use crate::sources::extract::apply_extract;
+
+/// One lookup enricher instance.
+pub struct LookupEnricher {
+    id: String,
+    kind: EnricherKind,
+    inject_field: String,
+    source_id: String,
+    extract: Option<ExtractExpr>,
+    default: Option<Value>,
+    timeout: Duration,
+    on_error: OnError,
+    scope: Scope,
+    cache: Arc<SourceCache>,
+}
+
+impl LookupEnricher {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        kind: EnricherKind,
+        inject_field: String,
+        source_id: String,
+        extract: Option<ExtractExpr>,
+        default: Option<Value>,
+        timeout: Duration,
+        on_error: OnError,
+        scope: Scope,
+        cache: Arc<SourceCache>,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            inject_field,
+            source_id,
+            extract,
+            default,
+            timeout,
+            on_error,
+            scope,
+            cache,
+        }
+    }
+
+    /// Render any `${detection.*}` / `${correlation.*}` references inside
+    /// the configured extract expression against the current result.
+    /// Returns the (possibly cloned) expression with literal text where
+    /// templates were.
+    fn render_extract(&self, result: &EvaluationResult) -> Option<ExtractExpr> {
+        let original = self.extract.as_ref()?;
+        let (lang, raw) = match original {
+            ExtractExpr::Jq(s) => ("jq", s),
+            ExtractExpr::JsonPath(s) => ("jsonpath", s),
+            ExtractExpr::Cel(s) => ("cel", s),
+        };
+        let rendered = render_template(raw, result);
+        Some(match lang {
+            "jq" => ExtractExpr::Jq(rendered),
+            "jsonpath" => ExtractExpr::JsonPath(rendered),
+            "cel" => ExtractExpr::Cel(rendered),
+            // The match above is exhaustive; keep the arm for the
+            // compiler's benefit if `ExtractExpr` ever grows a new
+            // variant.
+            _ => return None,
+        })
+    }
+}
+
+#[async_trait]
+impl Enricher for LookupEnricher {
+    fn kind(&self) -> EnricherKind {
+        self.kind
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn inject_field(&self) -> &str {
+        &self.inject_field
+    }
+    fn timeout(&self) -> Duration {
+        self.timeout
+    }
+    fn scope(&self) -> &Scope {
+        &self.scope
+    }
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+
+    async fn enrich(&self, result: &mut EvaluationResult) -> Result<(), EnrichError> {
+        let cached = self.cache.get(&self.source_id);
+
+        let cached_value = match cached {
+            Some(v) => v,
+            None => {
+                if let Some(d) = &self.default {
+                    inject_enrichment(result, &self.inject_field, d.clone());
+                    return Ok(());
+                }
+                return Err(EnrichError {
+                    enricher_id: self.id.clone(),
+                    kind: EnrichErrorKind::Fetch(format!(
+                        "cache miss for source '{}'",
+                        self.source_id
+                    )),
+                });
+            }
+        };
+
+        let extracted = match self.render_extract(result) {
+            None => cached_value.clone(),
+            Some(expr) => apply_extract(&cached_value, &expr).map_err(|e| EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Extract(format!("{}", e.kind)),
+            })?,
+        };
+
+        if extracted.is_null() {
+            if let Some(d) = &self.default {
+                inject_enrichment(result, &self.inject_field, d.clone());
+                return Ok(());
+            }
+            return Err(EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!(
+                    "no extract match for source '{}'",
+                    self.source_id
+                )),
+            });
+        }
+        inject_enrichment(result, &self.inject_field, extracted);
+        Ok(())
+    }
+}

--- a/crates/rsigma-runtime/src/enrichment/mod.rs
+++ b/crates/rsigma-runtime/src/enrichment/mod.rs
@@ -284,7 +284,16 @@ impl EnrichmentPipeline {
     /// Replace the metrics hook this pipeline reports into. The daemon
     /// passes its Prometheus-backed `Metrics` here; library consumers
     /// can pass any [`MetricsHook`] implementation.
+    ///
+    /// Pre-registers `(enricher_id, kind)` for every configured
+    /// enricher so `rsigma_enrichment_total{...}` and
+    /// `rsigma_enrichment_duration_seconds{...}` are emitted on
+    /// `/metrics` from the first scrape, even before any enricher has
+    /// fired.
     pub fn with_metrics(mut self, metrics: Arc<dyn MetricsHook>) -> Self {
+        for enricher in &self.enrichers {
+            metrics.register_enricher(enricher.id(), enricher.kind().as_str());
+        }
         self.metrics = metrics;
         self
     }

--- a/crates/rsigma-runtime/src/enrichment/mod.rs
+++ b/crates/rsigma-runtime/src/enrichment/mod.rs
@@ -42,6 +42,8 @@ use async_trait::async_trait;
 use rsigma_eval::{EvaluationResult, ResultBody};
 use tokio::sync::Semaphore;
 
+use crate::metrics::{MetricsHook, NoopMetrics};
+
 mod command;
 mod http;
 pub mod http_cache;
@@ -246,6 +248,7 @@ enum EnrichOutcome {
 pub struct EnrichmentPipeline {
     enrichers: Vec<Box<dyn Enricher>>,
     semaphore: Arc<Semaphore>,
+    metrics: Arc<dyn MetricsHook>,
 }
 
 impl std::fmt::Debug for EnrichmentPipeline {
@@ -262,6 +265,9 @@ impl EnrichmentPipeline {
     ///
     /// `max_concurrent_enrichments` bounds the number of results that can
     /// be enriched in parallel; defaults to 16 if zero is passed.
+    /// Metrics default to a no-op sink; call [`Self::with_metrics`] to
+    /// route counters and latency histograms into a real
+    /// [`MetricsHook`] implementation.
     pub fn new(enrichers: Vec<Box<dyn Enricher>>, max_concurrent_enrichments: usize) -> Self {
         let permits = if max_concurrent_enrichments == 0 {
             16
@@ -271,7 +277,16 @@ impl EnrichmentPipeline {
         Self {
             enrichers,
             semaphore: Arc::new(Semaphore::new(permits)),
+            metrics: Arc::new(NoopMetrics),
         }
+    }
+
+    /// Replace the metrics hook this pipeline reports into. The daemon
+    /// passes its Prometheus-backed `Metrics` here; library consumers
+    /// can pass any [`MetricsHook`] implementation.
+    pub fn with_metrics(mut self, metrics: Arc<dyn MetricsHook>) -> Self {
+        self.metrics = metrics;
+        self
     }
 
     /// Returns true if no enrichers are configured.
@@ -341,7 +356,7 @@ impl EnrichmentPipeline {
 
             let mut should_drop = false;
             for enricher in &self.enrichers {
-                match Self::run_one(enricher.as_ref(), result).await {
+                match Self::run_one(enricher.as_ref(), result, self.metrics.as_ref()).await {
                     EnrichOutcome::Drop => {
                         should_drop = true;
                         break;
@@ -367,10 +382,14 @@ impl EnrichmentPipeline {
 
     /// Run a single enricher against a single result, applying the
     /// kind-vs-body filter, scope filter, timeout, and on_error policy.
-    ///
-    /// `pub(crate)` so the metrics layer (Phase 4) can wire counter
-    /// increments around it without re-implementing the dispatch.
-    async fn run_one(enricher: &dyn Enricher, result: &mut EvaluationResult) -> EnrichOutcome {
+    /// Records `rsigma_enrichment_total{enricher_id, kind, status}` and
+    /// `rsigma_enrichment_duration_seconds{enricher_id, kind}` via the
+    /// configured `MetricsHook` for every non-filtered call.
+    async fn run_one(
+        enricher: &dyn Enricher,
+        result: &mut EvaluationResult,
+        metrics: &dyn MetricsHook,
+    ) -> EnrichOutcome {
         if !enricher.kind().matches(&result.body) {
             return EnrichOutcome::Filtered;
         }
@@ -381,12 +400,20 @@ impl EnrichmentPipeline {
         let inject_field = enricher.inject_field().to_string();
         let timeout = enricher.timeout();
         let id = enricher.id().to_string();
+        let kind_label = enricher.kind().as_str();
         let on_error = enricher.on_error();
 
+        metrics.on_enrichment_queue_depth_change(1);
+        let started = std::time::Instant::now();
         let outcome = tokio::time::timeout(timeout, enricher.enrich(result)).await;
+        let elapsed = started.elapsed().as_secs_f64();
+        metrics.on_enrichment_queue_depth_change(-1);
 
         let err = match outcome {
-            Ok(Ok(())) => return EnrichOutcome::Ok,
+            Ok(Ok(())) => {
+                metrics.on_enrichment_completed(&id, kind_label, "success", elapsed);
+                return EnrichOutcome::Ok;
+            }
             Ok(Err(e)) => e,
             Err(_) => EnrichError {
                 enricher_id: id.clone(),
@@ -394,20 +421,27 @@ impl EnrichmentPipeline {
             },
         };
 
+        let is_timeout = matches!(err.kind, EnrichErrorKind::Timeout);
         match on_error {
             OnError::Skip => {
                 tracing::warn!(
                     enricher_id = %id,
-                    kind = %enricher.kind().as_str(),
+                    kind = %kind_label,
                     error = %err,
                     "Enricher failed, skipping"
+                );
+                metrics.on_enrichment_completed(
+                    &id,
+                    kind_label,
+                    if is_timeout { "timeout" } else { "skip" },
+                    elapsed,
                 );
                 EnrichOutcome::Skip
             }
             OnError::Null => {
                 tracing::warn!(
                     enricher_id = %id,
-                    kind = %enricher.kind().as_str(),
+                    kind = %kind_label,
                     error = %err,
                     "Enricher failed, injecting null"
                 );
@@ -416,15 +450,22 @@ impl EnrichmentPipeline {
                     .enrichments
                     .get_or_insert_with(serde_json::Map::new);
                 map.insert(inject_field, serde_json::Value::Null);
+                metrics.on_enrichment_completed(
+                    &id,
+                    kind_label,
+                    if is_timeout { "timeout" } else { "error" },
+                    elapsed,
+                );
                 EnrichOutcome::Null
             }
             OnError::Drop => {
                 tracing::warn!(
                     enricher_id = %id,
-                    kind = %enricher.kind().as_str(),
+                    kind = %kind_label,
                     error = %err,
                     "Enricher failed, dropping result"
                 );
+                metrics.on_enrichment_completed(&id, kind_label, "drop", elapsed);
                 EnrichOutcome::Drop
             }
         }
@@ -434,6 +475,24 @@ impl EnrichmentPipeline {
 impl Default for EnrichmentPipeline {
     fn default() -> Self {
         Self::new(Vec::new(), 16)
+    }
+}
+
+impl Clone for EnrichmentPipeline {
+    fn clone(&self) -> Self {
+        // Boxes of `dyn Enricher` are not `Clone`, so a true deep clone
+        // is not possible here. The hot-reload path always rebuilds the
+        // pipeline from config rather than cloning, but `Clone` is
+        // useful for tests and for `ArcSwap` adapter code that wants a
+        // throwaway snapshot. Returning an empty pipeline that shares
+        // the metrics hook is the safest behaviour: a misuse degrades
+        // to "no enrichment" rather than panicking or silently
+        // double-counting.
+        Self {
+            enrichers: Vec::new(),
+            semaphore: Arc::clone(&self.semaphore),
+            metrics: Arc::clone(&self.metrics),
+        }
     }
 }
 

--- a/crates/rsigma-runtime/src/enrichment/mod.rs
+++ b/crates/rsigma-runtime/src/enrichment/mod.rs
@@ -1,0 +1,534 @@
+//! Post-evaluation enrichment for the rsigma daemon.
+//!
+//! Enrichment runs in the daemon's sink task, after `Engine::evaluate()` has
+//! produced a [`ProcessResult`] (a flat `Vec<EvaluationResult>`) and before
+//! that result is serialized to a sink. Each enricher inspects an
+//! [`EvaluationResult`], optionally fetches context (HTTP, command, source
+//! cache, pure template), and writes the result into
+//! `result.header.enrichments` under a configured `inject_field`.
+//!
+//! # Architecture
+//!
+//! A single [`Enricher`] trait covers every primitive (`template`, `lookup`,
+//! `http`, `command`) and any bespoke Rust-coded enrichers. Each enricher
+//! declares an [`EnricherKind`] at config time; the [`EnrichmentPipeline`]
+//! filters results by that declared kind against the
+//! [`EvaluationResult::body`] variant before invoking `enrich()`. There are no
+//! parallel `DetectionEnricher` / `CorrelationEnricher` traits and no separate
+//! context types; enrichers consume `&mut EvaluationResult` directly and
+//! match on `result.body` for kind-specific fields.
+//!
+//! # Concurrency
+//!
+//! Results within a single sink batch are enriched concurrently with bounded
+//! concurrency via a single [`tokio::sync::Semaphore`] owned by the pipeline.
+//! Within a single result the enricher chain runs sequentially (so later
+//! enrichers can depend on earlier ones via `${detection.enrichments.*}` in a
+//! follow-up implementation; for this initial cut the chain is linear and
+//! enrichers are independent).
+//!
+//! # Errors
+//!
+//! Failures are scoped per enricher and do not abort the chain by default;
+//! the per-enricher `on_error` policy ([`OnError`]) decides whether to
+//! `skip` the field, inject a JSON `null` for it, or `drop` the entire
+//! result before serialization. Timeouts are enforced via
+//! [`tokio::time::timeout`] using each enricher's [`Enricher::timeout`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rsigma_eval::{EvaluationResult, ResultBody};
+use tokio::sync::Semaphore;
+
+mod command;
+mod http;
+pub mod http_cache;
+mod lookup;
+mod scope;
+mod template;
+#[cfg(test)]
+mod tests;
+
+pub use command::{CommandEnricher, OutputFormat};
+pub use http::{HttpEnricher, HttpEnricherClient, build_default_http_client};
+pub use http_cache::{CacheKey, CacheOutcome, HttpResponseCache};
+pub use lookup::LookupEnricher;
+pub use scope::Scope;
+pub use template::{TemplateEnricher, TemplateError, validate_template_namespace};
+
+/// The kind of [`EvaluationResult`] an [`Enricher`] applies to.
+///
+/// Fixed at config load. Used for two things:
+/// 1. **Template-namespace validation at config load**: a `Detection` enricher
+///    may only reference `${detection.*}`; a `Correlation` enricher may only
+///    reference `${correlation.*}`. Cross-namespace references fail fast at
+///    startup.
+/// 2. **Runtime gating in [`EnrichmentPipeline::run`]**: enrichers whose
+///    declared kind does not match `result.body`'s variant are skipped before
+///    [`Enricher::enrich`] is invoked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EnricherKind {
+    /// Applies to detection results ([`ResultBody::Detection`]).
+    Detection,
+    /// Applies to correlation results ([`ResultBody::Correlation`]).
+    Correlation,
+}
+
+impl EnricherKind {
+    /// String label used in metrics, logs, and config errors.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EnricherKind::Detection => "detection",
+            EnricherKind::Correlation => "correlation",
+        }
+    }
+
+    /// Returns true if this kind matches the given result body variant.
+    pub fn matches(&self, body: &ResultBody) -> bool {
+        matches!(
+            (self, body),
+            (EnricherKind::Detection, ResultBody::Detection(_))
+                | (EnricherKind::Correlation, ResultBody::Correlation(_))
+        )
+    }
+}
+
+/// Behavior when an enricher fails (timeout, fetch error, parse error, …).
+///
+/// Applied per enricher. Defaults to [`OnError::Skip`] so a single failed
+/// enrichment never breaks the result stream.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OnError {
+    /// Deliver the result unenriched for this field. Default. Logs a warning.
+    #[default]
+    Skip,
+    /// Inject `null` under `inject_field` so downstream consumers see a
+    /// "we tried" marker rather than missing-field ambiguity.
+    Null,
+    /// Suppress the result entirely before serialization. Useful for
+    /// dedup / pre-filter style enrichers that intentionally drop matches
+    /// based on external context.
+    Drop,
+}
+
+/// A typed enrichment failure attributed to a specific enricher.
+#[derive(Debug, Clone)]
+pub struct EnrichError {
+    /// Stable ID of the enricher that produced the error.
+    pub enricher_id: String,
+    /// Categorized failure kind.
+    pub kind: EnrichErrorKind,
+}
+
+impl std::fmt::Display for EnrichError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "enricher '{}': {}", self.enricher_id, self.kind)
+    }
+}
+
+impl std::error::Error for EnrichError {}
+
+/// Categorized enrichment failure.
+#[derive(Debug, Clone)]
+pub enum EnrichErrorKind {
+    /// The per-enricher timeout elapsed before [`Enricher::enrich`] returned.
+    Timeout,
+    /// External fetch failed (HTTP non-2xx, connection refused, command exit
+    /// status non-zero, etc.).
+    Fetch(String),
+    /// External response could not be parsed (e.g. invalid JSON).
+    Parse(String),
+    /// Extract expression (jq / jsonpath / cel) failed during evaluation.
+    Extract(String),
+    /// Template rendering failed at runtime (missing variable in a strict
+    /// resolver, invalid expansion, …). The config-load-time validator
+    /// catches namespace violations earlier.
+    TemplateRender(String),
+}
+
+impl std::fmt::Display for EnrichErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EnrichErrorKind::Timeout => write!(f, "timeout"),
+            EnrichErrorKind::Fetch(m) => write!(f, "fetch failed: {m}"),
+            EnrichErrorKind::Parse(m) => write!(f, "parse failed: {m}"),
+            EnrichErrorKind::Extract(m) => write!(f, "extract failed: {m}"),
+            EnrichErrorKind::TemplateRender(m) => write!(f, "template render failed: {m}"),
+        }
+    }
+}
+
+/// Trait implemented by every enrichment primitive (`template`, `lookup`,
+/// `http`, `command`) and by any bespoke Rust-coded named enricher
+/// registered via [`register_builtin`].
+///
+/// Implementations read shared rule metadata from [`EvaluationResult::header`]
+/// and dispatch on `result.body` for kind-specific fields. The pipeline
+/// guarantees that `result.body` matches `self.kind()` before calling
+/// `enrich()`, so implementations may rely on the matching variant
+/// (e.g. via [`EvaluationResult::as_detection`] /
+/// [`EvaluationResult::as_correlation`]).
+///
+/// `enrich` is async to accommodate I/O-bound primitives (HTTP, command).
+/// Pure transformations (`template`) still implement `enrich` as `async fn`
+/// even though they perform no I/O.
+#[async_trait]
+pub trait Enricher: Send + Sync {
+    /// The kind of result this enricher applies to. Fixed at config load.
+    fn kind(&self) -> EnricherKind;
+
+    /// Stable identifier for this enricher instance. Used as a metric label
+    /// and in structured log fields. Conventionally something like
+    /// `asset_lookup_det` or `enrich_hash_virustotal`.
+    fn id(&self) -> &str;
+
+    /// Field name under [`RuleHeader::enrichments`](rsigma_eval::RuleHeader::enrichments)
+    /// that this enricher writes to.
+    fn inject_field(&self) -> &str;
+
+    /// Per-enricher timeout. The pipeline wraps each `enrich()` call in
+    /// [`tokio::time::timeout`] using this value. Defaults to 5 seconds.
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+
+    /// Optional scope filter. Applied after the kind-vs-body filter and
+    /// before `enrich()` runs. Default is [`Scope::default`] (always fires).
+    fn scope(&self) -> &Scope;
+
+    /// Behavior when this enricher fails (timeout, fetch error, …).
+    /// Defaults to [`OnError::Skip`].
+    fn on_error(&self) -> OnError {
+        OnError::Skip
+    }
+
+    /// Run the enrichment.
+    ///
+    /// Implementations write into [`RuleHeader::enrichments`](rsigma_eval::RuleHeader::enrichments)
+    /// under the configured [`Self::inject_field`]. The pipeline initializes
+    /// the map (`None` → `Some(empty)`) before invoking the first enricher
+    /// for a given result, so implementations can `unwrap` the map safely.
+    async fn enrich(&self, result: &mut EvaluationResult) -> Result<(), EnrichError>;
+}
+
+/// Outcome of running a single enricher against a single result.
+///
+/// Returned internally by [`EnrichmentPipeline::run_one`] so the pipeline
+/// driver can decide whether to drop the entire result, log, or continue.
+enum EnrichOutcome {
+    /// Enricher ran and (possibly) wrote into `enrichments`.
+    Ok,
+    /// Enricher errored or timed out and `on_error: skip` applied.
+    Skip,
+    /// Enricher errored or timed out and `on_error: null` applied; the
+    /// pipeline injected `null` under `inject_field`.
+    Null,
+    /// Enricher errored or timed out and `on_error: drop` applied; the
+    /// pipeline must remove this result from the output vec.
+    Drop,
+    /// Enricher was filtered out (kind or scope mismatch) before running.
+    Filtered,
+}
+
+/// Execution surface for a configured set of enrichers.
+///
+/// One pipeline owns one `Vec<Box<dyn Enricher>>` plus a shared
+/// [`Semaphore`] that bounds the number of in-flight enrichments across
+/// all results in a batch.
+///
+/// The pipeline is constructed by the daemon config layer
+/// (`crates/rsigma-cli/src/daemon/enrichment/config.rs`) and held inside
+/// the daemon's sink task. Each [`ProcessResult`](rsigma_eval::ProcessResult)
+/// (a `Vec<EvaluationResult>`) flows through [`EnrichmentPipeline::run`]
+/// before it is serialized.
+pub struct EnrichmentPipeline {
+    enrichers: Vec<Box<dyn Enricher>>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl std::fmt::Debug for EnrichmentPipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EnrichmentPipeline")
+            .field("enrichers", &self.enrichers.len())
+            .field("permits", &self.semaphore.available_permits())
+            .finish()
+    }
+}
+
+impl EnrichmentPipeline {
+    /// Build a pipeline from a list of configured enrichers.
+    ///
+    /// `max_concurrent_enrichments` bounds the number of results that can
+    /// be enriched in parallel; defaults to 16 if zero is passed.
+    pub fn new(enrichers: Vec<Box<dyn Enricher>>, max_concurrent_enrichments: usize) -> Self {
+        let permits = if max_concurrent_enrichments == 0 {
+            16
+        } else {
+            max_concurrent_enrichments
+        };
+        Self {
+            enrichers,
+            semaphore: Arc::new(Semaphore::new(permits)),
+        }
+    }
+
+    /// Returns true if no enrichers are configured.
+    ///
+    /// The daemon sink task uses this to skip enrichment work entirely
+    /// (no permit acquisition, no per-result loop) when no enrichers are
+    /// configured.
+    pub fn is_empty(&self) -> bool {
+        self.enrichers.is_empty()
+    }
+
+    /// Number of configured enrichers (across both kinds).
+    pub fn len(&self) -> usize {
+        self.enrichers.len()
+    }
+
+    /// Iterate over the configured enrichers (read-only view, used for
+    /// reload-diff logging and tests).
+    pub fn enrichers(&self) -> impl Iterator<Item = &dyn Enricher> {
+        self.enrichers.iter().map(|e| &**e)
+    }
+
+    /// Run every applicable enricher against each result in `results`.
+    ///
+    /// For each result the pipeline:
+    /// 1. Acquires a global semaphore permit (bounded concurrency).
+    /// 2. Iterates the configured enricher list.
+    /// 3. Skips enrichers whose [`EnricherKind`] does not match the
+    ///    result's body variant.
+    /// 4. Skips enrichers whose [`Scope`] excludes this result.
+    /// 5. Wraps each remaining `enrich()` call in
+    ///    [`tokio::time::timeout`] using the enricher's timeout.
+    /// 6. On error, applies the enricher's [`OnError`] policy.
+    /// 7. If any enricher in the chain returns
+    ///    [`EnrichOutcome::Drop`], the result is removed from the output.
+    ///
+    /// The pipeline initializes `result.header.enrichments` to
+    /// `Some(empty)` lazily on first successful injection, so the
+    /// `skip_serializing_if = "Option::is_none"` contract on
+    /// `RuleHeader::enrichments` is preserved when no enricher writes.
+    ///
+    /// Currently sequential per result; concurrent across results would
+    /// require splitting `results` into chunks across futures and is left
+    /// for a follow-up tuning pass once we have realistic throughput
+    /// numbers from the integration tests.
+    pub async fn run(&self, results: &mut Vec<EvaluationResult>) {
+        if self.enrichers.is_empty() || results.is_empty() {
+            return;
+        }
+
+        // Single-pass enrichment with drop bookkeeping.
+        //
+        // We cannot use `Vec::retain_mut` together with `.await` (the
+        // closure must be sync), so we collect drop indices first and
+        // apply them in a single linear pass at the end.
+        let mut drop_indices: Vec<usize> = Vec::new();
+
+        for (idx, result) in results.iter_mut().enumerate() {
+            let permit = self.semaphore.clone().acquire_owned().await.ok();
+            if permit.is_none() {
+                // Semaphore closed (only happens at shutdown). Drain
+                // remaining results unenriched rather than blocking.
+                tracing::debug!("Enrichment semaphore closed, draining remaining results");
+                return;
+            }
+            let _permit = permit.unwrap();
+
+            let mut should_drop = false;
+            for enricher in &self.enrichers {
+                match Self::run_one(enricher.as_ref(), result).await {
+                    EnrichOutcome::Drop => {
+                        should_drop = true;
+                        break;
+                    }
+                    EnrichOutcome::Ok
+                    | EnrichOutcome::Skip
+                    | EnrichOutcome::Null
+                    | EnrichOutcome::Filtered => {}
+                }
+            }
+            if should_drop {
+                drop_indices.push(idx);
+            }
+        }
+
+        if !drop_indices.is_empty() {
+            // Remove from the back so earlier indices stay valid.
+            for idx in drop_indices.into_iter().rev() {
+                results.swap_remove(idx);
+            }
+        }
+    }
+
+    /// Run a single enricher against a single result, applying the
+    /// kind-vs-body filter, scope filter, timeout, and on_error policy.
+    ///
+    /// `pub(crate)` so the metrics layer (Phase 4) can wire counter
+    /// increments around it without re-implementing the dispatch.
+    async fn run_one(enricher: &dyn Enricher, result: &mut EvaluationResult) -> EnrichOutcome {
+        if !enricher.kind().matches(&result.body) {
+            return EnrichOutcome::Filtered;
+        }
+        if !enricher.scope().matches(result) {
+            return EnrichOutcome::Filtered;
+        }
+
+        let inject_field = enricher.inject_field().to_string();
+        let timeout = enricher.timeout();
+        let id = enricher.id().to_string();
+        let on_error = enricher.on_error();
+
+        let outcome = tokio::time::timeout(timeout, enricher.enrich(result)).await;
+
+        let err = match outcome {
+            Ok(Ok(())) => return EnrichOutcome::Ok,
+            Ok(Err(e)) => e,
+            Err(_) => EnrichError {
+                enricher_id: id.clone(),
+                kind: EnrichErrorKind::Timeout,
+            },
+        };
+
+        match on_error {
+            OnError::Skip => {
+                tracing::warn!(
+                    enricher_id = %id,
+                    kind = %enricher.kind().as_str(),
+                    error = %err,
+                    "Enricher failed, skipping"
+                );
+                EnrichOutcome::Skip
+            }
+            OnError::Null => {
+                tracing::warn!(
+                    enricher_id = %id,
+                    kind = %enricher.kind().as_str(),
+                    error = %err,
+                    "Enricher failed, injecting null"
+                );
+                let map = result
+                    .header
+                    .enrichments
+                    .get_or_insert_with(serde_json::Map::new);
+                map.insert(inject_field, serde_json::Value::Null);
+                EnrichOutcome::Null
+            }
+            OnError::Drop => {
+                tracing::warn!(
+                    enricher_id = %id,
+                    kind = %enricher.kind().as_str(),
+                    error = %err,
+                    "Enricher failed, dropping result"
+                );
+                EnrichOutcome::Drop
+            }
+        }
+    }
+}
+
+impl Default for EnrichmentPipeline {
+    fn default() -> Self {
+        Self::new(Vec::new(), 16)
+    }
+}
+
+/// Helper for [`Enricher::enrich`] implementations: write `value` into
+/// `result.header.enrichments` under `inject_field`, allocating the map
+/// if it was previously `None`.
+pub fn inject_enrichment(
+    result: &mut EvaluationResult,
+    inject_field: &str,
+    value: serde_json::Value,
+) {
+    let map = result
+        .header
+        .enrichments
+        .get_or_insert_with(serde_json::Map::new);
+    map.insert(inject_field.to_string(), value);
+}
+
+// ---------------------------------------------------------------------------
+// Bespoke enricher registration
+// ---------------------------------------------------------------------------
+
+/// Factory function signature used by [`register_builtin`].
+///
+/// External crates that ship a bespoke enricher type register a
+/// `Box<dyn Fn(&serde_json::Value) -> Result<Box<dyn Enricher>, String>>`
+/// so the daemon config layer can construct the enricher from its YAML
+/// config block at startup. The `serde_json::Value` argument is the raw
+/// enricher-config block (after `kind` / `id` / `type` fields are
+/// extracted by the loader).
+pub type EnricherFactory =
+    Arc<dyn Fn(&serde_json::Value) -> Result<Box<dyn Enricher>, String> + Send + Sync>;
+
+/// Process-wide registry of bespoke enricher factories keyed by `type`.
+///
+/// External crates call [`register_builtin`] once at startup (typically
+/// in their `lib.rs` via `ctor` or an explicit init function) to wire a
+/// new `type: <name>` value into the daemon's config loader. Generic
+/// primitives (`template`, `lookup`, `http`, `command`) are not in this
+/// registry; they are constructed directly by the loader.
+///
+/// The registry is global and append-only — registering the same name
+/// twice is an error. Concurrent reads are lock-free via [`std::sync::OnceLock`]
+/// at the outer level and a [`std::sync::RwLock`] at the inner level for the
+/// (rare) `register_builtin` writes.
+fn registry() -> &'static std::sync::RwLock<std::collections::HashMap<String, EnricherFactory>> {
+    use std::sync::OnceLock;
+    static REGISTRY: OnceLock<
+        std::sync::RwLock<std::collections::HashMap<String, EnricherFactory>>,
+    > = OnceLock::new();
+    REGISTRY.get_or_init(|| std::sync::RwLock::new(std::collections::HashMap::new()))
+}
+
+/// Register a bespoke enricher factory under `type: <name>`.
+///
+/// Returns an error if `name` is already registered (registration is
+/// process-global and append-only) or if `name` collides with a built-in
+/// primitive type (`template`, `lookup`, `http`, `command`).
+///
+/// External crates call this once at startup before the daemon loads its
+/// config. After config load, the registry is read-only in practice.
+pub fn register_builtin(name: &str, factory: EnricherFactory) -> Result<(), String> {
+    if matches!(name, "template" | "lookup" | "http" | "command") {
+        return Err(format!(
+            "cannot register '{name}': name is reserved for a built-in primitive"
+        ));
+    }
+    let reg = registry();
+    let mut guard = reg
+        .write()
+        .map_err(|_| "enricher registry poisoned".to_string())?;
+    if guard.contains_key(name) {
+        return Err(format!("enricher type '{name}' is already registered"));
+    }
+    guard.insert(name.to_string(), factory);
+    Ok(())
+}
+
+/// Look up a registered bespoke enricher factory by `type` name.
+///
+/// Returns `None` if `name` is not registered. The daemon config loader
+/// uses this to construct bespoke enrichers; missing names are surfaced
+/// to the operator as a clear startup error.
+pub fn lookup_builtin(name: &str) -> Option<EnricherFactory> {
+    let reg = registry();
+    let guard = reg.read().ok()?;
+    guard.get(name).cloned()
+}
+
+/// Clear the bespoke enricher registry. **Test-only**: used by unit tests
+/// that need to register / re-register the same name. Not exposed to
+/// downstream crates.
+#[cfg(test)]
+pub(crate) fn clear_builtin_registry() {
+    if let Ok(mut guard) = registry().write() {
+        guard.clear();
+    }
+}

--- a/crates/rsigma-runtime/src/enrichment/scope.rs
+++ b/crates/rsigma-runtime/src/enrichment/scope.rs
@@ -1,0 +1,283 @@
+//! Scope filtering for enrichers.
+//!
+//! Each enricher carries an optional [`Scope`] that decides, on a per-result
+//! basis, whether the enricher should fire. Scope is applied **after** the
+//! kind-vs-body filter and **before** [`Enricher::enrich`](super::Enricher::enrich)
+//! runs, so an enricher pays no I/O cost for results it would have ignored
+//! anyway.
+//!
+//! Three independent axes:
+//!
+//! - `rules`: rule-id exact match or rule-title glob (via [`globset`]).
+//! - `tags`: tag-set intersection with prefix wildcard support
+//!   (`attack.*` matches `attack.t1059.001`).
+//! - `levels`: severity membership.
+//!
+//! All three axes are **AND-ed** when configured: an enricher fires only when
+//! every populated axis matches. Empty axes are not filters (an empty
+//! `tags: []` does not exclude every result; it means "no tag constraint").
+//! No `scope.kinds` axis exists — the top-level `kind` field on the enricher
+//! already gates which result-body variant it sees.
+
+use globset::{Glob, GlobMatcher};
+use rsigma_eval::EvaluationResult;
+use rsigma_parser::Level;
+
+/// Scope filter applied per result before [`Enricher::enrich`](super::Enricher::enrich).
+///
+/// Constructed once at config load and then read concurrently from the
+/// pipeline driver, so all internal state is immutable after `Scope::new`.
+#[derive(Debug, Default)]
+pub struct Scope {
+    rule_ids: Vec<String>,
+    rule_title_globs: Vec<GlobMatcher>,
+    tag_globs: Vec<TagPattern>,
+    levels: Vec<Level>,
+}
+
+/// A single tag-pattern entry. Either a literal tag (case-sensitive
+/// equality) or a prefix-wildcard pattern like `attack.*`.
+#[derive(Debug)]
+enum TagPattern {
+    Exact(String),
+    Prefix(String),
+}
+
+impl Scope {
+    /// Build a scope from raw config values.
+    ///
+    /// `rules` mixes exact rule IDs (anything without glob metacharacters)
+    /// and rule-title globs (anything containing `*`, `?`, or `[`).
+    /// `tags` mixes exact tags and prefix-wildcard patterns ending in
+    /// `.*` (e.g. `attack.*`). `levels` is a list of severity strings as
+    /// understood by [`Level::from_str`].
+    ///
+    /// Returns an error if any glob fails to compile or any level string
+    /// fails to parse, so the daemon refuses to start with a malformed
+    /// scope rather than silently mismatching at runtime.
+    pub fn new(rules: Vec<String>, tags: Vec<String>, levels: Vec<String>) -> Result<Self, String> {
+        let mut rule_ids = Vec::new();
+        let mut rule_title_globs = Vec::new();
+        for r in rules {
+            if has_glob_meta(&r) {
+                let glob =
+                    Glob::new(&r).map_err(|e| format!("invalid scope.rules glob '{r}': {e}"))?;
+                rule_title_globs.push(glob.compile_matcher());
+            } else {
+                rule_ids.push(r);
+            }
+        }
+
+        let mut tag_globs = Vec::new();
+        for t in tags {
+            if let Some(prefix) = t.strip_suffix(".*") {
+                tag_globs.push(TagPattern::Prefix(prefix.to_string()));
+            } else if t.ends_with('*') {
+                // Bare `*` suffix without `.` separator is allowed too.
+                let prefix = t.trim_end_matches('*').to_string();
+                tag_globs.push(TagPattern::Prefix(prefix));
+            } else {
+                tag_globs.push(TagPattern::Exact(t));
+            }
+        }
+
+        let mut parsed_levels = Vec::new();
+        for l in levels {
+            let lvl: Level = l
+                .parse()
+                .map_err(|_| format!("invalid scope.levels entry '{l}'"))?;
+            parsed_levels.push(lvl);
+        }
+
+        Ok(Self {
+            rule_ids,
+            rule_title_globs,
+            tag_globs,
+            levels: parsed_levels,
+        })
+    }
+
+    /// True when no axis is populated. The pipeline can fast-path past
+    /// empty scopes without inspecting the result.
+    pub fn is_unrestricted(&self) -> bool {
+        self.rule_ids.is_empty()
+            && self.rule_title_globs.is_empty()
+            && self.tag_globs.is_empty()
+            && self.levels.is_empty()
+    }
+
+    /// True when this scope admits the given result.
+    ///
+    /// Each populated axis must match; empty axes are skipped. An
+    /// unrestricted scope ([`Scope::is_unrestricted`]) admits every result.
+    pub fn matches(&self, result: &EvaluationResult) -> bool {
+        if self.is_unrestricted() {
+            return true;
+        }
+
+        if !self.rule_ids.is_empty() || !self.rule_title_globs.is_empty() {
+            let by_id = result
+                .header
+                .rule_id
+                .as_deref()
+                .is_some_and(|id| self.rule_ids.iter().any(|r| r == id));
+            let by_title = self
+                .rule_title_globs
+                .iter()
+                .any(|g| g.is_match(&result.header.rule_title));
+            if !(by_id || by_title) {
+                return false;
+            }
+        }
+
+        if !self.tag_globs.is_empty() {
+            let any_match = result
+                .header
+                .tags
+                .iter()
+                .any(|t| self.tag_globs.iter().any(|p| p.matches(t)));
+            if !any_match {
+                return false;
+            }
+        }
+
+        if !self.levels.is_empty() {
+            match result.header.level {
+                Some(lvl) if self.levels.contains(&lvl) => {}
+                _ => return false,
+            }
+        }
+
+        true
+    }
+}
+
+impl TagPattern {
+    fn matches(&self, tag: &str) -> bool {
+        match self {
+            TagPattern::Exact(t) => t == tag,
+            TagPattern::Prefix(p) => tag.starts_with(p),
+        }
+    }
+}
+
+/// Cheap probe for glob metacharacters. Anything containing `*`, `?`, or
+/// `[` is treated as a glob; otherwise the entry is a literal rule ID.
+fn has_glob_meta(s: &str) -> bool {
+    s.contains('*') || s.contains('?') || s.contains('[')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::{DetectionBody, EvaluationResult, ResultBody, RuleHeader};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn det(
+        title: &str,
+        id: Option<&str>,
+        tags: Vec<&str>,
+        level: Option<Level>,
+    ) -> EvaluationResult {
+        EvaluationResult {
+            header: RuleHeader {
+                rule_title: title.to_string(),
+                rule_id: id.map(|s| s.to_string()),
+                level,
+                tags: tags.into_iter().map(|s| s.to_string()).collect(),
+                custom_attributes: Arc::new(HashMap::new()),
+                enrichments: None,
+            },
+            body: ResultBody::Detection(DetectionBody {
+                matched_selections: vec![],
+                matched_fields: vec![],
+                event: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn unrestricted_scope_matches_anything() {
+        let scope = Scope::default();
+        assert!(scope.is_unrestricted());
+        assert!(scope.matches(&det("Anything", None, vec![], None)));
+    }
+
+    #[test]
+    fn rule_id_exact_match() {
+        let scope = Scope::new(vec!["abc-123".to_string()], vec![], vec![]).unwrap();
+        assert!(scope.matches(&det("X", Some("abc-123"), vec![], None)));
+        assert!(!scope.matches(&det("X", Some("abc-124"), vec![], None)));
+        assert!(!scope.matches(&det("X", None, vec![], None)));
+    }
+
+    #[test]
+    fn rule_title_glob_match() {
+        let scope = Scope::new(vec!["Suspicious *".to_string()], vec![], vec![]).unwrap();
+        assert!(scope.matches(&det("Suspicious PowerShell", None, vec![], None)));
+        assert!(!scope.matches(&det("Innocent thing", None, vec![], None)));
+    }
+
+    #[test]
+    fn tag_prefix_wildcard() {
+        let scope = Scope::new(vec![], vec!["attack.*".to_string()], vec![]).unwrap();
+        assert!(scope.matches(&det("X", None, vec!["attack.t1059.001"], None)));
+        assert!(!scope.matches(&det("X", None, vec!["other.tag"], None)));
+    }
+
+    #[test]
+    fn tag_exact_match_intersection() {
+        let scope = Scope::new(
+            vec![],
+            vec!["attack.execution".to_string(), "exfil".to_string()],
+            vec![],
+        )
+        .unwrap();
+        assert!(scope.matches(&det("X", None, vec!["attack.execution"], None)));
+        assert!(scope.matches(&det("X", None, vec!["exfil"], None)));
+        assert!(!scope.matches(&det("X", None, vec!["attack.execution.123"], None)));
+    }
+
+    #[test]
+    fn levels_membership() {
+        let scope = Scope::new(
+            vec![],
+            vec![],
+            vec!["high".to_string(), "critical".to_string()],
+        )
+        .unwrap();
+        assert!(scope.matches(&det("X", None, vec![], Some(Level::High))));
+        assert!(scope.matches(&det("X", None, vec![], Some(Level::Critical))));
+        assert!(!scope.matches(&det("X", None, vec![], Some(Level::Medium))));
+        assert!(!scope.matches(&det("X", None, vec![], None)));
+    }
+
+    #[test]
+    fn axes_and_combine() {
+        let scope = Scope::new(
+            vec![],
+            vec!["attack.*".to_string()],
+            vec!["high".to_string()],
+        )
+        .unwrap();
+        // Both match
+        assert!(scope.matches(&det("X", None, vec!["attack.t1059"], Some(Level::High))));
+        // Tag matches, level does not
+        assert!(!scope.matches(&det("X", None, vec!["attack.t1059"], Some(Level::Low))));
+        // Level matches, tag does not
+        assert!(!scope.matches(&det("X", None, vec!["other"], Some(Level::High))));
+    }
+
+    #[test]
+    fn invalid_glob_rejected_at_construction() {
+        let err = Scope::new(vec!["[unclosed".to_string()], vec![], vec![]).unwrap_err();
+        assert!(err.contains("invalid scope.rules glob"));
+    }
+
+    #[test]
+    fn invalid_level_rejected() {
+        let err = Scope::new(vec![], vec![], vec!["super-high".to_string()]).unwrap_err();
+        assert!(err.contains("invalid scope.levels"));
+    }
+}

--- a/crates/rsigma-runtime/src/enrichment/template.rs
+++ b/crates/rsigma-runtime/src/enrichment/template.rs
@@ -1,0 +1,412 @@
+//! `TemplateEnricher`: pure string interpolation for enrichment.
+//!
+//! `template` is the simplest of the four primitives: it performs no I/O,
+//! cannot fail at runtime past template parse errors caught at config load,
+//! and is intended for cheap synthetic fields like runbook URLs and summary
+//! strings.
+//!
+//! # Template syntax
+//!
+//! Two forms are recognized:
+//!
+//! - `${<name>}` (single segment, no dot): environment variable lookup.
+//!   Empty when the env var is unset.
+//! - `${detection.<path>}` or `${correlation.<path>}`: kind-specific
+//!   variable. Only the namespace matching the enricher's declared
+//!   [`EnricherKind`](super::EnricherKind) is allowed; the other namespace
+//!   fails [`validate_template_namespace`] at config load.
+//!
+//! Detection paths:
+//! - `rule.title` / `rule.id` / `rule.level`
+//! - `tags` (joined with `,`)
+//! - `fields.<name>` (the matched value of `<name>` from `matched_fields`)
+//! - `event.<dotted.path>` (navigate `DetectionBody::event` by JSON segment)
+//!
+//! Correlation paths:
+//! - `rule.title` / `rule.id` / `rule.level`
+//! - `tags` (joined with `,`)
+//! - `type` (`event_count`, `temporal`, …)
+//! - `aggregated_value` / `timespan_secs`
+//! - `group_key` (joined `field=value,…`) or `group_key.<field>`
+//!
+//! Anything else (unrecognized prefix, dotted env var, etc.) is rejected at
+//! config load, **not** at runtime, so a deployment with a typo never starts
+//! producing partly-rendered enrichments under load.
+
+use std::sync::LazyLock;
+
+use async_trait::async_trait;
+use regex::Regex;
+use rsigma_eval::{EvaluationResult, ResultBody};
+use rsigma_parser::Level;
+
+use super::{
+    EnrichError, EnrichErrorKind, Enricher, EnricherKind, OnError, Scope, inject_enrichment,
+};
+
+/// Matches `${<contents>}` where contents is anything except `}`.
+///
+/// We deliberately allow non-alphanumeric content inside the braces (dots,
+/// underscores) and leave classification to [`classify_ref`] so error
+/// messages can pinpoint the offending reference.
+static TEMPLATE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\$\{([^}]+)\}").unwrap());
+
+/// Classification of a single `${...}` reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VarRef {
+    /// `${detection.<rest>}`
+    Detection(String),
+    /// `${correlation.<rest>}`
+    Correlation(String),
+    /// `${ENV_VAR}` — single segment, no dot.
+    Env(String),
+    /// Anything else (dotted but unknown prefix, empty, …). Always an
+    /// error at config load.
+    Invalid(String),
+}
+
+fn classify_ref(name: &str) -> VarRef {
+    if let Some(rest) = name.strip_prefix("detection.") {
+        VarRef::Detection(rest.to_string())
+    } else if let Some(rest) = name.strip_prefix("correlation.") {
+        VarRef::Correlation(rest.to_string())
+    } else if name.contains('.') || name.is_empty() {
+        VarRef::Invalid(name.to_string())
+    } else {
+        VarRef::Env(name.to_string())
+    }
+}
+
+/// Failure modes for [`validate_template_namespace`].
+#[derive(Debug, Clone)]
+pub enum TemplateError {
+    /// Reference uses the opposite namespace from the enricher's declared
+    /// kind (e.g. `${correlation.*}` inside a `kind: detection` enricher).
+    CrossNamespace {
+        enricher_id: String,
+        enricher_kind: EnricherKind,
+        reference: String,
+        field: &'static str,
+    },
+    /// Reference is malformed (empty `${}`, dotted prefix that is neither
+    /// `detection.` nor `correlation.`, …).
+    Malformed {
+        enricher_id: String,
+        reference: String,
+        field: &'static str,
+    },
+}
+
+impl std::fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TemplateError::CrossNamespace {
+                enricher_id,
+                enricher_kind,
+                reference,
+                field,
+            } => write!(
+                f,
+                "enricher '{enricher_id}' (kind: {kind}) references '${{{reference}}}' in field '{field}'; this is the wrong namespace for a {kind} enricher",
+                kind = enricher_kind.as_str(),
+            ),
+            TemplateError::Malformed {
+                enricher_id,
+                reference,
+                field,
+            } => write!(
+                f,
+                "enricher '{enricher_id}': malformed template reference '${{{reference}}}' in field '{field}'; expected ${{detection.*}}, ${{correlation.*}}, or ${{ENV_VAR}}",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TemplateError {}
+
+/// Validate that every `${...}` reference inside `text` matches the
+/// enricher's declared kind.
+///
+/// `field` is included in the error message so operators can find the
+/// offending YAML key (e.g. `template`, `url`, `headers.Authorization`).
+/// Called at config load time for every templated config value across every
+/// enricher; rejects the daemon startup on the first failure rather than
+/// the first runtime hit.
+pub fn validate_template_namespace(
+    text: &str,
+    enricher_kind: EnricherKind,
+    enricher_id: &str,
+    field: &'static str,
+) -> Result<(), TemplateError> {
+    for caps in TEMPLATE_RE.captures_iter(text) {
+        let inner = caps.get(1).unwrap().as_str();
+        match classify_ref(inner) {
+            VarRef::Env(_) => {}
+            VarRef::Detection(_) if enricher_kind == EnricherKind::Detection => {}
+            VarRef::Correlation(_) if enricher_kind == EnricherKind::Correlation => {}
+            VarRef::Detection(_) | VarRef::Correlation(_) => {
+                return Err(TemplateError::CrossNamespace {
+                    enricher_id: enricher_id.to_string(),
+                    enricher_kind,
+                    reference: inner.to_string(),
+                    field,
+                });
+            }
+            VarRef::Invalid(_) => {
+                return Err(TemplateError::Malformed {
+                    enricher_id: enricher_id.to_string(),
+                    reference: inner.to_string(),
+                    field,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Render `text` against `result`, expanding every `${...}` reference.
+///
+/// Values for missing fields render as the empty string (matching the
+/// source-side `TemplateExpander` behaviour). Cross-namespace references
+/// are caught at config load by [`validate_template_namespace`] and
+/// therefore must not reach this function; if one does, it renders as
+/// the empty string rather than panicking, since the same render path is
+/// reused by tests.
+pub fn render_template(text: &str, result: &EvaluationResult) -> String {
+    TEMPLATE_RE
+        .replace_all(text, |caps: &regex::Captures| {
+            let inner = caps.get(1).unwrap().as_str();
+            match classify_ref(inner) {
+                VarRef::Env(name) => std::env::var(name).unwrap_or_default(),
+                VarRef::Detection(path) => match &result.body {
+                    ResultBody::Detection(_) => render_detection_path(&path, result),
+                    ResultBody::Correlation(_) => String::new(),
+                },
+                VarRef::Correlation(path) => match &result.body {
+                    ResultBody::Correlation(_) => render_correlation_path(&path, result),
+                    ResultBody::Detection(_) => String::new(),
+                },
+                VarRef::Invalid(_) => String::new(),
+            }
+        })
+        .into_owned()
+}
+
+fn render_detection_path(path: &str, result: &EvaluationResult) -> String {
+    let body = match result.as_detection() {
+        Some(b) => b,
+        None => return String::new(),
+    };
+    if let Some(rest) = path.strip_prefix("rule.") {
+        return render_rule_field(rest, result);
+    }
+    if path == "tags" {
+        return result.header.tags.join(",");
+    }
+    if let Some(name) = path.strip_prefix("fields.") {
+        for fm in &body.matched_fields {
+            if fm.field == name {
+                return json_to_string(&fm.value);
+            }
+        }
+        return String::new();
+    }
+    if let Some(rest) = path.strip_prefix("event.") {
+        if let Some(event) = &body.event {
+            return navigate_json(event, rest)
+                .map(json_to_string)
+                .unwrap_or_default();
+        }
+        return String::new();
+    }
+    if path == "event" {
+        return body.event.as_ref().map(json_to_string).unwrap_or_default();
+    }
+    String::new()
+}
+
+fn render_correlation_path(path: &str, result: &EvaluationResult) -> String {
+    let body = match result.as_correlation() {
+        Some(b) => b,
+        None => return String::new(),
+    };
+    if let Some(rest) = path.strip_prefix("rule.") {
+        return render_rule_field(rest, result);
+    }
+    if path == "tags" {
+        return result.header.tags.join(",");
+    }
+    if path == "type" {
+        return body.correlation_type.as_str().to_string();
+    }
+    if path == "aggregated_value" {
+        return format_f64(body.aggregated_value);
+    }
+    if path == "timespan_secs" {
+        return body.timespan_secs.to_string();
+    }
+    if path == "group_key" {
+        return body
+            .group_key
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(",");
+    }
+    if let Some(name) = path.strip_prefix("group_key.") {
+        for (k, v) in &body.group_key {
+            if k == name {
+                return v.clone();
+            }
+        }
+        return String::new();
+    }
+    String::new()
+}
+
+fn render_rule_field(rest: &str, result: &EvaluationResult) -> String {
+    match rest {
+        "title" => result.header.rule_title.clone(),
+        "id" => result.header.rule_id.clone().unwrap_or_default(),
+        "level" => result
+            .header
+            .level
+            .map(|l: Level| l.as_str().to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+/// Navigate a JSON value by dotted path (`"a.b.c"`).
+///
+/// Numeric segments index into arrays; everything else looks up object
+/// keys. Returns `None` on any miss. Mirrors the behaviour of
+/// [`crate::sources::TemplateExpander`]'s navigator so the two surfaces
+/// behave identically for operators.
+fn navigate_json<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        match current {
+            serde_json::Value::Object(map) => current = map.get(segment)?,
+            serde_json::Value::Array(arr) => {
+                let idx: usize = segment.parse().ok()?;
+                current = arr.get(idx)?;
+            }
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+fn json_to_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Format an `f64` matching the JSON `serde_json` default: integers as
+/// `"73"`, fractions as `"3.5"`. Avoids `to_string()`'s scientific
+/// notation drift for large values.
+fn format_f64(v: f64) -> String {
+    if v.is_finite() && v.fract() == 0.0 && v.abs() < 1e15 {
+        format!("{}", v as i64)
+    } else {
+        v.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TemplateEnricher implementation
+// ---------------------------------------------------------------------------
+
+/// Pure-template enricher: renders a single template string and writes the
+/// rendered value into `enrichments[<inject_field>]`.
+///
+/// All template namespace validation has happened at config load via
+/// [`validate_template_namespace`], so `enrich()` is infallible past
+/// runtime checks (the only failure mode is an opaque internal panic from
+/// the regex engine, which would itself be a bug).
+pub struct TemplateEnricher {
+    id: String,
+    kind: EnricherKind,
+    inject_field: String,
+    template: String,
+    timeout: std::time::Duration,
+    on_error: OnError,
+    scope: Scope,
+}
+
+impl TemplateEnricher {
+    /// Construct a `TemplateEnricher`.
+    ///
+    /// `template` is **not** re-validated here; callers must ensure
+    /// [`validate_template_namespace`] has been run at config load.
+    pub fn new(
+        id: String,
+        kind: EnricherKind,
+        inject_field: String,
+        template: String,
+        timeout: std::time::Duration,
+        on_error: OnError,
+        scope: Scope,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            inject_field,
+            template,
+            timeout,
+            on_error,
+            scope,
+        }
+    }
+}
+
+#[async_trait]
+impl Enricher for TemplateEnricher {
+    fn kind(&self) -> EnricherKind {
+        self.kind
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn inject_field(&self) -> &str {
+        &self.inject_field
+    }
+
+    fn timeout(&self) -> std::time::Duration {
+        self.timeout
+    }
+
+    fn scope(&self) -> &Scope {
+        &self.scope
+    }
+
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+
+    async fn enrich(&self, result: &mut EvaluationResult) -> Result<(), EnrichError> {
+        let rendered = render_template(&self.template, result);
+        inject_enrichment(
+            result,
+            &self.inject_field,
+            serde_json::Value::String(rendered),
+        );
+        Ok(())
+    }
+}
+
+// `EnrichError` / `EnrichErrorKind` are referenced by the trait definition
+// above via `super::*`; this `_use` keeps unused-import warnings off when
+// future expansions fold in custom errors here without changing the bound.
+#[allow(dead_code)]
+fn _use_err(_e: EnrichError) -> EnrichErrorKind {
+    EnrichErrorKind::TemplateRender(String::new())
+}

--- a/crates/rsigma-runtime/src/enrichment/tests.rs
+++ b/crates/rsigma-runtime/src/enrichment/tests.rs
@@ -1,0 +1,551 @@
+//! Unit tests for the enrichment foundation.
+//!
+//! Tests sit at `super::tests` so they share visibility with `mod.rs`'s
+//! crate-private hooks (`clear_builtin_registry`, `EnrichOutcome`, …).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rsigma_eval::{
+    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, ResultBody, RuleHeader,
+};
+use rsigma_parser::{CorrelationType, Level};
+
+use super::{
+    EnrichError, EnrichErrorKind, Enricher, EnricherKind, EnrichmentPipeline, OnError, Scope,
+    TemplateEnricher, register_builtin, validate_template_namespace,
+};
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+fn detection_result() -> EvaluationResult {
+    EvaluationResult {
+        header: RuleHeader {
+            rule_title: "Suspicious PowerShell".to_string(),
+            rule_id: Some("rule-pwsh".to_string()),
+            level: Some(Level::High),
+            tags: vec![
+                "attack.t1059.001".to_string(),
+                "attack.execution".to_string(),
+            ],
+            custom_attributes: Arc::new(HashMap::new()),
+            enrichments: None,
+        },
+        body: ResultBody::Detection(DetectionBody {
+            matched_selections: vec!["selection".to_string()],
+            matched_fields: vec![FieldMatch {
+                field: "CommandLine".to_string(),
+                value: serde_json::json!("powershell -enc QQA="),
+            }],
+            event: Some(serde_json::json!({"User": "alice", "Host": "dc01"})),
+        }),
+    }
+}
+
+fn correlation_result() -> EvaluationResult {
+    EvaluationResult {
+        header: RuleHeader {
+            rule_title: "SSH brute force".to_string(),
+            rule_id: Some("corr-ssh".to_string()),
+            level: Some(Level::High),
+            tags: vec!["attack.t1110".to_string()],
+            custom_attributes: Arc::new(HashMap::new()),
+            enrichments: None,
+        },
+        body: ResultBody::Correlation(CorrelationBody {
+            correlation_type: CorrelationType::EventCount,
+            group_key: vec![("SourceIP".to_string(), "203.0.113.4".to_string())],
+            aggregated_value: 73.0,
+            timespan_secs: 300,
+            events: None,
+            event_refs: None,
+        }),
+    }
+}
+
+fn template_enricher(
+    id: &str,
+    kind: EnricherKind,
+    inject: &str,
+    template: &str,
+) -> TemplateEnricher {
+    TemplateEnricher::new(
+        id.to_string(),
+        kind,
+        inject.to_string(),
+        template.to_string(),
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Template variable expansion tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn template_expands_detection_rule_fields() {
+    let mut r = detection_result();
+    let e = template_enricher(
+        "runbook_det",
+        EnricherKind::Detection,
+        "runbook_url",
+        "https://wiki/runbooks/${detection.rule.id}",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let map = r.header.enrichments.unwrap();
+    assert_eq!(
+        map.get("runbook_url").unwrap(),
+        &serde_json::json!("https://wiki/runbooks/rule-pwsh")
+    );
+}
+
+#[tokio::test]
+async fn template_expands_detection_field_value() {
+    let mut r = detection_result();
+    let e = template_enricher(
+        "echo_cmd",
+        EnricherKind::Detection,
+        "command_summary",
+        "saw: ${detection.fields.CommandLine}",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(
+        v.get("command_summary").unwrap(),
+        &serde_json::json!("saw: powershell -enc QQA=")
+    );
+}
+
+#[tokio::test]
+async fn template_expands_detection_event_jsonpath() {
+    let mut r = detection_result();
+    let e = template_enricher(
+        "user",
+        EnricherKind::Detection,
+        "by",
+        "user=${detection.event.User} host=${detection.event.Host}",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(
+        v.get("by").unwrap(),
+        &serde_json::json!("user=alice host=dc01")
+    );
+}
+
+#[tokio::test]
+async fn template_expands_detection_tags_joined() {
+    let mut r = detection_result();
+    let e = template_enricher(
+        "tags",
+        EnricherKind::Detection,
+        "all_tags",
+        "${detection.tags}",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(
+        v.get("all_tags").unwrap(),
+        &serde_json::json!("attack.t1059.001,attack.execution")
+    );
+}
+
+#[tokio::test]
+async fn template_expands_correlation_aggregate_and_group_key() {
+    let mut r = correlation_result();
+    let e = template_enricher(
+        "burst",
+        EnricherKind::Correlation,
+        "summary",
+        "Burst of ${correlation.aggregated_value} from ${correlation.group_key.SourceIP} over ${correlation.timespan_secs}s",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(
+        v.get("summary").unwrap(),
+        &serde_json::json!("Burst of 73 from 203.0.113.4 over 300s")
+    );
+}
+
+#[tokio::test]
+async fn template_expands_correlation_type_and_group_key_joined() {
+    let mut r = correlation_result();
+    let e = template_enricher(
+        "ct",
+        EnricherKind::Correlation,
+        "key",
+        "${correlation.type}|${correlation.group_key}",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(
+        v.get("key").unwrap(),
+        &serde_json::json!("event_count|SourceIP=203.0.113.4")
+    );
+}
+
+#[tokio::test]
+async fn template_missing_field_renders_empty() {
+    let mut r = detection_result();
+    let e = template_enricher(
+        "x",
+        EnricherKind::Detection,
+        "out",
+        "[${detection.fields.NotThere}]",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(v.get("out").unwrap(), &serde_json::json!("[]"));
+}
+
+#[tokio::test]
+async fn template_env_var_expansion() {
+    // SAFETY: tests run on a single thread per test function and we set a
+    // process-wide env var; the value is unique enough not to collide.
+    unsafe {
+        std::env::set_var("RSIGMA_TEST_ENRICH_ENV", "hello");
+    }
+    let mut r = detection_result();
+    let e = template_enricher(
+        "envprobe",
+        EnricherKind::Detection,
+        "out",
+        "v=${RSIGMA_TEST_ENRICH_ENV}",
+    );
+    e.enrich(&mut r).await.unwrap();
+    let v = r.header.enrichments.unwrap();
+    assert_eq!(v.get("out").unwrap(), &serde_json::json!("v=hello"));
+    unsafe {
+        std::env::remove_var("RSIGMA_TEST_ENRICH_ENV");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config-load-time namespace validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validator_rejects_correlation_ref_in_detection_enricher() {
+    let err = validate_template_namespace(
+        "https://wiki/${correlation.rule.id}",
+        EnricherKind::Detection,
+        "runbook_det",
+        "template",
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("wrong namespace"));
+}
+
+#[test]
+fn validator_rejects_detection_ref_in_correlation_enricher() {
+    let err = validate_template_namespace(
+        "${detection.fields.User}",
+        EnricherKind::Correlation,
+        "x",
+        "url",
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("wrong namespace"));
+}
+
+#[test]
+fn validator_accepts_matching_namespace_and_env_var() {
+    validate_template_namespace(
+        "https://wiki/${detection.rule.id}/${HOME}",
+        EnricherKind::Detection,
+        "x",
+        "template",
+    )
+    .unwrap();
+    validate_template_namespace(
+        "${correlation.aggregated_value}/${HOME}",
+        EnricherKind::Correlation,
+        "x",
+        "template",
+    )
+    .unwrap();
+}
+
+#[test]
+fn validator_rejects_malformed_dotted_reference() {
+    let err = validate_template_namespace(
+        "${something.weird}",
+        EnricherKind::Detection,
+        "x",
+        "template",
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("malformed"));
+}
+
+// Note: `${}` (empty inner) does not match the `\$\{([^}]+)\}` regex at
+// all, so it is not classified as a reference and renders literally. The
+// validator therefore accepts strings like `${}` as plain text. Operators
+// who type that almost certainly meant `${something}`, but the cost of
+// the extra regex pass to flag literal `${}` is not worth it.
+
+// ---------------------------------------------------------------------------
+// EnrichmentPipeline: kind filter and multi-enricher ordering
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pipeline_skips_enricher_when_kind_does_not_match_body() {
+    let mut results = vec![correlation_result()];
+    let det_enricher = Box::new(template_enricher(
+        "det",
+        EnricherKind::Detection,
+        "should_not_appear",
+        "static-value",
+    )) as Box<dyn Enricher>;
+    let corr_enricher = Box::new(template_enricher(
+        "corr",
+        EnricherKind::Correlation,
+        "should_appear",
+        "yes",
+    )) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![det_enricher, corr_enricher], 4);
+
+    pipeline.run(&mut results).await;
+
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert!(map.get("should_not_appear").is_none());
+    assert_eq!(map.get("should_appear").unwrap(), &serde_json::json!("yes"));
+}
+
+#[tokio::test]
+async fn pipeline_applies_multiple_enrichers_in_order() {
+    let mut results = vec![detection_result()];
+    let a = Box::new(template_enricher(
+        "a",
+        EnricherKind::Detection,
+        "field_a",
+        "first",
+    )) as Box<dyn Enricher>;
+    let b = Box::new(template_enricher(
+        "b",
+        EnricherKind::Detection,
+        "field_b",
+        "second",
+    )) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![a, b], 2);
+    pipeline.run(&mut results).await;
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(map.get("field_a").unwrap(), &serde_json::json!("first"));
+    assert_eq!(map.get("field_b").unwrap(), &serde_json::json!("second"));
+}
+
+#[tokio::test]
+async fn pipeline_with_no_enrichers_is_noop() {
+    let mut results = vec![detection_result(), correlation_result()];
+    let pipeline = EnrichmentPipeline::default();
+    pipeline.run(&mut results).await;
+    assert!(results[0].header.enrichments.is_none());
+    assert!(results[1].header.enrichments.is_none());
+}
+
+#[tokio::test]
+async fn pipeline_does_not_create_empty_enrichments_map() {
+    // A correlation result with only detection-kind enrichers should keep
+    // enrichments=None so the `skip_serializing_if` contract is preserved.
+    let mut results = vec![correlation_result()];
+    let det_only =
+        Box::new(template_enricher("det", EnricherKind::Detection, "x", "y")) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![det_only], 4);
+    pipeline.run(&mut results).await;
+    assert!(results[0].header.enrichments.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// On-error policy
+// ---------------------------------------------------------------------------
+
+/// Test-only enricher that always errors. Used to drive the `on_error`
+/// branches without spinning up an HTTP server.
+struct ErroringEnricher {
+    id: String,
+    kind: EnricherKind,
+    inject_field: String,
+    on_error: OnError,
+    scope: Scope,
+}
+
+#[async_trait::async_trait]
+impl Enricher for ErroringEnricher {
+    fn kind(&self) -> EnricherKind {
+        self.kind
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn inject_field(&self) -> &str {
+        &self.inject_field
+    }
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(1)
+    }
+    fn scope(&self) -> &Scope {
+        &self.scope
+    }
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+    async fn enrich(&self, _: &mut EvaluationResult) -> Result<(), EnrichError> {
+        Err(EnrichError {
+            enricher_id: self.id.clone(),
+            kind: EnrichErrorKind::Fetch("synthetic".to_string()),
+        })
+    }
+}
+
+#[tokio::test]
+async fn on_error_skip_leaves_enrichments_alone() {
+    let mut results = vec![detection_result()];
+    let e = Box::new(ErroringEnricher {
+        id: "boom".to_string(),
+        kind: EnricherKind::Detection,
+        inject_field: "out".to_string(),
+        on_error: OnError::Skip,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    EnrichmentPipeline::new(vec![e], 1).run(&mut results).await;
+    assert!(results[0].header.enrichments.is_none());
+}
+
+#[tokio::test]
+async fn on_error_null_injects_null() {
+    let mut results = vec![detection_result()];
+    let e = Box::new(ErroringEnricher {
+        id: "boom".to_string(),
+        kind: EnricherKind::Detection,
+        inject_field: "out".to_string(),
+        on_error: OnError::Null,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    EnrichmentPipeline::new(vec![e], 1).run(&mut results).await;
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(map.get("out").unwrap(), &serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn on_error_drop_removes_result_from_vec() {
+    let mut results = vec![detection_result(), correlation_result()];
+    let e = Box::new(ErroringEnricher {
+        id: "boom".to_string(),
+        kind: EnricherKind::Detection,
+        inject_field: "out".to_string(),
+        on_error: OnError::Drop,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    EnrichmentPipeline::new(vec![e], 1).run(&mut results).await;
+    // Detection got dropped, correlation survived.
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_correlation());
+}
+
+// ---------------------------------------------------------------------------
+// Timeout
+// ---------------------------------------------------------------------------
+
+struct SleepingEnricher {
+    id: String,
+    sleep_for: Duration,
+    timeout: Duration,
+    on_error: OnError,
+    scope: Scope,
+}
+
+#[async_trait::async_trait]
+impl Enricher for SleepingEnricher {
+    fn kind(&self) -> EnricherKind {
+        EnricherKind::Detection
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn inject_field(&self) -> &str {
+        "_"
+    }
+    fn timeout(&self) -> Duration {
+        self.timeout
+    }
+    fn scope(&self) -> &Scope {
+        &self.scope
+    }
+    fn on_error(&self) -> OnError {
+        self.on_error
+    }
+    async fn enrich(&self, _: &mut EvaluationResult) -> Result<(), EnrichError> {
+        tokio::time::sleep(self.sleep_for).await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn timeout_triggers_on_error_policy() {
+    let mut results = vec![detection_result()];
+    let e = Box::new(SleepingEnricher {
+        id: "slow".to_string(),
+        sleep_for: Duration::from_millis(200),
+        timeout: Duration::from_millis(20),
+        on_error: OnError::Null,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    EnrichmentPipeline::new(vec![e], 1).run(&mut results).await;
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(map.get("_").unwrap(), &serde_json::Value::Null);
+}
+
+// ---------------------------------------------------------------------------
+// register_builtin / lookup_builtin
+// ---------------------------------------------------------------------------
+//
+// The bespoke-enricher registry is process-global, so these tests must
+// not race each other. We serialize them under a `Mutex` and clear the
+// registry at the start of each.
+
+fn registry_test_lock() -> &'static std::sync::Mutex<()> {
+    use std::sync::OnceLock;
+    static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[test]
+fn register_builtin_rejects_reserved_names() {
+    let _guard = registry_test_lock().lock().unwrap();
+    super::clear_builtin_registry();
+    for reserved in ["template", "lookup", "http", "command"] {
+        let err = register_builtin(
+            reserved,
+            std::sync::Arc::new(|_| Err::<Box<dyn Enricher>, _>("unused".to_string())),
+        )
+        .unwrap_err();
+        assert!(err.contains("reserved"));
+    }
+}
+
+#[test]
+fn register_builtin_rejects_duplicate_name() {
+    let _guard = registry_test_lock().lock().unwrap();
+    super::clear_builtin_registry();
+    let factory: super::EnricherFactory =
+        std::sync::Arc::new(|_| Err::<Box<dyn Enricher>, _>("not-buildable".to_string()));
+    register_builtin("enrich_dup", factory.clone()).unwrap();
+    let err = register_builtin("enrich_dup", factory).unwrap_err();
+    assert!(err.contains("already registered"));
+}
+
+#[test]
+fn lookup_builtin_returns_registered_factory() {
+    let _guard = registry_test_lock().lock().unwrap();
+    super::clear_builtin_registry();
+    let factory: super::EnricherFactory =
+        std::sync::Arc::new(|_| Err::<Box<dyn Enricher>, _>("not-buildable".to_string()));
+    register_builtin("enrich_test_thing", factory).unwrap();
+    assert!(super::lookup_builtin("enrich_test_thing").is_some());
+    assert!(super::lookup_builtin("missing").is_none());
+}

--- a/crates/rsigma-runtime/src/enrichment/tests.rs
+++ b/crates/rsigma-runtime/src/enrichment/tests.rs
@@ -539,6 +539,160 @@ fn register_builtin_rejects_duplicate_name() {
     assert!(err.contains("already registered"));
 }
 
+// ---------------------------------------------------------------------------
+// Metrics hook
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct CollectingMetrics {
+    completed: std::sync::Mutex<Vec<(String, String, String)>>,
+    queue_changes: std::sync::Mutex<Vec<i64>>,
+    cache_hits: std::sync::Mutex<Vec<String>>,
+    cache_misses: std::sync::Mutex<Vec<String>>,
+    cache_expirations: std::sync::Mutex<Vec<String>>,
+}
+
+impl crate::MetricsHook for CollectingMetrics {
+    fn on_parse_error(&self) {}
+    fn on_events_processed(&self, _: u64) {}
+    fn on_detection_matches(&self, _: u64) {}
+    fn on_correlation_matches(&self, _: u64) {}
+    fn observe_processing_latency(&self, _: f64) {}
+    fn on_input_queue_depth_change(&self, _: i64) {}
+    fn on_back_pressure(&self) {}
+    fn observe_batch_size(&self, _: u64) {}
+    fn on_output_queue_depth_change(&self, _: i64) {}
+    fn observe_pipeline_latency(&self, _: f64) {}
+    fn set_correlation_state_entries(&self, _: u64) {}
+    fn on_enrichment_completed(
+        &self,
+        enricher_id: &str,
+        kind: &str,
+        status: &str,
+        _duration_seconds: f64,
+    ) {
+        self.completed.lock().unwrap().push((
+            enricher_id.to_string(),
+            kind.to_string(),
+            status.to_string(),
+        ));
+    }
+    fn on_enrichment_queue_depth_change(&self, delta: i64) {
+        self.queue_changes.lock().unwrap().push(delta);
+    }
+    fn on_enrichment_http_cache_hit(&self, enricher_id: &str) {
+        self.cache_hits
+            .lock()
+            .unwrap()
+            .push(enricher_id.to_string());
+    }
+    fn on_enrichment_http_cache_miss(&self, enricher_id: &str) {
+        self.cache_misses
+            .lock()
+            .unwrap()
+            .push(enricher_id.to_string());
+    }
+    fn on_enrichment_http_cache_expiration(&self, enricher_id: &str) {
+        self.cache_expirations
+            .lock()
+            .unwrap()
+            .push(enricher_id.to_string());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_records_success_and_queue_depth() {
+    let m = std::sync::Arc::new(CollectingMetrics::default());
+    let enricher = Box::new(template_enricher(
+        "ok_one",
+        EnricherKind::Detection,
+        "out",
+        "static-${detection.rule.id}",
+    )) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4)
+        .with_metrics(m.clone() as std::sync::Arc<dyn crate::MetricsHook>);
+    let mut results = vec![detection_result()];
+    pipeline.run(&mut results).await;
+
+    let completed = m.completed.lock().unwrap().clone();
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].0, "ok_one");
+    assert_eq!(completed[0].1, "detection");
+    assert_eq!(completed[0].2, "success");
+
+    let qc = m.queue_changes.lock().unwrap().clone();
+    assert_eq!(qc, vec![1, -1], "queue depth must rise then fall by 1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_records_skip_status_on_error() {
+    let m = std::sync::Arc::new(CollectingMetrics::default());
+    let e = Box::new(ErroringEnricher {
+        id: "boom".to_string(),
+        kind: EnricherKind::Detection,
+        inject_field: "out".to_string(),
+        on_error: OnError::Skip,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![e], 1)
+        .with_metrics(m.clone() as std::sync::Arc<dyn crate::MetricsHook>);
+    let mut results = vec![detection_result()];
+    pipeline.run(&mut results).await;
+    let completed = m.completed.lock().unwrap().clone();
+    assert_eq!(completed[0].2, "skip");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_records_drop_status() {
+    let m = std::sync::Arc::new(CollectingMetrics::default());
+    let e = Box::new(ErroringEnricher {
+        id: "drop_me".to_string(),
+        kind: EnricherKind::Detection,
+        inject_field: "out".to_string(),
+        on_error: OnError::Drop,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![e], 1)
+        .with_metrics(m.clone() as std::sync::Arc<dyn crate::MetricsHook>);
+    let mut results = vec![detection_result()];
+    pipeline.run(&mut results).await;
+    let completed = m.completed.lock().unwrap().clone();
+    assert_eq!(completed[0].2, "drop");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_records_timeout_status() {
+    let m = std::sync::Arc::new(CollectingMetrics::default());
+    let e = Box::new(SleepingEnricher {
+        id: "slow".to_string(),
+        sleep_for: Duration::from_millis(200),
+        timeout: Duration::from_millis(20),
+        on_error: OnError::Skip,
+        scope: Scope::default(),
+    }) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![e], 1)
+        .with_metrics(m.clone() as std::sync::Arc<dyn crate::MetricsHook>);
+    let mut results = vec![detection_result()];
+    pipeline.run(&mut results).await;
+    let completed = m.completed.lock().unwrap().clone();
+    assert_eq!(completed[0].2, "timeout");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_skips_filtered_results() {
+    // A correlation result hitting a detection-only enricher should not
+    // record anything (kind filter skips before metrics fire).
+    let m = std::sync::Arc::new(CollectingMetrics::default());
+    let e =
+        Box::new(template_enricher("det", EnricherKind::Detection, "x", "y")) as Box<dyn Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![e], 1)
+        .with_metrics(m.clone() as std::sync::Arc<dyn crate::MetricsHook>);
+    let mut results = vec![correlation_result()];
+    pipeline.run(&mut results).await;
+    assert!(m.completed.lock().unwrap().is_empty());
+    assert!(m.queue_changes.lock().unwrap().is_empty());
+}
+
 #[test]
 fn lookup_builtin_returns_registered_factory() {
     let _guard = registry_test_lock().lock().unwrap();

--- a/crates/rsigma-runtime/src/lib.rs
+++ b/crates/rsigma-runtime/src/lib.rs
@@ -43,6 +43,7 @@
 //! ```
 
 pub mod engine;
+pub mod enrichment;
 pub mod error;
 pub mod input;
 pub mod io;
@@ -52,6 +53,13 @@ pub mod processor;
 pub mod sources;
 
 pub use engine::{EngineStats, RuntimeEngine};
+pub use enrichment::{
+    CacheKey, CacheOutcome, CommandEnricher, EnrichError, EnrichErrorKind, Enricher,
+    EnricherFactory, EnricherKind, EnrichmentPipeline, HttpEnricher, HttpEnricherClient,
+    HttpResponseCache, LookupEnricher, OnError, OutputFormat, Scope, TemplateEnricher,
+    TemplateError, build_default_http_client, lookup_builtin, register_builtin,
+    validate_template_namespace,
+};
 pub use error::RuntimeError;
 pub use input::{EventInputDecoded, InputFormat, parse_line};
 pub use io::{

--- a/crates/rsigma-runtime/src/metrics.rs
+++ b/crates/rsigma-runtime/src/metrics.rs
@@ -56,6 +56,18 @@ pub trait MetricsHook: Send + Sync {
     fn on_enrichment_http_cache_miss(&self, _enricher_id: &str) {}
     /// HTTP enrichment cache lookup found an expired entry and evicted it.
     fn on_enrichment_http_cache_expiration(&self, _enricher_id: &str) {}
+
+    /// Pre-register an enricher's `enricher_id` + `kind` label set so
+    /// `rsigma_enrichment_total{...}` and
+    /// `rsigma_enrichment_duration_seconds{...}` are emitted with their
+    /// `# HELP` and `# TYPE` lines from the very first `/metrics`
+    /// scrape, even before the enricher has run. Called once per
+    /// configured enricher at pipeline construction.
+    fn register_enricher(&self, _enricher_id: &str, _kind: &str) {}
+    /// Pre-register the three HTTP-cache counter label sets for an
+    /// `HttpEnricher` instance so the cache counters are visible on
+    /// `/metrics` from startup, even before any cache event fires.
+    fn register_http_enricher_cache(&self, _enricher_id: &str) {}
 }
 
 /// No-op implementation for use when metrics are disabled (e.g., `rsigma run`).

--- a/crates/rsigma-runtime/src/metrics.rs
+++ b/crates/rsigma-runtime/src/metrics.rs
@@ -35,6 +35,27 @@ pub trait MetricsHook: Send + Sync {
         _correlation_type: &str,
     ) {
     }
+
+    /// One enrichment call completed (success, skip, error, timeout, drop).
+    /// `kind` is the enricher's declared kind (`detection` / `correlation`).
+    /// `status` is one of `success` / `skip` / `error` / `timeout` / `drop`.
+    fn on_enrichment_completed(
+        &self,
+        _enricher_id: &str,
+        _kind: &str,
+        _status: &str,
+        _duration_seconds: f64,
+    ) {
+    }
+    /// The enrichment queue depth changed (positive = a result entered the
+    /// pipeline, negative = a result completed). Sum across both kinds.
+    fn on_enrichment_queue_depth_change(&self, _delta: i64) {}
+    /// HTTP enrichment cache lookup hit a live entry.
+    fn on_enrichment_http_cache_hit(&self, _enricher_id: &str) {}
+    /// HTTP enrichment cache lookup missed (no entry).
+    fn on_enrichment_http_cache_miss(&self, _enricher_id: &str) {}
+    /// HTTP enrichment cache lookup found an expired entry and evicted it.
+    fn on_enrichment_http_cache_expiration(&self, _enricher_id: &str) {}
 }
 
 /// No-op implementation for use when metrics are disabled (e.g., `rsigma run`).

--- a/crates/rsigma-runtime/src/sources/extract.rs
+++ b/crates/rsigma-runtime/src/sources/extract.rs
@@ -23,10 +23,19 @@ pub fn apply_extract(
 }
 
 /// Apply a jq expression using jaq.
+///
+/// Loads the jaq core natives (`+`, `length`, `keys`, …) and the
+/// `jaq-std` library (`select`, `map`, `first`, `with_entries`, …) so
+/// the supported filter surface matches real jq for the operator-facing
+/// expressions documented in the dynamic-pipelines and enrichment
+/// references.
 fn apply_jq(data: &serde_json::Value, expr: &str) -> Result<serde_json::Value, SourceError> {
     use jaq_interpret::{Ctx, FilterT, RcIter, Val};
 
-    let mut defs = jaq_interpret::ParseCtx::new(vec![]);
+    let mut defs = jaq_interpret::ParseCtx::new(Vec::new());
+    defs.insert_natives(jaq_core::core());
+    defs.insert_defs(jaq_std::std());
+
     let (filter, errs) = jaq_parse::parse(expr, jaq_parse::main());
 
     if !errs.is_empty() || filter.is_none() {
@@ -37,6 +46,15 @@ fn apply_jq(data: &serde_json::Value, expr: &str) -> Result<serde_json::Value, S
     }
 
     let filter = defs.compile(filter.unwrap());
+    if !defs.errs.is_empty() {
+        return Err(SourceError {
+            source_id: String::new(),
+            kind: SourceErrorKind::Extract(format!(
+                "jq compile errors ({} in: {expr})",
+                defs.errs.len(),
+            )),
+        });
+    }
     let inputs = RcIter::new(std::iter::empty());
     let val = Val::from(data.clone());
 

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -95,25 +95,40 @@ pub trait SourceResolver: Send + Sync {
 
 /// Default source resolver that dispatches to file, command, and HTTP resolvers.
 pub struct DefaultSourceResolver {
-    cache: SourceCache,
+    cache: std::sync::Arc<SourceCache>,
 }
 
 impl DefaultSourceResolver {
     /// Create a new resolver with an in-memory cache.
     pub fn new() -> Self {
         Self {
-            cache: SourceCache::new(),
+            cache: std::sync::Arc::new(SourceCache::new()),
         }
     }
 
     /// Create a new resolver with the given cache.
     pub fn with_cache(cache: SourceCache) -> Self {
+        Self {
+            cache: std::sync::Arc::new(cache),
+        }
+    }
+
+    /// Create a new resolver that shares an existing `Arc<SourceCache>`
+    /// with another consumer (e.g. the daemon's enrichment pipeline,
+    /// which reads from the same cache for `lookup` enrichers).
+    pub fn with_arc_cache(cache: std::sync::Arc<SourceCache>) -> Self {
         Self { cache }
     }
 
     /// Get a reference to the cache (for inspection/testing).
     pub fn cache(&self) -> &SourceCache {
         &self.cache
+    }
+
+    /// Borrow the shared `Arc<SourceCache>` so other components (e.g.
+    /// the daemon's enrichment pipeline) can read from the same cache.
+    pub fn arc_cache(&self) -> std::sync::Arc<SourceCache> {
+        self.cache.clone()
     }
 }
 

--- a/crates/rsigma-runtime/tests/enrichment_integration.rs
+++ b/crates/rsigma-runtime/tests/enrichment_integration.rs
@@ -26,6 +26,44 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // ---------------------------------------------------------------------------
+// Platform-portable shell helpers
+// ---------------------------------------------------------------------------
+
+/// Wrap a shell command body in the right `argv` for the host platform.
+/// On Unix the body is passed to `/bin/sh -c <body>`; on Windows it is
+/// passed to `cmd.exe /C <body>`. Quoting differs slightly between the
+/// two shells so callers should keep the body simple (single-line, no
+/// embedded quotes) or use a static fixture file plus `cat` / `type`.
+fn shell_argv(body: &str) -> Vec<String> {
+    #[cfg(unix)]
+    {
+        vec!["/bin/sh".to_string(), "-c".to_string(), body.to_string()]
+    }
+    #[cfg(windows)]
+    {
+        vec!["cmd.exe".to_string(), "/C".to_string(), body.to_string()]
+    }
+}
+
+/// `cat` (Unix) / `type` (Windows) the given file. Used in tests that
+/// need a deterministic JSON payload from a command without dealing
+/// with cross-shell quote escaping.
+fn cat_argv(path: &str) -> Vec<String> {
+    #[cfg(unix)]
+    {
+        vec!["/bin/cat".to_string(), path.to_string()]
+    }
+    #[cfg(windows)]
+    {
+        vec![
+            "cmd.exe".to_string(),
+            "/C".to_string(),
+            format!("type \"{path}\""),
+        ]
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
@@ -352,15 +390,18 @@ async fn http_extract_jq_filters_response() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn command_json_output_parses_into_object() {
+    // Cross-shell quoting of `echo '{"k":"v"}'` is a tarpit; stage the
+    // payload as a fixture file and have the command read it back. The
+    // `cat_argv` helper picks `cat` on Unix and `type` on Windows.
+    let payload = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(payload.path(), r#"{"score": 12, "category": "internal"}"#).unwrap();
+    let argv = cat_argv(payload.path().to_str().unwrap());
+
     let enricher = Box::new(CommandEnricher::new(
         "echo_json".to_string(),
         EnricherKind::Detection,
         "ip_rep".to_string(),
-        vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            r#"echo '{"score": 12, "category": "internal"}'"#.to_string(),
-        ],
+        argv,
         HashMap::new(),
         Duration::from_secs(5),
         OnError::Skip,
@@ -385,11 +426,7 @@ async fn command_raw_output_strips_trailing_newline() {
         "raw".to_string(),
         EnricherKind::Detection,
         "out".to_string(),
-        vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            "echo hello".to_string(),
-        ],
+        shell_argv("echo hello"),
         HashMap::new(),
         Duration::from_secs(5),
         OnError::Skip,
@@ -418,11 +455,7 @@ async fn command_nonzero_exit_triggers_on_error_policy() {
         "false_cmd".to_string(),
         EnricherKind::Detection,
         "out".to_string(),
-        vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            "exit 7".to_string(),
-        ],
+        shell_argv("exit 7"),
         HashMap::new(),
         Duration::from_secs(5),
         OnError::Null,
@@ -447,16 +480,15 @@ async fn command_nonzero_exit_triggers_on_error_policy() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn command_template_expansion_for_correlation_kind() {
+    // The template engine renders `${correlation.*}` in the argv before
+    // it ever reaches the OS, so by the time `cmd.exe` / `sh` sees the
+    // body it is just `echo agg=73 ip=203.0.113.4`. That `echo` form
+    // works identically under both shells.
     let enricher = Box::new(CommandEnricher::new(
         "summary".to_string(),
         EnricherKind::Correlation,
         "summary".to_string(),
-        vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            "echo agg=${correlation.aggregated_value} ip=${correlation.group_key.SourceIP}"
-                .to_string(),
-        ],
+        shell_argv("echo agg=${correlation.aggregated_value} ip=${correlation.group_key.SourceIP}"),
         HashMap::new(),
         Duration::from_secs(5),
         OnError::Skip,

--- a/crates/rsigma-runtime/tests/enrichment_integration.rs
+++ b/crates/rsigma-runtime/tests/enrichment_integration.rs
@@ -48,6 +48,16 @@ fn shell_argv(body: &str) -> Vec<String> {
 /// `cat` (Unix) / `type` (Windows) the given file. Used in tests that
 /// need a deterministic JSON payload from a command without dealing
 /// with cross-shell quote escaping.
+///
+/// On Windows, `type` and the path go in their own argv elements
+/// rather than being baked into a `type "..."` blob. That avoids
+/// cmd.exe's `/C` quote-stripping pathology: Rust's CreateProcess
+/// quoting wraps a single string with embedded `"`s in outer quotes
+/// and escapes the inner ones, which cmd's `/C` parser then
+/// outer-strips, leaving `type \"...\"` -- a path that does not
+/// exist. With separate args, Rust quotes only the path element and
+/// cmd's `type` reads the file cleanly. `/D` disables AutoRun for
+/// hermeticity.
 fn cat_argv(path: &str) -> Vec<String> {
     #[cfg(unix)]
     {
@@ -57,8 +67,10 @@ fn cat_argv(path: &str) -> Vec<String> {
     {
         vec![
             "cmd.exe".to_string(),
+            "/D".to_string(),
             "/C".to_string(),
-            format!("type \"{path}\""),
+            "type".to_string(),
+            path.to_string(),
         ]
     }
 }

--- a/crates/rsigma-runtime/tests/enrichment_integration.rs
+++ b/crates/rsigma-runtime/tests/enrichment_integration.rs
@@ -1,0 +1,598 @@
+//! Integration tests for the four enrichment primitives.
+//!
+//! Spins up `wiremock` for HTTP coverage, exercises real `tokio::process`
+//! invocations for command coverage, and drives the
+//! [`EnrichmentPipeline`](rsigma_runtime::EnrichmentPipeline) end-to-end
+//! across both detection and correlation results.
+//!
+//! Per-test fixtures sit inline rather than behind a shared helper module
+//! to keep each test single-file readable.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rsigma_eval::pipeline::sources::ExtractExpr;
+use rsigma_eval::{
+    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, ResultBody, RuleHeader,
+};
+use rsigma_parser::{CorrelationType, Level};
+use rsigma_runtime::{
+    CommandEnricher, EnricherKind, EnrichmentPipeline, HttpEnricher, HttpEnricherClient,
+    HttpResponseCache, OnError, OutputFormat, Scope, build_default_http_client,
+};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn detection(rule_id: &str, command_line: &str) -> EvaluationResult {
+    EvaluationResult {
+        header: RuleHeader {
+            rule_title: format!("rule-{rule_id}"),
+            rule_id: Some(rule_id.to_string()),
+            level: Some(Level::High),
+            tags: vec!["attack.t1059".to_string()],
+            custom_attributes: Arc::new(HashMap::new()),
+            enrichments: None,
+        },
+        body: ResultBody::Detection(DetectionBody {
+            matched_selections: vec!["selection".to_string()],
+            matched_fields: vec![FieldMatch {
+                field: "CommandLine".to_string(),
+                value: json!(command_line),
+            }],
+            event: None,
+        }),
+    }
+}
+
+fn correlation(rule_id: &str, source_ip: &str, count: u64) -> EvaluationResult {
+    EvaluationResult {
+        header: RuleHeader {
+            rule_title: format!("corr-{rule_id}"),
+            rule_id: Some(rule_id.to_string()),
+            level: Some(Level::High),
+            tags: vec!["attack.t1110".to_string()],
+            custom_attributes: Arc::new(HashMap::new()),
+            enrichments: None,
+        },
+        body: ResultBody::Correlation(CorrelationBody {
+            correlation_type: CorrelationType::EventCount,
+            group_key: vec![("SourceIP".to_string(), source_ip.to_string())],
+            aggregated_value: count as f64,
+            timespan_secs: 300,
+            events: None,
+            event_refs: None,
+        }),
+    }
+}
+
+fn http_client_for_test() -> HttpEnricherClient {
+    build_default_http_client().expect("build reqwest client")
+}
+
+// ---------------------------------------------------------------------------
+// HttpEnricher integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_success_injects_full_response_object() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/asset/dc01"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "owner": "IT-Ops",
+            "criticality": "high"
+        })))
+        .mount(&server)
+        .await;
+
+    let url_template = format!("{}/asset/${{detection.fields.HostName}}", server.uri());
+    let mut det = detection("rule-x", "ps -ef");
+    det.as_detection_mut()
+        .unwrap()
+        .matched_fields
+        .push(FieldMatch {
+            field: "HostName".to_string(),
+            value: json!("dc01"),
+        });
+
+    let enricher = Box::new(HttpEnricher::new(
+        "asset_lookup".to_string(),
+        EnricherKind::Detection,
+        "asset_info".to_string(),
+        "GET".to_string(),
+        url_template,
+        Vec::new(),
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+        None,
+        http_client_for_test(),
+        HttpResponseCache::new(Duration::from_secs(0)),
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![det];
+    pipeline.run(&mut results).await;
+
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(
+        map.get("asset_info").unwrap(),
+        &json!({"owner": "IT-Ops", "criticality": "high"})
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_template_renders_path_and_authorization_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/asset/dc01"))
+        .and(header("Authorization", "Bearer secret-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .mount(&server)
+        .await;
+    // SAFETY: tests run as a single-threaded runtime per #[tokio::test]
+    // task; we set a process-wide env var, but it is unique enough not
+    // to collide.
+    unsafe {
+        std::env::set_var("CMDB_TOKEN", "secret-xyz");
+    }
+
+    let url_template = format!("{}/asset/${{detection.fields.HostName}}", server.uri());
+    let mut det = detection("rule-x", "ps -ef");
+    det.as_detection_mut()
+        .unwrap()
+        .matched_fields
+        .push(FieldMatch {
+            field: "HostName".to_string(),
+            value: json!("dc01"),
+        });
+
+    let enricher = Box::new(HttpEnricher::new(
+        "asset_lookup_with_auth".to_string(),
+        EnricherKind::Detection,
+        "asset".to_string(),
+        "GET".to_string(),
+        url_template,
+        vec![(
+            "Authorization".to_string(),
+            "Bearer ${CMDB_TOKEN}".to_string(),
+        )],
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+        None,
+        http_client_for_test(),
+        HttpResponseCache::new(Duration::from_secs(0)),
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![det];
+    pipeline.run(&mut results).await;
+
+    assert!(
+        results[0]
+            .header
+            .enrichments
+            .as_ref()
+            .unwrap()
+            .contains_key("asset")
+    );
+    unsafe {
+        std::env::remove_var("CMDB_TOKEN");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_500_triggers_on_error_policy() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/x"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let enricher = Box::new(HttpEnricher::new(
+        "boom".to_string(),
+        EnricherKind::Detection,
+        "out".to_string(),
+        "GET".to_string(),
+        format!("{}/x", server.uri()),
+        Vec::new(),
+        None,
+        Duration::from_secs(5),
+        OnError::Null,
+        Scope::default(),
+        None,
+        http_client_for_test(),
+        HttpResponseCache::new(Duration::from_secs(0)),
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection("rule-x", "ps -ef")];
+    pipeline.run(&mut results).await;
+
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(map.get("out").unwrap(), &serde_json::Value::Null);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_response_cache_eliminates_second_call() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/r"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"v": 1})))
+        // Strict: only one upstream request expected.
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache = HttpResponseCache::new(Duration::from_secs(60));
+    let make_enricher = |id: &str| {
+        Box::new(HttpEnricher::new(
+            id.to_string(),
+            EnricherKind::Detection,
+            format!("out_{id}"),
+            "GET".to_string(),
+            format!("{}/r", server.uri()),
+            Vec::new(),
+            None,
+            Duration::from_secs(5),
+            OnError::Skip,
+            Scope::default(),
+            None,
+            http_client_for_test(),
+            cache.clone(),
+        )) as Box<dyn rsigma_runtime::Enricher>
+    };
+
+    let pipeline =
+        EnrichmentPipeline::new(vec![make_enricher("first"), make_enricher("second")], 4);
+    let mut results = vec![detection("rule-x", "ps -ef")];
+    pipeline.run(&mut results).await;
+
+    // wiremock's `.expect(1)` is asserted on Drop; both enrichers fired
+    // but only the first hit the upstream. Both injected the same value.
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(map.get("out_first").unwrap(), &json!({"v": 1}));
+    assert_eq!(map.get("out_second").unwrap(), &json!({"v": 1}));
+
+    let (hits, misses, _exp) = cache.stats();
+    assert_eq!(misses, 1, "first call should be a miss");
+    assert_eq!(hits, 1, "second call should be a cache hit");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_cache_ttl_expires() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/r"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"v": 1})))
+        // Two upstream calls expected: TTL expires between them.
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let cache = HttpResponseCache::new(Duration::from_millis(40));
+    let make_enricher = |id: &str| {
+        Box::new(HttpEnricher::new(
+            id.to_string(),
+            EnricherKind::Detection,
+            format!("out_{id}"),
+            "GET".to_string(),
+            format!("{}/r", server.uri()),
+            Vec::new(),
+            None,
+            Duration::from_secs(5),
+            OnError::Skip,
+            Scope::default(),
+            None,
+            http_client_for_test(),
+            cache.clone(),
+        )) as Box<dyn rsigma_runtime::Enricher>
+    };
+
+    let p1 = EnrichmentPipeline::new(vec![make_enricher("first")], 4);
+    let p2 = EnrichmentPipeline::new(vec![make_enricher("second")], 4);
+
+    let mut r1 = vec![detection("rule-x", "ps -ef")];
+    p1.run(&mut r1).await;
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    let mut r2 = vec![detection("rule-x", "ps -ef")];
+    p2.run(&mut r2).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_extract_jq_filters_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/whois"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ip": "203.0.113.4",
+            "asn": 64512,
+            "country": "US"
+        })))
+        .mount(&server)
+        .await;
+
+    let enricher = Box::new(HttpEnricher::new(
+        "geoip".to_string(),
+        EnricherKind::Detection,
+        "country".to_string(),
+        "GET".to_string(),
+        format!("{}/whois", server.uri()),
+        Vec::new(),
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+        Some(ExtractExpr::Jq(".country".to_string())),
+        http_client_for_test(),
+        HttpResponseCache::new(Duration::from_secs(0)),
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection("rule-x", "ps -ef")];
+    pipeline.run(&mut results).await;
+
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(map.get("country").unwrap(), &json!("US"));
+}
+
+// ---------------------------------------------------------------------------
+// CommandEnricher integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn command_json_output_parses_into_object() {
+    let enricher = Box::new(CommandEnricher::new(
+        "echo_json".to_string(),
+        EnricherKind::Detection,
+        "ip_rep".to_string(),
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            r#"echo '{"score": 12, "category": "internal"}'"#.to_string(),
+        ],
+        HashMap::new(),
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+        OutputFormat::Json,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection("rule-x", "ps -ef")];
+    pipeline.run(&mut results).await;
+
+    let map = results[0].header.enrichments.as_ref().unwrap();
+    assert_eq!(
+        map.get("ip_rep").unwrap(),
+        &json!({"score": 12, "category": "internal"})
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn command_raw_output_strips_trailing_newline() {
+    let enricher = Box::new(CommandEnricher::new(
+        "raw".to_string(),
+        EnricherKind::Detection,
+        "out".to_string(),
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "echo hello".to_string(),
+        ],
+        HashMap::new(),
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+        OutputFormat::Raw,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection("rule-x", "ps -ef")];
+    pipeline.run(&mut results).await;
+    assert_eq!(
+        results[0]
+            .header
+            .enrichments
+            .as_ref()
+            .unwrap()
+            .get("out")
+            .unwrap(),
+        &json!("hello")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn command_nonzero_exit_triggers_on_error_policy() {
+    let enricher = Box::new(CommandEnricher::new(
+        "false_cmd".to_string(),
+        EnricherKind::Detection,
+        "out".to_string(),
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "exit 7".to_string(),
+        ],
+        HashMap::new(),
+        Duration::from_secs(5),
+        OnError::Null,
+        Scope::default(),
+        OutputFormat::Json,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection("rule-x", "ps -ef")];
+    pipeline.run(&mut results).await;
+    assert_eq!(
+        results[0]
+            .header
+            .enrichments
+            .as_ref()
+            .unwrap()
+            .get("out")
+            .unwrap(),
+        &serde_json::Value::Null
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn command_template_expansion_for_correlation_kind() {
+    let enricher = Box::new(CommandEnricher::new(
+        "summary".to_string(),
+        EnricherKind::Correlation,
+        "summary".to_string(),
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "echo agg=${correlation.aggregated_value} ip=${correlation.group_key.SourceIP}"
+                .to_string(),
+        ],
+        HashMap::new(),
+        Duration::from_secs(5),
+        OnError::Skip,
+        Scope::default(),
+        OutputFormat::Raw,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![correlation("c1", "203.0.113.4", 73)];
+    pipeline.run(&mut results).await;
+    assert_eq!(
+        results[0]
+            .header
+            .enrichments
+            .as_ref()
+            .unwrap()
+            .get("summary")
+            .unwrap(),
+        &json!("agg=73 ip=203.0.113.4")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// drop policy + concurrency
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_error_drop_removes_only_offending_result() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/x"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let enricher = Box::new(HttpEnricher::new(
+        "drop_me".to_string(),
+        EnricherKind::Detection,
+        "out".to_string(),
+        "GET".to_string(),
+        format!("{}/x", server.uri()),
+        Vec::new(),
+        None,
+        Duration::from_secs(5),
+        OnError::Drop,
+        Scope::default(),
+        None,
+        http_client_for_test(),
+        HttpResponseCache::new(Duration::from_secs(0)),
+    )) as Box<dyn rsigma_runtime::Enricher>;
+
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![
+        detection("alpha", "ps"),
+        correlation("corr1", "1.2.3.4", 10),
+        detection("beta", "ls"),
+    ];
+    pipeline.run(&mut results).await;
+
+    // Both detections should drop (the http enricher matches kind:detection
+    // and erroring on a 500 with on_error: drop), correlation survives.
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_correlation());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn semaphore_caps_concurrent_enrichments() {
+    // With 1 permit and three results, enrichments must run sequentially.
+    // We assert by stamping each result with a monotonic counter inside a
+    // synthetic enricher; if the semaphore is honoured, observed
+    // counters match the sequential-execution invariant (counter ==
+    // index after run).
+    use rsigma_runtime::Enricher;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Stamper {
+        counter: Arc<AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl Enricher for Stamper {
+        fn kind(&self) -> EnricherKind {
+            EnricherKind::Detection
+        }
+        fn id(&self) -> &str {
+            "stamper"
+        }
+        fn inject_field(&self) -> &str {
+            "n"
+        }
+        fn timeout(&self) -> Duration {
+            Duration::from_secs(5)
+        }
+        fn scope(&self) -> &Scope {
+            static EMPTY: std::sync::OnceLock<Scope> = std::sync::OnceLock::new();
+            EMPTY.get_or_init(Scope::default)
+        }
+        fn on_error(&self) -> OnError {
+            OnError::Skip
+        }
+        async fn enrich(
+            &self,
+            r: &mut EvaluationResult,
+        ) -> Result<(), rsigma_runtime::EnrichError> {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let n = self.counter.fetch_add(1, Ordering::SeqCst);
+            rsigma_runtime::EnrichmentPipeline::default(); // noop, just to use the type
+            r.header
+                .enrichments
+                .get_or_insert_with(serde_json::Map::new)
+                .insert("n".to_string(), json!(n));
+            Ok(())
+        }
+    }
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let enricher = Box::new(Stamper {
+        counter: counter.clone(),
+    }) as Box<dyn rsigma_runtime::Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 1);
+
+    let mut results = vec![
+        detection("a", "ls"),
+        detection("b", "ls"),
+        detection("c", "ls"),
+    ];
+    pipeline.run(&mut results).await;
+    assert_eq!(counter.load(Ordering::SeqCst), 3);
+    // Three sequential stamps.
+    let mut stamps: Vec<i64> = results
+        .iter()
+        .map(|r| {
+            r.header.enrichments.as_ref().unwrap()["n"]
+                .as_i64()
+                .unwrap()
+        })
+        .collect();
+    stamps.sort();
+    assert_eq!(stamps, vec![0, 1, 2]);
+}

--- a/crates/rsigma-runtime/tests/enrichment_lookup.rs
+++ b/crates/rsigma-runtime/tests/enrichment_lookup.rs
@@ -1,0 +1,462 @@
+//! Lookup enricher and scope-filter integration tests.
+//!
+//! Drives the [`LookupEnricher`](rsigma_runtime::LookupEnricher) end-to-end
+//! against an [`Arc<SourceCache>`] populated by hand. Covers all three
+//! extract languages, every cache-miss / no-extract-match cell of the
+//! decision matrix, and both detection and correlation results.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rsigma_eval::pipeline::sources::ExtractExpr;
+use rsigma_eval::{
+    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, ResultBody, RuleHeader,
+};
+use rsigma_parser::{CorrelationType, Level};
+use rsigma_runtime::{
+    EnricherKind, EnrichmentPipeline, LookupEnricher, OnError, Scope, SourceCache,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn detection_with_field(field: &str, value: serde_json::Value) -> EvaluationResult {
+    EvaluationResult {
+        header: RuleHeader {
+            rule_title: "ip_seen".to_string(),
+            rule_id: Some("rule-ip".to_string()),
+            level: Some(Level::Medium),
+            tags: vec!["attack.t1078".to_string()],
+            custom_attributes: Arc::new(HashMap::new()),
+            enrichments: None,
+        },
+        body: ResultBody::Detection(DetectionBody {
+            matched_selections: vec!["selection".to_string()],
+            matched_fields: vec![FieldMatch {
+                field: field.to_string(),
+                value,
+            }],
+            event: None,
+        }),
+    }
+}
+
+fn correlation_for_ip(ip: &str) -> EvaluationResult {
+    EvaluationResult {
+        header: RuleHeader {
+            rule_title: "ip_corr".to_string(),
+            rule_id: Some("corr-ip".to_string()),
+            level: Some(Level::High),
+            tags: vec!["attack.t1110".to_string()],
+            custom_attributes: Arc::new(HashMap::new()),
+            enrichments: None,
+        },
+        body: ResultBody::Correlation(CorrelationBody {
+            correlation_type: CorrelationType::EventCount,
+            group_key: vec![("SourceIP".to_string(), ip.to_string())],
+            aggregated_value: 42.0,
+            timespan_secs: 60,
+            events: None,
+            event_refs: None,
+        }),
+    }
+}
+
+fn populated_employee_cache() -> Arc<SourceCache> {
+    let cache = Arc::new(SourceCache::new());
+    cache.store(
+        "employee_directory",
+        &json!([
+            {"ip": "10.0.0.5", "user": "alice", "team": "Platform"},
+            {"ip": "10.0.0.7", "user": "bob", "team": "IT-Ops"}
+        ]),
+    );
+    cache
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lookup_enricher(
+    id: &str,
+    kind: EnricherKind,
+    inject: &str,
+    source: &str,
+    extract: Option<ExtractExpr>,
+    default: Option<serde_json::Value>,
+    cache: Arc<SourceCache>,
+    on_error: OnError,
+) -> Box<dyn rsigma_runtime::Enricher> {
+    Box::new(LookupEnricher::new(
+        id.to_string(),
+        kind,
+        inject.to_string(),
+        source.to_string(),
+        extract,
+        default,
+        Duration::from_secs(5),
+        on_error,
+        Scope::default(),
+        cache,
+    )) as Box<dyn rsigma_runtime::Enricher>
+}
+
+// ---------------------------------------------------------------------------
+// Cache hit + extract matches
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_extract_jq_returns_employee_record() {
+    let cache = populated_employee_cache();
+    let enricher = lookup_enricher(
+        "enrich_ip_employee",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        cache,
+        OnError::Skip,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("10.0.0.5"))];
+    pipeline.run(&mut results).await;
+
+    assert_eq!(
+        results[0].header.enrichments.as_ref().unwrap()["employee"],
+        json!({"ip": "10.0.0.5", "user": "alice", "team": "Platform"})
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_extract_jsonpath_returns_record() {
+    let cache = populated_employee_cache();
+    let enricher = lookup_enricher(
+        "enrich_ip_employee_jp",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::JsonPath(
+            "$[?(@.ip == '${detection.fields.SourceIp}')]".to_string(),
+        )),
+        None,
+        cache,
+        OnError::Skip,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("10.0.0.7"))];
+    pipeline.run(&mut results).await;
+
+    let v = &results[0].header.enrichments.as_ref().unwrap()["employee"];
+    let team = v
+        .pointer("/team")
+        .or_else(|| v.pointer("/0/team"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    assert_eq!(team, json!("IT-Ops"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_extract_cel_returns_filtered_list() {
+    let cache = populated_employee_cache();
+    // CEL `data.filter(x, x.ip == ...)` returns a list; the lookup
+    // enricher injects whatever the extract produced.
+    let enricher = lookup_enricher(
+        "enrich_ip_employee_cel",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::Cel(
+            "data.filter(x, x.ip == '${detection.fields.SourceIp}')".to_string(),
+        )),
+        None,
+        cache,
+        OnError::Skip,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("10.0.0.5"))];
+    pipeline.run(&mut results).await;
+
+    let v = &results[0].header.enrichments.as_ref().unwrap()["employee"];
+    assert!(v.is_array(), "got: {v}");
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["user"], json!("alice"));
+}
+
+// ---------------------------------------------------------------------------
+// Cache hit + no extract match
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_no_extract_match_uses_default() {
+    let cache = populated_employee_cache();
+    let enricher = lookup_enricher(
+        "enrich_ip_employee_dflt",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        Some(json!("unknown")),
+        cache,
+        OnError::Skip,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("99.99.99.99"))];
+    pipeline.run(&mut results).await;
+
+    assert_eq!(
+        results[0].header.enrichments.as_ref().unwrap()["employee"],
+        json!("unknown")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_no_extract_match_no_default_skips() {
+    let cache = populated_employee_cache();
+    let enricher = lookup_enricher(
+        "enrich_ip_employee_skip",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        cache,
+        OnError::Skip,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("99.99.99.99"))];
+    pipeline.run(&mut results).await;
+
+    // Skip leaves enrichments untouched.
+    assert!(results[0].header.enrichments.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_no_extract_match_null_injects_null() {
+    let cache = populated_employee_cache();
+    let enricher = lookup_enricher(
+        "enrich_ip_employee_null",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        cache,
+        OnError::Null,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("99.99.99.99"))];
+    pipeline.run(&mut results).await;
+    assert_eq!(
+        results[0].header.enrichments.as_ref().unwrap()["employee"],
+        serde_json::Value::Null
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_hit_no_extract_match_drop_removes_result() {
+    let cache = populated_employee_cache();
+    let enricher = lookup_enricher(
+        "enrich_drop",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        cache,
+        OnError::Drop,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![
+        detection_with_field("SourceIp", json!("99.99.99.99")),
+        correlation_for_ip("10.0.0.5"),
+    ];
+    pipeline.run(&mut results).await;
+    // Detection dropped (no match + drop), correlation untouched (kind mismatch).
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_correlation());
+}
+
+// ---------------------------------------------------------------------------
+// Cache miss
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_miss_uses_default() {
+    let cache = Arc::new(SourceCache::new()); // empty
+    let enricher = lookup_enricher(
+        "enrich_missing_default",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        None,
+        Some(json!({"name": "unknown"})),
+        cache,
+        OnError::Skip,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("10.0.0.5"))];
+    pipeline.run(&mut results).await;
+
+    assert_eq!(
+        results[0].header.enrichments.as_ref().unwrap()["employee"],
+        json!({"name": "unknown"})
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lookup_cache_miss_no_default_applies_on_error() {
+    let cache = Arc::new(SourceCache::new());
+    let enricher = lookup_enricher(
+        "enrich_missing_null",
+        EnricherKind::Detection,
+        "employee",
+        "employee_directory",
+        None,
+        None,
+        cache,
+        OnError::Null,
+    );
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+    let mut results = vec![detection_with_field("SourceIp", json!("10.0.0.5"))];
+    pipeline.run(&mut results).await;
+    assert_eq!(
+        results[0].header.enrichments.as_ref().unwrap()["employee"],
+        serde_json::Value::Null
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scope filter integration with lookup
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scope_excludes_low_severity_results() {
+    let cache = populated_employee_cache();
+    let scope = Scope::new(
+        vec![],
+        vec![],
+        vec!["high".to_string(), "critical".to_string()],
+    )
+    .unwrap();
+    let enricher = Box::new(LookupEnricher::new(
+        "scoped".to_string(),
+        EnricherKind::Detection,
+        "employee".to_string(),
+        "employee_directory".to_string(),
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        scope,
+        cache,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+
+    let mut medium = detection_with_field("SourceIp", json!("10.0.0.5"));
+    medium.header.level = Some(Level::Medium);
+    let mut results = vec![medium];
+    pipeline.run(&mut results).await;
+    // Medium is below the high/critical scope; enricher is skipped.
+    assert!(results[0].header.enrichments.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scope_includes_matching_tag_only() {
+    let cache = populated_employee_cache();
+    let scope = Scope::new(vec![], vec!["attack.t1078".to_string()], vec![]).unwrap();
+    let enricher = Box::new(LookupEnricher::new(
+        "scoped_by_tag".to_string(),
+        EnricherKind::Detection,
+        "employee".to_string(),
+        "employee_directory".to_string(),
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        scope,
+        cache,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+
+    let hit = detection_with_field("SourceIp", json!("10.0.0.5"));
+    let mut miss = detection_with_field("SourceIp", json!("10.0.0.5"));
+    miss.header.tags = vec!["unrelated.tag".to_string()];
+    let mut results = vec![hit, miss];
+    pipeline.run(&mut results).await;
+
+    assert!(results[0].header.enrichments.is_some());
+    assert!(results[1].header.enrichments.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scope_rule_id_exact_match() {
+    let cache = populated_employee_cache();
+    let scope = Scope::new(vec!["rule-ip".to_string()], vec![], vec![]).unwrap();
+    let enricher = Box::new(LookupEnricher::new(
+        "scoped_rule".to_string(),
+        EnricherKind::Detection,
+        "employee".to_string(),
+        "employee_directory".to_string(),
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        scope,
+        cache,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+
+    let hit = detection_with_field("SourceIp", json!("10.0.0.5"));
+    let mut miss = detection_with_field("SourceIp", json!("10.0.0.5"));
+    miss.header.rule_id = Some("other-rule".to_string());
+    let mut results = vec![hit, miss];
+    pipeline.run(&mut results).await;
+
+    assert!(results[0].header.enrichments.is_some());
+    assert!(results[1].header.enrichments.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scope_rule_title_glob_match() {
+    let cache = populated_employee_cache();
+    let scope = Scope::new(vec!["ip_*".to_string()], vec![], vec![]).unwrap();
+    let enricher = Box::new(LookupEnricher::new(
+        "scoped_glob".to_string(),
+        EnricherKind::Detection,
+        "employee".to_string(),
+        "employee_directory".to_string(),
+        Some(ExtractExpr::Jq(
+            ".[] | select(.ip == \"${detection.fields.SourceIp}\")".to_string(),
+        )),
+        None,
+        Duration::from_secs(5),
+        OnError::Skip,
+        scope,
+        cache,
+    )) as Box<dyn rsigma_runtime::Enricher>;
+    let pipeline = EnrichmentPipeline::new(vec![enricher], 4);
+
+    // `ip_seen` rule_title matches `ip_*`.
+    let mut results = vec![detection_with_field("SourceIp", json!("10.0.0.5"))];
+    pipeline.run(&mut results).await;
+    assert!(results[0].header.enrichments.is_some());
+}

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -50,6 +50,14 @@ For narrative coverage see [Streaming Detection](../../guide/streaming-detection
 | `-p, --pipeline <PIPELINES>` | Processing pipeline(s) to apply. Builtin names (`ecs_windows`, `sysmon`) or YAML file paths. Repeatable. |
 | `--allow-remote-include` | Allow `include:` directives in pipelines to reference remote (HTTP/NATS) sources. Off by default for security. |
 
+### Post-evaluation enrichment
+
+| Flag | Description |
+|------|-------------|
+| `--enrichers <PATH>` | YAML file declaring post-evaluation enrichers. Hot-reloaded on `SIGHUP`, file-watcher changes, and `POST /api/v1/reload`; failed reloads keep the previous pipeline active. See [Enrichers](../../guide/enrichers.md) for the schema, the four primitives, and the recipes catalog. |
+
+The enrichers file accepts `max_concurrent_enrichments: <N>` at the top level (default `16`) plus a list of enricher entries, each declaring `kind: detection | correlation`, a primitive `type:` (`template` / `lookup` / `http` / `command`), an `inject_field`, and primitive-specific keys (`template`, `url` / `headers` / `cache_ttl`, `command`, `source` / `extract` / `default`, ...). Cross-namespace template references are rejected at startup with a clear error pointing at the offending field.
+
 ### API server
 
 | Flag | Default | Description |

--- a/docs/developers/.pages
+++ b/docs/developers/.pages
@@ -4,4 +4,6 @@ nav:
   - Fuzzing: fuzzing.md
   - Adding Backends: adding-backends.md
   - Adding Input Formats: adding-input-formats.md
+  - Adding Enrichers: adding-enrichers.md
+  - Adding Dynamic Sources: adding-sources.md
   - Linter and LSP: linter-and-lsp.md

--- a/docs/developers/adding-enrichers.md
+++ b/docs/developers/adding-enrichers.md
@@ -223,7 +223,9 @@ For the YAML-loader path, exercise `register_builtin` + an `EnrichersFile` with 
 
 ## Observability
 
-Per-call metrics are emitted automatically; no extra hook is required. The pipeline records `rsigma_enrichment_total{enricher_id, kind, status}` and `rsigma_enrichment_duration_seconds{enricher_id, kind}` for every non-filtered call; `enricher_id` is the value you set in `Enricher::id()`. Bespoke types using a private cache or rate-limiter should emit their own counters under a `rsigma_enrichment_<name>_*` prefix to keep the namespace stable for downstream dashboards.
+Per-call metrics are emitted automatically; no extra hook is required. The pipeline records `rsigma_enrichment_total{enricher_id, kind, status}` and `rsigma_enrichment_duration_seconds{enricher_id, kind}` for every non-filtered call; `enricher_id` is the value you set in `Enricher::id()`. The pipeline also pre-registers your label triple at construction (via `MetricsHook::register_enricher`), so your enricher's metrics appear with zero values on `/metrics` from the first scrape, before any event has fired. You don't need to call this hook yourself.
+
+Bespoke types using a private cache or rate-limiter should emit their own counters under a `rsigma_enrichment_<name>_*` prefix to keep the namespace stable for downstream dashboards. If those counters use `IntCounterVec` with per-enricher labels, mirror the built-in pattern: pre-register the label sets at construction (the daemon's `Metrics` impl does this for the HTTP cache via `register_http_enricher_cache`) so operators see all your families on the first scrape.
 
 ## Document it
 

--- a/docs/developers/adding-enrichers.md
+++ b/docs/developers/adding-enrichers.md
@@ -1,0 +1,249 @@
+# Adding an enricher
+
+The four primitives `template`, `lookup`, `http`, and `command` cover almost every operational use case via [recipes](../guide/enrichers.md#composing-enrichers-recipes). When they don't, the runtime ships a bespoke enricher API: implement the `Enricher` trait, register it under a stable `type:` name with `register_builtin(name, factory)`, and operators reference it from their YAML by that name. This page is the recipe for that path.
+
+## Decide whether you actually need a bespoke enricher
+
+A bespoke Rust-coded enricher is justified only when at least one of these holds; the [user-facing guide](../guide/enrichers.md#promoting-a-recipe-to-a-bespoke-enricher) walks through the same criteria from the operator's angle:
+
+1. **It bundles non-trivial data**: a dataset committed to the repo and `include_bytes!`-ed at compile time (a MITRE ATT&CK STIX bundle, a vendored mini-IOC list). Recipes can't express vendored data.
+2. **It needs a parser the YAML primitives don't expose**: MaxMind's binary GeoLite2, the STIX 2.1 graph with parent/child resolution, a binary signature database. Adding the parser as a generic source might cost more than just shipping the enricher.
+3. **It provides a stable named contract**: downstream consumers reference a specific `enrichments.<field>` shape directly. A recipe-driven approach lets every operator pick their own `inject_field`, which is fine for ad-hoc enrichment but bad for a contract that crosses team or organisational boundaries.
+4. **It implements a non-obvious algorithm**: e.g. coalescing per-result hash lookups into one batched-GET request. This is implementable as a recipe but the implementation is fragile.
+
+If none of these apply, ship a recipe under `crates/rsigma-cli/README.md` instead. Promoting a recipe to a bespoke type later does not change the YAML shape, only the `type:` value.
+
+## Walkthrough: a hypothetical `enrich_ip_passive_dns_batched` enricher
+
+This example shipsbatched per-event lookups against a passive DNS API, coalescing repeated calls into one upstream request per `(api_key, ip)` tuple within a sliding 1-second window. The behaviour is fragile to express as a recipe; criterion (4) applies.
+
+The crate layout. Bespoke enrichers usually live in their own external crate so they can be versioned and feature-gated independently of `rsigma-runtime`. The skeleton:
+
+```text
+my-enrichers/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              ← public `register()` entry point
+    └── passive_dns.rs      ← the enricher impl
+```
+
+`Cargo.toml`:
+
+```toml
+[package]
+name = "my-enrichers"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rsigma-runtime = "0.12"
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["sync", "time"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+```
+
+Step 1: implement `Enricher`. The trait surface is small: declare your `kind`, `id`, `inject_field`, optional `timeout` / `scope` / `on_error`, and an `async enrich(&self, &mut EvaluationResult)`.
+
+```rust
+// my-enrichers/src/passive_dns.rs
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rsigma_runtime::{
+    EnrichError, EnrichErrorKind, Enricher, EnricherKind, OnError, Scope, inject_enrichment,
+};
+use rsigma_eval::EvaluationResult;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct PassiveDnsConfig {
+    pub id: String,
+    pub kind: String,             // "detection" | "correlation"
+    pub inject_field: String,
+    pub api_key_env: String,      // env var holding the API token
+    pub key_field: String,        // matched-field name to read the IP from
+}
+
+pub struct PassiveDnsEnricher {
+    id: String,
+    kind: EnricherKind,
+    inject_field: String,
+    api_key: String,
+    key_field: String,
+    client: Arc<reqwest::Client>,
+    scope: Scope,
+}
+
+impl PassiveDnsEnricher {
+    pub fn new(cfg: PassiveDnsConfig) -> Result<Self, String> {
+        let kind = match cfg.kind.as_str() {
+            "detection" => EnricherKind::Detection,
+            "correlation" => EnricherKind::Correlation,
+            other => return Err(format!("unknown kind '{other}'")),
+        };
+        let api_key = std::env::var(&cfg.api_key_env)
+            .map_err(|_| format!("env var '{}' not set", cfg.api_key_env))?;
+        Ok(Self {
+            id: cfg.id,
+            kind,
+            inject_field: cfg.inject_field,
+            api_key,
+            key_field: cfg.key_field,
+            client: Arc::new(reqwest::Client::new()),
+            scope: Scope::default(),
+        })
+    }
+}
+
+#[async_trait]
+impl Enricher for PassiveDnsEnricher {
+    fn kind(&self) -> EnricherKind { self.kind }
+    fn id(&self) -> &str { &self.id }
+    fn inject_field(&self) -> &str { &self.inject_field }
+    fn timeout(&self) -> Duration { Duration::from_secs(5) }
+    fn scope(&self) -> &Scope { &self.scope }
+    fn on_error(&self) -> OnError { OnError::Skip }
+
+    async fn enrich(&self, result: &mut EvaluationResult) -> Result<(), EnrichError> {
+        // Read the IP off `matched_fields` (the same surface
+        // `${detection.fields.<name>}` resolves against).
+        let ip = result
+            .as_detection()
+            .and_then(|d| {
+                d.matched_fields
+                    .iter()
+                    .find(|fm| fm.field == self.key_field)
+                    .map(|fm| fm.value.as_str().unwrap_or("").to_string())
+            })
+            .filter(|s| !s.is_empty())
+            .ok_or(EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Fetch(format!(
+                    "field '{}' missing on detection", self.key_field
+                )),
+            })?;
+
+        let resp = self
+            .client
+            .get(format!("https://passive-dns.example/{ip}"))
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+            .map_err(|e| EnrichError {
+                enricher_id: self.id.clone(),
+                kind: if e.is_timeout() {
+                    EnrichErrorKind::Timeout
+                } else {
+                    EnrichErrorKind::Fetch(e.to_string())
+                },
+            })?;
+        let value: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| EnrichError {
+                enricher_id: self.id.clone(),
+                kind: EnrichErrorKind::Parse(e.to_string()),
+            })?;
+        inject_enrichment(result, &self.inject_field, value);
+        Ok(())
+    }
+}
+```
+
+A few invariants the runtime guarantees, so you don't have to defend against them in `enrich()`:
+
+- `kind()` matches `result.body`'s variant. The pipeline filters before invoking you, so `result.as_detection()` (or `as_correlation()`) is `Some` whenever `enrich` is called.
+- The `Scope` filter has already passed for this result.
+- The call is wrapped in `tokio::time::timeout(self.timeout(), …)`. Timeouts surface as `EnrichErrorKind::Timeout` to the pipeline, then `OnError` decides whether to skip / null / drop.
+- `result.header.enrichments` is initialised lazily by `inject_enrichment`, so the `skip_serializing_if = "Option::is_none"` contract is preserved if every enricher errors.
+
+Step 2: wire `register_builtin`. The factory takes the raw YAML config block (after `serde_json::to_value`) and returns a `Box<dyn Enricher>`. Names are checked against four reserved primitives (`template`, `lookup`, `http`, `command`); duplicate registrations of the same name are rejected to keep the global registry append-only.
+
+```rust
+// my-enrichers/src/lib.rs
+mod passive_dns;
+use std::sync::Arc;
+
+pub fn register() -> Result<(), String> {
+    rsigma_runtime::register_builtin(
+        "enrich_ip_passive_dns_batched",
+        Arc::new(|raw: &serde_json::Value| -> Result<Box<dyn rsigma_runtime::Enricher>, String> {
+            let cfg: passive_dns::PassiveDnsConfig =
+                serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
+            Ok(Box::new(passive_dns::PassiveDnsEnricher::new(cfg)?))
+        }),
+    )
+}
+```
+
+Step 3: have the daemon call your `register()` before parsing the enrichers config. There are two patterns:
+
+1. **Linker-init (`ctor`).** Fragile across release toolchains; not recommended.
+2. **Explicit init in a CLI fork.** Add a new daemon binary (or a small wrapper around `cmd_daemon`) that calls `my_enrichers::register()` before `rsigma_cli::cmd_daemon(args)`. This is the supported pattern.
+
+```rust
+// my-rsigma-cli/src/main.rs
+fn main() {
+    my_enrichers::register().expect("register bespoke enrichers");
+    rsigma::run(); // your wrapper around `rsigma`'s main entry
+}
+```
+
+## YAML reference
+
+The config block is identical to the four primitives' shape; only `type:` differs. Operators do not need to know whether a type came from the primitive set or from a `register_builtin` call.
+
+```yaml
+enrichers:
+  - id: pdns_for_attackers
+    kind: detection
+    type: enrich_ip_passive_dns_batched
+    inject_field: passive_dns
+    timeout: 3s
+    on_error: skip
+    scope:
+      tags: ["attack.command_and_control"]
+    # Bespoke fields read by your factory:
+    api_key_env: PASSIVEDNS_API_KEY
+    key_field: SourceIp
+```
+
+The daemon's loader passes the entire block through to your factory; the factory deserializes whatever shape it needs. The `kind` field is read from the surrounding YAML, but your config struct can re-deserialize it (as in the example above) to keep the constructor self-contained.
+
+## Test it
+
+The unit-test pattern from `crates/rsigma-runtime/src/enrichment/tests.rs` carries over: build the enricher, drive it through `EnrichmentPipeline::new(vec![Box::new(enricher)], 1).run(&mut results).await`, assert the resulting `enrichments` map.
+
+Mock external dependencies. For HTTP, use `wiremock`; the existing `crates/rsigma-runtime/tests/enrichment_integration.rs` is the reference style. For commands, use `/bin/sh -c "echo ..."` with deterministic output.
+
+For the YAML-loader path, exercise `register_builtin` + an `EnrichersFile` with a `type: enrich_my_thing` entry to confirm the factory wires up cleanly. Reset the registry between tests with the test-only `clear_builtin_registry` helper if you `register_builtin` more than once across the same test binary.
+
+## Observability
+
+Per-call metrics are emitted automatically; no extra hook is required. The pipeline records `rsigma_enrichment_total{enricher_id, kind, status}` and `rsigma_enrichment_duration_seconds{enricher_id, kind}` for every non-filtered call; `enricher_id` is the value you set in `Enricher::id()`. Bespoke types using a private cache or rate-limiter should emit their own counters under a `rsigma_enrichment_<name>_*` prefix to keep the namespace stable for downstream dashboards.
+
+## Document it
+
+Three places to update when you ship the type:
+
+1. **A reference page** under your crate's docs site (or a README section) documenting the YAML schema your factory consumes, the expected `enrichments.<field>` shape, rate limits, and any required env vars.
+2. **The user-facing guide** in this repo's `docs/guide/enrichers.md` if the type is intended to ship as part of `rsigma-runtime` itself rather than as an external crate.
+3. **A recipe-vs-bespoke note** explaining which of the four criteria above justified the bespoke path. This avoids repeated debate when the next contributor wonders why a similar feature is not also a Rust type.
+
+## Checklist
+
+- [ ] `Enricher` trait implemented; `kind()` / `id()` / `inject_field()` are stable across reloads.
+- [ ] Constructor returns a clear `String` error on bad config (missing env var, unknown `kind`, schema mismatch).
+- [ ] `register_builtin(name, factory)` called once at process startup, before the daemon parses the enrichers YAML.
+- [ ] No internal locking on the hot path beyond what the pipeline already provides (the `Semaphore` bound, the per-enricher timeout).
+- [ ] Unit tests in your crate; integration test that exercises the YAML loader if shipping in-tree.
+- [ ] CHANGELOG entry on the crate that ships the type.
+
+## See also
+
+- [Enrichers](../guide/enrichers.md) — the operator-facing guide for the YAML schema, the four primitives, and the recipe catalog.
+- [`rsigma-runtime`](../library/runtime.md) — the public surface (`Enricher`, `EnrichmentPipeline`, `register_builtin`).
+- [Adding a dynamic source](adding-sources.md) — the analogous walkthrough for new pipeline source types.

--- a/docs/developers/adding-sources.md
+++ b/docs/developers/adding-sources.md
@@ -1,0 +1,270 @@
+# Adding a dynamic source type
+
+Dynamic pipeline sources (`http`, `command`, `file`, `nats`) live behind one trait: `SourceResolver`. Each `DynamicSource` carries a typed `SourceType` plus shared metadata (`id`, refresh policy, error policy, optional extract). The shipped `DefaultSourceResolver` dispatches on `SourceType`, hits the right adapter, and stores the result in a shared `Arc<SourceCache>`. This page walks through adding a new source type (S3, BigQuery, Redis, an internal HTTP endpoint with non-standard auth) and wiring it into the parser, resolver, and CLI.
+
+## Decide on the shape
+
+Two ways to add a new source:
+
+1. **In-tree `SourceType` variant.** Add a variant to `SourceType` in [`crates/rsigma-eval/src/pipeline/sources.rs`](https://github.com/timescale/rsigma/blob/main/crates/rsigma-eval/src/pipeline/sources.rs), parse the YAML into it, and dispatch on it inside `DefaultSourceResolver::resolve`. Use this when the new type is broadly useful (S3, Kafka, JetStream KV bucket) and you want it shipped in the upstream binary.
+2. **External `SourceResolver` impl.** Implement the trait in your own crate, wrap or compose with `DefaultSourceResolver`, and pass the wrapper to `RuntimeEngine::set_source_resolver`. Use this when the type is private to your deployment (an internal API with a custom auth scheme, a vendor-specific protocol you can't open-source).
+
+Both paths feed the same `SourceCache`, so `lookup` enrichers and `${source.X}` template references work identically against either.
+
+## Walkthrough: adding an `s3` source type (in-tree)
+
+Step 1: extend the typed `SourceType` enum.
+
+```text
+crates/rsigma-eval/src/pipeline/sources.rs
+```
+
+```rust
+pub enum SourceType {
+    File   { path: PathBuf, format: DataFormat, extract: Option<ExtractExpr> },
+    Command{ command: Vec<String>, format: DataFormat, extract: Option<ExtractExpr> },
+    Http   { url: String, method: Option<String>, headers: HashMap<String,String>,
+             format: DataFormat, extract: Option<ExtractExpr> },
+    Nats   { url: String, subject: String, format: DataFormat, extract: Option<ExtractExpr> },
+    S3     { bucket: String, key: String, region: Option<String>,        // ← new
+             format: DataFormat, extract: Option<ExtractExpr> },
+}
+```
+
+Step 2: parse the YAML. Every existing variant has a `parse_<type>_source` block in [`crates/rsigma-eval/src/pipeline/parsing.rs`](https://github.com/timescale/rsigma/blob/main/crates/rsigma-eval/src/pipeline/parsing.rs); copy one as a template. Keep the same field-name conventions (`format`, `extract`, `refresh`, `on_error`, `required`) so operators only learn one mental model.
+
+```yaml
+sources:
+  - id: cmdb_snapshot
+    type: s3
+    bucket: corp-cmdb-prod
+    key: snapshot.json
+    region: us-east-1
+    format: json
+    refresh:
+      interval: 600s
+    on_error: use_cached
+```
+
+Step 3: write the resolver adapter.
+
+```text
+crates/rsigma-runtime/src/sources/
+├── cache.rs
+├── command.rs
+├── extract.rs
+├── file.rs
+├── http.rs
+├── include.rs
+├── mod.rs               ← register the new module + dispatch
+├── nats.rs
+├── refresh.rs
+├── s3.rs                ← new
+└── template.rs
+```
+
+```rust
+// crates/rsigma-runtime/src/sources/s3.rs
+use rsigma_eval::pipeline::sources::{DataFormat, ExtractExpr};
+use super::{ResolvedValue, SourceError, SourceErrorKind};
+
+pub async fn resolve_s3(
+    bucket: &str,
+    key: &str,
+    region: Option<&str>,
+    format: DataFormat,
+    extract: Option<&ExtractExpr>,
+) -> Result<ResolvedValue, SourceError> {
+    // 1. Build an S3 client. Reuse `aws-config` / `aws-sdk-s3`.
+    let cfg = aws_config::load_from_env_with_region(region).await;
+    let client = aws_sdk_s3::Client::new(&cfg);
+
+    // 2. Hard cap: enforce the same MAX_SOURCE_RESPONSE_BYTES limit
+    //    as every other source so a poisoned bucket can't OOM the daemon.
+    let body = client.get_object().bucket(bucket).key(key).send().await
+        .map_err(|e| SourceError {
+            source_id: String::new(),
+            kind: SourceErrorKind::Fetch(e.to_string()),
+        })?;
+    let bytes = body.body.collect().await
+        .map_err(|e| SourceError {
+            source_id: String::new(),
+            kind: SourceErrorKind::Fetch(e.to_string()),
+        })?
+        .into_bytes();
+    if bytes.len() > super::MAX_SOURCE_RESPONSE_BYTES {
+        return Err(SourceError {
+            source_id: String::new(),
+            kind: SourceErrorKind::ResourceLimit(format!(
+                "S3 object exceeded {} bytes", super::MAX_SOURCE_RESPONSE_BYTES
+            )),
+        });
+    }
+
+    // 3. Parse + extract.
+    let parsed = parse_payload(&bytes, format)?;
+    let final_value = match extract {
+        Some(expr) => super::extract::apply_extract(&parsed, expr)?,
+        None => parsed,
+    };
+
+    Ok(ResolvedValue {
+        data: final_value,
+        resolved_at: std::time::Instant::now(),
+        from_cache: false,
+    })
+}
+```
+
+Mirror the existing modules' structure: a single `pub async fn resolve_<type>(...)`, parse via the shared `extract::apply_extract` helper, return a `ResolvedValue`. Keep error mapping consistent with the `SourceErrorKind` taxonomy (`Fetch`, `Parse`, `Extract`, `Timeout`, `ResourceLimit`); the daemon's instrumented resolver buckets metrics on those labels.
+
+Step 4: dispatch in `DefaultSourceResolver`.
+
+```text
+crates/rsigma-runtime/src/sources/mod.rs
+```
+
+```rust
+// In `impl SourceResolver for DefaultSourceResolver`:
+async fn resolve(&self, source: &DynamicSource) -> Result<ResolvedValue, SourceError> {
+    let result = match &source.source_type {
+        // ... existing arms ...
+        SourceType::S3 { bucket, key, region, format, extract } => {
+            s3::resolve_s3(bucket, key, region.as_deref(), *format, extract.as_ref()).await
+        }
+    };
+    // ... existing cache.store + on_error handling ...
+}
+```
+
+The `cache.store(&source.id, &value.data)` call in the success arm is shared across every `SourceType`, so your new variant gets cache write + `on_error: use_cached` / `use_default` / `fail` behaviour for free.
+
+Step 5: feature-flag heavy dependencies. The `aws-sdk-s3` crate pulls in tokio-compat I/O, a TLS stack, and a sigv4 implementation; gate it behind a feature so the default daemon binary stays small.
+
+```toml
+# crates/rsigma-runtime/Cargo.toml
+[features]
+s3 = ["dep:aws-sdk-s3", "dep:aws-config"]
+
+[dependencies]
+aws-sdk-s3 = { version = "1", optional = true }
+aws-config = { version = "1", optional = true }
+```
+
+```rust
+// crates/rsigma-runtime/src/sources/mod.rs
+#[cfg(feature = "s3")]
+pub mod s3;
+
+#[cfg(not(feature = "s3"))]
+SourceType::S3 { .. } => Err(SourceError {
+    source_id: source.id.clone(),
+    kind: SourceErrorKind::Fetch(
+        "S3 source requires the 's3' feature".into(),
+    ),
+}),
+```
+
+Mirror the `daemon-nats` and `daemon-otlp` propagation pattern: `crates/rsigma-cli/Cargo.toml` adds a passthrough `daemon-s3 = ["rsigma-runtime/s3", "daemon"]` so the binary opts in via one feature.
+
+## Walkthrough: adding a custom resolver out-of-tree
+
+When a source belongs in a private deployment, implementing `SourceResolver` in your own crate is enough; you don't have to touch `rsigma-eval` or `rsigma-runtime`.
+
+```rust
+// my-resolver/src/lib.rs
+use std::sync::Arc;
+use async_trait::async_trait;
+use rsigma_eval::pipeline::sources::{DynamicSource, SourceType};
+use rsigma_runtime::sources::{
+    DefaultSourceResolver, ResolvedValue, SourceCache, SourceError, SourceErrorKind, SourceResolver,
+};
+
+pub struct CompositeResolver {
+    inner: DefaultSourceResolver,
+    extras: Arc<MyVendorClient>,
+}
+
+impl CompositeResolver {
+    pub fn new(cache: Arc<SourceCache>, extras: Arc<MyVendorClient>) -> Self {
+        Self {
+            inner: DefaultSourceResolver::with_arc_cache(cache),
+            extras,
+        }
+    }
+}
+
+#[async_trait]
+impl SourceResolver for CompositeResolver {
+    async fn resolve(&self, source: &DynamicSource) -> Result<ResolvedValue, SourceError> {
+        // Recognise our private "vendor://..." URLs in the http variant.
+        if let SourceType::Http { url, .. } = &source.source_type
+            && let Some(rest) = url.strip_prefix("vendor://")
+        {
+            return self.extras.fetch(rest).await.map(|data| ResolvedValue {
+                data,
+                resolved_at: std::time::Instant::now(),
+                from_cache: false,
+            });
+        }
+        self.inner.resolve(source).await
+    }
+}
+```
+
+Wire it into your daemon via `RuntimeEngine::set_source_resolver(Arc::new(CompositeResolver::new(...)))`. Sharing the cache: pass the same `Arc<SourceCache>` you passed to `DefaultSourceResolver::with_arc_cache` to anything that needs to read pre-resolved data (an enrichment pipeline's `lookup` enrichers, for example).
+
+## Test it
+
+Three layers, mirroring the existing `crates/rsigma-runtime/tests/sources_integration.rs`:
+
+1. **Unit test the parser** (in `crates/rsigma-eval/src/pipeline/tests.rs`). Pin the YAML → typed `SourceType::S3 { … }` mapping, cover required-field-missing errors, default values, and the `extract` plumbing.
+2. **Integration test the resolver** against a stub backend. The existing `command.rs` test uses `echo`; the `http.rs` test uses `wiremock`. For S3, use `aws-smithy-http`'s test client or stand up a `LocalStack` container behind `testcontainers` (the daemon NATS tests use this pattern).
+3. **End-to-end test in the daemon** (under `crates/rsigma-cli/tests/`). Spawn `rsigma engine daemon` with a pipeline that declares your source, send a triggering event, assert the resulting NDJSON line carries the resolved value (via `${source.X}` template expansion) or a `lookup` enricher hit. The existing `cli_daemon_enrichment.rs` is the reference shape.
+
+## Observability
+
+Three things land automatically when you go through `DefaultSourceResolver::resolve` (the daemon wraps it in `InstrumentedResolver`):
+
+| Metric | Where it bumps |
+|---|---|
+| `rsigma_source_resolves_total{source_id, source_type}` | Per `resolve()` call. Set `source_type_label(...)` to `"s3"` so dashboards group correctly. |
+| `rsigma_source_resolve_errors_total{source_id, error_kind}` | On every `Err` return. `error_kind` is the `SourceErrorKind` variant. |
+| `rsigma_source_resolve_seconds` | Histogram, observed regardless of outcome. |
+
+Add the new label value (`"s3"`) to the daemon's `source_type_label` helper in [`crates/rsigma-cli/src/daemon/instrumented_resolver.rs`](https://github.com/timescale/rsigma/blob/main/crates/rsigma-cli/src/daemon/instrumented_resolver.rs). Existing alerts (`RsigmaSourceStale`, `RsigmaBackPressure`) cover the new type without rule changes.
+
+## Document it
+
+1. **Reference page** under [`docs/reference/dynamic-sources.md`](../reference/dynamic-sources.md): YAML schema for the new type, dependency on any feature flag, behaviour of `format`/`extract`/`refresh`/`on_error`, security notes (size cap, timeout, secret handling).
+2. **Guide page**: extend [`docs/guide/processing-pipelines.md`](../guide/processing-pipelines.md) with a one-paragraph example that uses the new type.
+3. **CHANGELOG** entry under the next release.
+
+## Security checklist
+
+Source resolution touches the network and the filesystem; before merging:
+
+- [ ] The 10 MB `MAX_SOURCE_RESPONSE_BYTES` cap is enforced on the response body.
+- [ ] A timeout is enforced on the fetch call (`tokio::time::timeout` or the underlying client's `request_timeout`).
+- [ ] Secrets (tokens, signing keys) come from env vars or `${ENV_VAR}` template expansion, not from inline YAML.
+- [ ] The new type is opt-in via a Cargo feature if it adds heavy or transitive deps.
+- [ ] Path-traversal / SSRF surfaces are bounded (file paths sandboxed if applicable, URL allow-list flag if the type is exposed remotely).
+
+## Checklist
+
+- [ ] `SourceType` variant added in `crates/rsigma-eval/src/pipeline/sources.rs`.
+- [ ] Parser block added in `crates/rsigma-eval/src/pipeline/parsing.rs` with required-field validation.
+- [ ] Resolver module added under `crates/rsigma-runtime/src/sources/<name>.rs`.
+- [ ] Dispatch arm added to `DefaultSourceResolver::resolve`.
+- [ ] Feature flag in `rsigma-runtime` and pass-through in `rsigma-cli` if heavy deps.
+- [ ] `source_type_label` extended in `instrumented_resolver.rs` so metrics label correctly.
+- [ ] Unit + integration + E2E tests in the layers above.
+- [ ] Reference + guide docs updated.
+- [ ] Security checklist signed off.
+- [ ] CHANGELOG entry.
+
+## See also
+
+- [Dynamic Pipeline Sources](../reference/dynamic-sources.md) — operator-facing reference for every shipped source type.
+- [`rsigma-runtime`](../library/runtime.md) — the `SourceResolver` trait and `DefaultSourceResolver`.
+- [Adding an enricher](adding-enrichers.md) — the analogous walkthrough for bespoke enrichers, which read from the same `SourceCache` via the `lookup` primitive.

--- a/docs/guide/.pages
+++ b/docs/guide/.pages
@@ -4,6 +4,7 @@ nav:
   - Rule Conversion: rule-conversion.md
   - Linting Rules: linting-rules.md
   - Processing Pipelines: processing-pipelines.md
+  - Enrichers: enrichers.md
   - Input Formats: input-formats.md
   - NATS Streaming: nats-streaming.md
   - OTLP Integration: otlp-integration.md

--- a/docs/guide/enrichers.md
+++ b/docs/guide/enrichers.md
@@ -286,7 +286,7 @@ The pipeline writes into `RuleHeader::enrichments` lazily, so detections and cor
 | `rsigma_enrichment_http_cache_misses_total` | `enricher_id` | HTTP enricher response-cache misses |
 | `rsigma_enrichment_http_cache_expirations_total` | `enricher_id` | HTTP enricher response-cache entries evicted on expiry |
 
-Filtered (kind- or scope-mismatched) calls do not increment any counters.
+Every `(enricher_id, kind, status)` triple and every HTTP-cache `enricher_id` row is pre-registered at startup, so all six families render at zero on the first `/metrics` scrape, before any event has fired. Filtered (kind- or scope-mismatched) calls do not increment any counters.
 
 ## See also
 

--- a/docs/guide/enrichers.md
+++ b/docs/guide/enrichers.md
@@ -92,14 +92,14 @@ Cheapest primitive. No I/O. Cannot fail past config-load-time template parse err
 
 ### `lookup`: read from the dynamic-pipelines source cache
 
-Reads a value from the dynamic-pipelines [source cache](../reference/dynamic-sources.md) by `source_id` and applies an `extract` expression (jq / JSONPath / CEL) with template-expanded variables to slice it. Zero-network-cost for anything already loaded as a pipeline source.
+Reads a value from the dynamic-pipelines [source cache](../reference/dynamic-sources.md) by `source_id` and applies an `extract` expression (jq / JSONPath / CEL) with template-expanded variables to slice it. Zero-network-cost for anything already loaded as a dynamic source.
 
 ```yaml
 - id: asset_context_corr
   kind: correlation
   type: lookup
   inject_field: asset_context
-  source: asset_inventory          # source_id from the pipeline `sources:` block
+  source: asset_inventory          # id of a dynamic source configured on the daemon
   extract: '.assets[] | select(.hostname == "${correlation.group_key.HostName}")'
   extract_type: jq                 # jq | jsonpath | cel; defaults to jq
   default: "unknown"               # injected on cache miss / no extract match
@@ -113,7 +113,7 @@ The decision matrix:
 - **Cache miss** → if `default` is configured, inject it; otherwise apply `on_error`
 - **Extract evaluation error** (invalid jq, type mismatch) → always applies `on_error`, even with `default` set
 
-`lookup` requires the daemon's pipelines to declare at least one dynamic source. The loader surfaces a clear error at startup if a `lookup` enricher is configured without a source cache.
+`lookup` requires at least one dynamic source to be configured on the daemon. The loader surfaces a clear error at startup if a `lookup` enricher is configured without a source cache.
 
 ### `http`: per-result HTTP fetch with optional response cache
 

--- a/docs/guide/enrichers.md
+++ b/docs/guide/enrichers.md
@@ -1,0 +1,296 @@
+# Enrichers
+
+Post-evaluation enrichers run after `engine.evaluate()` produces a `ProcessResult` and before each result is serialized to a sink. They inject contextual data — asset info, IP reputation, identity, GeoIP, runbook URLs — into the `enrichments.<field>` map on each detection or correlation, so every downstream consumer (RSoar, Grafana, Loki, custom scripts) sees the same structured context without re-fetching it.
+
+This page covers what to put in `--enrichers <path>`, how the four primitives compose into the IRQL `enrich_<keyfield>_<target>` recipe catalog, and how to promote a recipe to a Rust-coded named enricher when one of the four primitives is not enough. The CLI flag itself is documented under [`engine daemon`](../cli/engine/daemon.md#post-evaluation-enrichment); per-call Prometheus metrics live in [Prometheus metrics](../reference/metrics.md#enrichment-6-metrics).
+
+## Why post-evaluation, not in-pipeline
+
+Processing pipelines (`-p`) run *before* the engine evaluates a rule: they map field names, filter events, and inject literal values. Enrichers run *after* the engine has already decided that a detection or correlation fired. The two surfaces are complementary:
+
+- Use a pipeline when you want to normalise field names, drop noisy events, or inject a fixed list (threat-intel IOCs, allow-list users) into rule conditions. The pipeline runs once per event.
+- Use an enricher when you want to attach context to a *firing* detection (asset owner, IP reputation, runbook URL). The enricher runs once per match, not once per event, and its work never re-affects rule evaluation.
+
+This split keeps the evaluation hot path independent of any external system: a downstream HTTP outage cannot stop the engine from emitting detections, only from enriching them.
+
+## Config schema
+
+Pass a YAML file to `--enrichers <path>` on `engine daemon`. The file is hot-reloaded on `SIGHUP`, file-watcher changes, and `POST /api/v1/reload`; a reload that fails validation logs the error and keeps the previous pipeline active, so a typo never silently degrades production to "no enrichment".
+
+```yaml
+# Bound on concurrent enrichment chains. Defaults to 16.
+max_concurrent_enrichments: 16
+
+enrichers:
+  - id: <unique-string>            # required, used as a Prometheus label
+    kind: detection | correlation  # required, see "Kind and template namespaces"
+    type: template | lookup | http | command  # required, the primitive
+    inject_field: <field-name>     # required, key under enrichments.<...>
+    timeout: 5s                    # optional, humantime; default 5s
+    on_error: skip | null | drop   # optional; default skip
+    scope:                         # optional; see "Scope filtering"
+      rules: [<rule-id-or-glob>, ...]
+      tags:  [<tag-or-prefix.*>, ...]
+      levels: [low, medium, high, critical, informational]
+    # ... primitive-specific fields below ...
+```
+
+## Kind and template namespaces
+
+Every enricher declares a `kind: detection | correlation`. The kind drives two checks:
+
+1. **Config-load-time template validation.** A `kind: detection` enricher may only reference `${detection.*}` variables in its templated fields; a `kind: correlation` enricher may only reference `${correlation.*}`. Cross-namespace references are rejected at startup with a clear error pointing at the offending field. `${ENV_VAR}` is allowed in both namespaces.
+2. **Runtime body matching.** The pipeline skips enrichers whose declared kind does not match the current `EvaluationResult` body variant before invoking `enrich()`, so a detection-kind enricher pays no cost on correlation results and vice versa.
+
+Detection variables (`${detection.*}`):
+
+| Variable | Resolves to |
+|---|---|
+| `${detection.rule.title}` / `.id` / `.level` | Rule metadata from `RuleHeader` |
+| `${detection.tags}` | Comma-joined `tags` |
+| `${detection.fields.<name>}` | The matched value of `<name>` from `matched_fields` |
+| `${detection.event.<dotted.path>}` | JSON path into the original event (when `rsigma.include_event: "true"` on the rule) |
+
+Correlation variables (`${correlation.*}`):
+
+| Variable | Resolves to |
+|---|---|
+| `${correlation.rule.title}` / `.id` / `.level` | Rule metadata from `RuleHeader` |
+| `${correlation.tags}` | Comma-joined `tags` |
+| `${correlation.type}` | `event_count`, `temporal`, `value_sum`, ... |
+| `${correlation.aggregated_value}` | The value that crossed the condition threshold |
+| `${correlation.timespan_secs}` | Window size in seconds |
+| `${correlation.group_key.<field>}` | Look up a group-by field by name |
+| `${correlation.group_key}` | Joined `field=value,field=value` string |
+
+For enrichers that conceptually apply to both kinds (identity lookups, runbook URLs, any tag-based enricher), declare two YAML entries with the same `type` and `inject_field` but different `kind` and template namespaces.
+
+## Scope filtering
+
+`scope` limits when an enricher fires within its declared `kind`:
+
+- `scope.rules`: list of rule IDs (exact match) or rule-title globs (`Suspicious *`)
+- `scope.tags`: tag-set intersection with prefix wildcards (`attack.*` matches `attack.t1059.001`)
+- `scope.levels`: severity membership against `RuleHeader::level`
+- No scope = fires for every result of the enricher's declared kind (use for cheap enrichers like `template`)
+
+There is no `scope.kinds` axis: the top-level `kind` already gates which result variant the enricher sees. Axes are AND-ed; an empty axis is not a filter.
+
+## The four primitives
+
+### `template`: pure string interpolation
+
+Cheapest primitive. No I/O. Cannot fail past config-load-time template parse errors.
+
+```yaml
+- id: runbook_det
+  kind: detection
+  type: template
+  inject_field: runbook_url
+  template: "https://wiki.internal/runbooks/${detection.rule.id}"
+```
+
+### `lookup`: read from the dynamic-pipelines source cache
+
+Reads a value from the dynamic-pipelines [source cache](../reference/dynamic-sources.md) by `source_id` and applies an `extract` expression (jq / JSONPath / CEL) with template-expanded variables to slice it. Zero-network-cost for anything already loaded as a pipeline source.
+
+```yaml
+- id: asset_context_corr
+  kind: correlation
+  type: lookup
+  inject_field: asset_context
+  source: asset_inventory          # source_id from the pipeline `sources:` block
+  extract: '.assets[] | select(.hostname == "${correlation.group_key.HostName}")'
+  extract_type: jq                 # jq | jsonpath | cel; defaults to jq
+  default: "unknown"               # injected on cache miss / no extract match
+  on_error: skip                   # applied only when default is not configured
+```
+
+The decision matrix:
+
+- **Cache hit + extract matches** → inject the extracted value
+- **Cache hit + no extract match** → if `default` is configured, inject it; otherwise apply `on_error`
+- **Cache miss** → if `default` is configured, inject it; otherwise apply `on_error`
+- **Extract evaluation error** (invalid jq, type mismatch) → always applies `on_error`, even with `default` set
+
+`lookup` requires the daemon's pipelines to declare at least one dynamic source. The loader surfaces a clear error at startup if a `lookup` enricher is configured without a source cache.
+
+### `http`: per-result HTTP fetch with optional response cache
+
+Per-result `reqwest` request with template-expanded URL, headers, and optional body. Parses the response as JSON, optionally sliced by an `extract` expression. The optional response cache is keyed on `(method, url, body_hash)` with a configurable TTL; mandatory in practice for any rate-limited API.
+
+```yaml
+- id: hash_virustotal
+  kind: detection
+  type: http
+  inject_field: file_reputation
+  url: "https://www.virustotal.com/api/v3/files/${detection.fields.SHA256}"
+  method: GET                      # default GET
+  headers:
+    x-apikey: "${VIRUSTOTAL_API_KEY}"
+  cache_ttl: 1h                    # mandatory for the 4 req/min free tier
+  extract: ".data.attributes.last_analysis_stats"
+  extract_type: jq
+  on_error: skip
+  scope:
+    tags: ["attack.execution", "attack.defense_evasion"]
+```
+
+Each enricher instance owns its own response cache: two enrichers hitting the same URL with different `Authorization` headers do not share entries.
+
+### `command`: per-result local-process execution
+
+Per-result `tokio::process::Command` invocation with template-expanded argv and environment. Stdout is captured (capped at 10 MB) and parsed as JSON or as a raw string. Non-zero exit codes map to a fetch error with a snippet of stderr attached.
+
+```yaml
+- id: ip_reputation
+  kind: detection
+  type: command
+  inject_field: ip_reputation
+  command:
+    - "/usr/local/bin/check-ip-rep"
+    - "${detection.fields.SourceIp}"
+  env:
+    REP_LOCAL_DB: "/var/lib/iprep.db"
+  output: json                     # json (default) | raw
+  timeout: 3s
+  on_error: skip
+```
+
+## Composing enrichers (recipes)
+
+The four primitives cover almost every operational use case via composition. Recipes are *field-parametric*: substitute the field names your pipeline actually produces (`SourceIp`, `cip`, `client.ip`, `ClientIp`, ...) for the placeholders below.
+
+### `enrich_ip_employee` — identity lookup by source IP
+
+```yaml
+sources:
+  employee_directory:
+    type: file
+    path: /etc/rsigma/employees.json
+    format: json
+    extract:
+      expr: 'with_entries(.value |= {user: .user, team: .team})'
+      type: jq
+
+enrichers:
+  - id: enrich_ip_employee
+    kind: detection
+    type: lookup
+    inject_field: employee
+    source: employee_directory
+    extract: '."${detection.fields.SourceIp}"'
+    extract_type: jq
+    default: "unknown"
+    scope:
+      levels: [high, critical]
+```
+
+Expected `enrichments.employee` shape: `{"user": "alice", "team": "Platform"}` or `"unknown"` on miss.
+
+### `enrich_username_employee` — identity lookup by username
+
+Same source as above, key by username instead.
+
+### `enrich_ip_geoip` — country/city/ASN by IP
+
+Prefer `lookup` if a GeoIP dump fits in memory; fall back to `http` for vendor APIs.
+
+### `enrich_hash_virustotal` — hash reputation with cache
+
+`cache_ttl` is mandatory for the 4 req/min free tier and a major win for duplicate-detection bursts on any tier. See the YAML in the `http` example above.
+
+### `enrich_cve_kev` — known-exploited-vulnerability flag
+
+Pulls the CISA KEV catalog as a dynamic-pipelines source, then flags CVEs that appear in it.
+
+```yaml
+sources:
+  kev_catalog:
+    type: http
+    url: https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+    format: json
+    refresh: { interval: 3600s }
+
+enrichers:
+  - id: enrich_cve_kev
+    kind: detection
+    type: lookup
+    inject_field: kev
+    source: kev_catalog
+    extract: '.vulnerabilities[] | select(.cveID == "${detection.fields.CveId}")'
+    extract_type: jq
+    default: null
+```
+
+### `enrich_url_runbook` — synthesised runbook URL
+
+Pure string interpolation, no I/O. Use this any time a downstream consumer (Slack, PagerDuty, RSoar) needs a per-detection link.
+
+```yaml
+- id: enrich_url_runbook
+  kind: detection
+  type: template
+  inject_field: runbook_url
+  template: "https://wiki.internal/runbooks/${detection.rule.id}"
+```
+
+### When to pick which primitive
+
+- Prefer `lookup` if the data is bounded and refreshes infrequently (employee directory, KEV catalog, GeoIP dump).
+- Prefer `http` only when the data is genuinely per-result or too large to cache. Always set `cache_ttl` for rate-limited APIs.
+- Prefer `command` only when no other primitive will do (a binary parser, a vendored CLI tool, an existing script).
+- Never use `template` for anything that could be a YAML literal.
+
+## Promoting a recipe to a bespoke enricher
+
+The four primitives cover almost every use case via composition. A bespoke Rust-coded enricher is justified only when at least one of these holds:
+
+1. **It bundles non-trivial data** (a dataset committed to the repo and `include_bytes!`-ed at compile time). Recipes can't express vendored data.
+2. **It needs a parser the YAML primitives don't expose** (e.g. MaxMind's binary GeoLite2 format, the STIX 2.1 graph with parent/child resolution). Adding the parser as a generic source might cost more than just shipping the enricher.
+3. **It provides a stable named contract**: downstream consumers reference a specific `enrichments.<field>` shape directly. A recipe-driven approach lets every operator pick their own `inject_field`, which is fine for ad-hoc enrichment but bad for a contract that crosses team or organisational boundaries.
+4. **It implements a non-obvious algorithm** (e.g. coalescing per-result hash lookups into one batched-GET request). This is implementable as a recipe but the implementation is fragile.
+
+External crates wire a bespoke type via `register_builtin(name, factory)`:
+
+```rust
+use rsigma_runtime::{Enricher, register_builtin};
+
+register_builtin(
+    "enrich_my_thing",
+    std::sync::Arc::new(|raw_config: &serde_json::Value| -> Result<Box<dyn Enricher>, String> {
+        let cfg: MyConfig = serde_json::from_value(raw_config.clone()).map_err(|e| e.to_string())?;
+        Ok(Box::new(MyEnricher::new(cfg)))
+    }),
+).unwrap();
+```
+
+Reserved names (`template`, `lookup`, `http`, `command`) are rejected at registration time; duplicate registrations of the same name are rejected to keep the global registry append-only. Bespoke types follow the same `kind` / `scope` / template rules as the four primitives; promotion does not change the YAML shape, only the `type:` value.
+
+## Output shape
+
+The pipeline writes into `RuleHeader::enrichments` lazily, so detections and correlations that no enricher touched still serialize without an empty `enrichments` object. A typical NDJSON line looks like:
+
+```json
+{"rule_title":"Suspicious PowerShell encoded command","rule_id":"rule-pwsh-enc","level":"high","tags":["attack.t1059.001"],"matched_selections":["selection"],"matched_fields":[{"field":"CommandLine","value":"powershell -enc ..."}],"enrichments":{"asset_info":{"hostname":"dc01","owner":"IT-Ops"},"runbook_url":"https://wiki.internal/runbooks/rule-pwsh-enc"}}
+```
+
+## Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `rsigma_enrichment_total` | `enricher_id`, `kind`, `status` | Per-call outcome counter; `status` is `success` / `skip` / `error` / `timeout` / `drop` |
+| `rsigma_enrichment_duration_seconds` | `enricher_id`, `kind` | Per-enricher latency histogram |
+| `rsigma_enrichment_queue_depth` | – | Pending enrichment calls (sum across both kinds) |
+| `rsigma_enrichment_http_cache_hits_total` | `enricher_id` | HTTP enricher response-cache hits |
+| `rsigma_enrichment_http_cache_misses_total` | `enricher_id` | HTTP enricher response-cache misses |
+| `rsigma_enrichment_http_cache_expirations_total` | `enricher_id` | HTTP enricher response-cache entries evicted on expiry |
+
+Filtered (kind- or scope-mismatched) calls do not increment any counters.
+
+## See also
+
+- [`engine daemon` reference](../cli/engine/daemon.md) for the `--enrichers` flag.
+- [Dynamic Pipeline Sources](../reference/dynamic-sources.md) for the source cache that `lookup` reads from.
+- [Prometheus metrics](../reference/metrics.md) for the full metric definitions.
+- [`rsigma-runtime`](../library/runtime.md) for the `Enricher` trait, `EnrichmentPipeline`, and `register_builtin` API.

--- a/docs/library/runtime.md
+++ b/docs/library/runtime.md
@@ -48,6 +48,11 @@ tokio = { version = "1", features = ["full"] }
 | `SourceResolver` trait + `DefaultSourceResolver` | Dynamic-pipeline source resolution: HTTP, command, file, NATS. |
 | `SourceCache` | TTL-aware cache for resolved source values. Optional SQLite backing for cross-restart persistence. |
 | `TemplateExpander`, `RefreshScheduler`, `RefreshTrigger` | Substitutes `${source.X}` references in pipeline `vars:` and runs the refresh policies. |
+| `Enricher` trait + `EnrichmentPipeline` | Post-evaluation enrichment surface. Drives the four primitives (`TemplateEnricher`, `LookupEnricher`, `HttpEnricher`, `CommandEnricher`) and any bespoke types registered via `register_builtin`. |
+| `EnricherKind`, `OnError`, `Scope`, `EnrichError`, `EnrichErrorKind` | Configuration types: declared kind, error policy, scope filter, and the typed error returned by `Enricher::enrich`. |
+| `HttpResponseCache` (re-exported from `enrichment::http_cache`) | `(method, url, body_hash)`-keyed in-memory response cache with TTL and lazy eviction. Each `HttpEnricher` instance owns its own. |
+| `register_builtin(name, factory) -> Result<(), String>` | Process-global, append-only registry hook. External crates use it to ship a bespoke Rust-coded enricher type addressable via `type: <name>` in the daemon's enrichers config. Reserved names (`template` / `lookup` / `http` / `command`) and duplicate registrations are rejected. |
+| `lookup_builtin(name)` | Read-only registry probe used by the daemon config loader. |
 
 The full pipeline architecture, source resolution flow, and dynamic-pipeline contract are in [the crate README](https://github.com/timescale/rsigma/blob/main/crates/rsigma-runtime/README.md) and the [Architecture reference](../reference/architecture.md).
 
@@ -106,6 +111,41 @@ tokio::spawn(async move {
 ```
 
 The daemon's `notify` + SIGHUP + `POST /api/v1/reload` wiring lives in `rsigma-cli`; `LogProcessor` just exposes the primitive.
+
+## Post-evaluation enrichment
+
+`EnrichmentPipeline` runs after the engine has produced a `ProcessResult` and before the sink serializes it. Each enricher implements the `Enricher` trait, declares a `kind: detection | correlation` at construction, and writes into `RuleHeader::enrichments` under a configured `inject_field`. The pipeline filters per-result by declared kind against the body variant, applies the optional `Scope` filter, wraps the call in a per-enricher timeout, and applies the configured `OnError` policy on failure.
+
+```rust
+use rsigma_runtime::{
+    EnricherKind, EnrichmentPipeline, OnError, Scope, TemplateEnricher,
+};
+use std::time::Duration;
+
+let runbook = TemplateEnricher::new(
+    "runbook_det".to_string(),
+    EnricherKind::Detection,
+    "runbook_url".to_string(),
+    "https://wiki.internal/runbooks/${detection.rule.id}".to_string(),
+    Duration::from_secs(5),
+    OnError::Skip,
+    Scope::default(),
+);
+
+let pipeline = EnrichmentPipeline::new(
+    vec![Box::new(runbook)],
+    16, // max_concurrent_enrichments
+);
+
+// `results` is the engine's `Vec<EvaluationResult>`.
+// pipeline.run(&mut results).await;
+```
+
+Wire a `MetricsHook` via `EnrichmentPipeline::with_metrics` to surface `rsigma_enrichment_total` / `rsigma_enrichment_duration_seconds` / `rsigma_enrichment_queue_depth` (and the HTTP cache counters) into your own metrics backend. The daemon's Prometheus-backed `Metrics` struct implements the hook.
+
+For YAML-driven configuration, use the `rsigma-cli` `daemon::enrichment::build_enrichers_full` entry point in your own daemon, or copy the loader pattern from `rsigma-cli/src/daemon/enrichment/config.rs`.
+
+For the operator-facing schema, the four primitives, and the recipe catalog, see [Enrichers](../guide/enrichers.md).
 
 ## Custom metrics
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -55,7 +55,7 @@ The `error_kind` values come from `rsigma_runtime::sources::SourceErrorKind`. `F
 
 ## Enrichment (6 metrics)
 
-Exposed when the daemon is built with `daemon` and `--enrichers` is passed. Filtered (kind- or scope-mismatched) enricher calls do not increment any counter, so cardinality stays bounded by the number of configured enrichers.
+Exposed when the daemon is built with `daemon` and `--enrichers` is passed. Every `(enricher_id, kind, status)` triple and every HTTP-cache `enricher_id` row is pre-registered at startup, so all six families render with their `# HELP` / `# TYPE` lines and zeroed counters on the first scrape, even before any event has fired. Filtered (kind- or scope-mismatched) enricher calls do not increment any counter, so cardinality stays bounded by the number of configured enrichers.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -53,6 +53,21 @@ Exposed when one or more pipelines declare dynamic sources. The labelled counter
 
 The `error_kind` values come from `rsigma_runtime::sources::SourceErrorKind`. `Fetch` covers HTTP / file / command / NATS connect-or-read failures (per-protocol details land in the `error_message` log field, not the label). `ResourceLimit` covers the 10 MiB body cap, 30 s command exec cap, and similar.
 
+## Enrichment (6 metrics)
+
+Exposed when the daemon is built with `daemon` and `--enrichers` is passed. Filtered (kind- or scope-mismatched) enricher calls do not increment any counter, so cardinality stays bounded by the number of configured enrichers.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `rsigma_enrichment_total` | counter | `enricher_id`, `kind` (`detection`, `correlation`), `status` (`success`, `skip`, `error`, `timeout`, `drop`) | Per-call outcome counter. `kind` is the enricher's declared kind (the YAML `kind:` field), not a per-result discriminator. |
+| `rsigma_enrichment_duration_seconds` | histogram | `enricher_id`, `kind` | Per-enricher latency. Buckets target both fast `template` calls and slower `http`/`command` invocations. |
+| `rsigma_enrichment_queue_depth` | gauge | — | Pending enrichment calls (sum across both kinds). Watch this versus `max_concurrent_enrichments`. |
+| `rsigma_enrichment_http_cache_hits_total` | counter | `enricher_id` | HTTP enricher response-cache hits. Mandatory signal for any rate-limited API recipe. |
+| `rsigma_enrichment_http_cache_misses_total` | counter | `enricher_id` | HTTP enricher response-cache misses. |
+| `rsigma_enrichment_http_cache_expirations_total` | counter | `enricher_id` | HTTP enricher response-cache entries evicted on expiry. |
+
+The `kind` label is carried even though `enricher_id` typically already encodes it (`asset_lookup_det` vs `asset_lookup_corr`), so dashboards can compute `sum by (kind)` without depending on a naming convention.
+
 ## OTLP (3 metrics)
 
 Exposed when the daemon is built with `daemon-otlp` and an OTLP receiver is active. The labelled counters surface after the first request of that kind.
@@ -111,6 +126,15 @@ groups:
       - alert: RsigmaSourceStale
         expr: time() - rsigma_source_last_resolved_timestamp > 600
         for: 5m
+        labels: {severity: warning}
+
+      # Enricher consistently failing (timeouts or fetch errors).
+      - alert: RsigmaEnrichmentFailing
+        expr: |
+          sum by (enricher_id) (
+            rate(rsigma_enrichment_total{status=~"error|timeout"}[5m])
+          ) > 1
+        for: 10m
         labels: {severity: warning}
 ```
 


### PR DESCRIPTION
## Summary

Adds a post-evaluation enrichment layer to the daemon: each `EvaluationResult` (see #132) produced by the engine flows through a configured pipeline of enrichers before being serialized to a sink, and each enricher writes contextual data (asset info, IP reputation, identity, GeoIP, runbook URLs, and so on) into `enrichments.<field>` on the result.

The shape:

- One `Enricher` trait, four primitive types: `template`, `lookup`, `http`, `command`. Bespoke Rust types register via a public `register_builtin(name, factory)` hook.
- Every enricher declares a `kind: detection | correlation` at config time. Cross-namespace template references (`${correlation.*}` inside a `kind: detection` enricher and vice versa) are caught at config load with a clear error pointing at the offending field. At runtime the pipeline filters per-result by declared kind against the body variant before invoking `enrich()`.
- The `lookup` primitive reads from the dynamic-pipelines `SourceCache` (zero-network-cost for anything already loaded as a pipeline source) with optional `default` for cache miss / no-extract-match. The `http` primitive carries an opt-in response cache keyed on `(method, url, body_hash)` with configurable TTL.
- Per-enricher timeout via `tokio::time::timeout`, bounded global concurrency via `tokio::sync::Semaphore`, three `on_error` policies (`skip` / `null` / `drop`), and scope filtering by rule id / glob, tag prefix, or severity level.
- Six Prometheus metrics: `rsigma_enrichment_total{enricher_id, kind, status}`, `_duration_seconds`, `_queue_depth`, and `_http_cache_{hits,misses,expirations}_total{enricher_id}`. Filtered (kind- or scope-mismatched) calls do not increment any counter.
- Hot-reload via the existing reload loop (file watcher, SIGHUP, `POST /api/v1/reload`). Failed reloads keep the previous pipeline active and log the error so a typo in the enrichers config never silently degrades production to "no enrichment".

In passing the dynamic-pipelines `apply_jq` extractor now loads `jaq-core` and `jaq-std`, so `select`, `map`, `first`, `with_entries`, and the rest of the jq stdlib work in both pipeline-source `extract` expressions and `lookup` / `http` enricher extracts.

History is split into five logical commits (foundation, metrics, hot-reload, docs, end-to-end test) so they review cleanly in order.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` all green (228 runtime tests including 25 integration + 39 unit, 53 daemon tests including the new `cli_daemon_enrichment` E2E pair)
- [x] `mkdocs build --strict` clean against the new `docs/guide/enrichers.md` plus the updates to `docs/cli/engine/daemon.md`, `docs/library/runtime.md`, `docs/reference/metrics.md`, and the new developer pages (`docs/developers/adding-enrichers.md`, `docs/developers/adding-sources.md`)
- [x] Manual smoke test: spawn `rsigma engine daemon -r rules/ -p pipelines/...yml --enrichers enrichers.yml --input http`, send an event, verify the NDJSON output carries an `enrichments` object with each configured primitive's contribution
- [x] Manual smoke test: SIGHUP after editing the enrichers file picks up the new pipeline; a config with a cross-namespace reference fails the reload and leaves the previous pipeline in place
- [x] `/metrics` exposes the six new `rsigma_enrichment_*` counters with the documented label sets