### PR TITLE
feat(cli): hide deprecated flat subcommand aliases from `--help` (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,21 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Deprecated CLI aliases hidden from `--help` (#125)
+
+The 12 flat top-level CLI aliases (`eval`, `daemon`, `parse`, `validate`, `lint`, `fields`, `condition`, `stdin`, `convert`, `list-targets`, `list-formats`, `resolve`) introduced as visible-deprecated forwarders in v0.12.0 (PR #124) are now hidden from `rsigma --help` via `#[command(hide = true)]`. The dispatch arms and the `deprecation_warn` helper are otherwise unchanged, so:
+
+- Every alias still runs successfully and still prints the migration warning on stderr.
+- `rsigma <alias> --help` is still routable and renders the same flag list as the new grouped form, so scripts that introspect a subcommand keep working.
+- `rsigma --help` now lists only the four noun-led groups (`engine`, `rule`, `backend`, `pipeline`) plus `help`.
+
+The warning text was updated from "This alias will be hidden in the next release and removed in v1.0." to "This alias is hidden from `--help` and will be removed in v1.0." to reflect the new lifecycle stage. Removal at v1.0 is tracked in #126.
+
 ### Detached dynamic sources (#135)
 
 Dynamic source declarations are decoupled from pipeline YAML files. Sources are now a first-class daemon-level concept declared in standalone YAML files and loaded via the new `--source <file_or_dir>` flag (repeatable). Both pipelines and enrichers reference sources by `source_id` as before; the daemon resolves them through a unified `DaemonSourceRegistry` that enforces collision-error semantics (same ID in two sites is a startup error with both paths in the message).
 
-**Pipeline-embedded `sources:` is deprecated.** Existing pipeline files that declare `sources:` continue to work but emit a `tracing::warn!` at parse time recommending `--source` and `rsigma rule migrate-sources`. The deprecation follows the same three-release cycle as the CLI command groups (#125, #126): visible-deprecated this release, hidden from docs next release (#136), removed at v1.0 (#137).
+**Pipeline-embedded `sources:` is deprecated.** Existing pipeline files that declare `sources:` continue to work but emit a `tracing::warn!` at parse time recommending `--source` and `rsigma rule migrate-sources`. The deprecation runs over three releases: visible-deprecated this release, hidden from docs next release (#136), removed at v1.0 (#137).
 
 **New subcommand.** `rsigma rule migrate-sources -p <pipeline-dir> -o <out>` extracts every pipeline-embedded `sources:` block into a standalone file, deduplicating by source ID with collision detection, and rewrites the pipeline files with the `sources:` block removed. Supports `--strategy single` (default, one consolidated file) and `--strategy per-pipeline`.
 

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -49,7 +49,7 @@ Commands are grouped into four noun-led groups: `engine` (eval / daemon), `rule`
 
 ### Migrating from the old flat commands
 
-Every flat top-level command still works for one release as a visible-deprecated alias. Invoking the old form prints a stderr warning and forwards to the same implementation; stdout, exit codes, and every flag are unchanged.
+Every flat top-level command still works as a hidden, undocumented forwarder. Invoking the old form prints a stderr warning and dispatches to the same implementation; stdout, exit codes, and every flag are unchanged. The aliases no longer appear in `rsigma --help`, but `rsigma <alias> --help` is still routable so existing scripts that introspect a subcommand keep working.
 
 | Old (flat, deprecated) | New (grouped) |
 |------------------------|---------------|
@@ -66,7 +66,7 @@ Every flat top-level command still works for one release as a visible-deprecated
 | `rsigma list-formats TARGET` | `rsigma backend formats TARGET` |
 | `rsigma resolve ...` | `rsigma pipeline resolve ...` |
 
-Deprecation timeline: flat aliases are **visible** in `rsigma --help` this release (with `[deprecated]` in the about text), **hidden** from `--help` in the next release, and **removed** in v1.0. Migrate at your convenience within that window.
+Deprecation timeline: flat aliases are **hidden** from `rsigma --help` but stay functional with a stderr migration warning, and will be **removed** in v1.0. Migrate at your convenience within that window.
 
 ### `rule parse`: Parse a single rule
 

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -51,10 +51,12 @@ enum LogFormat {
 }
 
 // The new noun-led command groups (`engine`, `rule`, `backend`, `pipeline`)
-// are the source of truth. The flat top-level variants that follow
-// are deprecated aliases kept for one release; each carries `[deprecated]` in
-// its `about` text and prints a stderr warning before forwarding to the same
-// `cmd_*` helper.
+// are the source of truth. The flat top-level variants that follow are
+// deprecated aliases kept around for one more release as undocumented
+// forwarders. Each is marked `#[command(hide = true)]` so it no longer
+// appears in `rsigma --help`, but the dispatch arms below still accept the
+// invocation and print a stderr warning before delegating to the same
+// `cmd_*` helper. These variants are removed entirely at v1.0 (issue #126).
 //
 // We deliberately use a `//` comment (not `///`) so clap does not promote it
 // to the top-level `--help` `about` text and override the explicit
@@ -86,44 +88,54 @@ enum Commands {
         cmd: PipelineCommands,
     },
 
-    // ---- Deprecated flat aliases (visible this release, hidden next) ----
+    // ---- Deprecated flat aliases (hidden from `--help`, still functional) ----
     /// [deprecated] Use `rsigma engine eval` instead
+    #[command(hide = true)]
     Eval(EvalArgs),
 
     /// [deprecated] Use `rsigma engine daemon` instead
     #[cfg(feature = "daemon")]
+    #[command(hide = true)]
     Daemon(DaemonArgs),
 
     /// [deprecated] Use `rsigma rule parse` instead
+    #[command(hide = true)]
     Parse(ParseArgs),
 
     /// [deprecated] Use `rsigma rule validate` instead
+    #[command(hide = true)]
     Validate(ValidateArgs),
 
     /// [deprecated] Use `rsigma rule lint` instead
+    #[command(hide = true)]
     Lint(LintArgs),
 
     /// [deprecated] Use `rsigma rule fields` instead
+    #[command(hide = true)]
     Fields(FieldsArgs),
 
     /// [deprecated] Use `rsigma rule condition` instead
+    #[command(hide = true)]
     Condition(ConditionArgs),
 
     /// [deprecated] Use `rsigma rule stdin` instead
+    #[command(hide = true)]
     Stdin(StdinArgs),
 
     /// [deprecated] Use `rsigma backend convert` instead
+    #[command(hide = true)]
     Convert(ConvertArgs),
 
     /// [deprecated] Use `rsigma backend targets` instead
-    #[command(name = "list-targets")]
+    #[command(name = "list-targets", hide = true)]
     ListTargets,
 
     /// [deprecated] Use `rsigma backend formats` instead
-    #[command(name = "list-formats")]
+    #[command(name = "list-formats", hide = true)]
     ListFormats(ListFormatsArgs),
 
     /// [deprecated] Use `rsigma pipeline resolve` instead
+    #[command(hide = true)]
     Resolve(ResolveArgs),
 }
 
@@ -208,7 +220,7 @@ fn main() {
 fn deprecation_warn(old: &str, new: &str) {
     eprintln!(
         "warning: `rsigma {old}` is deprecated; use `rsigma {new}` instead. \
-         This alias will be hidden in the next release and removed in v1.0."
+         This alias is hidden from `--help` and will be removed in v1.0."
     );
 }
 

--- a/crates/rsigma-cli/tests/cli_deprecation.rs
+++ b/crates/rsigma-cli/tests/cli_deprecation.rs
@@ -2,8 +2,9 @@
 //!
 //! Each deprecated alias (`eval`, `daemon`, `parse`, `validate`, `lint`,
 //! `fields`, `condition`, `stdin`, `convert`, `list-targets`, `list-formats`,
-//! `resolve`) must keep working for one release before it is hidden in the
-//! next and removed in v1.0. This file asserts that:
+//! `resolve`) is hidden from `rsigma --help` but kept as a functional
+//! forwarder until v1.0 ([issue #126](https://github.com/timescale/rsigma/issues/126)).
+//! This file asserts that:
 //!
 //! 1. The flat invocation still succeeds (or fails with the same exit code
 //!    as the new grouped form for error paths).
@@ -11,8 +12,9 @@
 //!    message on stderr.
 //! 3. Where it makes sense (cheap stateless commands), the flat form
 //!    produces the same stdout as the new grouped form.
-//! 4. `rsigma --help` lists every deprecated alias with `[deprecated]` in
-//!    its about text, plus the five new groups.
+//! 4. `rsigma --help` lists only the four new groups (`engine`, `rule`,
+//!    `backend`, `pipeline`) plus `help`, and does NOT list any deprecated
+//!    alias.
 //! 5. Each new group's own `--help` lists the leaf subcommands.
 
 mod common;
@@ -27,38 +29,55 @@ const DEPRECATION_PREFIX: &str = "warning: `rsigma ";
 // ---------------------------------------------------------------------------
 
 #[test]
-fn root_help_lists_all_groups_and_deprecated_aliases() {
+fn root_help_hides_deprecated_aliases() {
     let assert = rsigma()
         .args(["--help"])
         .assert()
         .success()
-        // New groups appear with their short description.
+        // The four new groups still appear in the Commands list.
         .stdout(predicate::str::contains("engine"))
         .stdout(predicate::str::contains("rule"))
         .stdout(predicate::str::contains("backend"))
         .stdout(predicate::str::contains("pipeline"))
-        // Every deprecated alias keeps its row and is tagged `[deprecated]`.
-        .stdout(predicate::str::contains("[deprecated]"));
+        // The `[deprecated]` tag is no longer rendered anywhere because every
+        // alias that carried it is now hidden.
+        .stdout(predicate::str::contains("[deprecated]").not());
 
-    let output = assert.get_output();
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The Commands block ends at the first blank line after "Commands:". Scope
+    // the alias-absence check to that block so we don't trip on substring hits
+    // elsewhere in the help output (e.g. `--log-format` mentioning `engine
+    // daemon`, or the `--input-format` flag mentioning `stdin`).
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let commands_block = stdout
+        .split_once("Commands:")
+        .map(|(_, rest)| rest.split("\n\n").next().unwrap_or(""))
+        .expect("`Commands:` header should appear in `rsigma --help`");
+
+    // The single-word `eval`, `daemon`, `lint`, etc. would otherwise be
+    // substrings of `engine eval`, `engine daemon`, `rule lint`, etc.; the
+    // grouped form lives under each group's own `--help`, not the root one,
+    // so each token only appears in the root help if its deprecated alias
+    // is still rendered. Match the leading two-space indent + alias as a
+    // standalone command name in the Commands block.
     for alias in [
-        "eval",
-        "daemon",
-        "parse",
-        "validate",
-        "lint",
-        "fields",
-        "condition",
-        "stdin",
-        "convert",
-        "list-targets",
-        "list-formats",
-        "resolve",
+        "  eval ",
+        "  daemon ",
+        "  parse ",
+        "  validate ",
+        "  lint ",
+        "  fields ",
+        "  condition ",
+        "  stdin ",
+        "  convert ",
+        "  list-targets",
+        "  list-formats",
+        "  resolve ",
     ] {
         assert!(
-            stdout.contains(alias),
-            "`{alias}` should appear in `rsigma --help`, got:\n{stdout}"
+            !commands_block.contains(alias),
+            "deprecated alias `{}` should NOT appear in `rsigma --help` Commands block, got:\n{}",
+            alias.trim(),
+            commands_block,
         );
     }
 }
@@ -276,28 +295,21 @@ fn deprecated_list_formats_warns_and_matches_backend_formats() {
 // Daemon and resolve deprecation
 // ---------------------------------------------------------------------------
 
-/// `rsigma daemon` is the heaviest deprecated alias. We only assert that
-/// `--help` on the alias prints the deprecation warning and the same flag
-/// list as `engine daemon --help`. Spawning a real daemon is covered by
+/// `rsigma daemon` is the heaviest deprecated alias. Even though it is hidden
+/// from `rsigma --help`, the alias-specific `--help` page must still render so
+/// scripts that pass `--help` keep working through the deprecation window. We
+/// assert that `rsigma daemon --help` is reachable and surfaces the same flag
+/// list as `rsigma engine daemon --help`. Spawning a real daemon is covered by
 /// `cli_daemon.rs` (which already uses the new path).
 #[cfg(feature = "daemon")]
 #[test]
-fn deprecated_daemon_help_lists_new_path() {
+fn deprecated_daemon_help_still_works() {
     rsigma()
         .args(["daemon", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains("--rules"))
         .stdout(predicate::str::contains("--input"));
-
-    // The about line tags the flat form as deprecated.
-    rsigma()
-        .args(["--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "daemon        [deprecated] Use `rsigma engine daemon` instead",
-        ));
 }
 
 #[cfg(feature = "daemon")]

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -45,9 +45,9 @@ rsigma
     └── resolve                offline source resolution + dry-run for dynamic pipelines
 ```
 
-## Migration from flat subcommands (pre-0.11)
+## Migration from flat subcommands
 
-The 0.11 release moved twelve flat top-level subcommands into the five groups above. The flat aliases still work in this release but are deprecated. Each call prints a stderr warning that points at the new path.
+Twelve flat top-level subcommands were moved into the four groups above. The flat aliases are hidden from `rsigma --help` but kept as functional forwarders: each call still runs and prints a stderr migration warning pointing at the new path. `rsigma <alias> --help` is still routable so scripts that introspect a subcommand keep working through the deprecation window.
 
 | Old | New | Will be removed in |
 |-----|-----|------------|
@@ -63,8 +63,6 @@ The 0.11 release moved twelve flat top-level subcommands into the five groups ab
 | `rsigma list-targets` | `rsigma backend targets` | v1.0 |
 | `rsigma list-formats` | `rsigma backend formats` | v1.0 |
 | `rsigma resolve` | `rsigma pipeline resolve` | v1.0 |
-
-The intermediate visibility-only step (hide aliases from `--help` but keep them functional) is tracked in [#125](https://github.com/timescale/rsigma/issues/125).
 
 A scripted migration is one `sed`:
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -157,7 +157,7 @@ The RSigma CLI has been reorganized into noun-led command groups so it can scale
 | `backend` | `convert`, `targets`, `formats` | Generate backend-native queries. |
 | `pipeline` | `resolve` | Test dynamic pipeline source resolution. |
 
-The previous flat commands (`rsigma eval`, `rsigma daemon`, ...) still work for one release as deprecated aliases. See the [CLI reference](../cli/index.md) for the full migration table.
+The previous flat commands (`rsigma eval`, `rsigma daemon`, ...) still work as hidden deprecated aliases that print a migration warning on stderr and forward to the new path; they are removed in v1.0. See the [CLI reference](../cli/index.md) for the full migration table.
 
 ## Output
 


### PR DESCRIPTION
Closes #125.

## Summary

Hides the 12 deprecated flat top-level CLI aliases (`eval`, `daemon`, `parse`, `validate`, `lint`, `fields`, `condition`, `stdin`, `convert`, `list-targets`, `list-formats`, `resolve`) from `rsigma --help` while keeping them as functional forwarders.

The aliases were introduced as visible-deprecated forwarders in #124 with a planned three-stage lifecycle: visible -> hidden -> removed. This PR is the hidden stage. Removal at v1.0 is tracked in #126.

## What changed

**`crates/rsigma-cli/src/main.rs`**

- `#[command(hide = true)]` added to every deprecated variant in `enum Commands`.
- The `deprecation_warn` helper's text is updated to match the new lifecycle stage: `"This alias is hidden from `--help` and will be removed in v1.0."`
- Dispatch arms and forwarding behavior are unchanged.

**`crates/rsigma-cli/tests/cli_deprecation.rs`**

- `root_help_lists_all_groups_and_deprecated_aliases` rewritten as `root_help_hides_deprecated_aliases`. Asserts `[deprecated]` is no longer rendered anywhere in `--help`, then walks the Commands block and confirms each deprecated alias name is absent. The check is scoped to the Commands block so substrings like `engine daemon` (in `--log-format`'s description) or `stdin` (in `--input-format`'s value list) don't false-positive.
- `deprecated_daemon_help_lists_new_path` renamed to `deprecated_daemon_help_still_works`. Drops the obsolete assertion that the root help listed the deprecated daemon row, but keeps the assertion that `rsigma daemon --help` itself is still routable and renders `--rules` / `--input`.
- All 12 per-alias smoke tests (success + warning + stdout parity vs the new grouped form) are unchanged.

**`crates/rsigma-cli/README.md`** — Migration section updated. Aliases described as "hidden, undocumented forwarders" with the note that `rsigma <alias> --help` is still routable so existing scripts keep working. Deprecation timeline updated to past/present/future tense matching the new stage.

**`CHANGELOG.md`** — Adds a `### Deprecated CLI aliases hidden from --help (#125)` entry under `## [Unreleased]` describing the change and linking #126 for v1.0 removal.

## What `rsigma --help` looks like now

```
Commands:
  engine    Run rules against events (eval / daemon)
  rule      Inspect and operate on Sigma rule files
  backend   Convert Sigma rules to backend-native queries
  pipeline  Pipeline tooling (resolve dynamic sources, …)
  help      Print this message or the help of the given subcommand(s)
```

## What still works

```
$ rsigma stdin < rule.yml
warning: `rsigma stdin` is deprecated; use `rsigma rule stdin` instead. This alias is hidden from `--help` and will be removed in v1.0.
... (same stdout as `rsigma rule stdin`)

$ rsigma daemon --help
... (full flag list, same as `rsigma engine daemon --help`)
```

## Test plan

- [x] `cargo build -p rsigma --all-features` — clean (4 crates compiled)
- [x] `cargo test -p rsigma --features daemon --test cli_deprecation` — 17 passed, 0 failed
- [x] `cargo test -p rsigma --features daemon` (full suite) — 199 passed across 15 suites, 0 failed
- [x] `cargo clippy -p rsigma --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p rsigma --no-default-features` — unchanged (same 10 pre-existing errors, not caused by this PR)
- [x] Manual smoke: `rsigma --help` no longer lists the 12 aliases; `rsigma stdin`, `rsigma list-targets`, etc. still work and still warn.

## Follow-ups

- #126 — remove the deprecated flat aliases entirely at v1.0.
