### PR TITLE
feat(lint): de-duplicate layered config lists and document tag namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Custom tag namespaces for the linter (#161)
+
+`rsigma rule lint` no longer forces teams to disable `unknown_tag_namespace` wholesale just to use organisation-specific tags. A repeatable `--tag-namespace <ns>` flag and a `tag_namespaces` list in `.rsigma-lint.yml` register extra namespaces that are recognised alongside the built-in spec set (`attack`, `car`, `cve`, `d3fend`, `detection`, `stp`, `tlp`). Namespace values are normalised to lowercase, and when `unknown_tag_namespace` does fire its message lists the full combined set of known namespaces.
+
+On the library side, `LintConfig` gains a `tag_namespaces` field that layers through the same merge path as `disabled_rules` and `exclude_patterns`. Both list-valued fields, `exclude_patterns` and `tag_namespaces`, are now de-duplicated (first occurrence wins) when a config file and CLI flags are layered, so overlapping entries no longer accumulate. Docs cover the new flag and config key across the lint CLI reference, the linting guide, the lint-rules reference, and the linter developer guide; the CLI and root READMEs list the flag.
+
 ### TTY-aware output + structured output formats (#157)
 
 Every rsigma subcommand can now emit its structured output in one of five formats, selected by a new **global** `--output-format <json|ndjson|table|csv|tsv>` flag. The default is TTY-aware: pretty JSON when stdout is a terminal, plain NDJSON when piped or redirected, so `rsigma engine eval … | jq` does the right thing without any extra flag and `rsigma engine eval` in a terminal is finally readable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### Custom tag namespaces for the linter (#161)
+### Custom tag namespaces for the linter (#161, #162)
 
 `rsigma rule lint` no longer forces teams to disable `unknown_tag_namespace` wholesale just to use organisation-specific tags. A repeatable `--tag-namespace <ns>` flag and a `tag_namespaces` list in `.rsigma-lint.yml` register extra namespaces that are recognised alongside the built-in spec set (`attack`, `car`, `cve`, `d3fend`, `detection`, `stp`, `tlp`). Namespace values are normalised to lowercase, and when `unknown_tag_namespace` does fire its message lists the full combined set of known namespaces.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For rule quality and editor integration, a built-in linter validates rules again
 * **TLS termination:** Use in-process TLS termination for the daemon API listener (HTTP REST, `/metrics`, OTLP/HTTP, OTLP/gRPC) with optional mutual TLS, `aws-lc-rs` crypto, and cross-platform certificate hot-reload
 * **NATS JetStream:** Use NATS JetStream support with authentication (credentials, mTLS), replay, consumer groups, and dead-letter queues
 * **OTLP ingestion:** Use OTLP support for any OpenTelemetry-compatible agent (Grafana Alloy, Vector, Fluent Bit, OTel Collector) via HTTP or gRPC
-* **Built-in linter:** Validate rules with 66 checks, four severity levels, a full suppression system, and auto-fix (`--fix`) for 13 safe rules
+* **Built-in linter:** Validate rules with 66 checks, four severity levels, a full suppression system, configurable custom tag namespaces (`--tag-namespace`), and auto-fix (`--fix`) for 13 safe rules
 * **LSP server:** Use real-time diagnostics, completions, hover documentation, document symbols, and quick-fix code actions
 * **Docker images:** Use multi-arch Docker images (linux/amd64, linux/arm64) with cosign signatures, SBOM, and SLSA Build L3 provenance
 * **Release binaries:** Use cross-platform binaries for Linux, macOS, and Windows on amd64 and arm64

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -161,6 +161,7 @@ Run 66 built-in lint rules with optional JSON schema validation.
 | `--disable` | string | `""` | Comma-separated lint rule IDs to suppress |
 | `--config` | path | none | Explicit path to `.rsigma-lint.yml` (otherwise auto-discovered by walking ancestor directories) |
 | `--exclude` | string | none | Glob pattern for paths to skip (repeatable, relative to lint root) |
+| `--tag-namespace` | string | none | Allow an additional tag namespace beyond the built-in spec set (repeatable). Tags using the namespace no longer trigger `unknown_tag_namespace`. Values are lowercased. |
 | `--fix` | flag | `false` | Automatically apply safe fixes (lowercase keys, correct typos, remove duplicates, etc.) |
 | `--fail-level` | string | `"error"` | Minimum severity for non-zero exit: `error` (default), `warning`, or `info` |
 
@@ -175,6 +176,7 @@ rsigma rule lint rules/ --disable missing_description,missing_author  # suppress
 rsigma rule lint rules/ --config my-lint.yml        # explicit config file
 rsigma rule lint rules/ --exclude "config/**"       # skip non-rule files
 rsigma rule lint rules/ --exclude "config/**" --exclude "**/unsupported/**"  # multiple patterns
+rsigma rule lint rules/ --tag-namespace myorg --tag-namespace internal  # allow custom tag namespaces
 rsigma rule lint rules/ --fix                       # auto-fix safe issues
 rsigma rule lint rules/ --fail-level warning        # CI: fail on warnings too
 rsigma rule lint rules/ --fail-level info           # CI: fail on any finding

--- a/crates/rsigma-parser/src/lint/mod.rs
+++ b/crates/rsigma-parser/src/lint/mod.rs
@@ -775,6 +775,14 @@ struct RawLintConfig {
     tag_namespaces: Vec<String>,
 }
 
+/// Remove duplicate entries from a list while keeping the first occurrence of
+/// each, so merged `exclude_patterns` / `tag_namespaces` stay stable and don't
+/// repeat a value that appears in both the config file and a CLI flag.
+fn dedup_preserving_order(items: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    items.retain(|item| seen.insert(item.clone()));
+}
+
 impl LintConfig {
     pub fn load(path: &Path) -> crate::error::Result<Self> {
         let content = std::fs::read_to_string(path)?;
@@ -797,15 +805,21 @@ impl LintConfig {
             severity_overrides.insert(rule.clone(), sev);
         }
 
+        let mut exclude_patterns = raw.exclude;
+        dedup_preserving_order(&mut exclude_patterns);
+
+        let mut tag_namespaces: Vec<String> = raw
+            .tag_namespaces
+            .into_iter()
+            .map(|s| s.to_lowercase())
+            .collect();
+        dedup_preserving_order(&mut tag_namespaces);
+
         Ok(LintConfig {
             disabled_rules,
             severity_overrides,
-            exclude_patterns: raw.exclude,
-            tag_namespaces: raw
-                .tag_namespaces
-                .into_iter()
-                .map(|s| s.to_lowercase())
-                .collect(),
+            exclude_patterns,
+            tag_namespaces,
         })
     }
 
@@ -838,8 +852,10 @@ impl LintConfig {
         }
         self.exclude_patterns
             .extend(other.exclude_patterns.iter().cloned());
+        dedup_preserving_order(&mut self.exclude_patterns);
         self.tag_namespaces
             .extend(other.tag_namespaces.iter().cloned());
+        dedup_preserving_order(&mut self.tag_namespaces);
     }
 
     pub fn is_disabled(&self, rule: &LintRule) -> bool {
@@ -1565,6 +1581,63 @@ detection:
         assert_eq!(base.severity_overrides.get("rule_d"), Some(&Severity::Hint));
         assert_eq!(base.exclude_patterns, vec!["test/**".to_string()]);
         assert!(base.tag_namespaces.contains(&"myns".to_string()));
+    }
+
+    #[test]
+    fn lint_config_merge_dedups_lists() {
+        let mut base = LintConfig {
+            exclude_patterns: vec!["config/**".to_string(), "shared/**".to_string()],
+            tag_namespaces: vec!["myorg".to_string(), "shared".to_string()],
+            ..Default::default()
+        };
+        let other = LintConfig {
+            // "shared/**" and "shared" overlap with base on purpose.
+            exclude_patterns: vec!["shared/**".to_string(), "extra/**".to_string()],
+            tag_namespaces: vec!["shared".to_string(), "internal".to_string()],
+            ..Default::default()
+        };
+
+        base.merge(&other);
+
+        assert_eq!(
+            base.exclude_patterns,
+            vec![
+                "config/**".to_string(),
+                "shared/**".to_string(),
+                "extra/**".to_string()
+            ]
+        );
+        assert_eq!(
+            base.tag_namespaces,
+            vec![
+                "myorg".to_string(),
+                "shared".to_string(),
+                "internal".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn lint_config_load_dedups_and_normalises() {
+        let yaml = r#"
+exclude:
+  - "config/**"
+  - "config/**"
+tag_namespaces:
+  - MyOrg
+  - myorg
+  - internal
+"#;
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".yml").unwrap();
+        std::io::Write::write_all(&mut tmp, yaml.as_bytes()).unwrap();
+        let config = LintConfig::load(tmp.path()).unwrap();
+
+        assert_eq!(config.exclude_patterns, vec!["config/**".to_string()]);
+        // "MyOrg" lowercases to "myorg" and then collapses with the duplicate.
+        assert_eq!(
+            config.tag_namespaces,
+            vec!["myorg".to_string(), "internal".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-on to #161 (custom tag namespaces for the linter). It applies the same polish to `exclude_patterns` that #161 applied to `tag_namespaces`, and backfills the documentation that #161 missed.

## Summary

- De-duplicate both list-valued `LintConfig` fields, `exclude_patterns` and `tag_namespaces`, in `LintConfig::load` and `LintConfig::merge` (first occurrence wins, order preserved), so overlapping config-file and CLI entries no longer accumulate duplicates across configuration layers.
- Document the `--tag-namespace` flag in the CLI README (flag table plus an example) and the root README linter bullet.
- Add the `[Unreleased]` CHANGELOG entry for the custom tag-namespace feature from #161, which was not recorded when that PR merged.

## Why

During the #161 review, `exclude_patterns` was flagged as having the same duplicate-accumulation behavior as `tag_namespaces`, but only `tag_namespaces` was addressed (and only in the warning message, not in storage). This change makes the two fields consistent at the storage level via a shared `dedup_preserving_order` helper, and closes the doc gaps.

## Tests

- `lint_config_merge_dedups_lists`: overlapping entries across two layers collapse to a single ordered list for both fields.
- `lint_config_load_dedups_and_normalises`: a config file with duplicate `exclude` globs and mixed-case duplicate `tag_namespaces` loads de-duplicated and lowercased.
- `cargo test -p rsigma-parser lint::` passes (149 tests), `cargo fmt --all -- --check` clean, `cargo clippy -p rsigma-parser --all-targets --all-features -- -D warnings` clean.

## Test plan

- [ ] CI green (fmt, clippy, tests, docs)
- [ ] Confirm CHANGELOG wording reads well in the rendered release notes