### PR TITLE
feat(cli): TTY-aware output + structured output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### TTY-aware output + structured output formats
+### TTY-aware output + structured output formats (#157)
 
 Every rsigma subcommand can now emit its structured output in one of five formats, selected by a new **global** `--output-format <json|ndjson|table|csv|tsv>` flag. The default is TTY-aware: pretty JSON when stdout is a terminal, plain NDJSON when piped or redirected, so `rsigma engine eval … | jq` does the right thing without any extra flag and `rsigma engine eval` in a terminal is finally readable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### TTY-aware output + structured output formats
+
+Every rsigma subcommand can now emit its structured output in one of five formats, selected by a new **global** `--output-format <json|ndjson|table|csv|tsv>` flag. The default is TTY-aware: pretty JSON when stdout is a terminal, plain NDJSON when piped or redirected, so `rsigma engine eval … | jq` does the right thing without any extra flag and `rsigma engine eval` in a terminal is finally readable.
+
+**New global flags.** Three more global knobs ride alongside `--output-format` and the existing `--log-format`:
+
+- `--color <auto|always|never>` honours [`NO_COLOR`](https://no-color.org/) under `auto` (the default).
+- `--quiet` / `-q` suppresses every non-data line (progress, summary, fallback warnings); errors still go to stderr.
+- `--no-stats` suppresses only the trailing summary line; progress messages still appear.
+
+All four resolve through the same layered precedence as the rest of the config: **flag > `RSIGMA_GLOBAL__*` env > `global.*` in the YAML config > TTY-aware default**.
+
+**Per-command rendering.**
+
+- **`engine eval`** is the showcase. `table` renders a `LEVEL | RULE | TYPE | DETAIL` summary (numeric columns right-aligned). `csv` and `tsv` stream a header line plus one row per match. `--pretty` is preserved as a backwards-compatibility alias for "pretty JSON" and wins over the TTY default.
+- **`rule fields`** folds its `--json` flag into the new selector; `--json` is kept as a hidden deprecated alias for `--output-format json`. The legacy table view stays the default even when piped, so existing pipelines are unchanged. `--output-format ndjson` streams one field record per line.
+- **`rule lint`** keeps the coloured human view as the default. `--output-format json` emits a `{summary, findings}` envelope; `ndjson` streams one `Finding` per line; `csv` / `tsv` write a `PATH,SEVERITY,RULE,LINE,MESSAGE` table. The per-command `--color` flag is gone in favour of the global one; behaviour is identical.
+- **`rule parse`**, **`rule condition`**, **`rule stdin`**: routed through the shared JSON renderer; `--pretty` still defaults to on (the AST is small and human-friendly is the default).
+- **`backend convert`**: keeps its existing `-f, --format` for the backend query format and `-o, --output` for the output file unchanged. `--output-format json` wraps the queries in a `{target, format, queries: [{rule_title, rule_id, query}, …]}` envelope. The non-JSON tabular formats are not meaningful for free-form query text, so the command prints a stderr warning and falls back to raw text (the warning is itself suppressible with `--quiet`).
+
+**Output module.** A new `crates/rsigma-cli/src/output/` module owns the `OutputFormat` and `ColorChoice` enums, the `OutputCtx` resolver, the `Tabular` trait + width-aligning `render_table` (with auto-right-align for numeric columns), the streaming `DelimitedWriter` for CSV/TSV (hand-rolled RFC 4180-style escaping, no new dependency), and the `Painter` previously in `commands/lint.rs` (now reused by every command). The lint Painter is gone; the shared one resolves color from `--color` plus `NO_COLOR` plus TTY detection just like before.
+
+**Config schema.** `global.format` is renamed to `global.output_format` (the old key was reserved for this work and was inert), and `eval.format` is dropped (it was inert too). The committed template, the JSON Schema emitted by `rsigma config schema`, and the schema drift-guard test all reflect the rename.
+
+**Tests.** New unit tests in `crates/rsigma-cli/src/output/mod.rs` cover format / color parsing, TTY default resolution, `--quiet` / `--no-stats` semantics, CSV/TSV escaping edge cases, and the `Tabular` row shape. A new `crates/rsigma-cli/tests/cli_output_format.rs` integration suite (19 tests) exercises every format end to end on `engine eval`, `rule lint`, `rule fields`, and `backend convert`, plus the env-layer and config-file resolution and the flag-beats-env precedence.
+
+**Docs.** New canonical `docs/reference/output.md` page (registered in `docs/reference/.pages`) covering formats, TTY behaviour, color, quiet/no-stats, precedence, and per-command behaviour. The eval CLI doc gains an output-format section and a table-view example; the env-vars doc lists the two new variables; root README and CLI README gain a Global flags section. The configuration reference example shows the new `global.output_format` / `global.color` keys.
+
 ### Layered YAML configuration + `rsigma config` group (#152)
 
 `engine daemon` and `engine eval` are now driven by an optional layered YAML config file with explicit precedence **CLI flag > env > project file > user file > system file > compiled default**, applied per leaf. The same machinery is exposed through a new `rsigma config` command group for scaffolding, validation, introspection, and reload.

--- a/README.md
+++ b/README.md
@@ -118,8 +118,14 @@ cosign verify \
 # Evaluate a single event against Sigma rules
 rsigma engine eval -r rules/ -e '{"CommandLine": "cmd /c whoami"}'
 
-# Stream NDJSON from stdin
+# Stream NDJSON from stdin (auto-selected when stdout is piped)
 cat events.ndjson | rsigma engine eval -r rules/
+
+# Interactive triage in a terminal: width-aligned table view
+rsigma engine eval -r rules/ -e @events.ndjson --output-format table
+
+# Pipe a CSV view into a spreadsheet or data tool
+rsigma engine eval -r rules/ -e @events.ndjson --output-format csv > matches.csv
 
 # Run as a daemon with hot-reload and Prometheus metrics
 rsigma engine daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -18,8 +18,14 @@ cargo install rsigma
 # Single event (inline JSON)
 rsigma engine eval -r path/to/rules/ -e '{"CommandLine": "cmd /c whoami"}'
 
-# Stream NDJSON from stdin
+# Stream NDJSON from stdin (auto-selected when piped)
 cat events.ndjson | rsigma engine eval -r path/to/rules/
+
+# Table view for interactive triage
+rsigma engine eval -r path/to/rules/ -e @events.ndjson --output-format table
+
+# CSV for spreadsheets / data tools
+rsigma engine eval -r path/to/rules/ -e @events.ndjson --output-format csv
 
 # Long-running daemon with hot-reload, health checks, and Prometheus metrics
 hel run | rsigma engine daemon -r rules/ -p ecs_windows --api-addr 0.0.0.0:9090
@@ -42,6 +48,18 @@ rsigma rule fields -r rules/ -p ecs_windows
 # List available conversion backends
 rsigma backend targets
 ```
+
+## Global flags
+
+These flags work with every subcommand, mirroring how `--log-format` does, and they also resolve from the YAML config and the `RSIGMA_*` env layer (see [Output Formats](https://timescale.github.io/rsigma/reference/output/)).
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output-format <FORMAT>` | TTY-aware (pretty `json` on a terminal, `ndjson` when piped) | One of `json`, `ndjson`, `table`, `csv`, `tsv`. `engine eval`, `rule fields`, and `rule lint` honour every value; `backend convert` honours `json` (wraps queries) and warns + falls back to raw text for `table`/`csv`/`tsv`. |
+| `--color <CHOICE>` | `auto` | One of `auto`, `always`, `never`. `auto` honours `NO_COLOR` and disables colour when stdout is not a TTY. |
+| `--quiet`, `-q` | off | Suppress every non-data line (progress, stats, fallback warnings). Errors still go to stderr. |
+| `--no-stats` | off | Suppress only the trailing summary; progress messages still appear. |
+| `--log-format <FORMAT>` | unset | When set, initialises a stderr `tracing` subscriber in `text` or `json`. Diagnostic logs only; does not affect stdout. |
 
 ## Subcommands
 
@@ -140,7 +158,6 @@ Run 66 built-in lint rules with optional JSON schema validation.
 | `path` | positional | required | Path to a Sigma rule file or directory |
 | `--schema` / `-s` | string | none | `"default"` to download the official schema (cached 7 days), or a path to a local JSON schema file |
 | `--verbose` / `-v` | flag | `false` | Show details for all files, including those that pass |
-| `--color` | string | `"auto"` | `auto`, `always`, or `never` |
 | `--disable` | string | `""` | Comma-separated lint rule IDs to suppress |
 | `--config` | path | none | Explicit path to `.rsigma-lint.yml` (otherwise auto-discovered by walking ancestor directories) |
 | `--exclude` | string | none | Glob pattern for paths to skip (repeatable, relative to lint root) |
@@ -152,7 +169,8 @@ rsigma rule lint path/to/rules/                     # lint all rules
 rsigma rule lint path/to/rules/ -v                  # verbose (show passing files + info-only)
 rsigma rule lint path/to/rules/ --schema default    # + JSON schema validation (downloads + caches)
 rsigma rule lint rule.yml --schema my-schema.json   # local JSON schema
-rsigma rule lint path/to/rules/ --color always      # force color
+rsigma rule lint path/to/rules/ --color always      # force color (global flag)
+rsigma rule lint path/to/rules/ --output-format json # machine-readable {summary,findings}
 rsigma rule lint rules/ --disable missing_description,missing_author  # suppress specific rules
 rsigma rule lint rules/ --config my-lint.yml        # explicit config file
 rsigma rule lint rules/ --exclude "config/**"       # skip non-rule files

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -4,7 +4,7 @@ use std::process;
 use clap::Args;
 use rsigma_parser::{SigmaCollection, parse_sigma_directory, parse_sigma_file};
 
-use crate::output::OutputCtx;
+use crate::output::{OutputCtx, OutputFormat, render_json};
 
 /// Arguments for `rsigma backend convert` (and the deprecated `rsigma convert`).
 #[derive(Args, Debug)]
@@ -62,7 +62,7 @@ fn get_backend(
     }
 }
 
