### PR TITLE
feat(lint): add --tag-namespace flag and config file support

### DIFF
--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -608,7 +608,10 @@ fn build_lint_config(
         let cli_config = LintConfig {
             disabled_rules: disable.into_iter().collect(),
             exclude_patterns: exclude,
-            tag_namespaces,
+            tag_namespaces: tag_namespaces
+                .into_iter()
+                .map(|s| s.to_lowercase())
+                .collect(),
             ..Default::default()
         };
         config.merge(&cli_config);

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -59,6 +59,11 @@ pub(crate) struct LintArgs {
     #[arg(long = "fail-level", default_value = "error",
            value_parser = ["error", "warning", "info"])]
     pub fail_level: String,
+
+    /// Allow additional tag namespaces (repeatable).
+    /// Example: --tag-namespace myorg --tag-namespace internal
+    #[arg(long = "tag-namespace")]
+    pub tag_namespaces: Vec<String>,
 }
 
 pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
@@ -71,11 +76,12 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
         exclude,
         fix: apply_fix,
         fail_level: _,
+        tag_namespaces,
     } = args;
     let p = Painter::new(ctx.color);
 
     // 0. Build lint config from file + CLI flags
-    let config = build_lint_config(&path, disable, lint_config_path, exclude);
+    let config = build_lint_config(&path, disable, lint_config_path, exclude, tag_namespaces);
 
     // 1. Run built-in lint checks (with suppression)
     let results: Vec<FileLintResult> = if path.is_dir() {
@@ -559,12 +565,13 @@ fn merge_schema_results(
 // Lint config
 // ---------------------------------------------------------------------------
 
-/// Build a `LintConfig` from a config file (auto-discovered or explicit) + CLI `--disable` flags.
+/// Build a `LintConfig` from a config file (auto-discovered or explicit) + CLI flags.
 fn build_lint_config(
     path: &std::path::Path,
     disable: Vec<String>,
     lint_config_path: Option<PathBuf>,
     exclude: Vec<String>,
+    tag_namespaces: Vec<String>,
 ) -> LintConfig {
     // Load config file
     let mut config = if let Some(explicit) = lint_config_path {
@@ -596,11 +603,12 @@ fn build_lint_config(
         LintConfig::default()
     };
 
-    // Merge --disable and --exclude CLI flags
-    if !disable.is_empty() || !exclude.is_empty() {
+    // Merge --disable, --exclude, and --tag-namespace CLI flags
+    if !disable.is_empty() || !exclude.is_empty() || !tag_namespaces.is_empty() {
         let cli_config = LintConfig {
             disabled_rules: disable.into_iter().collect(),
             exclude_patterns: exclude,
+            tag_namespaces,
             ..Default::default()
         };
         config.merge(&cli_config);

--- a/crates/rsigma-parser/src/lint/mod.rs
+++ b/crates/rsigma-parser/src/lint/mod.rs
@@ -535,8 +535,7 @@ pub fn lint_yaml_value(value: &Value) -> Vec<LintWarning> {
     lint_yaml_value_ext(value, &[])
 }
 
-/// Lint a raw YAML string, returning warnings with resolved source spans.
-pub fn lint_yaml_str(text: &str) -> Vec<LintWarning> {
+fn lint_yaml_str_ext(text: &str, extra_ns: &[String]) -> Vec<LintWarning> {
     let mut all_warnings = Vec::new();
 
     for doc in yaml_serde::Deserializer::from_str(text) {
@@ -561,14 +560,18 @@ pub fn lint_yaml_str(text: &str) -> Vec<LintWarning> {
             }
         };
 
-        let warnings = lint_yaml_value(&value);
-        for mut w in warnings {
+        for mut w in lint_yaml_value_ext(&value, extra_ns) {
             w.span = resolve_path_to_span(text, &w.path);
             all_warnings.push(w);
         }
     }
 
     all_warnings
+}
+
+/// Lint a raw YAML string, returning warnings with resolved source spans.
+pub fn lint_yaml_str(text: &str) -> Vec<LintWarning> {
+    lint_yaml_str_ext(text, &[])
 }
 
 fn resolve_path_to_span(text: &str, path: &str) -> Option<Span> {
@@ -798,7 +801,11 @@ impl LintConfig {
             disabled_rules,
             severity_overrides,
             exclude_patterns: raw.exclude,
-            tag_namespaces: raw.tag_namespaces,
+            tag_namespaces: raw
+                .tag_namespaces
+                .into_iter()
+                .map(|s| s.to_lowercase())
+                .collect(),
         })
     }
 
@@ -982,38 +989,9 @@ pub fn apply_suppressions(
 }
 
 pub fn lint_yaml_str_with_config(text: &str, config: &LintConfig) -> Vec<LintWarning> {
-    let mut all_warnings = Vec::new();
-
-    for doc in yaml_serde::Deserializer::from_str(text) {
-        let value: Value = match Value::deserialize(doc) {
-            Ok(v) => v,
-            Err(e) => {
-                let mut w = err(
-                    LintRule::YamlParseError,
-                    format!("YAML parse error: {e}"),
-                    "/",
-                );
-                if let Some(loc) = e.location() {
-                    w.span = Some(Span {
-                        start_line: loc.line().saturating_sub(1) as u32,
-                        start_col: loc.column() as u32,
-                        end_line: loc.line().saturating_sub(1) as u32,
-                        end_col: loc.column() as u32 + 1,
-                    });
-                }
-                all_warnings.push(w);
-                break;
-            }
-        };
-
-        for mut w in lint_yaml_value_ext(&value, &config.tag_namespaces) {
-            w.span = resolve_path_to_span(text, &w.path);
-            all_warnings.push(w);
-        }
-    }
-
+    let warnings = lint_yaml_str_ext(text, &config.tag_namespaces);
     let inline = parse_inline_suppressions(text);
-    apply_suppressions(all_warnings, config, &inline)
+    apply_suppressions(warnings, config, &inline)
 }
 
 pub fn lint_yaml_file_with_config(
@@ -1577,7 +1555,7 @@ detection:
                 .into_iter()
                 .collect(),
             exclude_patterns: vec!["test/**".to_string()],
-            ..Default::default()
+            tag_namespaces: vec!["myns".to_string()],
         };
 
         base.merge(&other);
@@ -1586,6 +1564,7 @@ detection:
         assert_eq!(base.severity_overrides.get("rule_b"), Some(&Severity::Info));
         assert_eq!(base.severity_overrides.get("rule_d"), Some(&Severity::Hint));
         assert_eq!(base.exclude_patterns, vec!["test/**".to_string()]);
+        assert!(base.tag_namespaces.contains(&"myns".to_string()));
     }
 
     #[test]
@@ -1790,10 +1769,9 @@ tag_namespaces:
   - myorg
   - internal
 "#;
-        let tmp = std::env::temp_dir().join("rsigma_test_tag_ns.yml");
-        std::fs::write(&tmp, yaml).unwrap();
-        let config = LintConfig::load(&tmp).unwrap();
-        std::fs::remove_file(&tmp).ok();
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".yml").unwrap();
+        std::io::Write::write_all(&mut tmp, yaml.as_bytes()).unwrap();
+        let config = LintConfig::load(tmp.path()).unwrap();
 
         assert!(config.tag_namespaces.contains(&"myorg".to_string()));
         assert!(config.tag_namespaces.contains(&"internal".to_string()));

--- a/crates/rsigma-parser/src/lint/mod.rs
+++ b/crates/rsigma-parser/src/lint/mod.rs
@@ -501,8 +501,7 @@ fn is_action_fragment(m: &yaml_serde::Mapping) -> bool {
 // Public API
 // =============================================================================
 
-/// Lint a single YAML document value.
-pub fn lint_yaml_value(value: &Value) -> Vec<LintWarning> {
+fn lint_yaml_value_ext(value: &Value, extra_ns: &[String]) -> Vec<LintWarning> {
     let Some(m) = value.as_mapping() else {
         return vec![err(
             LintRule::NotAMapping,
@@ -521,7 +520,7 @@ pub fn lint_yaml_value(value: &Value) -> Vec<LintWarning> {
 
     let doc_type = detect_doc_type(m);
     match doc_type {
-        DocType::Detection => rules::detection::lint_detection_rule(m, &mut warnings),
+        DocType::Detection => rules::detection::lint_detection_rule(m, &mut warnings, extra_ns),
         DocType::Correlation => rules::correlation::lint_correlation_rule(m, &mut warnings),
         DocType::Filter => rules::filter::lint_filter_rule(m, &mut warnings),
     }
@@ -529,6 +528,11 @@ pub fn lint_yaml_value(value: &Value) -> Vec<LintWarning> {
     rules::shared::lint_unknown_keys(m, doc_type, &mut warnings);
 
     warnings
+}
+
+/// Lint a single YAML document value.
+pub fn lint_yaml_value(value: &Value) -> Vec<LintWarning> {
+    lint_yaml_value_ext(value, &[])
 }
 
 /// Lint a raw YAML string, returning warnings with resolved source spans.
@@ -752,6 +756,8 @@ pub struct LintConfig {
     pub disabled_rules: HashSet<String>,
     pub severity_overrides: HashMap<String, Severity>,
     pub exclude_patterns: Vec<String>,
+    /// Extra tag namespaces recognised in addition to the built-in set.
+    pub tag_namespaces: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -762,6 +768,8 @@ struct RawLintConfig {
     severity_overrides: HashMap<String, String>,
     #[serde(default)]
     exclude: Vec<String>,
+    #[serde(default)]
+    tag_namespaces: Vec<String>,
 }
 
 impl LintConfig {
@@ -790,6 +798,7 @@ impl LintConfig {
             disabled_rules,
             severity_overrides,
             exclude_patterns: raw.exclude,
+            tag_namespaces: raw.tag_namespaces,
         })
     }
 
@@ -822,6 +831,8 @@ impl LintConfig {
         }
         self.exclude_patterns
             .extend(other.exclude_patterns.iter().cloned());
+        self.tag_namespaces
+            .extend(other.tag_namespaces.iter().cloned());
     }
 
     pub fn is_disabled(&self, rule: &LintRule) -> bool {
@@ -971,9 +982,38 @@ pub fn apply_suppressions(
 }
 
 pub fn lint_yaml_str_with_config(text: &str, config: &LintConfig) -> Vec<LintWarning> {
-    let warnings = lint_yaml_str(text);
+    let mut all_warnings = Vec::new();
+
+    for doc in yaml_serde::Deserializer::from_str(text) {
+        let value: Value = match Value::deserialize(doc) {
+            Ok(v) => v,
+            Err(e) => {
+                let mut w = err(
+                    LintRule::YamlParseError,
+                    format!("YAML parse error: {e}"),
+                    "/",
+                );
+                if let Some(loc) = e.location() {
+                    w.span = Some(Span {
+                        start_line: loc.line().saturating_sub(1) as u32,
+                        start_col: loc.column() as u32,
+                        end_line: loc.line().saturating_sub(1) as u32,
+                        end_col: loc.column() as u32 + 1,
+                    });
+                }
+                all_warnings.push(w);
+                break;
+            }
+        };
+
+        for mut w in lint_yaml_value_ext(&value, &config.tag_namespaces) {
+            w.span = resolve_path_to_span(text, &w.path);
+            all_warnings.push(w);
+        }
+    }
+
     let inline = parse_inline_suppressions(text);
-    apply_suppressions(warnings, config, &inline)
+    apply_suppressions(all_warnings, config, &inline)
 }
 
 pub fn lint_yaml_file_with_config(
@@ -1537,6 +1577,7 @@ detection:
                 .into_iter()
                 .collect(),
             exclude_patterns: vec!["test/**".to_string()],
+            ..Default::default()
         };
 
         base.merge(&other);
@@ -1714,5 +1755,47 @@ EventID: 4624
         for key_str in ALL_LINT_KEYS {
             assert!(KEY_CACHE.contains_key(key_str), "key not cached: {key_str}");
         }
+    }
+
+    #[test]
+    fn extra_tag_namespace_suppresses_warning() {
+        let text = r#"title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        field: value
+    condition: selection
+level: medium
+tags:
+    - myorg.custom_tag
+"#;
+        // Without extra namespaces, unknown_tag_namespace fires.
+        let warnings = lint_yaml_str(text);
+        assert!(has_rule(&warnings, LintRule::UnknownTagNamespace));
+
+        // With "myorg" added, the warning is gone.
+        let config = LintConfig {
+            tag_namespaces: vec!["myorg".to_string()],
+            ..Default::default()
+        };
+        let warnings = lint_yaml_str_with_config(text, &config);
+        assert!(has_no_rule(&warnings, LintRule::UnknownTagNamespace));
+    }
+
+    #[test]
+    fn extra_tag_namespace_from_config_file() {
+        let yaml = r#"
+tag_namespaces:
+  - myorg
+  - internal
+"#;
+        let tmp = std::env::temp_dir().join("rsigma_test_tag_ns.yml");
+        std::fs::write(&tmp, yaml).unwrap();
+        let config = LintConfig::load(&tmp).unwrap();
+        std::fs::remove_file(&tmp).ok();
+
+        assert!(config.tag_namespaces.contains(&"myorg".to_string()));
+        assert!(config.tag_namespaces.contains(&"internal".to_string()));
     }
 }

--- a/crates/rsigma-parser/src/lint/rules/detection.rs
+++ b/crates/rsigma-parser/src/lint/rules/detection.rs
@@ -200,10 +200,12 @@ pub(crate) fn lint_detection_rule(
                         && !KNOWN_TAG_NAMESPACES.contains(&ns)
                         && !extra_namespaces.iter().any(|n| n.as_str() == ns)
                     {
+                        let mut seen = std::collections::HashSet::new();
                         let known_list: Vec<&str> = KNOWN_TAG_NAMESPACES
                             .iter()
                             .copied()
                             .chain(extra_namespaces.iter().map(String::as_str))
+                            .filter(|n| seen.insert(*n))
                             .collect();
                         warnings.push(warning(
                             LintRule::UnknownTagNamespace,

--- a/crates/rsigma-parser/src/lint/rules/detection.rs
+++ b/crates/rsigma-parser/src/lint/rules/detection.rs
@@ -45,7 +45,11 @@ fn is_valid_logsource_value(s: &str) -> bool {
         })
 }
 
-pub(crate) fn lint_detection_rule(m: &yaml_serde::Mapping, warnings: &mut Vec<LintWarning>) {
+pub(crate) fn lint_detection_rule(
+    m: &yaml_serde::Mapping,
+    warnings: &mut Vec<LintWarning>,
+    extra_namespaces: &[String],
+) {
     // ── level ─────────────────────────────────────────────────────────────
     if !m.contains_key(key("level")) {
         warnings.push(warning(
@@ -194,12 +198,18 @@ pub(crate) fn lint_detection_rule(m: &yaml_serde::Mapping, warnings: &mut Vec<Li
                 } else {
                     if let Some(ns) = tag.split('.').next()
                         && !KNOWN_TAG_NAMESPACES.contains(&ns)
+                        && !extra_namespaces.iter().any(|n| n.as_str() == ns)
                     {
+                        let known_list: Vec<&str> = KNOWN_TAG_NAMESPACES
+                            .iter()
+                            .copied()
+                            .chain(extra_namespaces.iter().map(String::as_str))
+                            .collect();
                         warnings.push(warning(
                             LintRule::UnknownTagNamespace,
                             format!(
                                 "unknown tag namespace \"{ns}\", known namespaces: {}",
-                                KNOWN_TAG_NAMESPACES.join(", ")
+                                known_list.join(", ")
                             ),
                             format!("/tags/{i}"),
                         ));

--- a/docs/cli/rule/lint.md
+++ b/docs/cli/rule/lint.md
@@ -44,6 +44,7 @@ For the narrative version with the full lint-rule catalog and CI patterns see [L
 |------|-------------|
 | `--disable <IDS>` | Disable specific lint rules. Comma-separated: `--disable missing_author,missing_description`. |
 | `--config <PATH>` | Path to a `.rsigma-lint.yml`. If unset, ancestors of `<PATH>` are searched. |
+| `--tag-namespace <NS>` | Allow an additional tag namespace (repeatable). Tags using the given namespace no longer trigger `unknown_tag_namespace`. Example: `--tag-namespace myorg --tag-namespace internal`. |
 
 Inline `# rsigma-disable` and `# rsigma-disable-next-line` comments also work; see [Linting Rules: suppression](../../guide/linting-rules.md#suppression-three-tiers).
 

--- a/docs/developers/linter-and-lsp.md
+++ b/docs/developers/linter-and-lsp.md
@@ -146,7 +146,7 @@ Three operations:
 Two layers, both already implemented:
 
 - **YAML comments.** A line comment `# rsigma-disable-next-line: missing_title, invalid_status` suppresses those rules for the immediately following line; `# rsigma-disable-next-line` (no list) suppresses all rules on the next line. A file-level `# rsigma-disable: missing_title` suppresses those rules across the whole document, and `# rsigma-disable` (no list) suppresses every rule in the document. The parser is in `parse_inline_suppressions`.
-- **`LintConfig`.** Programmatic; CLI flags map as `--disable <id1,id2>` -> `LintConfig.disabled_rules`, `--exclude '<glob>'` -> `LintConfig.exclude_patterns`, and a YAML config file (`rsigma-lint.yml` or `--lint-config`) feeds all three fields plus `severity_overrides`.
+- **`LintConfig`.** Programmatic; CLI flags map as `--disable <id1,id2>` -> `LintConfig.disabled_rules`, `--exclude '<glob>'` -> `LintConfig.exclude_patterns`, `--tag-namespace <ns>` -> `LintConfig.tag_namespaces`, and a YAML config file (`rsigma-lint.yml` or `--lint-config`) feeds all four fields plus `severity_overrides`.
 
 `apply_suppressions(warnings, &LintConfig, &InlineSuppressions) -> Vec<LintWarning>` filters out suppressed warnings and applies the severity overrides. Both the CLI and the LSP call it after linting.
 

--- a/docs/guide/linting-rules.md
+++ b/docs/guide/linting-rules.md
@@ -123,6 +123,9 @@ severity_overrides:
 exclude:
   - "config/**"
   - "**/unsupported/**"
+tag_namespaces:
+  - myorg
+  - internal
 ```
 
 `severity_overrides` lets you keep a rule active but change how loud it is. Setting `title_too_long: info` keeps the check but stops it from failing `--fail-level warning` builds.

--- a/docs/reference/lint-rules.md
+++ b/docs/reference/lint-rules.md
@@ -314,6 +314,14 @@ tags:
 
 The recognised tag namespaces are `attack.*`, `cve.*`, `detection.*`, `tlp.*`, `stp.*`, and `informational.*`. The fix is to manually replace the unknown namespace with the closest valid one (the linter doesn't auto-correct; tag namespaces are ambiguous enough that silent rewrites would be unsafe).
 
+To allow organisation-specific namespaces, pass `--tag-namespace <name>` on the CLI (repeatable) or add a `tag_namespaces` list to `.rsigma-lint.yml`:
+
+```yaml
+tag_namespaces:
+  - myorg
+  - internal
+```
+
 ### `null_in_value_list`
 
 Trigger:


### PR DESCRIPTION
Adds a --tag-namespace flag to rsigma rule lint (repeatable) and a tag_namespaces list field to .rsigma-lint.yml so teams can register organisation-specific tag namespaces without disabling the unknown_tag_namespace rule entirely.

On the library side, LintConfig gains a tag_namespaces field that is merged through the same layering as disabled_rules and exclude_patterns. lint_yaml_str_with_config now passes the extra namespaces down to lint_detection_rule at check time rather than filtering after the fact, so the warning message lists the full combined set of known namespaces when it does fire.

Two new tests cover both paths: extra namespaces passed through LintConfig suppress the warning, and the tag_namespaces key in a config file round-trips correctly through LintConfig::load.