### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-26
+
+**TL;DR**
+RSigma v0.13.0 is the "post-evaluation enrichment, server-side TLS, and field observability" release:
+* Post-evaluation enrichment between `engine.evaluate()` and the sinks: four primitives (`template`, `lookup`, `http`, `command`), strict detection-vs-correlation kind separation, scope filters, `on_error` policies, six new Prometheus metrics, and a public `register_builtin(name, factory)` registry.
+* Server-side TLS on the daemon API listener (Axum REST + Prometheus + OTLP/HTTP + OTLP/gRPC sharing one socket via ALPN), gated by the new `daemon-tls` Cargo feature, with optional mutual TLS and cross-platform cert hot-reload via `POST /api/v1/reload`.
+* Field observability: opt-in `--observe-fields` on `engine daemon` and `engine eval` exposes the gap and broken-coverage signals via four `/api/v1/fields/*` endpoints and three Prometheus surfaces, sharing a `RuleFieldSet` + `FieldCoverage` join primitive across CLI and daemon.
+* Detached dynamic sources: declare sources in standalone YAML loaded via `--source <file_or_dir>`, with a unified `DaemonSourceRegistry` and a new `rsigma rule migrate-sources` helper. Pipeline-embedded `sources:` is visible-deprecated this release.
+* Library API: `MatchResult` and `CorrelationResult` collapse into a single `EvaluationResult` (`RuleHeader` + `ResultBody`), wire shape preserved. Deprecated CLI aliases are now hidden from `rsigma --help`. The reserved-but-empty `attack` subcommand group is removed.
+* Dependency bumps: jsonschema 0.46.5, jaq-core / jaq-std 1.x to 3.0 with jaq-json 2.0 (Radically Open Security audit fixes), assert_cmd 2.2.2, plus CI action bumps and two VS Code Dependabot security fixes (`@azure/msal-node` ^5.2.2, `brace-expansion` ^5.0.6).
+
 ### Unknown-field discovery API (#149)
 
 The `engine daemon` learns to surface two halves of detection coverage live from inside the process: which event fields are not referenced by any loaded rule (gap signal) and which rule fields have never appeared in an event (broken-coverage signal). RSigma owns both rule parsing and event ingestion end-to-end, so this view does not need an external pipeline.
@@ -185,6 +196,8 @@ Rolls up five open Dependabot PRs and closes two Dependabot security alerts. Rus
 * **Enrichment wording:** the `lookup` enricher's startup error message and `docs/guide/enrichers.md` describe sources as "configured on the daemon" rather than "declared in your pipeline `sources:` block" so the copy stays accurate after a forthcoming release lets sources be declared independently of pipelines.
 * **README and home page:** [Detection Engineering Weekly #157](https://www.detectionengineering.net/p/dew-157-shai-hulud-goes-open-source) added to the "featured in" list (`README.md` and `docs/index.md`) with a quote calling out RSigma's dynamic-pipelines model.
 * **Contributing guidelines:** the `docs/` MkDocs site is now listed as a release deliverable in `CONTRIBUTING.md` alongside the crate READMEs, with a page-to-change matrix that maps each kind of change (new CLI flag, new daemon config key, new library API, new metric, new feature flag) to the page that must stay in sync.
+
+[v0.12.0...v0.13.0](https://github.com/timescale/rsigma/compare/v0.12.0...v0.13.0)
 
 ## [0.12.0] - 2026-05-20
 
@@ -1405,6 +1418,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.13.0]: https://github.com/timescale/rsigma/releases/tag/v0.13.0
 [0.12.0]: https://github.com/timescale/rsigma/releases/tag/v0.12.0
 [0.11.0]: https://github.com/timescale/rsigma/releases/tag/v0.11.0
 [0.10.0]: https://github.com/timescale/rsigma/releases/tag/v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arc-swap",
  "assert_cmd",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "insta",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "globset",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arc-swap",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -30,10 +30,10 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.12.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.12.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.12.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.13.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.13.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.13.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.12.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.13.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.12.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.13.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -19,8 +19,8 @@ evtx = ["dep:evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.12.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.12.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.13.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde_json = "1"
 yaml_serde = "0.10"


### PR DESCRIPTION
## Summary

Release v0.13.0. Bumps the workspace from 0.12.0 to 0.13.0 (workspace package version + six inter-crate path pins), refreshes `Cargo.lock` workspace-only, and finalizes [`CHANGELOG.md`](CHANGELOG.md) by renaming the `[Unreleased]` block to `[0.13.0] - 2026-05-26` with a TL;DR.

Headline framing: the "post-evaluation enrichment, server-side TLS, and field observability" release.

- Post-evaluation enrichment (#134): four primitives, kind separation, scope filters, six metrics, `register_builtin` registry.
- Server-side TLS for the daemon API listener (#128): `daemon-tls` feature, mTLS, cross-platform cert hot-reload.
- Field observability (#149): `--observe-fields` on daemon and eval, four `/api/v1/fields/*` endpoints, three Prometheus surfaces.
- Detached dynamic sources (#135): `--source <file_or_dir>`, `DaemonSourceRegistry`, `rsigma rule migrate-sources`.
- Unified `EvaluationResult` (#132) and the deprecated CLI aliases hidden from `--help` (#125).
- Drop reserved `attack` subcommand group; namespace freed for a future contributor PR.
- Dependency and security bumps (#145).

Full release notes: see the new `[0.13.0]` section in `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (1491 passed)
- [x] `mkdocs build --strict`
- [x] `cargo deny check`

## Post-merge

After merge, tag `v0.13.0` on `main` and create the GitHub Release using the `[0.13.0]` body verbatim. The `publish.yml`, `release-binaries.yml`, and `docker.yml` workflows fire on `release: published`.