### PR TITLE
fix(runtime): isolate pipeline-deprecation dedup tests

### DIFF
--- a/crates/rsigma-runtime/src/pipeline_deprecation.rs
+++ b/crates/rsigma-runtime/src/pipeline_deprecation.rs
@@ -118,8 +118,16 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    /// `SEEN_INLINE_SOURCES` is process-wide, so these tests cannot run
+    /// concurrently: each one resets the set and then asserts on its
+    /// contents, and cargo runs unit tests in parallel by default. This lock
+    /// serialises them. `into_inner` recovers from a poisoned guard left by an
+    /// earlier failing run so one failure does not cascade into the other.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn dedup_suppresses_repeat_warnings_for_same_canonical_path() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut file = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
         writeln!(file, "name: deprecated_pipeline").unwrap();
         reset_inline_sources_dedup_for_tests();
@@ -127,8 +135,10 @@ mod tests {
         warn_pipeline_inline_sources(file.path(), "deprecated_pipeline");
         warn_pipeline_inline_sources(file.path(), "deprecated_pipeline");
 
+        // Snapshot (which drops the global guard) before asserting so a failed
+        // assertion cannot poison `SEEN_INLINE_SOURCES`.
         let canonical = file.path().canonicalize().unwrap();
-        let seen = SEEN_INLINE_SOURCES.get().unwrap().lock().unwrap();
+        let seen = tests_only_snapshot();
         assert!(
             seen.contains(&canonical),
             "canonical path should be recorded in dedup set"
@@ -137,6 +147,7 @@ mod tests {
 
     #[test]
     fn dedup_distinguishes_distinct_canonical_paths() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let a = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
         let b = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
         reset_inline_sources_dedup_for_tests();
@@ -144,7 +155,7 @@ mod tests {
         warn_pipeline_inline_sources(a.path(), "a");
         warn_pipeline_inline_sources(b.path(), "b");
 
-        let seen = SEEN_INLINE_SOURCES.get().unwrap().lock().unwrap();
+        let seen = tests_only_snapshot();
         assert!(seen.contains(&a.path().canonicalize().unwrap()));
         assert!(seen.contains(&b.path().canonicalize().unwrap()));
     }


### PR DESCRIPTION
## Summary

The two `pipeline_deprecation` unit tests (`dedup_suppresses_repeat_warnings_for_same_canonical_path` and `dedup_distinguishes_distinct_canonical_paths`) flake because they share the process-wide `SEEN_INLINE_SOURCES` dedup set. cargo runs unit tests in parallel, so one test's `reset_inline_sources_dedup_for_tests()` can clear the set mid-flight in the other, failing its `seen.contains(...)` assertion. That assertion held the global mutex guard, so the panic poisoned the lock and cascaded into the second test as a `PoisonError { .. }`.

Observed failure:

```
thread '...dedup_distinguishes_distinct_canonical_paths' panicked at pipeline_deprecation.rs:148:9:
assertion failed: seen.contains(&a.path().canonicalize().unwrap())

thread '...dedup_suppresses_repeat_warnings_for_same_canonical_path' panicked at pipeline_deprecation.rs:64:33:
inline-sources warn mutex poisoned: PoisonError { .. }
```

## Changes

- Serialise the two tests with a shared `TEST_LOCK` (recovering from a poisoned guard via `into_inner` so a single failure can't cascade).
- Snapshot the dedup set with the existing `tests_only_snapshot()` helper (which drops the global guard) before asserting, so a failed assertion can never poison `SEEN_INLINE_SOURCES`.

Test-only change; no production behavior is affected.

## Test plan

- [x] `cargo test -p rsigma-runtime --lib` passes (141 tests) across 3 consecutive full-suite runs with no flake or poison.
- [x] No new lint errors.