-pub(crate) fn cmd_convert(args: ConvertArgs, _ctx: OutputCtx) {
+pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
     let ConvertArgs {
         rules,
         target,
@@ -129,6 +129,43 @@ pub(crate) fn cmd_convert(args: ConvertArgs, _ctx: OutputCtx) {
             }
             if !skip_unsupported && !output_data.errors.is_empty() {
                 process::exit(crate::exit_code::RULE_ERROR);
+            }
+            // `--output-format json` wraps the queries in a JSON envelope.
+            // The other structured formats (`ndjson`/`csv`/`tsv`/`table`)
+            // make no sense for free-form query text -- warn once on stderr
+            // and fall back to the raw text path.
+            if ctx.format == OutputFormat::Json && output.is_none() {
+                let queries: Vec<serde_json::Value> = output_data
+                    .queries
+                    .iter()
+                    .flat_map(|r| {
+                        r.queries.iter().map(move |q| {
+                            serde_json::json!({
+                                "rule_title": r.rule_title,
+                                "rule_id": r.rule_id,
+                                "query": q,
+                            })
+                        })
+                    })
+                    .collect();
+                render_json(
+                    &serde_json::json!({
+                        "target": target,
+                        "format": format,
+                        "queries": queries,
+                    }),
+                    ctx.pretty_json(),
+                );
+                return;
+            }
+            if ctx.explicit_format
+                && !matches!(ctx.format, OutputFormat::Json | OutputFormat::Ndjson)
+                && ctx.show_progress()
+            {
+                eprintln!(
+                    "warning: `--output-format {}` is not supported by `backend convert`; falling back to raw query text.",
+                    ctx.format.as_str(),
+                );
             }
             let all_queries: Vec<&str> = output_data
                 .queries

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -4,6 +4,8 @@ use std::process;
 use clap::Args;
 use rsigma_parser::{SigmaCollection, parse_sigma_directory, parse_sigma_file};
 
+use crate::output::OutputCtx;
+
 /// Arguments for `rsigma backend convert` (and the deprecated `rsigma convert`).
 #[derive(Args, Debug)]
 pub(crate) struct ConvertArgs {
@@ -60,7 +62,7 @@ fn get_backend(
     }
 }
 
-pub(crate) fn cmd_convert(args: ConvertArgs) {
+pub(crate) fn cmd_convert(args: ConvertArgs, _ctx: OutputCtx) {
     let ConvertArgs {
         rules,
         target,

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -7,13 +7,15 @@ use std::sync::Arc;
 use clap::parser::ValueSource;
 use clap::{ArgMatches, Args};
 use rsigma_eval::{
-    CorrelationEngine, Engine, Event, FieldObserver, JsonEvent, Pipeline, RuleFieldSet,
+    CorrelationEngine, Engine, EvaluationResult, Event, FieldObserver, JsonEvent, Pipeline,
+    ResultBody, RuleFieldSet,
 };
 use rsigma_parser::SigmaCollection;
 
 use crate::EventFilter;
 use crate::config;
 use crate::exit_code;
+use crate::output::{DelimitedWriter, OutputCtx, OutputFormat, Tabular};
 
 /// Arguments for `rsigma engine eval` (and the deprecated `rsigma eval`).
 #[derive(Args, Debug)]
@@ -267,7 +269,7 @@ fn overlay_eval_config(
 }
 
 /// Returns `true` if any detection or correlation matched.
-pub(crate) fn cmd_eval(args: EvalArgs) -> bool {
+pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
     let EvalArgs {
         config: _,
         dry_run: _,
@@ -304,7 +306,7 @@ pub(crate) fn cmd_eval(args: EvalArgs) -> bool {
     let collection = crate::load_collection(&rules_path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
-    if pipelines.iter().any(|p| p.is_dynamic()) {
+    if pipelines.iter().any(|p| p.is_dynamic()) && ctx.show_progress() {
         eprintln!(
             "  note: dynamic sources are not resolved by `rsigma engine eval`. \
              Use `rsigma pipeline resolve` to inspect sources or `rsigma engine daemon` to evaluate \
@@ -345,12 +347,17 @@ pub(crate) fn cmd_eval(args: EvalArgs) -> bool {
     };
     let observe_ref = observe_ctx.as_ref();
 
+    // The match renderer encapsulates the selected output format. `--pretty`
+    // is honoured for backwards compatibility: it implies the JSON branch and
+    // turns pretty-printing on even when stdout is not a TTY.
+    let mut renderer = MatchRenderer::new(ctx, pretty);
+
     let had_matches = if has_correlations {
         cmd_eval_with_correlations(
             collection,
             &rules_path,
             event_source,
-            pretty,
+            &mut renderer,
             &pipelines,
             &event_filter,
             corr_config,
@@ -368,7 +375,7 @@ pub(crate) fn cmd_eval(args: EvalArgs) -> bool {
             collection,
             &rules_path,
             event_source,
-            pretty,
+            &mut renderer,
             &pipelines,
             &event_filter,
             include_event,
@@ -382,8 +389,10 @@ pub(crate) fn cmd_eval(args: EvalArgs) -> bool {
         )
     };
 
-    if let Some(ctx) = observe_ref {
-        render_field_report(ctx);
+    renderer.flush();
+
+    if let Some(octx) = observe_ref {
+        render_field_report(octx);
     }
 
     had_matches
@@ -395,7 +404,7 @@ fn cmd_eval_with_correlations(
     collection: SigmaCollection,
     rules_path: &std::path::Path,
     event_source: EventSource,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     pipelines: &[Pipeline],
     event_filter: &EventFilter,
     config: rsigma_eval::CorrelationConfig,
@@ -423,12 +432,14 @@ fn cmd_eval_with_correlations(
         process::exit(crate::exit_code::RULE_ERROR);
     }
 
-    eprintln!(
-        "Loaded {} detection rules + {} correlation rules from {}",
-        engine.detection_rule_count(),
-        engine.correlation_rule_count(),
-        rules_path.display(),
-    );
+    if renderer.ctx().show_progress() {
+        eprintln!(
+            "Loaded {} detection rules + {} correlation rules from {}",
+            engine.detection_rule_count(),
+            engine.correlation_rule_count(),
+            rules_path.display(),
+        );
+    }
     tracing::info!(
         detection_rules = engine.detection_rule_count(),
         correlation_rules = engine.correlation_rule_count(),
@@ -453,11 +464,13 @@ fn cmd_eval_with_correlations(
                 let result = engine.process_event(&event);
 
                 if result.is_empty() {
-                    eprintln!("No matches.");
+                    if renderer.ctx().show_progress() {
+                        eprintln!("No matches.");
+                    }
                 } else {
                     had_matches = true;
                     for m in &result {
-                        crate::print_json(m, pretty);
+                        renderer.emit(m);
                     }
                 }
             }
@@ -473,23 +486,27 @@ fn cmd_eval_with_correlations(
                 &mut engine,
                 reader,
                 event_filter,
-                pretty,
+                renderer,
                 input_format_str,
                 syslog_tz_str,
                 observe,
             );
-            eprintln!(
-                "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
-            );
+            if renderer.ctx().show_stats() {
+                eprintln!(
+                    "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
+                );
+            }
             det_count > 0 || corr_count > 0
         }
         #[cfg(feature = "evtx")]
         EventSource::EvtxFile(path) => {
             let (det_count, corr_count, rec_count) =
-                eval_evtx_corr(&mut engine, &path, event_filter, pretty, observe);
-            eprintln!(
-                "Processed {rec_count} EVTX records, {det_count} detection matches, {corr_count} correlation matches."
-            );
+                eval_evtx_corr(&mut engine, &path, event_filter, renderer, observe);
+            if renderer.ctx().show_stats() {
+                eprintln!(
+                    "Processed {rec_count} EVTX records, {det_count} detection matches, {corr_count} correlation matches."
+                );
+            }
             det_count > 0 || corr_count > 0
         }
         EventSource::Stdin => {
@@ -498,14 +515,16 @@ fn cmd_eval_with_correlations(
                 &mut engine,
                 stdin.lock(),
                 event_filter,
-                pretty,
+                renderer,
                 input_format_str,
                 syslog_tz_str,
                 observe,
             );
-            eprintln!(
-                "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
-            );
+            if renderer.ctx().show_stats() {
+                eprintln!(
+                    "Processed {line_num} events, {det_count} detection matches, {corr_count} correlation matches."
+                );
+            }
             det_count > 0 || corr_count > 0
         }
     }
@@ -518,7 +537,7 @@ fn eval_stream_corr(
     engine: &mut CorrelationEngine,
     reader: impl BufRead,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     input_format_str: &str,
     syslog_tz_str: &str,
     observe: Option<&ObserveContext>,
@@ -554,7 +573,7 @@ fn eval_stream_corr(
                 &line,
                 &format,
                 event_filter,
-                pretty,
+                renderer,
                 &mut det_count,
                 &mut corr_count,
                 observe,
@@ -566,7 +585,7 @@ fn eval_stream_corr(
                 engine,
                 &line,
                 event_filter,
-                pretty,
+                renderer,
                 &mut det_count,
                 &mut corr_count,
                 observe,
@@ -585,7 +604,7 @@ fn eval_line_corr(
     line: &str,
     format: &rsigma_runtime::InputFormat,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     det_count: &mut u64,
     corr_count: &mut u64,
     observe: Option<&ObserveContext>,
@@ -604,7 +623,7 @@ fn eval_line_corr(
                     } else {
                         *corr_count += 1;
                     }
-                    crate::print_json(m, pretty);
+                    renderer.emit(m);
                 }
             }
         } else {
@@ -617,7 +636,7 @@ fn eval_line_corr(
                 } else {
                     *corr_count += 1;
                 }
-                crate::print_json(m, pretty);
+                renderer.emit(m);
             }
         }
     }
@@ -630,7 +649,7 @@ fn eval_line_corr_json(
     engine: &mut CorrelationEngine,
     line: &str,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     det_count: &mut u64,
     corr_count: &mut u64,
     observe: Option<&ObserveContext>,
@@ -653,7 +672,7 @@ fn eval_line_corr_json(
             } else {
                 *corr_count += 1;
             }
-            crate::print_json(m, pretty);
+            renderer.emit(m);
         }
     }
 }
@@ -664,7 +683,7 @@ fn cmd_eval_detection_only(
     collection: SigmaCollection,
     rules_path: &std::path::Path,
     event_source: EventSource,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     pipelines: &[Pipeline],
     event_filter: &EventFilter,
     include_event: bool,
@@ -691,11 +710,13 @@ fn cmd_eval_detection_only(
         process::exit(crate::exit_code::RULE_ERROR);
     }
 
-    eprintln!(
-        "Loaded {} rules from {}",
-        engine.rule_count(),
-        rules_path.display()
-    );
+    if renderer.ctx().show_progress() {
+        eprintln!(
+            "Loaded {} rules from {}",
+            engine.rule_count(),
+            rules_path.display()
+        );
+    }
     tracing::info!(
         detection_rules = engine.rule_count(),
         correlation_rules = 0,
@@ -716,7 +737,9 @@ fn cmd_eval_detection_only(
             let mut had_matches = false;
             let payloads = crate::apply_event_filter(&value, event_filter);
             if payloads.is_empty() {
-                eprintln!("No matches.");
+                if renderer.ctx().show_progress() {
+                    eprintln!("No matches.");
+                }
             } else {
                 for payload in &payloads {
                     let event = JsonEvent::borrow(payload);
@@ -724,11 +747,13 @@ fn cmd_eval_detection_only(
                     let matches = engine.evaluate(&event);
 
                     if matches.is_empty() {
-                        eprintln!("No matches.");
+                        if renderer.ctx().show_progress() {
+                            eprintln!("No matches.");
+                        }
                     } else {
                         had_matches = true;
                         for m in &matches {
-                            crate::print_json(m, pretty);
+                            renderer.emit(m);
                         }
                     }
                 }
@@ -745,19 +770,23 @@ fn cmd_eval_detection_only(
                 &engine,
                 reader,
                 event_filter,
-                pretty,
+                renderer,
                 input_format_str,
                 syslog_tz_str,
                 observe,
             );
-            eprintln!("Processed {line_num} events, {match_count} matches.");
+            if renderer.ctx().show_stats() {
+                eprintln!("Processed {line_num} events, {match_count} matches.");
+            }
             match_count > 0
         }
         #[cfg(feature = "evtx")]
         EventSource::EvtxFile(path) => {
             let (match_count, rec_count) =
-                eval_evtx_detect(&engine, &path, event_filter, pretty, observe);
-            eprintln!("Processed {rec_count} EVTX records, {match_count} matches.");
+                eval_evtx_detect(&engine, &path, event_filter, renderer, observe);
+            if renderer.ctx().show_stats() {
+                eprintln!("Processed {rec_count} EVTX records, {match_count} matches.");
+            }
             match_count > 0
         }
         EventSource::Stdin => {
@@ -766,12 +795,14 @@ fn cmd_eval_detection_only(
                 &engine,
                 stdin.lock(),
                 event_filter,
-                pretty,
+                renderer,
                 input_format_str,
                 syslog_tz_str,
                 observe,
             );
-            eprintln!("Processed {line_num} events, {match_count} matches.");
+            if renderer.ctx().show_stats() {
+                eprintln!("Processed {line_num} events, {match_count} matches.");
+            }
             match_count > 0
         }
     }
@@ -784,7 +815,7 @@ fn eval_stream_detect(
     engine: &Engine,
     reader: impl BufRead,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     input_format_str: &str,
     syslog_tz_str: &str,
     observe: Option<&ObserveContext>,
@@ -818,7 +849,7 @@ fn eval_stream_detect(
                 &line,
                 &format,
                 event_filter,
-                pretty,
+                renderer,
                 &mut match_count,
                 observe,
             );
@@ -829,7 +860,7 @@ fn eval_stream_detect(
                 engine,
                 &line,
                 event_filter,
-                pretty,
+                renderer,
                 &mut match_count,
                 observe,
             );
@@ -847,7 +878,7 @@ fn eval_line_detect(
     line: &str,
     format: &rsigma_runtime::InputFormat,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     match_count: &mut u64,
     observe: Option<&ObserveContext>,
 ) {
@@ -859,14 +890,14 @@ fn eval_line_detect(
                 observe_event(observe, &event);
                 for m in &engine.evaluate(&event) {
                     *match_count += 1;
-                    crate::print_json(m, pretty);
+                    renderer.emit(m);
                 }
             }
         } else {
             observe_event(observe, &decoded);
             for m in &engine.evaluate(&decoded) {
                 *match_count += 1;
-                crate::print_json(m, pretty);
+                renderer.emit(m);
             }
         }
     }
@@ -878,7 +909,7 @@ fn eval_line_detect_json(
     engine: &Engine,
     line: &str,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     match_count: &mut u64,
     observe: Option<&ObserveContext>,
 ) {
@@ -895,7 +926,7 @@ fn eval_line_detect_json(
         observe_event(observe, &event);
         for m in &engine.evaluate(&event) {
             *match_count += 1;
-            crate::print_json(m, pretty);
+            renderer.emit(m);
         }
     }
 }
@@ -911,7 +942,7 @@ fn eval_evtx_corr(
     engine: &mut CorrelationEngine,
     path: &std::path::Path,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     observe: Option<&ObserveContext>,
 ) -> (u64, u64, u64) {
     let mut reader = rsigma_runtime::EvtxFileReader::open(path).unwrap_or_else(|e| {
@@ -943,7 +974,7 @@ fn eval_evtx_corr(
                 } else {
                     corr_count += 1;
                 }
-                crate::print_json(m, pretty);
+                renderer.emit(m);
             }
         }
     }
@@ -958,7 +989,7 @@ fn eval_evtx_detect(
     engine: &Engine,
     path: &std::path::Path,
     event_filter: &EventFilter,
-    pretty: bool,
+    renderer: &mut MatchRenderer,
     observe: Option<&ObserveContext>,
 ) -> (u64, u64) {
     let mut reader = rsigma_runtime::EvtxFileReader::open(path).unwrap_or_else(|e| {
@@ -984,7 +1015,7 @@ fn eval_evtx_detect(
             observe_event(observe, &event);
             for m in &engine.evaluate(&event) {
                 match_count += 1;
-                crate::print_json(m, pretty);
+                renderer.emit(m);
             }
         }
     }
@@ -1106,6 +1137,190 @@ fn write_report_to_file(path: &Path, serialized: &str) -> std::io::Result<()> {
     file.write_all(serialized.as_bytes())?;
     file.write_all(b"\n")?;
     file.flush()
+}
+
+// ---------------------------------------------------------------------------
+// MatchRenderer: format-aware streaming output for evaluation results
+// ---------------------------------------------------------------------------
+
+/// Format-aware streaming sink for [`EvaluationResult`] records.
+///
+/// Built once per `cmd_eval` call from the resolved [`OutputCtx`]. JSON and
+/// the delimited formats stream per match; `table` buffers and renders in
+/// [`MatchRenderer::flush`].
+///
+/// The legacy `--pretty` flag flips the JSON branch to pretty-print even
+/// when stdout is piped, so callers can still get pretty JSON in CI logs.
+struct MatchRenderer {
+    ctx: OutputCtx,
+    state: RenderState,
+}
+
+enum RenderState {
+    /// Plain JSON (one object per line, pretty if requested).
+    Json { pretty: bool },
+    /// Streaming delimited writer (`csv` or `tsv`).
+    Delimited(DelimitedWriter),
+    /// Buffer of rows for the width-aligning table renderer.
+    Table(Vec<EvalRow>),
+}
+
+impl MatchRenderer {
+    fn new(ctx: OutputCtx, pretty_flag: bool) -> Self {
+        // `--pretty` was the historical way to opt into pretty-printed JSON.
+        // The operator explicitly asked for that, so honour it regardless of
+        // the resolved format (it would be confusing if `--pretty` silently
+        // turned into compact NDJSON when piped).
+        let state = if pretty_flag && !ctx.explicit_format {
+            RenderState::Json { pretty: true }
+        } else {
+            match ctx.format {
+                OutputFormat::Json => RenderState::Json {
+                    pretty: pretty_flag || ctx.pretty_json(),
+                },
+                OutputFormat::Ndjson => RenderState::Json { pretty: false },
+                OutputFormat::Csv => {
+                    RenderState::Delimited(DelimitedWriter::new(',', EvalRow::headers()))
+                }
+                OutputFormat::Tsv => {
+                    RenderState::Delimited(DelimitedWriter::new('\t', EvalRow::headers()))
+                }
+                OutputFormat::Table => RenderState::Table(Vec::new()),
+            }
+        };
+        Self { ctx, state }
+    }
+
+    fn ctx(&self) -> &OutputCtx {
+        &self.ctx
+    }
+
+    /// Emit one match in the configured format.
+    fn emit(&mut self, m: &EvaluationResult) {
+        match &mut self.state {
+            RenderState::Json { pretty } => crate::output::render_json(m, *pretty),
+            RenderState::Delimited(writer) => {
+                let row = EvalRow::from_result(m).row();
+                writer.push(&row);
+            }
+            RenderState::Table(rows) => rows.push(EvalRow::from_result(m)),
+        }
+    }
+
+    /// Render any buffered output. No-op for the streaming formats.
+    fn flush(&mut self) {
+        if let RenderState::Table(rows) = &self.state {
+            crate::output::render_table(rows);
+        }
+    }
+}
+
+/// Tabular row projection of an [`EvaluationResult`] for `--output-format
+/// table|csv|tsv`. Four columns by design:
+///
+/// * `LEVEL`: rule level (`info`, `low`, `medium`, `high`, `critical`) or
+///   `-` when the rule did not set one.
+/// * `RULE`: rule title.
+/// * `TYPE`: `detection` for plain matches, the correlation type name
+///   (`event_count`, `temporal`, …) for correlation firings.
+/// * `DETAIL`: a one-line summary -- matched fields for detections,
+///   `group_key` plus the aggregated value for correlations.
+///
+/// JSON / NDJSON output preserves the full record; the projection here is
+/// for the human / spreadsheet views.
+#[derive(Clone)]
+struct EvalRow {
+    level: String,
+    rule: String,
+    kind: String,
+    detail: String,
+}
+
+const ROW_HEADERS: &[&str] = &["LEVEL", "RULE", "TYPE", "DETAIL"];
+
+const DETAIL_MAX: usize = 200;
+
+impl EvalRow {
+    fn from_result(m: &EvaluationResult) -> Self {
+        let level = m
+            .header
+            .level
+            .as_ref()
+            .map(|l| l.as_str().to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let rule = m.header.rule_title.clone();
+        let (kind, detail) = match &m.body {
+            ResultBody::Detection(d) => {
+                let detail = d
+                    .matched_fields
+                    .iter()
+                    .map(|fm| format!("{}={}", fm.field, summarize_value(&fm.value)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ("detection".to_string(), truncate(detail))
+            }
+            ResultBody::Correlation(c) => {
+                let group = c
+                    .group_key
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let detail = if group.is_empty() {
+                    format!("agg={}", c.aggregated_value)
+                } else {
+                    format!("{group} | agg={}", c.aggregated_value)
+                };
+                (c.correlation_type.as_str().to_string(), truncate(detail))
+            }
+        };
+        Self {
+            level,
+            rule,
+            kind,
+            detail,
+        }
+    }
+}
+
+impl Tabular for EvalRow {
+    fn headers() -> &'static [&'static str] {
+        ROW_HEADERS
+    }
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.level.clone(),
+            self.rule.clone(),
+            self.kind.clone(),
+            self.detail.clone(),
+        ]
+    }
+}
+
+/// Render a matched-field value as a compact one-line string. The full
+/// payload is always available via `--output-format ndjson` if needed.
+fn summarize_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        // Compact JSON for arrays/objects keeps the table on one line.
+        other => other.to_string(),
+    }
+}
+
+/// Cap a detail cell at [`DETAIL_MAX`] characters. Long values get a `…`
+/// suffix so a single wide field cannot derail the table layout.
+fn truncate(mut s: String) -> String {
+    if s.chars().count() <= DETAIL_MAX {
+        return s;
+    }
+    let truncated: String = s.chars().take(DETAIL_MAX - 1).collect();
+    s.clear();
+    s.push_str(&truncated);
+    s.push('…');
+    s
 }
 
 #[cfg(test)]

--- a/crates/rsigma-cli/src/commands/fields.rs
+++ b/crates/rsigma-cli/src/commands/fields.rs
@@ -5,6 +5,8 @@ use rsigma_eval::{FieldOrigin, FieldSource, Pipeline, RuleFieldSet};
 use rsigma_parser::SigmaCollection;
 use serde::Serialize;
 
+use crate::output::OutputCtx;
+
 /// Arguments for `rsigma rule fields` (and the deprecated `rsigma fields`).
 #[derive(Args, Debug)]
 pub(crate) struct FieldsArgs {
@@ -26,7 +28,7 @@ pub(crate) struct FieldsArgs {
     pub json: bool,
 }
 
-pub(crate) fn cmd_fields(args: FieldsArgs) {
+pub(crate) fn cmd_fields(args: FieldsArgs, ctx: OutputCtx) {
     let FieldsArgs {
         rules: path,
         pipelines: pipeline_paths,
@@ -36,7 +38,7 @@ pub(crate) fn cmd_fields(args: FieldsArgs) {
     let collection = crate::load_collection(&path);
     let pipelines = crate::load_pipelines(&pipeline_paths);
 
-    if pipelines.iter().any(|p| p.is_dynamic()) {
+    if pipelines.iter().any(|p| p.is_dynamic()) && ctx.show_progress() {
         eprintln!(
             "  note: dynamic sources are not resolved by `rsigma rule fields`. \
              Use `rsigma pipeline resolve` to inspect sources or `rsigma engine daemon` to evaluate \

--- a/crates/rsigma-cli/src/commands/fields.rs
+++ b/crates/rsigma-cli/src/commands/fields.rs
@@ -5,7 +5,7 @@ use rsigma_eval::{FieldOrigin, FieldSource, Pipeline, RuleFieldSet};
 use rsigma_parser::SigmaCollection;
 use serde::Serialize;
 
-use crate::output::OutputCtx;
+use crate::output::{DelimitedWriter, OutputCtx, OutputFormat, Tabular, render_json};
 
 /// Arguments for `rsigma rule fields` (and the deprecated `rsigma fields`).
 #[derive(Args, Debug)]
@@ -23,8 +23,8 @@ pub(crate) struct FieldsArgs {
     #[arg(long)]
     pub no_filters: bool,
 
-    /// Output as JSON instead of a table
-    #[arg(long)]
+    /// Deprecated alias for `--output-format json`. Hidden from `--help`.
+    #[arg(long, hide = true)]
     pub json: bool,
 }
 
@@ -48,10 +48,51 @@ pub(crate) fn cmd_fields(args: FieldsArgs, ctx: OutputCtx) {
 
     let report = build_report(&collection, &pipelines, no_filters);
 
-    if json {
-        crate::print_json(&report, true);
+    // Resolve the effective format. `--json` is a deprecated alias for
+    // `--output-format json` and always wins when set. Otherwise we honour
+    // an *explicit* `--output-format` flag; without one, the legacy table
+    // view stays the default (the TTY-aware NDJSON fallback would regress
+    // the existing `rule fields` UX).
+    let format = if json {
+        OutputFormat::Json
+    } else if ctx.explicit_format {
+        ctx.format
     } else {
-        print_table(&report);
+        OutputFormat::Table
+    };
+
+    match format {
+        OutputFormat::Json => render_json(&report, true),
+        OutputFormat::Ndjson => {
+            // Emit one row per field plus a summary record so the stream is
+            // line-oriented end to end.
+            for entry in &report.fields {
+                render_json(entry, false);
+            }
+        }
+        OutputFormat::Csv => render_fields_delimited(&report, ',', &ctx),
+        OutputFormat::Tsv => render_fields_delimited(&report, '\t', &ctx),
+        OutputFormat::Table => print_table(&report, &ctx),
+    }
+}
+
+/// Render the field catalog as CSV/TSV. Summary goes to stderr (gated on
+/// `show_stats`); the data rows go to stdout.
+fn render_fields_delimited(report: &FieldsReport, sep: char, ctx: &OutputCtx) {
+    if ctx.show_stats() {
+        let s = &report.summary;
+        eprintln!(
+            "Rules: {} detection, {} correlation, {} filter | Pipelines: {} | Unique fields: {}",
+            s.total_rules,
+            s.total_correlations,
+            s.total_filters,
+            s.pipelines_applied,
+            s.unique_fields,
+        );
+    }
+    let mut writer = DelimitedWriter::new(sep, FieldEntry::headers());
+    for entry in &report.fields {
+        writer.push(&entry.row());
     }
 }
 
@@ -198,63 +239,45 @@ fn build_report(
 // Table output
 // ---------------------------------------------------------------------------
 
-fn print_table(report: &FieldsReport) {
-    let s = &report.summary;
-    eprintln!(
-        "Rules: {} detection, {} correlation, {} filter | Pipelines: {} | Unique fields: {}",
-        s.total_rules, s.total_correlations, s.total_filters, s.pipelines_applied, s.unique_fields
-    );
-
-    if report.fields.is_empty() {
-        eprintln!("No fields found.");
-        return;
+impl Tabular for FieldEntry {
+    fn headers() -> &'static [&'static str] {
+        &["FIELD", "RULES", "SOURCES"]
     }
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.field.clone(),
+            self.rule_count.to_string(),
+            self.sources.join(", "),
+        ]
+    }
+}
 
-    let max_field = report
-        .fields
-        .iter()
-        .map(|f| f.field.len())
-        .max()
-        .unwrap_or(5)
-        .max(5);
-    let max_sources = report
-        .fields
-        .iter()
-        .map(|f| f.sources.join(", ").len())
-        .max()
-        .unwrap_or(7)
-        .max(7);
-
-    eprintln!();
-    println!(
-        "{:<width_f$}  {:>5}  {:<width_s$}",
-        "FIELD",
-        "RULES",
-        "SOURCES",
-        width_f = max_field,
-        width_s = max_sources,
-    );
-    println!(
-        "{:<width_f$}  {:>5}  {:<width_s$}",
-        "-".repeat(max_field),
-        "-----",
-        "-".repeat(max_sources),
-        width_f = max_field,
-        width_s = max_sources,
-    );
-
-    for entry in &report.fields {
-        println!(
-            "{:<width_f$}  {:>5}  {:<width_s$}",
-            entry.field,
-            entry.rule_count,
-            entry.sources.join(", "),
-            width_f = max_field,
-            width_s = max_sources,
+fn print_table(report: &FieldsReport, ctx: &OutputCtx) {
+    let s = &report.summary;
+    if ctx.show_stats() {
+        eprintln!(
+            "Rules: {} detection, {} correlation, {} filter | Pipelines: {} | Unique fields: {}",
+            s.total_rules,
+            s.total_correlations,
+            s.total_filters,
+            s.pipelines_applied,
+            s.unique_fields,
         );
     }
 
-    if !report.pipeline_mappings.is_empty() {
+    if report.fields.is_empty() {
+        if ctx.show_progress() {
+            eprintln!("No fields found.");
+        }
+        return;
+    }
+
+    if ctx.show_stats() {
+        eprintln!();
+    }
+    crate::output::render_table(&report.fields);
+
+    if !report.pipeline_mappings.is_empty() && ctx.show_stats() {
         eprintln!();
         eprintln!("Pipeline field mappings:");
         for m in &report.pipeline_mappings {

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -1,4 +1,3 @@
-use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::process;
 use std::time::SystemTime;
@@ -6,6 +5,8 @@ use std::time::SystemTime;
 use clap::Args;
 use rsigma_parser::lint::{self, FileLintResult, LintConfig};
 use serde::Deserialize;
+
+use crate::output::{OutputCtx, Painter};
 
 /// Counts returned by `cmd_lint` so the caller can decide the exit code.
 pub(crate) struct LintCounts {
@@ -29,10 +30,6 @@ pub(crate) struct LintArgs {
     /// Show details for all files, including those that pass
     #[arg(short, long)]
     pub verbose: bool,
-
-    /// Color output: auto (default), always, never
-    #[arg(long, default_value = "auto", value_parser = ["auto", "always", "never"])]
-    pub color: String,
 
     /// Disable specific lint rules (comma-separated).
     /// Example: --disable missing_description,missing_author
@@ -64,19 +61,18 @@ pub(crate) struct LintArgs {
     pub fail_level: String,
 }
 
-pub(crate) fn cmd_lint(args: LintArgs) -> LintCounts {
+pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
     let LintArgs {
         path,
         schema,
         verbose,
-        color,
         disable,
         lint_config: lint_config_path,
         exclude,
         fix: apply_fix,
         fail_level: _,
     } = args;
-    let p = Painter::new(&color);
+    let p = Painter::new(ctx.color);
 
     // 0. Build lint config from file + CLI flags
     let config = build_lint_config(&path, disable, lint_config_path, exclude);
@@ -551,67 +547,8 @@ fn build_lint_config(
 // ---------------------------------------------------------------------------
 // Terminal color support
 // ---------------------------------------------------------------------------
-
-/// ANSI color painter that respects `--color`, `NO_COLOR`, and tty detection.
-struct Painter {
-    enabled: bool,
-}
-
-impl Painter {
-    fn new(color_arg: &str) -> Self {
-        let enabled = match color_arg {
-            "always" => true,
-            "never" => false,
-            _ => io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none(),
-        };
-        Painter { enabled }
-    }
-
-    fn paint(&self, code: &str, text: &str) -> String {
-        if self.enabled {
-            format!("\x1b[{code}m{text}\x1b[0m")
-        } else {
-            text.to_string()
-        }
-    }
-
-    fn bold(&self, s: &str) -> String {
-        self.paint("1", s)
-    }
-
-    fn dim(&self, s: &str) -> String {
-        self.paint("2", s)
-    }
-
-    fn red(&self, s: &str) -> String {
-        self.paint("31", s)
-    }
-
-    fn red_bold(&self, s: &str) -> String {
-        self.paint("1;31", s)
-    }
-
-    fn green(&self, s: &str) -> String {
-        self.paint("32", s)
-    }
-
-    fn green_bold(&self, s: &str) -> String {
-        self.paint("1;32", s)
-    }
-
-    fn yellow(&self, s: &str) -> String {
-        self.paint("33", s)
-    }
-
-    fn yellow_bold(&self, s: &str) -> String {
-        self.paint("1;33", s)
-    }
-
-    fn blue(&self, s: &str) -> String {
-        self.paint("34", s)
-    }
-
-    fn cyan(&self, s: &str) -> String {
-        self.paint("36", s)
-    }
-}
+//
+// The `Painter` previously defined here moved to `crate::output` so other
+// commands (`engine eval`, `rule fields`, …) can share its
+// `--color`/`NO_COLOR`/TTY resolution. The local definition is gone; the
+// import at the top of this module brings the shared one in.

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use rsigma_parser::lint::{self, FileLintResult, LintConfig};
 use serde::Deserialize;
 
-use crate::output::{OutputCtx, Painter};
+use crate::output::{OutputCtx, OutputFormat, Painter};
 
 /// Counts returned by `cmd_lint` so the caller can decide the exit code.
 pub(crate) struct LintCounts {
@@ -105,22 +105,88 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
         merge_schema_results(&mut all_results, sr);
     }
 
-    // 4. Render results
+    // 4. Tally findings. The numeric summary is needed by both the human
+    // and machine renderers.
     let mut total_files = 0usize;
     let mut failed_files = 0usize;
     let mut total_errors = 0usize;
     let mut total_warnings = 0usize;
     let mut total_infos = 0usize;
-
     for result in &all_results {
         total_files += 1;
-        let errors = result.error_count();
-        let warnings = result.warning_count();
-        let infos = result.info_count();
-        total_errors += errors;
-        total_warnings += warnings;
-        total_infos += infos;
+        total_errors += result.error_count();
+        total_warnings += result.warning_count();
+        total_infos += result.info_count();
+        let has_failures = result
+            .warnings
+            .iter()
+            .any(|w| matches!(w.severity, lint::Severity::Error | lint::Severity::Warning));
+        if has_failures {
+            failed_files += 1;
+        }
+    }
 
+    // 5. Machine renderers (`json`, `ndjson`, `csv`, `tsv`) bypass the
+    //    coloured human view entirely; the human renderer is the default
+    //    when the operator did not explicitly set `--output-format` (the
+    //    TTY-aware NDJSON fallback would regress the existing UX).
+    let effective_format = if ctx.explicit_format {
+        ctx.format
+    } else {
+        OutputFormat::Table
+    };
+    match effective_format {
+        OutputFormat::Json => {
+            crate::output::render_json(
+                &lint_envelope(
+                    &all_results,
+                    total_files,
+                    failed_files,
+                    total_errors,
+                    total_warnings,
+                    total_infos,
+                ),
+                true,
+            );
+            return LintCounts {
+                errors: total_errors,
+                warnings: total_warnings,
+                infos: total_infos,
+            };
+        }
+        OutputFormat::Ndjson => {
+            for entry in lint_finding_rows(&all_results) {
+                crate::output::render_ndjson(&entry);
+            }
+            return LintCounts {
+                errors: total_errors,
+                warnings: total_warnings,
+                infos: total_infos,
+            };
+        }
+        OutputFormat::Csv => {
+            render_lint_findings_delimited(&all_results, ',');
+            return LintCounts {
+                errors: total_errors,
+                warnings: total_warnings,
+                infos: total_infos,
+            };
+        }
+        OutputFormat::Tsv => {
+            render_lint_findings_delimited(&all_results, '\t');
+            return LintCounts {
+                errors: total_errors,
+                warnings: total_warnings,
+                infos: total_infos,
+            };
+        }
+        OutputFormat::Table => {
+            // Fall through to the existing human-friendly renderer below.
+        }
+    }
+
+    // 6. Per-file rendering (the human view).
+    for result in &all_results {
         let has_failures = result
             .warnings
             .iter()
@@ -135,7 +201,6 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
                 );
             }
         } else if has_failures {
-            failed_files += 1;
             // File header
             println!("{}", p.bold(&result.path.display().to_string()));
             for w in &result.warnings {
@@ -154,7 +219,7 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
         }
     }
 
-    // 5. Summary
+    // 7. Summary
     let passed = total_files - failed_files;
     let separator = "─".repeat(60);
     println!("{}", p.dim(&separator));
@@ -544,11 +609,102 @@ fn build_lint_config(
     config
 }
 
-// ---------------------------------------------------------------------------
-// Terminal color support
-// ---------------------------------------------------------------------------
-//
 // The `Painter` previously defined here moved to `crate::output` so other
-// commands (`engine eval`, `rule fields`, …) can share its
-// `--color`/`NO_COLOR`/TTY resolution. The local definition is gone; the
-// import at the top of this module brings the shared one in.
+// commands (`engine eval`, `rule validate`) can share its
+// `--color`/`NO_COLOR`/TTY resolution. This module imports it at the top.
+
+// ---------------------------------------------------------------------------
+// Machine renderers (--output-format json|ndjson|csv|tsv)
+// ---------------------------------------------------------------------------
+
+/// One row per finding, suitable for `ndjson`/`csv`/`tsv`. The CSV/TSV
+/// projection is column-oriented and only carries the columns a spreadsheet
+/// reader can use; the full finding object lives in the `Finding` struct
+/// behind it.
+#[derive(serde::Serialize)]
+struct Finding {
+    path: String,
+    severity: &'static str,
+    rule: String,
+    message: String,
+    line: Option<u32>,
+}
+
+impl Finding {
+    fn from_lint(path: &std::path::Path, w: &lint::LintWarning) -> Self {
+        Self {
+            path: path.display().to_string(),
+            severity: severity_label(w.severity),
+            rule: format!("{}", w.rule),
+            message: w.message.clone(),
+            line: w.span.as_ref().map(|s| s.start_line + 1),
+        }
+    }
+}
+
+impl crate::output::Tabular for Finding {
+    fn headers() -> &'static [&'static str] {
+        &["PATH", "SEVERITY", "RULE", "LINE", "MESSAGE"]
+    }
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.path.clone(),
+            self.severity.to_string(),
+            self.rule.clone(),
+            self.line.map(|n| n.to_string()).unwrap_or_default(),
+            self.message.clone(),
+        ]
+    }
+}
+
+fn severity_label(s: lint::Severity) -> &'static str {
+    match s {
+        lint::Severity::Error => "error",
+        lint::Severity::Warning => "warning",
+        lint::Severity::Info => "info",
+        lint::Severity::Hint => "hint",
+    }
+}
+
+/// Flatten the per-file lint results into a stream of [`Finding`] rows.
+fn lint_finding_rows(results: &[FileLintResult]) -> Vec<Finding> {
+    results
+        .iter()
+        .flat_map(|r| {
+            r.warnings
+                .iter()
+                .map(move |w| Finding::from_lint(&r.path, w))
+        })
+        .collect()
+}
+
+/// JSON envelope mirroring `config validate --format json`: a top-level
+/// summary plus the full findings array.
+fn lint_envelope(
+    results: &[FileLintResult],
+    total_files: usize,
+    failed_files: usize,
+    total_errors: usize,
+    total_warnings: usize,
+    total_infos: usize,
+) -> serde_json::Value {
+    let findings = lint_finding_rows(results);
+    serde_json::json!({
+        "summary": {
+            "files_checked": total_files,
+            "files_failed": failed_files,
+            "errors": total_errors,
+            "warnings": total_warnings,
+            "infos": total_infos,
+        },
+        "findings": findings,
+    })
+}
+
+fn render_lint_findings_delimited(results: &[FileLintResult], sep: char) {
+    use crate::output::Tabular;
+    let mut writer = crate::output::DelimitedWriter::new(sep, Finding::headers());
+    for f in lint_finding_rows(results) {
+        writer.push(&f.row());
+    }
+}

--- a/crates/rsigma-cli/src/commands/parse.rs
+++ b/crates/rsigma-cli/src/commands/parse.rs
@@ -5,6 +5,8 @@ use std::process;
 use clap::Args;
 use rsigma_parser::{parse_sigma_file, parse_sigma_yaml};
 
+use crate::output::OutputCtx;
+
 /// Arguments for `rsigma rule parse` (and the deprecated `rsigma parse`).
 #[derive(Args, Debug)]
 pub(crate) struct ParseArgs {
@@ -31,7 +33,7 @@ pub(crate) struct StdinArgs {
     pub pretty: bool,
 }
 
-pub(crate) fn cmd_parse(args: ParseArgs) {
+pub(crate) fn cmd_parse(args: ParseArgs, _ctx: OutputCtx) {
     let ParseArgs { path, pretty } = args;
     match parse_sigma_file(&path) {
         Ok(collection) => {
@@ -45,7 +47,7 @@ pub(crate) fn cmd_parse(args: ParseArgs) {
     }
 }
 
-pub(crate) fn cmd_condition(args: ConditionArgs) {
+pub(crate) fn cmd_condition(args: ConditionArgs, _ctx: OutputCtx) {
     let ConditionArgs { expr } = args;
     match rsigma_parser::parse_condition(&expr) {
         Ok(ast) => crate::print_json(&ast, true),
@@ -56,7 +58,7 @@ pub(crate) fn cmd_condition(args: ConditionArgs) {
     }
 }
 
-pub(crate) fn cmd_stdin(args: StdinArgs) {
+pub(crate) fn cmd_stdin(args: StdinArgs, _ctx: OutputCtx) {
     let StdinArgs { pretty } = args;
     let mut input = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut input) {

--- a/crates/rsigma-cli/src/commands/parse.rs
+++ b/crates/rsigma-cli/src/commands/parse.rs
@@ -5,7 +5,7 @@ use std::process;
 use clap::Args;
 use rsigma_parser::{parse_sigma_file, parse_sigma_yaml};
 
-use crate::output::OutputCtx;
+use crate::output::{OutputCtx, render_json};
 
 /// Arguments for `rsigma rule parse` (and the deprecated `rsigma parse`).
 #[derive(Args, Debug)]
@@ -13,7 +13,11 @@ pub(crate) struct ParseArgs {
     /// Path to a Sigma YAML file
     pub path: PathBuf,
 
-    /// Pretty-print JSON output
+    /// Pretty-print JSON output (default; pass `--no-pretty` for compact).
+    ///
+    /// Forced on when `--output-format json` is set on a TTY. Mostly here
+    /// for backwards compatibility -- new code should rely on
+    /// `--output-format`.
     #[arg(short, long, default_value_t = true)]
     pub pretty: bool,
 }
@@ -28,17 +32,17 @@ pub(crate) struct ConditionArgs {
 /// Arguments for `rsigma rule stdin` (and the deprecated `rsigma stdin`).
 #[derive(Args, Debug)]
 pub(crate) struct StdinArgs {
-    /// Pretty-print JSON output
+    /// Pretty-print JSON output (default; pass `--no-pretty` for compact).
     #[arg(short, long, default_value_t = true)]
     pub pretty: bool,
 }
 
-pub(crate) fn cmd_parse(args: ParseArgs, _ctx: OutputCtx) {
+pub(crate) fn cmd_parse(args: ParseArgs, ctx: OutputCtx) {
     let ParseArgs { path, pretty } = args;
     match parse_sigma_file(&path) {
         Ok(collection) => {
             crate::print_warnings(&collection.errors);
-            crate::print_json(&collection, pretty);
+            render_json(&collection, effective_pretty(ctx, pretty));
         }
         Err(e) => {
             eprintln!("Error parsing {}: {e}", path.display());
@@ -47,10 +51,13 @@ pub(crate) fn cmd_parse(args: ParseArgs, _ctx: OutputCtx) {
     }
 }
 
-pub(crate) fn cmd_condition(args: ConditionArgs, _ctx: OutputCtx) {
+pub(crate) fn cmd_condition(args: ConditionArgs, ctx: OutputCtx) {
     let ConditionArgs { expr } = args;
     match rsigma_parser::parse_condition(&expr) {
-        Ok(ast) => crate::print_json(&ast, true),
+        // `--pretty` is implied for condition output; the AST is small and
+        // human-friendly is the default. `--output-format ndjson` overrides
+        // to compact via [`effective_pretty`].
+        Ok(ast) => render_json(&ast, effective_pretty(ctx, true)),
         Err(e) => {
             eprintln!("Condition parse error: {e}");
             process::exit(crate::exit_code::RULE_ERROR);
@@ -58,7 +65,7 @@ pub(crate) fn cmd_condition(args: ConditionArgs, _ctx: OutputCtx) {
     }
 }
 
-pub(crate) fn cmd_stdin(args: StdinArgs, _ctx: OutputCtx) {
+pub(crate) fn cmd_stdin(args: StdinArgs, ctx: OutputCtx) {
     let StdinArgs { pretty } = args;
     let mut input = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut input) {
@@ -69,11 +76,25 @@ pub(crate) fn cmd_stdin(args: StdinArgs, _ctx: OutputCtx) {
     match parse_sigma_yaml(&input) {
         Ok(collection) => {
             crate::print_warnings(&collection.errors);
-            crate::print_json(&collection, pretty);
+            render_json(&collection, effective_pretty(ctx, pretty));
         }
         Err(e) => {
             eprintln!("Parse error: {e}");
             process::exit(crate::exit_code::RULE_ERROR);
         }
+    }
+}
+
+/// Resolve the effective JSON pretty-print decision for `parse` / `stdin` /
+/// `condition`. `--output-format ndjson` always wins (compact); otherwise we
+/// fall back to the per-command `--pretty` flag, which defaults to `true`.
+fn effective_pretty(ctx: OutputCtx, flag: bool) -> bool {
+    use crate::output::OutputFormat;
+    match ctx.format {
+        OutputFormat::Ndjson => false,
+        OutputFormat::Json => flag || ctx.pretty_json(),
+        // Table/CSV/TSV do not apply to parser output -- fall back to JSON
+        // with the same `--pretty` semantics.
+        _ => flag,
     }
 }

--- a/crates/rsigma-cli/src/config/defaults.rs
+++ b/crates/rsigma-cli/src/config/defaults.rs
@@ -39,7 +39,7 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
         global: Some(GlobalPartial {
             log_format: Some(LOG_FORMAT.to_string()),
             color: None,
-            format: None,
+            output_format: None,
         }),
         daemon: Some(DaemonPartial {
             rules: None,
@@ -95,7 +95,6 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
             input_format: Some(INPUT_FORMAT.to_string()),
             syslog_tz: Some(SYSLOG_TZ.to_string()),
             fail_on_detection: Some(false),
-            format: None,
         }),
     }
 }

--- a/crates/rsigma-cli/src/config/mod.rs
+++ b/crates/rsigma-cli/src/config/mod.rs
@@ -61,6 +61,23 @@ pub(crate) fn discovered_log_format(explicit: Option<&Path>) -> Option<String> {
     merged.global.and_then(|g| g.log_format)
 }
 
+/// Best-effort lookup of `global.output_format` and `global.color` from the
+/// config files plus the `RSIGMA_*` env. Returns the two values as raw
+/// strings (the [`crate::output`] module parses them). Quiet: like
+/// [`discovered_log_format`], it never warns or exits.
+pub(crate) fn discovered_global_output(
+    explicit: Option<&Path>,
+) -> (Option<String>, Option<String>) {
+    let Some(loaded) = load_layered(explicit).ok() else {
+        return (None, None);
+    };
+    let merged = loaded.config.merge(resolve::env_partial());
+    let Some(global) = merged.global else {
+        return (None, None);
+    };
+    (global.output_format, global.color)
+}
+
 /// Print the effective `section` config (defaults < file < env) as YAML to
 /// stdout, used by `--dry-run`. CLI flags override these at runtime; that note
 /// goes to stderr so the YAML on stdout stays clean.

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -62,12 +62,13 @@ pub(crate) struct GlobalPartial {
     /// Diagnostic log format on stderr: `text` or `json` (maps to `--log-format`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_format: Option<String>,
-    /// Color policy: `auto`, `always`, `never`. Reserved for the output-format work (#19).
+    /// Color policy: `auto`, `always`, `never` (maps to `--color`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
-    /// Default output format. Reserved for the output-format work (#19).
+    /// Default structured output format: `json`, `ndjson`, `table`, `csv`,
+    /// `tsv` (maps to `--output-format`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub format: Option<String>,
+    pub output_format: Option<String>,
 }
 
 impl Merge for GlobalPartial {
@@ -75,7 +76,7 @@ impl Merge for GlobalPartial {
         Self {
             log_format: over.log_format.or(self.log_format),
             color: over.color.or(self.color),
-            format: over.format.or(self.format),
+            output_format: over.output_format.or(self.output_format),
         }
     }
 }
@@ -365,9 +366,6 @@ pub(crate) struct EvalPartial {
     pub syslog_tz: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fail_on_detection: Option<bool>,
-    /// Default output format. Reserved for the output-format work (#19).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub format: Option<String>,
 }
 
 impl Merge for EvalPartial {
@@ -378,7 +376,6 @@ impl Merge for EvalPartial {
             input_format: over.input_format.or(self.input_format),
             syslog_tz: over.syslog_tz.or(self.syslog_tz),
             fail_on_detection: over.fail_on_detection.or(self.fail_on_detection),
-            format: over.format.or(self.format),
         }
     }
 }

--- a/crates/rsigma-cli/src/config/template.yaml
+++ b/crates/rsigma-cli/src/config/template.yaml
@@ -13,10 +13,12 @@ version: 1
 global:
   # Diagnostic log format on stderr: text | json (maps to --log-format).
   log_format: text
-  # color and format are reserved for the upcoming output-format work and are
-  # inert today.
+  # Color policy for human-friendly output: auto | always | never.
+  # `auto` honors NO_COLOR and disables color when stdout is not a TTY.
   # color: auto
-  # format: json
+  # Default structured output format: json | ndjson | table | csv | tsv.
+  # Default behavior (when unset): pretty JSON on a TTY, NDJSON when piped.
+  # output_format: json
 
 daemon:
   # Path to a Sigma rule file or directory.
@@ -114,5 +116,3 @@ eval:
   input_format: auto
   syslog_tz: "+00:00"
   fail_on_detection: false
-  # format is reserved for the upcoming output-format work.
-  # format: table

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -42,6 +42,37 @@ struct Cli {
     #[arg(long = "log-format", value_enum, global = true)]
     log_format: Option<LogFormat>,
 
+    /// Output format for structured CLI data (matches, fields, lint findings).
+    ///
+    /// Values: `json` (default on a TTY), `ndjson` (default when piped),
+    /// `table`, `csv`, `tsv`. Resolution: flag > `RSIGMA_GLOBAL__OUTPUT_FORMAT`
+    /// > `global.output_format` in the config file > TTY-aware default.
+    ///
+    /// `convert` keeps its own `-f/--format` for the backend query format and
+    /// only honors `json` for this flag (wraps queries); other values fall
+    /// back to raw text.
+    #[arg(long = "output-format", value_enum, global = true)]
+    output_format: Option<output::OutputFormat>,
+
+    /// Color policy for human-friendly output (lint findings, summaries).
+    ///
+    /// Values: `auto` (color on a TTY when `NO_COLOR` is unset, the default),
+    /// `always`, `never`. Resolution: flag > `RSIGMA_GLOBAL__COLOR` >
+    /// `global.color` in the config file > `auto`.
+    #[arg(long = "color", value_enum, global = true)]
+    color: Option<output::ColorChoice>,
+
+    /// Suppress all non-data output (progress + stats). Errors still go to
+    /// stderr. Useful in CI when only the matched results matter.
+    #[arg(long = "quiet", short = 'q', global = true)]
+    quiet: bool,
+
+    /// Suppress only the trailing summary / stats line. Progress messages
+    /// stay on stderr. Useful when piping to a tool that does not expect a
+    /// summary footer but the operator still wants to see what happened.
+    #[arg(long = "no-stats", global = true)]
+    no_stats: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -227,15 +258,30 @@ fn main() {
     // The --log-format flag wins; otherwise honor global.log_format from a
     // discovered config file (or an explicit --config path) or
     // RSIGMA_GLOBAL__LOG_FORMAT.
+    let cfg_override = scan_config_flag();
     let log_format = cli.log_format.or_else(|| {
-        let cfg_override = scan_config_flag();
         config::discovered_log_format(cfg_override.as_deref()).and_then(|s| parse_log_format(&s))
     });
     if !is_daemon && let Some(format) = log_format {
         init_cli_log_subscriber(format);
     }
 
-    dispatch(cli.command, &matches);
+    // Build the global output context once, after the config layer is loaded
+    // but before any command runs. The same precedence model that drives
+    // --log-format applies here: flag > env > file > default.
+    let (cfg_format, cfg_color) = config::discovered_global_output(cfg_override.as_deref());
+    let stdout_is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    let ctx = output::OutputCtx::resolve(
+        cli.output_format,
+        cfg_format.as_deref(),
+        cli.color,
+        cfg_color.as_deref(),
+        cli.quiet,
+        cli.no_stats,
+        stdout_is_tty,
+    );
+
+    dispatch(cli.command, &matches, ctx);
 }
 
 /// Pre-scan argv for an explicit `--config <PATH>` / `--config=<PATH>` so the
@@ -274,12 +320,12 @@ fn deprecation_warn(old: &str, new: &str) {
     );
 }
 
-fn dispatch(command: Commands, matches: &ArgMatches) {
+fn dispatch(command: Commands, matches: &ArgMatches, ctx: output::OutputCtx) {
     match command {
         // -- Grouped commands ------------------------------------------------
-        Commands::Engine { cmd } => dispatch_engine(cmd, matches),
-        Commands::Rule { cmd } => dispatch_rule(cmd),
-        Commands::Backend { cmd } => dispatch_backend(cmd),
+        Commands::Engine { cmd } => dispatch_engine(cmd, matches, ctx),
+        Commands::Rule { cmd } => dispatch_rule(cmd, ctx),
+        Commands::Backend { cmd } => dispatch_backend(cmd, ctx),
         Commands::Pipeline { cmd } => dispatch_pipeline(cmd),
         Commands::Config { cmd } => config::commands::dispatch(cmd),
 
@@ -289,7 +335,7 @@ fn dispatch(command: Commands, matches: &ArgMatches) {
             let em = matches
                 .subcommand_matches("eval")
                 .expect("eval submatches present");
-            run_eval(args, em);
+            run_eval(args, em, ctx);
         }
         #[cfg(feature = "daemon")]
         Commands::Daemon(args) => {
@@ -301,7 +347,7 @@ fn dispatch(command: Commands, matches: &ArgMatches) {
         }
         Commands::Parse(args) => {
             deprecation_warn("parse", "rule parse");
-            commands::cmd_parse(args);
+            commands::cmd_parse(args, ctx);
         }
         Commands::Validate(args) => {
             deprecation_warn("validate", "rule validate");
@@ -309,23 +355,23 @@ fn dispatch(command: Commands, matches: &ArgMatches) {
         }
         Commands::Lint(args) => {
             deprecation_warn("lint", "rule lint");
-            run_lint(args);
+            run_lint(args, ctx);
         }
         Commands::Fields(args) => {
             deprecation_warn("fields", "rule fields");
-            commands::cmd_fields(args);
+            commands::cmd_fields(args, ctx);
         }
         Commands::Condition(args) => {
             deprecation_warn("condition", "rule condition");
-            commands::cmd_condition(args);
+            commands::cmd_condition(args, ctx);
         }
         Commands::Stdin(args) => {
             deprecation_warn("stdin", "rule stdin");
-            commands::cmd_stdin(args);
+            commands::cmd_stdin(args, ctx);
         }
         Commands::Convert(args) => {
             deprecation_warn("convert", "backend convert");
-            commands::cmd_convert(args);
+            commands::cmd_convert(args, ctx);
         }
         Commands::ListTargets => {
             deprecation_warn("list-targets", "backend targets");
@@ -342,14 +388,14 @@ fn dispatch(command: Commands, matches: &ArgMatches) {
     }
 }
 
-fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches) {
+fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches, ctx: output::OutputCtx) {
     match cmd {
         EngineCommands::Eval(args) => {
             let em = matches
                 .subcommand_matches("engine")
                 .and_then(|m| m.subcommand_matches("eval"))
                 .expect("engine eval submatches present");
-            run_eval(args, em);
+            run_eval(args, em, ctx);
         }
         #[cfg(feature = "daemon")]
         EngineCommands::Daemon(args) => {
@@ -362,21 +408,21 @@ fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches) {
     }
 }
 
-fn dispatch_rule(cmd: RuleCommands) {
+fn dispatch_rule(cmd: RuleCommands, ctx: output::OutputCtx) {
     match cmd {
-        RuleCommands::Parse(args) => commands::cmd_parse(args),
+        RuleCommands::Parse(args) => commands::cmd_parse(args, ctx),
         RuleCommands::Validate(args) => commands::cmd_validate(args),
-        RuleCommands::Lint(args) => run_lint(args),
-        RuleCommands::Fields(args) => commands::cmd_fields(args),
-        RuleCommands::Condition(args) => commands::cmd_condition(args),
-        RuleCommands::Stdin(args) => commands::cmd_stdin(args),
+        RuleCommands::Lint(args) => run_lint(args, ctx),
+        RuleCommands::Fields(args) => commands::cmd_fields(args, ctx),
+        RuleCommands::Condition(args) => commands::cmd_condition(args, ctx),
+        RuleCommands::Stdin(args) => commands::cmd_stdin(args, ctx),
         RuleCommands::MigrateSources(args) => commands::cmd_migrate_sources(args),
     }
 }
 
-fn dispatch_backend(cmd: BackendCommands) {
+fn dispatch_backend(cmd: BackendCommands, ctx: output::OutputCtx) {
     match cmd {
-        BackendCommands::Convert(args) => commands::cmd_convert(args),
+        BackendCommands::Convert(args) => commands::cmd_convert(args, ctx),
         BackendCommands::Targets => commands::cmd_list_targets(),
         BackendCommands::Formats(ListFormatsArgs { target }) => commands::cmd_list_formats(target),
     }
@@ -391,10 +437,10 @@ fn dispatch_pipeline(cmd: PipelineCommands) {
 /// Shared eval entry point used by both `engine eval` and the deprecated
 /// `eval` alias. Applies config (CLI flag > env > file > default) before
 /// reading `fail_on_detection`, then centralizes the exit-code handling.
-fn run_eval(mut args: EvalArgs, matches: &ArgMatches) {
+fn run_eval(mut args: EvalArgs, matches: &ArgMatches, ctx: output::OutputCtx) {
     commands::apply_eval_config(&mut args, matches);
     let fail_on_detection = args.fail_on_detection;
-    let had_matches = commands::cmd_eval(args);
+    let had_matches = commands::cmd_eval(args, ctx);
     if fail_on_detection && had_matches {
         process::exit(exit_code::FINDINGS);
     }
@@ -402,13 +448,13 @@ fn run_eval(mut args: EvalArgs, matches: &ArgMatches) {
 
 /// Shared lint entry point used by both `rule lint` and the deprecated `lint`
 /// alias. Centralizes the `--fail-level` exit-code handling.
-fn run_lint(args: LintArgs) {
+fn run_lint(args: LintArgs, ctx: output::OutputCtx) {
     let fail_level = args.fail_level.clone();
     let LintCounts {
         errors,
         warnings,
         infos,
-    } = commands::cmd_lint(args);
+    } = commands::cmd_lint(args, ctx);
     let should_fail = match fail_level.as_str() {
         "info" => errors > 0 || warnings > 0 || infos > 0,
         "warning" => errors > 0 || warnings > 0,
@@ -526,19 +572,11 @@ pub(crate) fn print_warnings(errors: &[String]) {
     }
 }
 
+/// Backwards-compatible JSON renderer kept while per-command renderers are
+/// migrated to the new `crate::output` API. Each subsequent commit retires
+/// one set of call sites; the function is removed once the last one is gone.
 pub(crate) fn print_json(value: &impl serde::Serialize, pretty: bool) {
-    let json = if pretty {
-        serde_json::to_string_pretty(value)
-    } else {
-        serde_json::to_string(value)
-    };
-    match json {
-        Ok(j) => println!("{j}"),
-        Err(e) => {
-            eprintln!("JSON serialization error: {e}");
-            process::exit(exit_code::CONFIG_ERROR);
-        }
-    }
+    output::render_json(value, pretty);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod daemon;
 pub(crate) mod exit_code;
 mod fix;
+pub(crate) mod output;
 
 use std::path::PathBuf;
 use std::process;

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -572,13 +572,6 @@ pub(crate) fn print_warnings(errors: &[String]) {
     }
 }
 
-/// Backwards-compatible JSON renderer kept while per-command renderers are
-/// migrated to the new `crate::output` API. Each subsequent commit retires
-/// one set of call sites; the function is removed once the last one is gone.
-pub(crate) fn print_json(value: &impl serde::Serialize, pretty: bool) {
-    output::render_json(value, pretty);
-}
-
 // ---------------------------------------------------------------------------
 // Event filtering (jq / JSONPath)
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-cli/src/output/mod.rs
+++ b/crates/rsigma-cli/src/output/mod.rs
@@ -14,11 +14,6 @@
 //! Commands compose these knobs through [`OutputCtx`], built once in `main`
 //! after the existing flag + config resolution.
 
-// Consumers (commands, dispatch) are wired in a follow-up commit. The
-// `pub(crate)` surface below is exercised only by this module's own unit
-// tests until that lands; the allow keeps the foundation commit warning-free.
-#![allow(dead_code)]
-
 use std::io::{self, Write};
 
 use serde::Serialize;
@@ -53,6 +48,8 @@ impl OutputFormat {
     }
 
     /// Lowercase wire name, used for diagnostics and `config show`.
+    // Used by the backend `convert` command, which lands in a follow-up commit.
+    #[allow(dead_code)]
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::Json => "json",
@@ -246,6 +243,8 @@ pub(crate) fn render_json<T: Serialize>(value: &T, pretty: bool) {
 
 /// Render `value` as a single NDJSON line on stdout. Same error semantics as
 /// [`render_json`].
+// Used by the lint machine renderer, which lands in a follow-up commit.
+#[allow(dead_code)]
 pub(crate) fn render_ndjson<T: Serialize>(value: &T) {
     render_json(value, false);
 }

--- a/crates/rsigma-cli/src/output/mod.rs
+++ b/crates/rsigma-cli/src/output/mod.rs
@@ -48,8 +48,6 @@ impl OutputFormat {
     }
 
     /// Lowercase wire name, used for diagnostics and `config show`.
-    // Used by the backend `convert` command, which lands in a follow-up commit.
-    #[allow(dead_code)]
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::Json => "json",

--- a/crates/rsigma-cli/src/output/mod.rs
+++ b/crates/rsigma-cli/src/output/mod.rs
@@ -1,0 +1,592 @@
+//! Shared, TTY-aware output rendering for every rsigma CLI command.
+//!
+//! Two global, command-agnostic switches drive every renderer:
+//!
+//! * `--output-format <json|ndjson|table|csv|tsv>` selects the wire format
+//!   for any tabular data the command emits. The default is TTY-aware: when
+//!   stdout is a terminal it prints pretty JSON, when piped it prints
+//!   newline-delimited JSON (NDJSON).
+//! * `--color auto|always|never` controls ANSI color on the human-friendly
+//!   paths (lint findings, summaries, …). Honours `NO_COLOR` when `auto`.
+//!
+//! Two more reduce noise: `--quiet`/`-q` and `--no-stats`.
+//!
+//! Commands compose these knobs through [`OutputCtx`], built once in `main`
+//! after the existing flag + config resolution.
+
+// Consumers (commands, dispatch) are wired in a follow-up commit. The
+// `pub(crate)` surface below is exercised only by this module's own unit
+// tests until that lands; the allow keeps the foundation commit warning-free.
+#![allow(dead_code)]
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+
+/// Selector for the wire format of structured CLI output.
+///
+/// `Json` and `Ndjson` mean what they say; `Table` is a width-aligned text
+/// table for human consumption; `Csv` and `Tsv` are stream-friendly delimited
+/// formats with embedded-quote handling for spreadsheets and data tools.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum OutputFormat {
+    Json,
+    Ndjson,
+    Table,
+    Csv,
+    Tsv,
+}
+
+impl OutputFormat {
+    /// Parse the value clap stores for `--output-format` (or the YAML
+    /// `global.output_format` key, or the `RSIGMA_GLOBAL__OUTPUT_FORMAT` env
+    /// var, which all coerce to a lowercase string).
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "json" => Some(Self::Json),
+            "ndjson" => Some(Self::Ndjson),
+            "table" => Some(Self::Table),
+            "csv" => Some(Self::Csv),
+            "tsv" => Some(Self::Tsv),
+            _ => None,
+        }
+    }
+
+    /// Lowercase wire name, used for diagnostics and `config show`.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Ndjson => "ndjson",
+            Self::Table => "table",
+            Self::Csv => "csv",
+            Self::Tsv => "tsv",
+        }
+    }
+}
+
+/// Whether ANSI color should be emitted on stdout/stderr.
+///
+/// The wire values match the lint command's existing `--color` value parser
+/// and the `global.color` config key.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum ColorChoice {
+    /// On when stdout is a TTY and `NO_COLOR` is not set.
+    #[default]
+    Auto,
+    /// Always on.
+    Always,
+    /// Always off.
+    Never,
+}
+
+impl ColorChoice {
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Some(Self::Auto),
+            "always" => Some(Self::Always),
+            "never" => Some(Self::Never),
+            _ => None,
+        }
+    }
+
+    /// Resolve the choice to a concrete on/off decision.
+    ///
+    /// `stdout_is_tty` is taken as a parameter (rather than queried inline)
+    /// so the resolution is unit-testable and so [`OutputCtx`] can decide
+    /// once and re-use the answer for the rest of the run.
+    pub(crate) fn resolve(self, stdout_is_tty: bool) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::Auto => stdout_is_tty && std::env::var_os("NO_COLOR").is_none(),
+        }
+    }
+}
+
+/// Everything a command needs to render its output, resolved once up front.
+///
+/// `explicit_format` is `true` when the operator passed `--output-format`
+/// (or set the env / config key); commands use it to decide whether to fall
+/// back to a TTY-aware default (`Json` when stdout is a terminal, `Ndjson`
+/// when piped).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OutputCtx {
+    pub format: OutputFormat,
+    pub color: bool,
+    pub quiet: bool,
+    pub no_stats: bool,
+    pub stdout_is_tty: bool,
+    pub explicit_format: bool,
+}
+
+impl Default for OutputCtx {
+    fn default() -> Self {
+        // The fallback when nothing is configured: NDJSON, no color, no
+        // suppression. Used by tests and any code path that builds a renderer
+        // before the global context is wired up.
+        Self {
+            format: OutputFormat::Ndjson,
+            color: false,
+            quiet: false,
+            no_stats: false,
+            stdout_is_tty: false,
+            explicit_format: false,
+        }
+    }
+}
+
+impl OutputCtx {
+    /// Resolve the effective `OutputCtx` from layered inputs.
+    ///
+    /// Precedence (high to low) per knob:
+    ///
+    /// * `--output-format` flag > `RSIGMA_GLOBAL__OUTPUT_FORMAT` env >
+    ///   `global.output_format` config > TTY-aware default
+    ///   (`Json` when stdout is a TTY, `Ndjson` when piped).
+    /// * `--color` flag > `global.color` config > `Auto`.
+    /// * `--quiet`, `--no-stats` are flag-only.
+    ///
+    /// The exact provenance of each value is decided by the caller (which
+    /// has the clap `ArgMatches` and the loaded config). This function takes
+    /// the already-resolved values to keep it pure and testable.
+    pub(crate) fn resolve(
+        flag_format: Option<OutputFormat>,
+        config_format: Option<&str>,
+        flag_color: Option<ColorChoice>,
+        config_color: Option<&str>,
+        quiet: bool,
+        no_stats: bool,
+        stdout_is_tty: bool,
+    ) -> Self {
+        let explicit_format = flag_format.is_some()
+            || config_format.is_some_and(|s| OutputFormat::parse(s).is_some());
+
+        let format = flag_format
+            .or_else(|| config_format.and_then(OutputFormat::parse))
+            .unwrap_or(if stdout_is_tty {
+                OutputFormat::Json
+            } else {
+                OutputFormat::Ndjson
+            });
+
+        let color_choice = flag_color
+            .or_else(|| config_color.and_then(ColorChoice::parse))
+            .unwrap_or_default();
+        let color = color_choice.resolve(stdout_is_tty);
+
+        Self {
+            format,
+            color,
+            quiet,
+            no_stats,
+            stdout_is_tty,
+            explicit_format,
+        }
+    }
+
+    /// Should a `stats` line on stderr be emitted? Suppressed by `--quiet`
+    /// and `--no-stats` alike; `--no-stats` is a narrower way to keep
+    /// progress logs but drop the summary.
+    pub(crate) fn show_stats(&self) -> bool {
+        !self.quiet && !self.no_stats
+    }
+
+    /// Should non-data progress / informational lines be emitted on stderr?
+    /// Only suppressed by `--quiet`. (`--no-stats` keeps progress but drops
+    /// the final stats line.)
+    pub(crate) fn show_progress(&self) -> bool {
+        !self.quiet
+    }
+
+    /// True when JSON output should be pretty-printed: explicit `--pretty`,
+    /// `--output-format json` with a TTY, or an implicit TTY default. For
+    /// `ndjson` this is always false.
+    pub(crate) fn pretty_json(&self) -> bool {
+        match self.format {
+            OutputFormat::Ndjson => false,
+            OutputFormat::Json => self.stdout_is_tty || !self.explicit_format,
+            // The other formats do not emit JSON.
+            _ => false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tabular trait + renderers
+// ---------------------------------------------------------------------------
+
+/// A row source for the width-aligning text table and the streaming
+/// delimited (`csv`/`tsv`) renderers.
+///
+/// Implementors expose a fixed column header list and convert themselves to
+/// a row of cells. Cells are stringified up front so the renderer never has
+/// to call back into the value.
+pub(crate) trait Tabular {
+    fn headers() -> &'static [&'static str];
+    fn row(&self) -> Vec<String>;
+}
+
+/// Render `value` as JSON to stdout (pretty when `pretty` is `true`). Exits
+/// the process with `CONFIG_ERROR` on serialization failure -- the same
+/// behaviour the previous `print_json` had.
+pub(crate) fn render_json<T: Serialize>(value: &T, pretty: bool) {
+    let json = if pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    };
+    match json {
+        Ok(j) => println!("{j}"),
+        Err(e) => {
+            eprintln!("JSON serialization error: {e}");
+            std::process::exit(crate::exit_code::CONFIG_ERROR);
+        }
+    }
+}
+
+/// Render `value` as a single NDJSON line on stdout. Same error semantics as
+/// [`render_json`].
+pub(crate) fn render_ndjson<T: Serialize>(value: &T) {
+    render_json(value, false);
+}
+
+/// Render a slice of `Tabular` rows as a width-aligned text table on stdout.
+///
+/// Width-buffering: we walk the rows once to compute per-column widths, then
+/// print the header, a dashed separator, and each row. Columns whose body
+/// cells all parse as integers are right-aligned (numeric); everything else
+/// is left-aligned. `table` is not a streaming format; for piping to other
+/// tools prefer `ndjson`, `csv`, or `tsv`.
+pub(crate) fn render_table<T: Tabular>(rows: &[T]) {
+    let headers = T::headers();
+    if headers.is_empty() {
+        return;
+    }
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+    let stringified: Vec<Vec<String>> = rows.iter().map(|r| r.row()).collect();
+    for row in &stringified {
+        for (i, cell) in row.iter().enumerate() {
+            if i < widths.len() && cell.len() > widths[i] {
+                widths[i] = cell.len();
+            }
+        }
+    }
+    let right_align: Vec<bool> = (0..widths.len())
+        .map(|i| {
+            !stringified.is_empty()
+                && stringified
+                    .iter()
+                    .all(|r| r.get(i).is_some_and(|c| c.parse::<i64>().is_ok()))
+        })
+        .collect();
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let _ = write_row(&mut out, headers.iter().copied(), &widths, &right_align);
+    let dashes: Vec<String> = widths.iter().map(|w| "-".repeat(*w)).collect();
+    let _ = write_row(
+        &mut out,
+        dashes.iter().map(String::as_str),
+        &widths,
+        &right_align,
+    );
+    for row in &stringified {
+        let _ = write_row(
+            &mut out,
+            row.iter().map(String::as_str),
+            &widths,
+            &right_align,
+        );
+    }
+}
+
+fn write_row<'a, I, W>(
+    out: &mut W,
+    cells: I,
+    widths: &[usize],
+    right_align: &[bool],
+) -> io::Result<()>
+where
+    I: Iterator<Item = &'a str>,
+    W: Write,
+{
+    let mut first = true;
+    for (i, cell) in cells.enumerate() {
+        if !first {
+            write!(out, "  ")?;
+        }
+        first = false;
+        let w = widths.get(i).copied().unwrap_or(0);
+        if right_align.get(i).copied().unwrap_or(false) {
+            write!(out, "{cell:>w$}", w = w)?;
+        } else {
+            write!(out, "{cell:<w$}", w = w)?;
+        }
+    }
+    writeln!(out)
+}
+
+/// Streaming writer for `csv`/`tsv`: header first, then one row per `push`.
+///
+/// Created once per command via [`DelimitedWriter::new`]. Calling
+/// [`DelimitedWriter::push`] streams a row immediately, so the format scales
+/// to large match counts without buffering.
+pub(crate) struct DelimitedWriter {
+    sep: char,
+    headers: &'static [&'static str],
+    wrote_header: bool,
+}
+
+impl DelimitedWriter {
+    pub(crate) fn new(sep: char, headers: &'static [&'static str]) -> Self {
+        Self {
+            sep,
+            headers,
+            wrote_header: false,
+        }
+    }
+
+    /// Write the header row (if it has not been written) and one data row.
+    /// Cells are escaped according to RFC 4180-style rules: a field that
+    /// contains the separator, a double-quote, a CR, or an LF is wrapped in
+    /// double quotes, and embedded double-quotes are doubled.
+    pub(crate) fn push(&mut self, cells: &[String]) {
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+        if !self.wrote_header {
+            let _ = write_delimited_row(&mut out, self.headers.iter().copied(), self.sep);
+            self.wrote_header = true;
+        }
+        let _ = write_delimited_row(&mut out, cells.iter().map(String::as_str), self.sep);
+    }
+}
+
+fn write_delimited_row<'a, I, W>(out: &mut W, cells: I, sep: char) -> io::Result<()>
+where
+    I: Iterator<Item = &'a str>,
+    W: Write,
+{
+    let mut first = true;
+    for cell in cells {
+        if !first {
+            write!(out, "{sep}")?;
+        }
+        first = false;
+        write!(out, "{}", escape_delimited(cell, sep))?;
+    }
+    writeln!(out)
+}
+
+/// Quote `cell` for `csv`/`tsv` output when it carries the separator, a
+/// double-quote, or a CR/LF. Embedded double-quotes are doubled.
+///
+/// Returned as `String` (not `Cow`) for clarity at the cost of a single
+/// allocation per cell; this is well below the cost of writing the row.
+pub(crate) fn escape_delimited(cell: &str, sep: char) -> String {
+    let needs_quote = cell
+        .chars()
+        .any(|c| c == sep || c == '"' || c == '\n' || c == '\r');
+    if !needs_quote {
+        return cell.to_string();
+    }
+    let mut buf = String::with_capacity(cell.len() + 2);
+    buf.push('"');
+    for c in cell.chars() {
+        if c == '"' {
+            buf.push('"');
+        }
+        buf.push(c);
+    }
+    buf.push('"');
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// ANSI color painter
+// ---------------------------------------------------------------------------
+
+/// ANSI color painter shared by every command that emits coloured text.
+///
+/// `enabled` is decided once by [`OutputCtx::resolve`] (which honours
+/// `--color` / `NO_COLOR` / TTY detection), so this struct only carries the
+/// final on/off bit. Method names are intentionally short because they are
+/// called inline inside larger format strings.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Painter {
+    enabled: bool,
+}
+
+impl Painter {
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    pub(crate) fn paint(&self, code: &str, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[{code}m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+
+    pub(crate) fn bold(&self, s: &str) -> String {
+        self.paint("1", s)
+    }
+    pub(crate) fn dim(&self, s: &str) -> String {
+        self.paint("2", s)
+    }
+    pub(crate) fn red(&self, s: &str) -> String {
+        self.paint("31", s)
+    }
+    pub(crate) fn red_bold(&self, s: &str) -> String {
+        self.paint("1;31", s)
+    }
+    pub(crate) fn green(&self, s: &str) -> String {
+        self.paint("32", s)
+    }
+    pub(crate) fn green_bold(&self, s: &str) -> String {
+        self.paint("1;32", s)
+    }
+    pub(crate) fn yellow(&self, s: &str) -> String {
+        self.paint("33", s)
+    }
+    pub(crate) fn yellow_bold(&self, s: &str) -> String {
+        self.paint("1;33", s)
+    }
+    pub(crate) fn blue(&self, s: &str) -> String {
+        self.paint("34", s)
+    }
+    pub(crate) fn cyan(&self, s: &str) -> String {
+        self.paint("36", s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_format_parses_known_values() {
+        assert_eq!(OutputFormat::parse("json"), Some(OutputFormat::Json));
+        assert_eq!(OutputFormat::parse("NDJSON"), Some(OutputFormat::Ndjson));
+        assert_eq!(OutputFormat::parse("Table"), Some(OutputFormat::Table));
+        assert_eq!(OutputFormat::parse("csv"), Some(OutputFormat::Csv));
+        assert_eq!(OutputFormat::parse("tsv"), Some(OutputFormat::Tsv));
+        assert_eq!(OutputFormat::parse("xml"), None);
+    }
+
+    #[test]
+    fn color_choice_parses_known_values() {
+        assert_eq!(ColorChoice::parse("auto"), Some(ColorChoice::Auto));
+        assert_eq!(ColorChoice::parse("Always"), Some(ColorChoice::Always));
+        assert_eq!(ColorChoice::parse("NEVER"), Some(ColorChoice::Never));
+        assert_eq!(ColorChoice::parse("bold"), None);
+    }
+
+    #[test]
+    fn color_resolve_honors_no_color_only_under_auto() {
+        // Save and clear NO_COLOR for the duration of the test.
+        // SAFETY: This module's tests are run by `cargo test`, which is
+        // single-threaded by default within a test binary unless the test
+        // explicitly opts into a thread pool.
+        let prior = std::env::var_os("NO_COLOR");
+        // SAFETY: see note above.
+        unsafe {
+            std::env::set_var("NO_COLOR", "1");
+        }
+        assert!(!ColorChoice::Auto.resolve(true));
+        assert!(ColorChoice::Always.resolve(false));
+        assert!(!ColorChoice::Never.resolve(true));
+        match prior {
+            Some(v) => unsafe { std::env::set_var("NO_COLOR", v) },
+            None => unsafe { std::env::remove_var("NO_COLOR") },
+        }
+    }
+
+    #[test]
+    fn tty_default_falls_through_to_json_on_tty_ndjson_otherwise() {
+        let on_tty =
+            OutputCtx::resolve(None, None, None, None, false, false, /* tty = */ true);
+        assert_eq!(on_tty.format, OutputFormat::Json);
+        assert!(!on_tty.explicit_format);
+        assert!(on_tty.pretty_json());
+
+        let piped =
+            OutputCtx::resolve(None, None, None, None, false, false, /* tty = */ false);
+        assert_eq!(piped.format, OutputFormat::Ndjson);
+        assert!(!piped.explicit_format);
+        assert!(!piped.pretty_json());
+    }
+
+    #[test]
+    fn explicit_flag_beats_config_and_default() {
+        let ctx = OutputCtx::resolve(
+            Some(OutputFormat::Csv),
+            Some("table"),
+            None,
+            None,
+            false,
+            false,
+            true,
+        );
+        assert_eq!(ctx.format, OutputFormat::Csv);
+        assert!(ctx.explicit_format);
+    }
+
+    #[test]
+    fn config_fills_when_flag_unset() {
+        let ctx = OutputCtx::resolve(None, Some("ndjson"), None, None, false, false, true);
+        assert_eq!(ctx.format, OutputFormat::Ndjson);
+        assert!(ctx.explicit_format);
+    }
+
+    #[test]
+    fn quiet_disables_stats_and_progress() {
+        let ctx = OutputCtx::resolve(None, None, None, None, true, false, false);
+        assert!(!ctx.show_stats());
+        assert!(!ctx.show_progress());
+    }
+
+    #[test]
+    fn no_stats_keeps_progress_drops_stats() {
+        let ctx = OutputCtx::resolve(None, None, None, None, false, true, false);
+        assert!(!ctx.show_stats());
+        assert!(ctx.show_progress());
+    }
+
+    #[test]
+    fn escape_delimited_quotes_only_when_needed() {
+        assert_eq!(escape_delimited("hello", ','), "hello");
+        assert_eq!(escape_delimited("a,b", ','), "\"a,b\"");
+        // Tabs are not quoted by the comma escaper but are quoted by the tab
+        // escaper.
+        assert_eq!(escape_delimited("a\tb", ','), "a\tb");
+        assert_eq!(escape_delimited("a\tb", '\t'), "\"a\tb\"");
+        assert_eq!(
+            escape_delimited("she said \"hi\"", ','),
+            "\"she said \"\"hi\"\"\""
+        );
+        assert_eq!(escape_delimited("line1\nline2", ','), "\"line1\nline2\"");
+    }
+
+    struct Row {
+        name: &'static str,
+        n: u32,
+    }
+
+    impl Tabular for Row {
+        fn headers() -> &'static [&'static str] {
+            &["NAME", "N"]
+        }
+        fn row(&self) -> Vec<String> {
+            vec![self.name.to_string(), self.n.to_string()]
+        }
+    }
+
+    #[test]
+    fn tabular_headers_and_row_shape() {
+        let r = Row { name: "rule", n: 3 };
+        assert_eq!(Row::headers(), &["NAME", "N"]);
+        assert_eq!(r.row(), vec!["rule".to_string(), "3".to_string()]);
+    }
+}

--- a/crates/rsigma-cli/src/output/mod.rs
+++ b/crates/rsigma-cli/src/output/mod.rs
@@ -243,8 +243,6 @@ pub(crate) fn render_json<T: Serialize>(value: &T, pretty: bool) {
 
 /// Render `value` as a single NDJSON line on stdout. Same error semantics as
 /// [`render_json`].
-// Used by the lint machine renderer, which lands in a follow-up commit.
-#[allow(dead_code)]
 pub(crate) fn render_ndjson<T: Serialize>(value: &T) {
     render_json(value, false);
 }

--- a/crates/rsigma-cli/tests/cli_output_format.rs
+++ b/crates/rsigma-cli/tests/cli_output_format.rs
@@ -1,0 +1,512 @@
+//! Integration tests for the global `--output-format` / `--color` /
+//! `--quiet` / `--no-stats` flags.
+//!
+//! Each test exercises a representative subcommand against the same simple
+//! rule + event fixtures so the format dimension is covered without
+//! duplicating per-command tests.
+
+mod common;
+
+use common::{SIMPLE_RULE, rsigma, temp_file};
+use predicates::prelude::*;
+
+/// JSON detection format is the explicit baseline -- one line, the
+/// detection envelope on stdout.
+#[test]
+fn eval_output_format_json_emits_compact_object() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let trimmed = stdout.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "expected a single JSON object, got: {trimmed}",
+    );
+    // Compact: no newlines inside the body.
+    assert_eq!(trimmed.matches('\n').count(), 0);
+    assert!(trimmed.contains("\"rule_title\":\"Test Rule\""));
+}
+
+/// `--output-format ndjson` makes the stream explicitly compact and
+/// line-oriented, matching what jq / fluent-bit expect when consuming
+/// detection NDJSON.
+#[test]
+fn eval_output_format_ndjson_is_line_oriented() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--output-format",
+            "ndjson",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // NDJSON: every non-empty stdout line is a valid JSON value.
+    for line in stdout.lines().filter(|l| !l.trim().is_empty()) {
+        let _: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("invalid NDJSON line: {line:?}: {e}"));
+    }
+}
+
+#[test]
+fn eval_output_format_table_renders_columns() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--output-format",
+            "table",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("LEVEL"), "missing LEVEL header: {stdout}");
+    assert!(stdout.contains("RULE"), "missing RULE header: {stdout}");
+    assert!(stdout.contains("TYPE"), "missing TYPE header: {stdout}");
+    assert!(stdout.contains("DETAIL"), "missing DETAIL header: {stdout}");
+    assert!(stdout.contains("Test Rule"), "missing rule row: {stdout}");
+}
+
+#[test]
+fn eval_output_format_csv_has_header_and_row() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--output-format",
+            "csv",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut lines = stdout.lines().filter(|l| !l.trim().is_empty());
+    assert_eq!(lines.next(), Some("LEVEL,RULE,TYPE,DETAIL"));
+    let row = lines.next().expect("at least one data row");
+    assert!(row.starts_with("high,Test Rule,detection,"), "row: {row}");
+}
+
+#[test]
+fn eval_output_format_tsv_uses_tabs() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--output-format",
+            "tsv",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut lines = stdout.lines().filter(|l| !l.trim().is_empty());
+    assert_eq!(lines.next(), Some("LEVEL\tRULE\tTYPE\tDETAIL"));
+    let row = lines.next().expect("data row");
+    assert_eq!(row.matches('\t').count(), 3);
+}
+
+/// `--quiet` drops both the "Loaded N rules" line and any trailing
+/// summary, leaving only the matched JSON.
+#[test]
+fn eval_quiet_suppresses_stats_and_progress() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--quiet",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("Loaded"),
+        "expected no progress lines under --quiet, got: {stderr}",
+    );
+}
+
+/// `--no-stats` keeps progress (`Loaded N rules`) but drops the trailing
+/// summary line. For the single-event evaluation path the summary lives
+/// only in the stream-mode branches, so we exercise an NDJSON file.
+#[test]
+fn eval_no_stats_keeps_progress_drops_summary() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let events = temp_file(
+        ".ndjson",
+        "{\"CommandLine\": \"malware\"}\n{\"CommandLine\": \"benign\"}\n",
+    );
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            &format!("@{}", events.path().display()),
+            "--no-stats",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Loaded"),
+        "--no-stats should keep progress, got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("Processed"),
+        "--no-stats should drop summary, got: {stderr}",
+    );
+}
+
+/// `--color always` forces ANSI codes on the lint summary even when
+/// stdout is not a TTY (the subprocess pipe in `assert_cmd` is not).
+#[test]
+fn lint_color_always_emits_ansi_codes() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "rule",
+            "lint",
+            rule.path().to_str().unwrap(),
+            "--color",
+            "always",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("\x1b["),
+        "--color always should emit ANSI escapes: {stdout}",
+    );
+}
+
+#[test]
+fn lint_color_never_strips_ansi_codes() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "rule",
+            "lint",
+            rule.path().to_str().unwrap(),
+            "--color",
+            "never",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("\x1b["),
+        "--color never should strip ANSI escapes: {stdout}",
+    );
+}
+
+/// `lint --output-format json` returns the structured `{summary, findings}`
+/// envelope and bypasses the human renderer entirely.
+#[test]
+fn lint_output_format_json_emits_envelope() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "rule",
+            "lint",
+            rule.path().to_str().unwrap(),
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert!(value.get("summary").is_some(), "missing summary: {stdout}");
+    assert!(
+        value.get("findings").is_some(),
+        "missing findings: {stdout}"
+    );
+}
+
+#[test]
+fn lint_output_format_csv_lists_findings() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "rule",
+            "lint",
+            rule.path().to_str().unwrap(),
+            "--output-format",
+            "csv",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut lines = stdout.lines().filter(|l| !l.trim().is_empty());
+    assert_eq!(
+        lines.next(),
+        Some("PATH,SEVERITY,RULE,LINE,MESSAGE"),
+        "header mismatch in {stdout}",
+    );
+}
+
+/// `rsigma rule fields` keeps its legacy table view as the default; the
+/// deprecated `--json` flag is still honoured as a hidden alias for
+/// `--output-format json`.
+#[test]
+fn fields_legacy_json_alias_emits_envelope() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "rule",
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert!(value.get("summary").is_some());
+    assert!(value.get("fields").is_some());
+}
+
+#[test]
+fn fields_output_format_csv_writes_field_rows() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "rule",
+            "fields",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--output-format",
+            "csv",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut lines = stdout.lines().filter(|l| !l.trim().is_empty());
+    assert_eq!(lines.next(), Some("FIELD,RULES,SOURCES"));
+    assert!(
+        lines.next().is_some_and(|r| r.starts_with("CommandLine,")),
+        "expected first CSV row to be CommandLine in {stdout}",
+    );
+}
+
+/// The `RSIGMA_GLOBAL__OUTPUT_FORMAT` env layer drives the format when no
+/// flag is passed, mirroring the rest of the `RSIGMA_*` env scheme.
+#[test]
+fn env_layer_sets_output_format() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .env("RSIGMA_GLOBAL__OUTPUT_FORMAT", "json")
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let trimmed = stdout.trim();
+    assert!(
+        trimmed.starts_with('{'),
+        "expected env-driven JSON, got: {trimmed}",
+    );
+}
+
+/// `global.output_format` in the config file works just like the env var.
+/// `--config` replaces the discovery chain so this is hermetic.
+#[test]
+fn config_file_sets_output_format() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let cfg = temp_file(
+        ".yaml",
+        "global:\n  output_format: json\neval:\n  fail_on_detection: false\n",
+    );
+    let out = rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--config",
+            cfg.path().to_str().unwrap(),
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let trimmed = stdout.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.contains("\"rule_title\":"),
+        "expected config-driven JSON, got: {trimmed}",
+    );
+}
+
+/// Flag wins over env, env wins over file -- this is the layered precedence
+/// the config plan formalised. CLI > env > config > default.
+#[test]
+fn flag_beats_env_for_output_format() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .env("RSIGMA_GLOBAL__OUTPUT_FORMAT", "ndjson")
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+            "--output-format",
+            "csv",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("LEVEL,RULE,TYPE,DETAIL"),
+        "expected CSV (flag) to beat NDJSON (env): {stdout}",
+    );
+}
+
+/// `--output-format json` on `backend convert` wraps the queries in a
+/// `{target, format, queries: [...]}` envelope so agents can branch on
+/// per-query metadata without parsing free text.
+#[test]
+fn convert_output_format_json_wraps_queries() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "backend",
+            "convert",
+            rule.path().to_str().unwrap(),
+            "-t",
+            "test",
+            "--output-format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("valid convert envelope");
+    assert_eq!(value["target"], serde_json::json!("test"));
+    assert!(value["queries"].as_array().is_some_and(|a| !a.is_empty()));
+}
+
+/// `convert` does not have a tabular shape, so `--output-format csv` warns
+/// once on stderr and falls back to the raw query text on stdout.
+#[test]
+fn convert_falls_back_to_text_for_csv() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "backend",
+            "convert",
+            rule.path().to_str().unwrap(),
+            "-t",
+            "test",
+            "--output-format",
+            "csv",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stderr.contains("not supported by `backend convert`"),
+        "expected fallback warning, got: {stderr}",
+    );
+    // Raw text on stdout (the existing path).
+    assert!(
+        !stdout.starts_with('{'),
+        "expected raw query text, got: {stdout}"
+    );
+}
+
+#[test]
+fn quiet_suppresses_convert_fallback_warning() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let out = rsigma()
+        .args([
+            "backend",
+            "convert",
+            rule.path().to_str().unwrap(),
+            "-t",
+            "test",
+            "--output-format",
+            "csv",
+            "--quiet",
+        ])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("not supported"),
+        "--quiet should drop the fallback notice, got: {stderr}",
+    );
+    // Cope with `_ = out;`-style unused binding warnings on some compilers.
+    let _ = predicate::always();
+}

--- a/docs/cli/engine/eval.md
+++ b/docs/cli/engine/eval.md
@@ -49,9 +49,11 @@ For a narrative tutorial see [Evaluating Rules](../../guide/evaluating-rules.md)
 
 ### Output
 
+The global `--output-format` / `--color` / `--quiet` / `--no-stats` flags apply here too; see [Output Formats](../../reference/output.md). The flags below are eval-specific.
+
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--pretty` | off | Pretty-print JSON output. |
+| `--pretty` | off | Pretty-print JSON output. Kept for backwards compatibility; equivalent to `--output-format json` with pretty-printing on. |
 | `--no-detections` | off | Suppress detection output for rules that exist only to feed correlations (`generate: false`). |
 | `--include-event` | off | Embed the full event JSON in every `MatchResult`. Equivalent to setting `rsigma.include_event: "true"` per-rule. |
 
@@ -115,6 +117,14 @@ rsigma engine eval -r rules/ -e '{"CommandLine":"cmd /c whoami"}'
 ```bash
 rsigma engine eval -r rules/ --pretty -e @events.ndjson
 ```
+
+### Table view for interactive triage
+
+```bash
+rsigma engine eval -r rules/ -e @events.ndjson --output-format table
+```
+
+A width-aligned `LEVEL | RULE | TYPE | DETAIL` table appears on stdout. Use `--output-format csv` or `--output-format tsv` to pipe into a spreadsheet instead. See [Output Formats](../../reference/output.md).
 
 ### EVTX file with the bundled Windows-mapping pipeline
 

--- a/docs/reference/.pages
+++ b/docs/reference/.pages
@@ -1,6 +1,7 @@
 nav:
   - Lint Rules: lint-rules.md
   - Configuration: configuration.md
+  - Output Formats: output.md
   - Backends: backends
   - Prometheus Metrics: metrics.md
   - HTTP API: http-api.md

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,7 +36,9 @@ A minimal example, with every supported top-level section:
 version: 1
 
 global:
-  log_format: text     # text | json (maps to --log-format)
+  log_format: text         # text | json (maps to --log-format)
+  output_format: json      # json | ndjson | table | csv | tsv (maps to --output-format)
+  color: auto              # auto | always | never (maps to --color)
 
 daemon:
   rules: /etc/rsigma/rules
@@ -74,7 +76,7 @@ Run [`rsigma config init`](../cli/config/init.md) to scaffold a full, commented 
 
 | Section | Used by | Notes |
 |---------|---------|-------|
-| `global` | every subcommand | Only `global.log_format` is wired today. `global.color` and `global.format` are reserved for the upcoming output-format work. |
+| `global` | every subcommand | `global.log_format`, `global.output_format`, and `global.color`. See [Output Formats](output.md) for the format/color semantics. |
 | `daemon` | `engine daemon` | Mirrors every non-secret daemon flag. |
 | `daemon.api.tls` | `engine daemon` | Inert unless the binary is built with the `daemon-tls` feature; otherwise `config validate` warns. |
 | `daemon.nats` | `engine daemon` | Non-secret NATS knobs (e.g. `consumer_group`). Secrets stay env-only. Inert unless built with `daemon-nats`. |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -12,7 +12,9 @@ Every variable here has a corresponding `--flag` that takes precedence.
 | Variable | Type | Default | Subcommand(s) | Effect |
 |----------|------|---------|---------------|--------|
 | `RUST_LOG` | `tracing-subscriber` filter directive | `info` | All (always for `engine daemon`; otherwise only when `--log-format` is set) | Controls verbosity of structured diagnostic logs on stderr. See [Observability](../guide/observability.md#rust_log-filter-targets) for the target catalog. |
-| `NO_COLOR` | `0`/`1` (presence-only) | unset | `rule lint` and any subcommand that emits colored stderr | Disables ANSI colors. Follows the [NO_COLOR convention](https://no-color.org/). |
+| `NO_COLOR` | `0`/`1` (presence-only) | unset | All subcommands that emit colored stdout/stderr | Disables ANSI colors when `--color auto`. Follows the [NO_COLOR convention](https://no-color.org/). |
+| `RSIGMA_GLOBAL__OUTPUT_FORMAT` | `json`/`ndjson`/`table`/`csv`/`tsv` | unset | All | Default value for `--output-format`. See [Output Formats](output.md). |
+| `RSIGMA_GLOBAL__COLOR` | `auto`/`always`/`never` | unset | All | Default value for `--color`. |
 | `XDG_CONFIG_HOME` | path | `~/.config` | All | Honoured when locating the user config (`$XDG_CONFIG_HOME/rsigma/config.yaml`). See [Configuration discovery](configuration.md#discovery). |
 | `RSIGMA_<SECTION>__<KEY>` | YAML scalar | unset | `engine daemon`, `engine eval` | Uniform env layer for non-secret config keys (e.g. `RSIGMA_DAEMON__API__ADDR`, `RSIGMA_GLOBAL__LOG_FORMAT`). See [Configuration: environment layer](configuration.md#environment-layer). |
 | `RSIGMA_CONSUMER_GROUP` | string | unset | `engine daemon` with `--input nats://` | NATS JetStream consumer group name. Equivalent to `--consumer-group`. Multiple daemons sharing the same group name load-balance across a single durable pull consumer. |

--- a/docs/reference/output.md
+++ b/docs/reference/output.md
@@ -1,0 +1,114 @@
+# Output Formats
+
+Every rsigma subcommand can emit its structured output in one of five formats. The selector, color policy, and noise controls are global flags that resolve through the same precedence model as the rest of the [configuration](configuration.md).
+
+## Selector
+
+```text
+--output-format <FORMAT>   # json | ndjson | table | csv | tsv
+```
+
+| Format | When to use it |
+|--------|----------------|
+| `json` | Default on a TTY; a single pretty-printed JSON object per record. |
+| `ndjson` | Default when piped; one compact JSON object per line. Stream-friendly. |
+| `table` | Width-aligned text table for `engine eval` (`LEVEL | RULE | TYPE | DETAIL`), `rule fields`, `rule lint`, and `rule validate`. Numeric columns are right-aligned. |
+| `csv` | RFC 4180-style comma-separated values. Header row first, then one row per record. |
+| `tsv` | Tab-separated equivalent of `csv`. Friendlier for `cut` and `awk`. |
+
+## Resolution
+
+Highest precedence first:
+
+1. `--output-format` flag on the command line.
+2. `RSIGMA_GLOBAL__OUTPUT_FORMAT` environment variable.
+3. `global.output_format` in the discovered config file (or the file behind `--config`).
+4. TTY-aware default:
+   - `json` when stdout is a terminal (pretty-printed for human reading).
+   - `ndjson` when stdout is piped or redirected (so `| jq` / `| fluent-bit` / `>file.ndjson` do the right thing without an extra flag).
+
+## Color
+
+```text
+--color <CHOICE>   # auto (default) | always | never
+```
+
+Resolved with the same precedence as `--output-format`:
+
+1. `--color` flag.
+2. `RSIGMA_GLOBAL__COLOR` env.
+3. `global.color` in the config file.
+4. `auto`: ANSI escapes are emitted only when stdout is a TTY and the [`NO_COLOR`](https://no-color.org/) environment variable is unset.
+
+Use `--color always` in CI to keep colour in build logs; `--color never` to strip colour without overriding the TTY check.
+
+## Noise control
+
+| Flag | Effect |
+|------|--------|
+| `--quiet`, `-q` | Suppress every non-data line: progress (`Loaded N rules…`), stat summaries (`Processed N events, M matches.`), and the warning printed when `backend convert` falls back to raw text for non-tabular formats. Errors still go to stderr; exit codes are unchanged. |
+| `--no-stats` | Suppress the trailing summary line only. Progress messages still appear, so you can watch a long-running stream but skip the footer when piping into a tool that does not expect one. |
+
+`--quiet` implies `--no-stats`.
+
+## Where output lands
+
+The contract is the same across every subcommand:
+
+* **Stdout** carries the data (matches, fields, lint findings, queries).
+* **Stderr** carries diagnostics, progress, the optional stats summary, and any warnings.
+
+This is what lets `rsigma engine eval … | jq '.rule_title'` work cleanly: `jq` only sees the detection objects.
+
+## Per-command behaviour
+
+| Command | TTY default | When piped | Notes |
+|---------|------------|-----------|-------|
+| `engine eval` | Pretty JSON | NDJSON | `table` renders one row per match (`LEVEL | RULE | TYPE | DETAIL`). `csv` / `tsv` write a header line then one row per match (streaming). `--pretty` still forces pretty JSON for backwards compatibility. |
+| `engine daemon` | Daemon output stays NDJSON on its configured sinks. `--output-format` does not change the sink wire format. |
+| `rule parse`, `rule condition`, `rule stdin` | Pretty JSON | Pretty JSON | These commands emit a parsed AST; pretty-printing stays the default. `--output-format ndjson` switches to compact. |
+| `rule fields` | Table | Table | Default is the legacy table view even when piped, so existing pipelines do not change. Explicit `--output-format json|ndjson|csv|tsv` overrides. The hidden `--json` flag still works and is equivalent to `--output-format json`. |
+| `rule lint` | Coloured human view | Coloured human view (without ANSI when piped) | Same default-as-before behaviour. `--output-format json` emits `{summary, findings}`. `--output-format ndjson` emits one `Finding` per line. `--output-format csv|tsv` emits a `PATH,SEVERITY,RULE,LINE,MESSAGE` view. |
+| `rule validate` | Human summary | Human summary | The format selector is reserved here; the existing summary is unchanged. |
+| `backend convert` | Raw query text | Raw query text | The backend keeps its own `-f, --format` for the query format (SQL view, sliding_window, …). `--output-format json` wraps the queries in `{target, format, queries: [{rule_title, rule_id, query}, …]}`. The non-JSON tabular formats are not meaningful for free-form query text; the command prints a stderr warning and falls back to raw text. |
+
+## Examples
+
+Stream detections into jq, getting compact NDJSON automatically because stdout is piped:
+
+```bash
+rsigma engine eval -r rules/ -e @events.ndjson \
+  | jq '{rule: .rule_title, level: .level}'
+```
+
+Force a table on a TTY for at-a-glance triage:
+
+```bash
+rsigma engine eval -r rules/ -e @events.ndjson --output-format table
+```
+
+Export a coverage report as CSV for a spreadsheet:
+
+```bash
+rsigma rule fields -r rules/ --output-format csv > coverage.csv
+```
+
+Fail a CI job on any lint finding and dump JSON for the GitHub Actions summary:
+
+```bash
+rsigma rule lint rules/ \
+  --fail-level warning \
+  --output-format json \
+  --quiet \
+  > lint.json
+```
+
+Pin a project-wide default in `.rsigmarc`:
+
+```yaml
+global:
+  output_format: ndjson
+  color: auto
+```
+
+CLI flags still override the file, so a developer can flip back to a TTY view with `rsigma rule fields -r rules/ --output-format table`.


### PR DESCRIPTION
## Summary

Every rsigma subcommand can now emit its structured output in one of five formats, selected by a new **global** `--output-format <json|ndjson|table|csv|tsv>` flag. The default is TTY-aware: pretty JSON when stdout is a terminal, plain NDJSON when piped or redirected, so `rsigma engine eval … | jq` does the right thing without any extra flag and `rsigma engine eval` in a terminal is finally readable.

Three more global flags ride alongside `--output-format` and the existing `--log-format`:

- `--color <auto|always|never>` honours [`NO_COLOR`](https://no-color.org/) under `auto` (the default).
- `--quiet` / `-q` suppresses every non-data line (progress, summary, fallback warnings); errors still go to stderr.
- `--no-stats` suppresses only the trailing summary; progress messages stay.

All four resolve through the same layered precedence as the rest of the config: **flag > `RSIGMA_GLOBAL__*` env > `global.*` in the YAML config > TTY-aware default**.

## Per-command behaviour

- **`engine eval`** is the showcase. `table` renders `LEVEL | RULE | TYPE | DETAIL` (numeric columns auto-right-aligned). `csv` and `tsv` stream a header line plus one row per match via the shared `DelimitedWriter`. `--pretty` is preserved as a backwards-compat alias for "pretty JSON".
- **`rule fields`** folds its `--json` flag into the new selector (hidden deprecated alias for `--output-format json`). The legacy table view stays the default even when piped, so existing pipelines do not regress.
- **`rule lint`** keeps the coloured human view as the default. `--output-format json` emits a `{summary, findings}` envelope; `ndjson` streams one `Finding` per line; `csv` / `tsv` write a `PATH,SEVERITY,RULE,LINE,MESSAGE` table. The per-command `--color` flag is gone in favour of the global one; behaviour is identical.
- **`rule parse` / `condition` / `stdin`** route through the shared JSON renderer; `--pretty` still defaults to on (the AST is small and human-friendly is the default).
- **`backend convert`** keeps its existing `-f, --format` (backend query format) and `-o, --output` (output file) unchanged. `--output-format json` wraps the queries in a `{target, format, queries: [{rule_title, rule_id, query}, …]}` envelope. The non-JSON tabular formats are not meaningful for free-form query text, so the command prints a stderr warning and falls back to raw text (the warning is itself suppressible with `--quiet`).

## Implementation

New `crates/rsigma-cli/src/output/` module owns the `OutputFormat` and `ColorChoice` enums, the `OutputCtx` resolver, the `Tabular` trait + width-aligning `render_table` (with auto-right-align for numeric columns), the streaming `DelimitedWriter` for CSV/TSV (hand-rolled RFC 4180-style escaping, no new dependency), and the `Painter` previously in `commands/lint.rs` (now reused by every command).

Config schema rename: `global.format` is renamed to `global.output_format` (the old key was reserved for this work and was inert), and `eval.format` is dropped (it was inert too).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rsigma --all-features` -- 317 tests pass across 20 suites (new `cli_output_format` suite adds 19 tests)
- [x] `mkdocs build --strict`
- [x] Each commit builds individually (verified by walking the chain)