### PR TITLE
fix: sigma correctness (multi-field correlations, empty median, convert modifier dispatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### Sigma correctness: multi-field correlations, empty median, unsupported convert modifiers
+### Sigma correctness: multi-field correlations, empty median, unsupported convert modifiers (#166)
 
 Closes a cluster of silently-wrong evaluation and conversion behaviors so v0.14.0 ships none of them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Sigma correctness: multi-field correlations, empty median, unsupported convert modifiers
+
+Closes a cluster of silently-wrong evaluation and conversion behaviors so v0.14.0 ships none of them.
+
+**Multi-field `value_count` now uses a composite distinct-key.** Previously the engine read `fields.first()` and ignored the rest, so `field: [User, SrcIp]` over events with the same user from different source IPs counted as one distinct value. The fix joins the rendered field values with the ASCII Unit Separator (`\u{1f}`) and counts distinct tuples; a missing field on any component drops the event (matching the prior single-field behavior). The single-field hot path keeps its old allocation profile.
+
+**Multi-field `value_sum` / `value_avg` / `value_percentile` / `value_median` are now rejected at compile time.** The Sigma spec does not define how to combine several numeric fields under one of these aggregations. The previous behavior silently used only the first field and dropped data. The compiler now returns a structured `CorrelationError` listing the offending fields.
+
+**Empty `value_median` windows now return `None`.** They used to return `0.0`, which spuriously satisfied predicates like `lte: 0` and `eq: 0`. The behavior now mirrors `value_percentile`, which already returned `None` for empty windows.
+
+**Detection-name selector matching is now consistent across crates.** The evaluator's `pattern_matches` lacked the middle-`*` branch (`sel*main`) that the converter had, so the same selector pattern silently resolved to different detection sets in eval vs convert. Hoist a single `detection_name_matches` (plus `SelectorPattern::matches_detection_name`) into `rsigma-parser` and reuse it from both crates, with cross-crate tests covering exact, full wildcard, prefix wildcard, suffix wildcard, and middle wildcard cases.
+
+**The `rsigma-convert` default item dispatch rejects modifiers it cannot express.** `default_convert_detection_item` previously fell through to `Backend::convert_field_eq_str` for any modifier it did not handle explicitly, so a rule using `|neq`, `|base64`, `|base64offset`, `|wide`, `|utf16`, `|utf16be`, `|windash`, `|expand`, regex flags without `re` (`|m`, `|s`), or timestamp parts (`|minute`/`|hour`/`|day`/`|week`/`|month`/`|year`) shipped SQL/SPL with different semantics from what the author wrote. The dispatch now returns `ConvertError::UnsupportedModifier` before the fall-through. Backends that handle one of these modifiers natively can override `Backend::convert_detection_item` and bypass the default. A defensive `ok_or_else` replaces the last `unwrap()` on the selector-dispatch path.
+
+**Dependency cleanup.** `base64` and `ipnet` were declared in `crates/rsigma-convert/Cargo.toml` but never referenced from anywhere under `crates/rsigma-convert/src/`. Dropped.
+
+**Docs.** `crates/rsigma-eval/README.md` now explains that `percentile` selects *which* percentile to compute (not the threshold), that an empty window does not fire, and that the four numeric aggregations require a single field.
+
 ### Custom tag namespaces for the linter (#161, #162)
 
 `rsigma rule lint` no longer forces teams to disable `unknown_tag_namespace` wholesale just to use organisation-specific tags. A repeatable `--tag-namespace <ns>` flag and a `tag_namespaces` list in `.rsigma-lint.yml` register extra namespaces that are recognised alongside the built-in spec set (`attack`, `car`, `cve`, `d3fend`, `detection`, `stp`, `tlp`). Namespace values are normalised to lowercase, and when `unknown_tag_namespace` does fire its message lists the full combined set of known namespaces.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,9 +3887,7 @@ dependencies = [
 name = "rsigma-convert"
 version = "0.13.0"
 dependencies = [
- "base64",
  "insta",
- "ipnet",
  "log",
  "regex",
  "rsigma-eval",

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -16,9 +16,7 @@ thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"
 regex = "1"
-ipnet = "2"
 log = "0.4"
-base64 = "0.22"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/rsigma-convert/src/backends/test.rs
+++ b/crates/rsigma-convert/src/backends/test.rs
@@ -1255,7 +1255,14 @@ detection:
         // the value before comparison. The generic dispatch only emits raw
         // equality, so the resulting query never matches what the rule
         // intended.
-        for modifier in ["base64", "base64offset", "wide", "utf16", "utf16be", "windash"] {
+        for modifier in [
+            "base64",
+            "base64offset",
+            "wide",
+            "utf16",
+            "utf16be",
+            "windash",
+        ] {
             let yaml = format!(
                 r#"
 title: Test

--- a/crates/rsigma-convert/src/backends/test.rs
+++ b/crates/rsigma-convert/src/backends/test.rs
@@ -1217,4 +1217,126 @@ detection:
         // `/` is in re_escape, so both slashes get escaped.
         assert_eq!(queries, vec!["Path=/C:\\/Windows\\/.*/"]);
     }
+
+    /// Convert a rule expected to fail and return the resulting error message.
+    fn convert_rule_yaml_err(yaml: &str) -> ConvertError {
+        let collection = parse_sigma_yaml(yaml).unwrap();
+        let backend = TextQueryTestBackend::new();
+        backend
+            .convert_rule(&collection.rules[0], "default", &PipelineState::default())
+            .expect_err("rule should fail to convert")
+    }
+
+    #[test]
+    fn test_default_path_rejects_neq_modifier() {
+        // `Field|neq: value` would silently become equality through the
+        // generic dispatch. Reject loudly with UnsupportedModifier so the
+        // generated query is never wrong.
+        let err = convert_rule_yaml_err(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Field|neq: forbidden
+    condition: selection
+"#,
+        );
+        assert!(
+            matches!(&err, ConvertError::UnsupportedModifier(m) if m.contains("Neq")),
+            "expected UnsupportedModifier(Neq), got: {err}",
+        );
+    }
+
+    #[test]
+    fn test_default_path_rejects_encoding_modifiers() {
+        // base64, base64offset, wide, utf16, utf16be, windash all transform
+        // the value before comparison. The generic dispatch only emits raw
+        // equality, so the resulting query never matches what the rule
+        // intended.
+        for modifier in ["base64", "base64offset", "wide", "utf16", "utf16be", "windash"] {
+            let yaml = format!(
+                r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Field|{modifier}: payload
+    condition: selection
+"#
+            );
+            let err = convert_rule_yaml_err(&yaml);
+            assert!(
+                matches!(&err, ConvertError::UnsupportedModifier(_)),
+                "expected UnsupportedModifier for `{modifier}`, got: {err}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_path_rejects_timestamp_part_modifiers() {
+        for modifier in ["minute", "hour", "day", "week", "month", "year"] {
+            let yaml = format!(
+                r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        TimeField|{modifier}: 5
+    condition: selection
+"#
+            );
+            let err = convert_rule_yaml_err(&yaml);
+            assert!(
+                matches!(&err, ConvertError::UnsupportedModifier(_)),
+                "expected UnsupportedModifier for `{modifier}`, got: {err}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_path_rejects_regex_flag_without_re() {
+        // `m` (multiline) and `s` (dotall) only have meaning alongside `re`;
+        // outside that branch they would be silently dropped.
+        for modifier in ["m", "s"] {
+            let yaml = format!(
+                r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        Field|{modifier}: anything
+    condition: selection
+"#
+            );
+            let err = convert_rule_yaml_err(&yaml);
+            assert!(
+                matches!(&err, ConvertError::UnsupportedModifier(_)),
+                "expected UnsupportedModifier for `{modifier}`, got: {err}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_path_keeps_safe_modifiers_working() {
+        // Sanity check: modifiers that ARE supported by the generic
+        // dispatch (`contains`, `startswith`, `endswith`, `cased`, `i`)
+        // still produce a query, so the new gate does not over-reject.
+        let queries = convert_rule_yaml(
+            r#"
+title: Test
+logsource:
+    category: test
+detection:
+    selection:
+        CommandLine|contains: whoami
+    condition: selection
+"#,
+        );
+        assert_eq!(queries.len(), 1);
+    }
 }

--- a/crates/rsigma-convert/src/condition.rs
+++ b/crates/rsigma-convert/src/condition.rs
@@ -46,15 +46,10 @@ pub fn convert_condition_expr(
             quantifier,
             pattern,
         } => {
-            let names: Vec<&String> = match pattern {
-                SelectorPattern::Them => {
-                    detections.keys().filter(|n| !n.starts_with('_')).collect()
-                }
-                SelectorPattern::Pattern(pat) => detections
-                    .keys()
-                    .filter(|n| pattern_matches(pat, n))
-                    .collect(),
-            };
+            let names: Vec<&String> = detections
+                .keys()
+                .filter(|n| pattern.matches_detection_name(n))
+                .collect();
 
             if names.is_empty() {
                 return Err(ConvertError::RuleConversion(
@@ -78,57 +73,5 @@ pub fn convert_condition_expr(
                 ))),
             }
         }
-    }
-}
-
-/// Simple wildcard match on detection names (supports `*` glob at end, start, or middle).
-fn pattern_matches(pattern: &str, name: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
-    if let Some(prefix) = pattern.strip_suffix('*') {
-        return name.starts_with(prefix);
-    }
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        return name.ends_with(suffix);
-    }
-    if let Some((prefix, suffix)) = pattern.split_once('*') {
-        return name.starts_with(prefix) && name.ends_with(suffix);
-    }
-    pattern == name
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_pattern_matches_star_suffix() {
-        assert!(pattern_matches("selection_*", "selection_main"));
-        assert!(pattern_matches("selection_*", "selection_"));
-        assert!(!pattern_matches("selection_*", "filter_main"));
-    }
-
-    #[test]
-    fn test_pattern_matches_star_prefix() {
-        assert!(pattern_matches("*_main", "selection_main"));
-        assert!(!pattern_matches("*_main", "selection_alt"));
-    }
-
-    #[test]
-    fn test_pattern_matches_star_middle() {
-        assert!(pattern_matches("sel*main", "selection_main"));
-        assert!(!pattern_matches("sel*main", "filter_main"));
-    }
-
-    #[test]
-    fn test_pattern_matches_exact() {
-        assert!(pattern_matches("selection", "selection"));
-        assert!(!pattern_matches("selection", "filter"));
-    }
-
-    #[test]
-    fn test_pattern_matches_star_only() {
-        assert!(pattern_matches("*", "anything"));
     }
 }

--- a/crates/rsigma-convert/src/condition.rs
+++ b/crates/rsigma-convert/src/condition.rs
@@ -60,7 +60,15 @@ pub fn convert_condition_expr(
             let parts: Vec<String> = names
                 .iter()
                 .map(|name| {
-                    let det = detections.get(*name).unwrap();
+                    // The name came from `detections.keys()` immediately
+                    // above, so this lookup will normally succeed; surface a
+                    // clear error rather than panic if the invariant is ever
+                    // broken (defensive: no unwrap on shared dispatch paths).
+                    let det = detections.get(*name).ok_or_else(|| {
+                        ConvertError::RuleConversion(format!(
+                            "selector matched detection '{name}' but it disappeared before lookup"
+                        ))
+                    })?;
                     backend.convert_detection(det, state)
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/crates/rsigma-convert/src/convert.rs
+++ b/crates/rsigma-convert/src/convert.rs
@@ -279,7 +279,9 @@ pub fn default_convert_detection_item(
     // SQL/SPL. Backends that handle these modifiers natively can override
     // `Backend::convert_detection_item` and bypass the default dispatch.
     if let Some(unsupported) = first_unsupported_default_modifier(modifiers) {
-        return Err(ConvertError::UnsupportedModifier(format!("{unsupported:?}")));
+        return Err(ConvertError::UnsupportedModifier(format!(
+            "{unsupported:?}"
+        )));
     }
 
     let use_all = item.field.has_modifier(rsigma_parser::Modifier::All);

--- a/crates/rsigma-convert/src/convert.rs
+++ b/crates/rsigma-convert/src/convert.rs
@@ -133,6 +133,46 @@ pub fn convert_collection(
     Ok(output)
 }
 
+/// Modifiers whose semantics cannot be expressed by the generic
+/// [`default_convert_detection_item`] dispatch.
+///
+/// The default path emits string or number equality. Any modifier that
+/// changes the comparison operator (`neq` → `!=`), transforms the value
+/// before comparison (`base64`, `base64offset`, `wide`, `utf16`, `utf16be`,
+/// `windash`, `expand`), or needs a backend-specific extraction such as
+/// `date_part` (timestamp parts) or a regex flag without `re` (`m`, `s`)
+/// would be silently dropped by the generic dispatch, producing a query
+/// with different semantics than the rule. Backends that handle these
+/// modifiers natively should override [`Backend::convert_detection_item`]
+/// and bypass the default dispatch.
+const DEFAULT_PATH_UNSUPPORTED_MODIFIERS: &[rsigma_parser::Modifier] = &[
+    rsigma_parser::Modifier::Neq,
+    rsigma_parser::Modifier::Base64,
+    rsigma_parser::Modifier::Base64Offset,
+    rsigma_parser::Modifier::Wide,
+    rsigma_parser::Modifier::Utf16,
+    rsigma_parser::Modifier::Utf16be,
+    rsigma_parser::Modifier::WindAsh,
+    rsigma_parser::Modifier::Expand,
+    rsigma_parser::Modifier::Multiline,
+    rsigma_parser::Modifier::DotAll,
+    rsigma_parser::Modifier::Minute,
+    rsigma_parser::Modifier::Hour,
+    rsigma_parser::Modifier::Day,
+    rsigma_parser::Modifier::Week,
+    rsigma_parser::Modifier::Month,
+    rsigma_parser::Modifier::Year,
+];
+
+fn first_unsupported_default_modifier(
+    modifiers: &[rsigma_parser::Modifier],
+) -> Option<rsigma_parser::Modifier> {
+    DEFAULT_PATH_UNSUPPORTED_MODIFIERS
+        .iter()
+        .copied()
+        .find(|m| modifiers.contains(m))
+}
+
 /// Default detection-item dispatch logic.
 ///
 /// Used by backends that don't need custom item-level handling.
@@ -226,6 +266,20 @@ pub fn default_convert_detection_item(
             };
             return backend.convert_field_compare(field_name, &m, num, state);
         }
+    }
+
+    // The fall-through dispatch below emits string/number equality through
+    // `convert_field_eq_str` / `convert_field_eq_num`. Any modifier that
+    // changes the operator (`neq`), transforms the value (encoding,
+    // `windash`), or requires backend-specific extraction (timestamp parts,
+    // `expand`) cannot be expressed by that path. Reaching this point with
+    // such a modifier means the generic path would silently produce a query
+    // with different semantics than the rule. Reject those modifiers loudly
+    // so backends without explicit support do not ship semantically wrong
+    // SQL/SPL. Backends that handle these modifiers natively can override
+    // `Backend::convert_detection_item` and bypass the default dispatch.
+    if let Some(unsupported) = first_unsupported_default_modifier(modifiers) {
+        return Err(ConvertError::UnsupportedModifier(format!("{unsupported:?}")));
     }
 
     let use_all = item.field.has_modifier(rsigma_parser::Modifier::All);

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -224,7 +224,11 @@ Stateful processing with sliding time windows, group-by aggregation, and all 8 c
 
 ### Value Percentile
 
-`value_percentile` uses linear interpolation (C=1 method). The condition threshold represents the percentile rank (0-100), clamped to that range.
+`value_percentile` uses linear interpolation (C=1 method). The `percentile` field on the condition (0-100, clamped) selects *which* percentile to compute from the window's values; the predicate threshold (`gte`, `lte`, etc.) is then compared against that computed value. For example, `percentile: 95` with `lte: 100` fires when the 95th-percentile latency in the window is at most 100ms. An empty window has no percentile and the condition is not evaluated.
+
+`value_median` is the 50th percentile under the same semantics. As with `value_percentile`, an empty window returns no value rather than `0.0`, so predicates like `lte: 0` cannot fire spuriously.
+
+`value_sum`, `value_avg`, `value_percentile`, and `value_median` operate on a single numeric field. Declaring multiple fields under `condition.field` for these correlation types is rejected at compile time, since the Sigma specification does not define how to combine several numeric fields under one of these aggregations. `value_count` supports a list of fields and counts distinct tuples.
 
 ## Output Types
 

--- a/crates/rsigma-eval/src/compiler/helpers.rs
+++ b/crates/rsigma-eval/src/compiler/helpers.rs
@@ -6,20 +6,6 @@ use rsigma_parser::SigmaValue;
 
 use crate::error::{EvalError, Result};
 
-/// Check if a detection name matches a selector pattern (supports `*` wildcard).
-pub(super) fn pattern_matches(pattern: &str, name: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
-    if let Some(prefix) = pattern.strip_suffix('*') {
-        return name.starts_with(prefix);
-    }
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        return name.ends_with(suffix);
-    }
-    pattern == name
-}
-
 /// Convert a `yaml_serde::Value` to a `serde_json::Value`.
 pub(super) fn yaml_to_json(value: &yaml_serde::Value) -> serde_json::Value {
     match value {

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -38,8 +38,8 @@ use crate::result::{DetectionBody, EvaluationResult, FieldMatch, ResultBody, Rul
 
 pub(crate) use helpers::yaml_to_json_map;
 use helpers::{
-    base64_offset_patterns, build_regex, expand_windash, sigma_string_to_bytes,
-    to_utf16_bom_bytes, to_utf16be_bytes, to_utf16le_bytes, value_to_f64, value_to_plain_string,
+    base64_offset_patterns, build_regex, expand_windash, sigma_string_to_bytes, to_utf16_bom_bytes,
+    to_utf16be_bytes, to_utf16le_bytes, value_to_f64, value_to_plain_string,
 };
 
 // =============================================================================

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -27,8 +27,8 @@ use regex::Regex;
 
 use rsigma_parser::value::{SpecialChar, StringPart};
 use rsigma_parser::{
-    ConditionExpr, Detection, DetectionItem, Level, LogSource, Modifier, Quantifier,
-    SelectorPattern, SigmaRule, SigmaString, SigmaValue,
+    ConditionExpr, Detection, DetectionItem, Level, LogSource, Modifier, Quantifier, SigmaRule,
+    SigmaString, SigmaValue,
 };
 
 use crate::error::{EvalError, Result};
@@ -38,7 +38,7 @@ use crate::result::{DetectionBody, EvaluationResult, FieldMatch, ResultBody, Rul
 
 pub(crate) use helpers::yaml_to_json_map;
 use helpers::{
-    base64_offset_patterns, build_regex, expand_windash, pattern_matches, sigma_string_to_bytes,
+    base64_offset_patterns, build_regex, expand_windash, sigma_string_to_bytes,
     to_utf16_bom_bytes, to_utf16be_bytes, to_utf16le_bytes, value_to_f64, value_to_plain_string,
 };
 
@@ -811,16 +811,10 @@ where
             quantifier,
             pattern,
         } => {
-            let matching_names: Vec<&String> = match pattern {
-                SelectorPattern::Them => detections
-                    .keys()
-                    .filter(|name| !name.starts_with('_'))
-                    .collect(),
-                SelectorPattern::Pattern(pat) => detections
-                    .keys()
-                    .filter(|name| pattern_matches(pat, name))
-                    .collect(),
-            };
+            let matching_names: Vec<&String> = detections
+                .keys()
+                .filter(|name| pattern.matches_detection_name(name))
+                .collect();
 
             let mut match_count = 0u64;
             for name in &matching_names {

--- a/crates/rsigma-eval/src/compiler/tests.rs
+++ b/crates/rsigma-eval/src/compiler/tests.rs
@@ -304,17 +304,6 @@ fn test_base64_offset_patterns() {
 }
 
 #[test]
-fn test_pattern_matches() {
-    assert!(pattern_matches("selection_*", "selection_main"));
-    assert!(pattern_matches("selection_*", "selection_"));
-    assert!(!pattern_matches("selection_*", "filter_main"));
-    assert!(pattern_matches("*", "anything"));
-    assert!(pattern_matches("*_filter", "my_filter"));
-    assert!(pattern_matches("exact", "exact"));
-    assert!(!pattern_matches("exact", "other"));
-}
-
-#[test]
 fn test_eval_condition_and() {
     let items_sel = vec![make_item(
         "CommandLine",

--- a/crates/rsigma-eval/src/correlation/compiler.rs
+++ b/crates/rsigma-eval/src/correlation/compiler.rs
@@ -105,17 +105,41 @@ fn compile_condition(
             predicates,
             field,
             percentile,
-        } => Ok((
-            CompiledCondition {
-                field: field.clone(),
-                predicates: predicates
-                    .iter()
-                    .map(|(op, count)| (*op, *count as f64))
-                    .collect(),
-                percentile: *percentile,
-            },
-            None,
-        )),
+        } => {
+            // Numeric aggregations operate on a single numeric field. The
+            // Sigma specification does not define how to combine several
+            // numeric fields under sum/avg/percentile/median, so reject the
+            // multi-field case at compile time rather than silently using
+            // only the first field (the historical behavior of this engine,
+            // which dropped data without warning).
+            if matches!(
+                corr_type,
+                CorrelationType::ValueSum
+                    | CorrelationType::ValueAvg
+                    | CorrelationType::ValuePercentile
+                    | CorrelationType::ValueMedian
+            ) && let Some(fields) = field
+                && fields.len() > 1
+            {
+                return Err(EvalError::CorrelationError(format!(
+                    "{:?} correlation requires a single numeric field, but {} were declared: {:?}",
+                    corr_type,
+                    fields.len(),
+                    fields
+                )));
+            }
+            Ok((
+                CompiledCondition {
+                    field: field.clone(),
+                    predicates: predicates
+                        .iter()
+                        .map(|(op, count)| (*op, *count as f64))
+                        .collect(),
+                    percentile: *percentile,
+                },
+                None,
+            ))
+        }
         CorrelationCondition::Extended(expr) => {
             match corr_type {
                 CorrelationType::Temporal | CorrelationType::TemporalOrdered => {

--- a/crates/rsigma-eval/src/correlation/tests.rs
+++ b/crates/rsigma-eval/src/correlation/tests.rs
@@ -498,6 +498,123 @@ fn test_value_percentile_empty_window() {
 }
 
 #[test]
+fn test_value_median_empty_window_returns_none() {
+    // Regression: an empty median window used to return `0.0`, which
+    // spuriously satisfied `lte: 0` / `eq: 0` predicates. It must mirror the
+    // percentile branch and return `None` when there is no data to summarize.
+    let state = WindowState::new_for(CorrelationType::ValueMedian);
+    let cond = CompiledCondition {
+        field: Some(vec!["latency".to_string()]),
+        predicates: vec![(ConditionOperator::Lte, 0.0)],
+        percentile: None,
+    };
+    assert!(
+        state
+            .check_condition(&cond, CorrelationType::ValueMedian, &[], None)
+            .is_none(),
+        "empty median window must not fire on lte: 0"
+    );
+}
+
+#[test]
+fn test_compile_correlation_rejects_multi_field_numeric_aggregations() {
+    use rsigma_parser::parse_sigma_yaml;
+
+    // value_sum, value_avg, value_percentile, and value_median expect a
+    // single numeric field. The Sigma spec does not define how to combine
+    // several numeric fields, so compile must fail rather than silently use
+    // only the first field (the historical, data-losing behavior).
+    let kinds = [
+        // (correlation type, extra `condition:` lines).
+        ("value_sum", ""),
+        ("value_avg", ""),
+        ("value_percentile", "        percentile: 95\n"),
+        ("value_median", ""),
+    ];
+    for (corr_type, extra_condition) in kinds {
+        let yaml = format!(
+            r#"
+title: Base Rule
+id: 11111111-2222-3333-4444-555555555555
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: "s3.amazonaws.com"
+    condition: selection
+level: low
+---
+title: Multi-field numeric aggregation
+id: 22222222-3333-4444-5555-666666666666
+correlation:
+    type: {corr_type}
+    rules:
+        - 11111111-2222-3333-4444-555555555555
+    group-by:
+        - userIdentity.arn
+    timespan: 1h
+    condition:
+        field: [bytesIn, bytesOut]
+{extra_condition}        gte: 100
+level: high
+"#
+        );
+        let collection =
+            parse_sigma_yaml(&yaml).unwrap_or_else(|e| panic!("parse failed for {corr_type}: {e}"));
+        assert_eq!(
+            collection.correlations.len(),
+            1,
+            "no correlation parsed for {corr_type}; collected errors: {:?}",
+            collection.errors
+        );
+        let err = compile_correlation(&collection.correlations[0]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("single numeric field"),
+            "expected single-field error for `{corr_type}`, got: {msg}"
+        );
+    }
+}
+
+#[test]
+fn test_compile_correlation_accepts_single_field_numeric_aggregations() {
+    use rsigma_parser::parse_sigma_yaml;
+
+    let yaml = r#"
+title: Base Rule
+id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: "s3.amazonaws.com"
+    condition: selection
+level: low
+---
+title: Single-field median
+id: bbbbbbbb-cccc-dddd-eeee-ffffffffffff
+correlation:
+    type: value_median
+    rules:
+        - aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    group-by:
+        - userIdentity.arn
+    timespan: 1h
+    condition:
+        field: latency
+        gte: 100
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(collection.correlations.len(), 1);
+    let compiled = compile_correlation(&collection.correlations[0]).unwrap();
+    assert_eq!(compiled.correlation_type, CorrelationType::ValueMedian);
+    assert_eq!(compiled.condition.field, Some(vec!["latency".to_string()]));
+}
+
+#[test]
 fn test_extended_temporal_or_single_rule() {
     // "rule_a or rule_b" — only rule_a fired
     let mut rule_hits = HashMap::new();

--- a/crates/rsigma-eval/src/correlation/window.rs
+++ b/crates/rsigma-eval/src/correlation/window.rs
@@ -232,24 +232,26 @@ impl WindowState {
                 return Some(pval);
             }
             (WindowState::NumericAgg { entries }, CorrelationType::ValueMedian) => {
+                // An empty window has no median. Returning `0.0` here would
+                // spuriously satisfy predicates like `lte: 0` or `eq: 0`, so
+                // match the percentile branch and skip evaluation.
                 if entries.is_empty() {
-                    0.0
+                    return None;
+                }
+                let mut values: Vec<f64> = entries
+                    .iter()
+                    .map(|(_, v)| *v)
+                    .filter(|v| v.is_finite())
+                    .collect();
+                if values.is_empty() {
+                    return None;
+                }
+                values.sort_by(|a, b| a.total_cmp(b));
+                let mid = values.len() / 2;
+                if values.len().is_multiple_of(2) && values.len() >= 2 {
+                    (values[mid - 1] + values[mid]) / 2.0
                 } else {
-                    let mut values: Vec<f64> = entries
-                        .iter()
-                        .map(|(_, v)| *v)
-                        .filter(|v| v.is_finite())
-                        .collect();
-                    if values.is_empty() {
-                        return None;
-                    }
-                    values.sort_by(|a, b| a.total_cmp(b));
-                    let mid = values.len() / 2;
-                    if values.len().is_multiple_of(2) && values.len() >= 2 {
-                        (values[mid - 1] + values[mid]) / 2.0
-                    } else {
-                        values[mid]
-                    }
+                    values[mid]
                 }
             }
             _ => return None, // mismatched state/type

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -681,11 +681,9 @@ impl CorrelationEngine {
             }
             CorrelationType::ValueCount => {
                 if let Some(ref fields) = corr.condition.field
-                    && let Some(field_name) = fields.first()
-                    && let Some(val) = event.get_field(field_name)
-                    && let Some(s) = value_to_string_for_count(&val)
+                    && let Some(key) = composite_value_count_key(event, fields)
                 {
-                    state.push_value_count(ts, s);
+                    state.push_value_count(ts, key);
                 }
             }
             CorrelationType::Temporal | CorrelationType::TemporalOrdered => {
@@ -1267,6 +1265,30 @@ fn value_to_string_for_count(v: &EventValue) -> Option<String> {
         EventValue::Null => Some("null".to_string()),
         _ => None,
     }
+}
+
+/// Build a composite distinct-key for `value_count` over one or more fields.
+///
+/// Each field's value is rendered with [`value_to_string_for_count`] and the
+/// rendered parts are joined with `\u{1f}` (the ASCII Unit Separator), which
+/// is unlikely to occur in normal log data. If any field is missing or has a
+/// type that does not produce a stable string representation, the event is
+/// excluded from the distinct count (return `None`), matching the historical
+/// single-field behavior.
+fn composite_value_count_key(event: &impl Event, fields: &[String]) -> Option<String> {
+    // Common case: exactly one field. Avoid the separator overhead.
+    if let [field_name] = fields {
+        let val = event.get_field(field_name)?;
+        return value_to_string_for_count(&val);
+    }
+
+    let mut parts = Vec::with_capacity(fields.len());
+    for field_name in fields {
+        let val = event.get_field(field_name)?;
+        let rendered = value_to_string_for_count(&val)?;
+        parts.push(rendered);
+    }
+    Some(parts.join("\u{1f}"))
 }
 
 /// Convert an [`EventValue`] to f64 for numeric aggregation.

--- a/crates/rsigma-eval/src/correlation_engine/tests.rs
+++ b/crates/rsigma-eval/src/correlation_engine/tests.rs
@@ -419,6 +419,137 @@ level: high
     }
 }
 
+#[test]
+fn test_value_count_multi_field_uses_composite_key() {
+    // value_count with `field: [User, SrcIp]` must count distinct (User,
+    // SrcIp) tuples, not silently fall back to the first field. The previous
+    // behavior used `fields.first()` and counted only distinct users, so
+    // three events for the same user from different source IPs would never
+    // fire a `gte: 3` threshold.
+    let yaml = r#"
+title: Failed Login
+id: failed-login-002
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: failed_login
+    condition: selection
+level: low
+---
+title: Failed Logins From Many User-Sources
+id: corr-vc-002
+correlation:
+    type: value_count
+    rules:
+        - failed-login-002
+    group-by:
+        - Host
+    timespan: 60s
+    condition:
+        field: [User, SrcIp]
+        gte: 3
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let ts = 1000i64;
+    // Same user, three distinct source IPs: should fire under the tuple key
+    // but never under the old first-field behavior.
+    let events = [
+        ("alice", "10.0.0.1"),
+        ("alice", "10.0.0.2"),
+        ("alice", "10.0.0.3"),
+    ];
+    let mut fired = false;
+    for (i, (user, ip)) in events.iter().enumerate() {
+        let v = json!({
+            "EventType": "failed_login",
+            "Host": "srv01",
+            "User": user,
+            "SrcIp": ip,
+        });
+        let event = JsonEvent::borrow(&v);
+        let r = engine.process_event_at(&event, ts + i as i64);
+        if r.correlation_count() == 1 {
+            fired = true;
+            assert_eq!(
+                r.correlations()
+                    .next()
+                    .unwrap()
+                    .as_correlation()
+                    .unwrap()
+                    .aggregated_value,
+                3.0
+            );
+        }
+    }
+    assert!(
+        fired,
+        "value_count with multi-field key should fire when 3 distinct (User, SrcIp) tuples are seen"
+    );
+}
+
+#[test]
+fn test_value_count_multi_field_duplicate_tuple_does_not_double_count() {
+    // Same (User, SrcIp) tuple repeated should be counted as one distinct
+    // value, regardless of how many times it appears.
+    let yaml = r#"
+title: Failed Login
+id: failed-login-003
+logsource:
+    category: auth
+detection:
+    selection:
+        EventType: failed_login
+    condition: selection
+level: low
+---
+title: Distinct (User, SrcIp) Threshold
+id: corr-vc-003
+correlation:
+    type: value_count
+    rules:
+        - failed-login-003
+    group-by:
+        - Host
+    timespan: 60s
+    condition:
+        field: [User, SrcIp]
+        gte: 3
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let ts = 1000i64;
+    // Two distinct tuples repeated; the threshold of 3 should never trigger.
+    let events = [
+        ("alice", "10.0.0.1"),
+        ("alice", "10.0.0.2"),
+        ("alice", "10.0.0.1"),
+        ("alice", "10.0.0.2"),
+    ];
+    for (i, (user, ip)) in events.iter().enumerate() {
+        let v = json!({
+            "EventType": "failed_login",
+            "Host": "srv01",
+            "User": user,
+            "SrcIp": ip,
+        });
+        let event = JsonEvent::borrow(&v);
+        let r = engine.process_event_at(&event, ts + i as i64);
+        assert_eq!(
+            r.correlation_count(),
+            0,
+            "only 2 distinct tuples seen so far; should not fire"
+        );
+    }
+}
+
 // =========================================================================
 // Temporal correlation
 // =========================================================================

--- a/crates/rsigma-parser/src/lib.rs
+++ b/crates/rsigma-parser/src/lib.rs
@@ -68,7 +68,6 @@ pub use ast::{
     SigmaCollection, SigmaDocument, SigmaRule, Status,
 };
 pub use condition::parse_condition;
-pub use selector::detection_name_matches;
 pub use error::{Result, SigmaParserError, SourceLocation};
 pub use lint::{
     FileLintResult, Fix, FixDisposition, FixPatch, InlineSuppressions, LintConfig, LintRule,
@@ -77,4 +76,5 @@ pub use lint::{
     lint_yaml_str_with_config, lint_yaml_value, parse_inline_suppressions,
 };
 pub use parser::{parse_field_spec, parse_sigma_directory, parse_sigma_file, parse_sigma_yaml};
+pub use selector::detection_name_matches;
 pub use value::{SigmaString, SigmaValue, SpecialChar, StringPart, Timespan};

--- a/crates/rsigma-parser/src/lib.rs
+++ b/crates/rsigma-parser/src/lib.rs
@@ -57,6 +57,7 @@ pub mod condition;
 pub mod error;
 pub mod lint;
 pub mod parser;
+pub mod selector;
 pub mod value;
 
 // Re-export the most commonly used types and functions at crate root
@@ -67,6 +68,7 @@ pub use ast::{
     SigmaCollection, SigmaDocument, SigmaRule, Status,
 };
 pub use condition::parse_condition;
+pub use selector::detection_name_matches;
 pub use error::{Result, SigmaParserError, SourceLocation};
 pub use lint::{
     FileLintResult, Fix, FixDisposition, FixPatch, InlineSuppressions, LintConfig, LintRule,

--- a/crates/rsigma-parser/src/selector.rs
+++ b/crates/rsigma-parser/src/selector.rs
@@ -1,0 +1,130 @@
+//! Detection-name glob matching for `... of selection_*` selector expressions.
+//!
+//! The selector matcher is shared by the parser, the evaluator, and the
+//! converter so that a pattern like `sel*main` resolves to the same set of
+//! detection identifiers regardless of which subsystem expands it. Keeping the
+//! semantics in one place also avoids the historical drift between `eval` and
+//! `convert`, where `convert` supported a middle `*` (`sel*main`) but `eval`
+//! did not.
+
+use crate::ast::SelectorPattern;
+
+/// Check whether a detection identifier matches a glob `pattern`.
+///
+/// A single `*` is treated as a wildcard. The supported shapes are:
+///
+/// - `*` — match any identifier
+/// - `selection_*` — match identifiers starting with `selection_`
+/// - `*_main` — match identifiers ending with `_main`
+/// - `sel*main` — match identifiers starting with `sel` and ending with `main`
+/// - `selection` — exact match
+///
+/// All other characters are matched literally. The function does not interpret
+/// any other meta-character; in particular `?` is not a wildcard.
+///
+/// # Examples
+///
+/// ```
+/// use rsigma_parser::detection_name_matches;
+/// assert!(detection_name_matches("selection_*", "selection_main"));
+/// assert!(detection_name_matches("*_main", "selection_main"));
+/// assert!(detection_name_matches("sel*main", "selection_main"));
+/// assert!(!detection_name_matches("sel*main", "filter_main"));
+/// ```
+pub fn detection_name_matches(pattern: &str, name: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return name.starts_with(prefix);
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return name.ends_with(suffix);
+    }
+    if let Some((prefix, suffix)) = pattern.split_once('*') {
+        return name.starts_with(prefix) && name.ends_with(suffix);
+    }
+    pattern == name
+}
+
+impl SelectorPattern {
+    /// Return true if this selector pattern matches a detection identifier.
+    ///
+    /// Identifiers beginning with `_` are conventionally hidden from `them`
+    /// expansions (matching the behavior already shared between the evaluator
+    /// and the converter). For [`SelectorPattern::Pattern`], dispatch goes
+    /// through [`detection_name_matches`].
+    pub fn matches_detection_name(&self, name: &str) -> bool {
+        match self {
+            SelectorPattern::Them => !name.starts_with('_'),
+            SelectorPattern::Pattern(pat) => detection_name_matches(pat, name),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn star_only_matches_anything() {
+        assert!(detection_name_matches("*", "anything"));
+        assert!(detection_name_matches("*", ""));
+    }
+
+    #[test]
+    fn star_suffix_matches_prefix() {
+        assert!(detection_name_matches("selection_*", "selection_main"));
+        assert!(detection_name_matches("selection_*", "selection_"));
+        assert!(!detection_name_matches("selection_*", "filter_main"));
+    }
+
+    #[test]
+    fn star_prefix_matches_suffix() {
+        assert!(detection_name_matches("*_main", "selection_main"));
+        assert!(!detection_name_matches("*_main", "selection_alt"));
+    }
+
+    #[test]
+    fn star_middle_matches_prefix_and_suffix() {
+        // The regression that previously diverged between eval and convert:
+        // eval did not implement the middle `*` branch, so the same selector
+        // pattern resolved to different detection sets in the two crates.
+        assert!(detection_name_matches("sel*main", "selection_main"));
+        assert!(!detection_name_matches("sel*main", "filter_main"));
+        assert!(!detection_name_matches("sel*main", "selection_alt"));
+    }
+
+    #[test]
+    fn exact_match_without_star() {
+        assert!(detection_name_matches("selection", "selection"));
+        assert!(!detection_name_matches("selection", "filter"));
+        assert!(!detection_name_matches("selection", "selection_main"));
+    }
+
+    #[test]
+    fn underscore_pattern_is_literal() {
+        // A leading underscore in the pattern is treated as a literal character
+        // (the `_`-prefix convention only suppresses identifiers from `them`).
+        assert!(detection_name_matches("_helper", "_helper"));
+        assert!(!detection_name_matches("_helper", "helper"));
+    }
+
+    #[test]
+    fn selector_pattern_them_skips_underscore_names() {
+        let them = SelectorPattern::Them;
+        assert!(them.matches_detection_name("selection"));
+        assert!(!them.matches_detection_name("_internal"));
+    }
+
+    #[test]
+    fn selector_pattern_pattern_uses_glob() {
+        let pat = SelectorPattern::Pattern("selection_*".to_string());
+        assert!(pat.matches_detection_name("selection_main"));
+        assert!(!pat.matches_detection_name("filter_main"));
+        // A pattern with a literal `_` prefix still applies normally; the
+        // `_`-prefix convention only matters for the `them` form.
+        let internal = SelectorPattern::Pattern("_internal".to_string());
+        assert!(internal.matches_detection_name("_internal"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes a cluster of silently-wrong evaluation and conversion behaviors so v0.14.0 ships none of them. The fixes span `rsigma-parser`, `rsigma-eval`, and `rsigma-convert`, with one shared helper unifying detection-name selector matching across crates.

## Behavior changes

- **Detection-name selector matching is consistent across crates.** A single `detection_name_matches` (plus `SelectorPattern::matches_detection_name`) lives in `rsigma-parser` and is reused by eval and convert. The previous evaluator matcher lacked the middle-`*` branch the converter already supported, so the same `sel*main` selector silently resolved to different detection sets in the two crates.
- **Multi-field `value_count` counts distinct tuples.** `field: [User, SrcIp]` now joins the rendered field values with the ASCII Unit Separator (`\u{1f}`) and counts distinct tuples; a missing value on any component drops the event (matching the existing single-field behavior). Previously the engine read `fields.first()` and ignored the rest, so the same user from different source IPs counted as one distinct value. Single-field rules are unaffected.
- **Multi-field `value_sum` / `value_avg` / `value_percentile` / `value_median` fail to compile.** The Sigma specification does not define how to combine several numeric fields under these aggregations. The compiler now returns a structured `CorrelationError` listing the offending fields. Previously the runtime silently used only the first field and dropped data.
- **Empty `value_median` windows return `None`.** Mirrors the existing `value_percentile` behavior. Previously empty windows returned `0.0`, which spuriously satisfied predicates like `lte: 0` and `eq: 0`.
- **`rsigma-convert` rejects modifiers the generic dispatch cannot express.** `default_convert_detection_item` now returns `ConvertError::UnsupportedModifier` for `|neq`, `|base64`, `|base64offset`, `|wide`, `|utf16`, `|utf16be`, `|windash`, `|expand`, regex flags without `re` (`|m`, `|s`), and timestamp parts (`|minute` / `|hour` / `|day` / `|week` / `|month` / `|year`). Backends that handle one of these modifiers natively can override `Backend::convert_detection_item` and bypass the default. Previously these fell through to `Backend::convert_field_eq_str`, so rules using them shipped SQL / SPL with different semantics from what the author wrote.
- **Convert selector dispatch no longer hides an `unwrap`.** A defensive `ok_or_else` replaces the last `unwrap()` on the path that re-fetches a detection by name after the selector filter; the case was unreachable today but a needless panic surface on a shared dispatch path.
- **`crates/rsigma-eval/README.md` clarifies percentile semantics.** It now explains that the `percentile` field selects *which* percentile to compute (not the predicate threshold), that an empty window does not fire, and that the four numeric aggregations require a single field.
- **`crates/rsigma-convert/Cargo.toml` drops `base64` and `ipnet`.** Neither was referenced anywhere under `crates/rsigma-convert/src/`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — 1575 passed across 48 suites (locally).
- [x] `mkdocs build --strict` — clean.
- [x] CI on this PR (parser / eval / convert tests, MSRV 1.88.0, SigmaHQ corpus regression, cargo deny, audit).

New tests cover:

- 8 selector glob cases in `rsigma_parser::selector` (full `*`, prefix, suffix, middle, exact, underscore literal vs `them`, plus `SelectorPattern` method dispatch).
- Multi-field `value_count` composite key (firing) and duplicate-tuple short-circuit (non-firing) via the end-to-end correlation engine.
- Multi-field numeric correlations rejected at compile time (parametric across `value_sum`, `value_avg`, `value_percentile`, `value_median`).
- Single-field median accepted at compile time (regression-guard).
- Empty `value_median` window with `lte: 0` no longer fires.
- Convert default-path rejection of `neq`, the six encoding modifiers, the six timestamp-part modifiers, and `m` / `s` without `re`, plus a sanity check that `contains` still produces a query.