### PR TITLE
fix(daemon): exit promptly on signal with idle stdin

### DIFF
--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -776,7 +776,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     let engine_dlq_tx = dlq_tx.clone();
     let dlq_enabled = config.dlq.is_some();
     #[cfg(feature = "daemon-otlp")]
-    let engine_source_done = source_done_notify;
+    let engine_source_done = source_done_notify.clone();
     let engine_handle = tokio::spawn(async move {
         let filter_fn = move |v: &serde_json::Value| crate::apply_event_filter(v, &event_filter);
         #[cfg(feature = "daemon-otlp")]
@@ -1102,6 +1102,15 @@ pub async fn run_daemon(config: DaemonConfig) {
             h.abort();
             tracing::info!("Source task aborted");
         }
+
+        // Tell the engine to stop pulling new events and drain what is already
+        // buffered. The stdin reader cannot be cancelled mid-read, so without
+        // this the engine would block on `event_rx.recv()` (holding `sink_tx`
+        // open) until the drain timeout elapses, falsely warning that events
+        // were lost. The engine closes its receiver on this signal, drains the
+        // buffered events, then exits, which lets the sink/ack tasks finish.
+        #[cfg(feature = "daemon-otlp")]
+        source_done_notify.notify_one();
 
         let drain = async {
             let _ = sink_handle.await;

--- a/crates/rsigma-cli/tests/cli_daemon.rs
+++ b/crates/rsigma-cli/tests/cli_daemon.rs
@@ -895,3 +895,122 @@ fn daemon_state_db_migration_from_old_schema() {
         "schema should be migrated to include source_timestamp"
     );
 }
+
+/// Regression test: a daemon reading from stdin must shut down promptly on
+/// SIGINT even when stdin is idle (open but no pending line, no EOF).
+///
+/// `tokio::io::stdin()` reads via an uncancellable blocking thread that the
+/// runtime waits for at shutdown, so the daemon used to hang on Ctrl+C until
+/// another line or EOF arrived. The dedicated `std::thread`-based stdin reader
+/// fixes that. This is Unix-only because it relies on POSIX signal delivery.
+#[cfg(all(unix, feature = "daemon"))]
+#[test]
+fn daemon_stdin_exits_promptly_on_sigint() {
+    use std::io::{BufRead, BufReader};
+    use std::net::TcpStream;
+    use std::process::{Command as StdCommand, Stdio};
+    use std::time::{Duration, Instant};
+
+    let rules = temp_file(".yml", SIMPLE_RULE);
+
+    let mut child = StdCommand::new(common::rsigma_bin())
+        .args([
+            "engine",
+            "daemon",
+            "-r",
+            rules.path().to_str().unwrap(),
+            "--api-addr",
+            "127.0.0.1:0",
+        ])
+        // Hold the write end of stdin open for the whole test: the source has
+        // no input and never sees EOF, which is the scenario that used to hang.
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn daemon");
+    let _stdin = child.stdin.take().expect("piped stdin");
+
+    // Forward stderr lines so we can read the bound API address.
+    let stderr = child.stderr.take().unwrap();
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines() {
+            let Ok(line) = line else { return };
+            if tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+
+    let kill_and_reap = |child: &mut std::process::Child| {
+        let _ = child.kill();
+        let _ = child.wait();
+    };
+
+    // Wait for the "API server listening" line and pull out the address.
+    let addr_deadline = Instant::now() + Duration::from_secs(10);
+    let api_addr = loop {
+        let remaining = addr_deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        match rx.recv_timeout(remaining) {
+            Ok(line) if line.contains("API server listening") => {
+                let addr = serde_json::from_str::<serde_json::Value>(&line)
+                    .ok()
+                    .and_then(|v| v["fields"]["addr"].as_str().map(str::to_string));
+                if let Some(addr) = addr {
+                    break addr;
+                }
+            }
+            Ok(_) => {}
+            Err(_) => {
+                kill_and_reap(&mut child);
+                panic!("daemon never logged its API address within 10s");
+            }
+        }
+    };
+
+    // Connect to the API socket. Once it accepts, the serve task has polled
+    // its graceful-shutdown future, so the SIGINT handler is installed and the
+    // signal will trigger a clean shutdown rather than the default kill.
+    let socket: std::net::SocketAddr = api_addr.parse().expect("valid api addr");
+    let ready_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect_timeout(&socket, Duration::from_millis(200)).is_ok() {
+            break;
+        }
+        if Instant::now() >= ready_deadline {
+            kill_and_reap(&mut child);
+            panic!("daemon API never became reachable within 5s");
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    let signaled = StdCommand::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status()
+        .expect("failed to run kill");
+    assert!(signaled.success(), "kill -INT did not succeed");
+
+    // The default drain timeout is 5s; a healthy shutdown is near-instant, so
+    // 10s is a generous bound that still fails fast if the runtime hangs.
+    let exit_deadline = Instant::now() + Duration::from_secs(10);
+    let status = loop {
+        match child.try_wait().expect("try_wait failed") {
+            Some(status) => break status,
+            None => {
+                if Instant::now() >= exit_deadline {
+                    kill_and_reap(&mut child);
+                    panic!("daemon did not exit within 10s of SIGINT (stdin shutdown hang)");
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+
+    assert!(
+        status.success(),
+        "daemon should exit cleanly on SIGINT, got {status:?}"
+    );
+}

--- a/crates/rsigma-runtime/src/io/stdin.rs
+++ b/crates/rsigma-runtime/src/io/stdin.rs
@@ -1,13 +1,22 @@
-use tokio::io::{AsyncBufReadExt, BufReader};
+use std::io::BufRead;
+
+use tokio::sync::mpsc;
 
 use super::{AckToken, EventSource, RawEvent};
 
 /// Reads events from stdin, one per line.
 ///
-/// Uses `tokio::io::stdin()` with `AsyncBufReadExt::lines()` for fully async
-/// reading without a background blocking thread.
+/// Reading happens on a dedicated OS thread (`std::thread`) that forwards
+/// each line over a bounded channel, rather than via `tokio::io::stdin()`.
+/// `tokio::io::stdin()` is implemented with an ordinary blocking read on a
+/// runtime-managed thread that cannot be cancelled; when no input is pending,
+/// that read parks until the next line or EOF and the Tokio runtime waits for
+/// it during shutdown. That makes the daemon hang on Ctrl+C / SIGTERM until
+/// more input arrives (see the `tokio::io::stdin` docs). Because a plain
+/// `std::thread` is not a runtime blocking task, the runtime does not wait for
+/// it at shutdown, so the daemon exits promptly even with an idle stdin.
 pub struct StdinSource {
-    lines: tokio::io::Lines<BufReader<tokio::io::Stdin>>,
+    rx: mpsc::Receiver<String>,
 }
 
 impl Default for StdinSource {
@@ -18,28 +27,48 @@ impl Default for StdinSource {
 
 impl StdinSource {
     pub fn new() -> Self {
-        let stdin = tokio::io::stdin();
-        let lines = BufReader::new(stdin).lines();
-        StdinSource { lines }
+        // Bounded so a slow pipeline back-pressures the reader thread (which
+        // then stops draining the OS stdin buffer) instead of buffering
+        // unboundedly.
+        let (tx, rx) = mpsc::channel(1024);
+        std::thread::Builder::new()
+            .name("rsigma-stdin".to_string())
+            .spawn(move || {
+                let stdin = std::io::stdin();
+                for line in stdin.lock().lines() {
+                    match line {
+                        // `blocking_send` only errors when the receiver is
+                        // dropped, i.e. the daemon is shutting down; stop
+                        // reading so the thread can exit.
+                        Ok(line) => {
+                            if tx.blocking_send(line).is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Error reading stdin");
+                            break;
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn stdin reader thread");
+        StdinSource { rx }
     }
 }
 
 impl EventSource for StdinSource {
     async fn recv(&mut self) -> Option<RawEvent> {
         loop {
-            match self.lines.next_line().await {
-                Ok(Some(line)) if !line.trim().is_empty() => {
+            match self.rx.recv().await {
+                Some(line) if !line.trim().is_empty() => {
                     return Some(RawEvent {
                         payload: line,
                         ack_token: AckToken::Noop,
                     });
                 }
-                Ok(Some(_)) => continue,
-                Ok(None) => return None,
-                Err(e) => {
-                    tracing::warn!(error = %e, "Error reading stdin");
-                    return None;
-                }
+                Some(_) => continue,
+                None => return None,
             }
         }
     }


### PR DESCRIPTION
## Summary

The daemon would hang on Ctrl+C / SIGTERM when reading from an idle stdin (open, no pending line, no EOF), as reported during local testing. Pushing another event or hitting EOF unblocked it, and `--input http` was unaffected.

Root cause: `StdinSource` was built on `tokio::io::stdin()`, whose blocking read runs on a runtime-managed thread that "is impossible to cancel" and that the Tokio runtime waits for at shutdown (per the tokio docs). So the runtime drop blocked until the next line/EOF. Separately, the engine task kept waiting on `event_rx.recv()` (holding the sink channel open) until the `drain_timeout` elapsed, producing a misleading `Drain timeout exceeded, some events may be lost` warning even though nothing was lost.

## Changes

- `rsigma-runtime`: rewrite `StdinSource` to read on a dedicated `std::thread` and forward lines over a bounded `tokio::sync::mpsc` channel. Because a plain OS thread is not a runtime blocking task, the runtime no longer waits for it at shutdown. This is the pattern the `tokio::io::stdin` docs recommend. The previous doc comment claiming "fully async reading without a background blocking thread" was also inaccurate and is corrected.
- `rsigma-cli` daemon: on shutdown, signal the engine to close its receiver, drain already-buffered events, and exit, removing the spurious 5s drain wait and the false data-loss warning. The non-otlp path already aborts the source task, which now works because the new source is cancel-safe.
- Add a Unix-only regression test (`daemon_stdin_exits_promptly_on_sigint`) that holds stdin open with no input and asserts a clean exit within seconds of SIGINT.

## Test plan

- [x] `cargo check` / `cargo clippy` pass for default, `daemon-otlp`, and `daemon-nats` feature sets (one pre-existing `collapsible_if` lint in `commands/daemon.rs` from a clippy version bump is unrelated and left untouched).
- [x] Daemon integration tests pass: 30 streaming/HTTP + 9 OTLP.
- [x] New regression test passes on default and `daemon-otlp` builds.
- [x] Verified the new test FAILS (daemon hangs past the deadline) when `StdinSource` is reverted to the old `tokio::io::stdin()` version, confirming it guards the regression.
- [x] Manual: idle daemon reading from a never-EOF FIFO now exits in ~0.1s on SIGINT (code 0) with no drain-timeout warning; the normal piped-events + EOF path still detects and exits cleanly.