### PR TITLE
ci: harden release pipeline, CI, Docker, and supply chain before v0.14.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,19 @@ editors/
 *.md
 LICENSE
 
+# Workspace-root content not needed for the daemon binary build. Each
+# entry trims the build context that buildkit ships to the container
+# layer, which both shrinks the build and tightens the cache key. The
+# leading slash anchors at the build context root so per-crate
+# directories of the same name (e.g. `crates/<crate>/tests/`) are
+# unaffected.
+/fuzz
+/tests
+/docs
+/docs-drafts
+/site
+/benches
+
 # Secrets and credentials -- must never enter build context
 .env
 .env.*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,27 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+
+  # Track base-image updates for the multi-stage Dockerfile. Pinned by
+  # digest in the manifest, so Dependabot will surface a PR whenever
+  # the upstream `rust:1-alpine` tag points at a new digest.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  # Track the VS Code extension's npm dependencies (TypeScript types,
+  # @vscode/vsce, eslint, etc.).
+  - package-ecosystem: npm
+    directory: "/editors/vscode"
+    schedule:
+      interval: weekly
+    groups:
+      npm-updates:
+        update-types:
+          - "patch"
+          - "minor"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,9 +32,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      # GitHub-hosted runners ship with `rustup`; install + override
+      # the workspace's `rust-toolchain.toml` pin (MSRV) with stable
+      # for this job inline rather than via a third-party action.
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
       # Pull `cargo-audit` from prebuilt artifacts rather than building
       # it from source every run; saves ~30s per audit invocation.
       - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/audit.yml"
   pull_request:
     branches: [main]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/audit.yml"
 
 permissions: {}
 
@@ -31,7 +35,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
-      - run: cargo install cargo-audit --locked
+      # Pull `cargo-audit` from prebuilt artifacts rather than building
+      # it from source every run; saves ~30s per audit invocation.
+      - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
+        with:
+          tool: cargo-audit
       - run: cargo audit
 
   deny:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      # Runners already ship `rustup`; install + override the
+      # workspace's MSRV pin with stable for this job inline rather
+      # than via a third-party action.
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check --workspace --all-targets --all-features --locked
 
@@ -53,9 +57,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: "1.88.0"
+      # Install MSRV inline. No `rustup override set` here because the
+      # workspace's `rust-toolchain.toml` already pins to 1.88.0, so
+      # `cargo` will pick that toolchain automatically once it is
+      # installed.
+      - name: Install Rust 1.88.0
+        run: rustup toolchain install 1.88.0 --profile minimal --no-self-update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # `--all-targets` so tests, examples, and benches compile against
       # the MSRV too. Without it a contributor can add a test-only
@@ -71,10 +78,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: rustfmt
+      - name: Install Rust stable with rustfmt
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup override set stable
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -86,10 +93,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: clippy
+      - name: Install Rust stable with clippy
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy --no-self-update
+          rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
@@ -106,9 +113,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust stable
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --workspace --all-features --locked
 
@@ -121,10 +130,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: llvm-tools-preview
+      - name: Install Rust stable with llvm-tools-preview
+        run: |
+          rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
+          rustup override set stable
       - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
         with:
           tool: cargo-llvm-cov
@@ -156,9 +165,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # Fail the build on broken intra-doc links and any other rustdoc
       # warning. `--no-deps` keeps the work bounded to first-party
@@ -184,9 +194,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build rsigma
         run: cargo build --release --all-features --locked -p rsigma

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,27 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  doc:
+    name: Doc
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # Fail the build on broken intra-doc links and any other rustdoc
+      # warning. `--no-deps` keeps the work bounded to first-party
+      # crates so this job does not chase a transitive dep's doc
+      # comment.
+      - env:
+          RUSTDOCFLAGS: "-D warnings -D rustdoc::broken-intra-doc-links"
+        run: cargo doc --workspace --all-features --locked --no-deps
+
   sigma-corpus:
     name: Sigma Corpus Regression
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
         with:
           toolchain: "1.88.0"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo check --workspace --all-features --locked
+      # `--all-targets` so tests, examples, and benches compile against
+      # the MSRV too. Without it a contributor can add a test-only
+      # dependency that requires a newer Rust without anyone noticing.
+      - run: cargo check --workspace --all-targets --all-features --locked
 
   fmt:
     name: Format
@@ -133,12 +136,29 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           cargo llvm-cov report --summary-only 2>&1 >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+      # Upload the lcov report so external coverage trackers (Codecov,
+      # Coveralls, …) can ingest it without re-running the suite, and
+      # so PR reviewers can download the raw file from the run summary.
+      - name: Upload lcov report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          if-no-files-found: error
+          retention-days: 14
 
   sigma-corpus:
     name: Sigma Corpus Regression
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Pin the upstream corpus to a specific commit so a SigmaHQ rule
+    # tweak cannot turn a green run red without a deliberate bump
+    # here. Update by changing the SHA in this block (and `--branch`
+    # is not used because GitHub does not advertise `master` as a
+    # refspec via `--depth 1`).
+    env:
+      SIGMA_CORPUS_SHA: "994da16651194500b607a3007186c29779e1f961"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -149,8 +169,15 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build rsigma
         run: cargo build --release --all-features --locked -p rsigma
-      - name: Clone SigmaHQ rules
-        run: git clone --depth 1 https://github.com/SigmaHQ/sigma.git /tmp/sigma
+      - name: Fetch SigmaHQ rules at pinned SHA
+        run: |
+          mkdir -p /tmp/sigma
+          cd /tmp/sigma
+          git init -q
+          git remote add origin https://github.com/SigmaHQ/sigma.git
+          git fetch --depth 1 origin "${SIGMA_CORPUS_SHA}"
+          git checkout -q FETCH_HEAD
+          echo "Checked out SigmaHQ/sigma at ${SIGMA_CORPUS_SHA}"
       - name: Validate and compile all Sigma rules
         run: ./target/release/rsigma rule validate /tmp/sigma/rules/ --verbose
       - name: Validate SigmaHQ corpus with dynamic pipelines

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,9 +73,14 @@ jobs:
           retention-days: 1
 
   scan:
-    name: Vulnerability scan
+    name: Vulnerability scan (${{ matrix.arch }})
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
 
     permissions:
       contents: read # checkout (implicit)
@@ -89,10 +94,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download amd64 digest
+      - name: Download ${{ matrix.arch }} digest
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: digests-amd64
+          name: digests-${{ matrix.arch }}
           path: /tmp/digests
 
       - name: Resolve digest
@@ -111,6 +116,7 @@ jobs:
         if: always()
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: docker-${{ matrix.arch }}
 
   push:
     name: Create manifest and sign

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,69 +33,79 @@ jobs:
         with:
           toolchain: stable
 
+      # No build cache here: rust-cache on a publish workflow exposes the
+      # signed crate artifacts to a cache-poisoning vector (a malicious PR
+      # that lands earlier could seed a tampered build cache). Publishing
+      # happens once per release, so the cache miss is acceptable.
+
+      # Pre-flight: dry-run every crate in dependency order before any
+      # side-effecting publish. Catches authentication, dep-version, and
+      # manifest issues up front so a half-released set of crates cannot
+      # leave the workspace in an inconsistent state on crates.io.
+      - name: Pre-flight dry-run
+        run: |
+          for crate in rsigma-parser rsigma-eval rsigma-convert rsigma-runtime rsigma rsigma-lsp; do
+            echo "::group::cargo publish --dry-run -p ${crate}"
+            cargo publish --dry-run --locked -p "${crate}"
+            echo "::endgroup::"
+          done
+
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
 
+      # `workflow_dispatch` runs every publish step in dry-run mode for
+      # an end-to-end rehearsal without touching crates.io; the actual
+      # release event runs the real publish.
       - name: Publish rsigma-parser
-        run: |
-          echo "::notice::Publishing rsigma-parser (dry-run: ${DRY_RUN})"
-          cargo publish ${DRY_RUN} -p rsigma-parser || echo "::warning::rsigma-parser already published or failed"
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma-parser
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
 
-      - name: Wait for crates.io index update
+      # Wait for the published version to appear in the registry index
+      # before the next crate attempts to resolve it as a dependency.
+      - name: Wait for crates.io index update (rsigma-parser)
         if: github.event_name != 'workflow_dispatch'
         run: sleep 30
 
       - name: Publish rsigma-eval
-        run: |
-          echo "::notice::Publishing rsigma-eval (dry-run: ${DRY_RUN})"
-          cargo publish ${DRY_RUN} -p rsigma-eval || echo "::warning::rsigma-eval already published or failed"
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma-eval
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
 
-      - name: Wait for crates.io index update
+      - name: Wait for crates.io index update (rsigma-eval)
         if: github.event_name != 'workflow_dispatch'
         run: sleep 30
 
       - name: Publish rsigma-convert
-        run: |
-          echo "::notice::Publishing rsigma-convert (dry-run: ${DRY_RUN})"
-          cargo publish ${DRY_RUN} -p rsigma-convert || echo "::warning::rsigma-convert already published or failed"
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma-convert
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
 
-      - name: Wait for crates.io index update
+      - name: Wait for crates.io index update (rsigma-convert)
         if: github.event_name != 'workflow_dispatch'
         run: sleep 30
 
       - name: Publish rsigma-runtime
-        run: |
-          echo "::notice::Publishing rsigma-runtime (dry-run: ${DRY_RUN})"
-          cargo publish ${DRY_RUN} -p rsigma-runtime || echo "::warning::rsigma-runtime already published or failed"
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma-runtime
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
 
-      - name: Wait for crates.io index update
+      - name: Wait for crates.io index update (rsigma-runtime)
         if: github.event_name != 'workflow_dispatch'
         run: sleep 30
 
       - name: Publish rsigma
-        run: |
-          echo "::notice::Publishing rsigma (dry-run: ${DRY_RUN})"
-          cargo publish ${DRY_RUN} -p rsigma || echo "::warning::rsigma already published or failed"
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
 
       - name: Publish rsigma-lsp
-        run: |
-          echo "::notice::Publishing rsigma-lsp (dry-run: ${DRY_RUN})"
-          cargo publish ${DRY_RUN} -p rsigma-lsp || echo "::warning::rsigma-lsp already published or failed"
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma-lsp
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
 
       # No build cache here: rust-cache on a publish workflow exposes the
       # signed crate artifacts to a cache-poisoning vector (a malicious PR

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -38,14 +38,19 @@ jobs:
         with:
           persist-credentials: false
 
-      # Pin the toolchain to `stable` rather than `rustup update`-ing to
-      # whatever channel the runner image happens to have cached. The
-      # cross-compile target is installed in the same step so the build
-      # step does not need a separate `rustup target add`.
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
+      # Install stable inline; the cross-compile target installs in the
+      # same step so the build step does not need a separate `rustup
+      # target add`. `rustup override set` makes stable take precedence
+      # over the workspace's `rust-toolchain.toml` (MSRV) pin for this
+      # release build.
+      - name: Install Rust stable and target
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
+          rustup target add "${TARGET}"
+        env:
+          TARGET: ${{ matrix.target }}
 
       # No build cache here: rust-cache on a release workflow opens a
       # cache-poisoning vector against the signed artifacts. Release

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -38,14 +38,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust target
-        run: |
-          rustup update
-          rustup target add "${TARGET}"
-        env:
-          TARGET: ${{ matrix.target }}
-        shell: bash
+      # Pin the toolchain to `stable` rather than `rustup update`-ing to
+      # whatever channel the runner image happens to have cached. The
+      # cross-compile target is installed in the same step so the build
+      # step does not need a separate `rustup target add`.
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
 
+      # No build cache here: rust-cache on a release workflow opens a
+      # cache-poisoning vector against the signed artifacts. Release
+      # builds run once per tag, so a cold build is acceptable.
       - name: Build release
         run: cargo build --release --all-features --locked --target "${TARGET}" -p rsigma -p rsigma-lsp
         env:
@@ -91,6 +95,16 @@ jobs:
 
       - name: List artifacts
         run: ls -l distrib/
+
+      # Generate a SHA256SUMS manifest that downstream consumers can
+      # verify against the SLSA build-provenance attestation. The
+      # manifest is uploaded as a separate release asset alongside the
+      # archives.
+      - name: Generate SHA256SUMS
+        working-directory: distrib
+        run: |
+          shasum -a 256 ./* > SHA256SUMS
+          cat SHA256SUMS
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,4 @@
-rules:
-  superfluous-actions:
-    ignore:
-      - audit.yml
-      - ci.yml
-      - publish.yml
+# Zizmor configuration. Audits inherit zizmor's default behaviour;
+# add rule-level ignores here when a workflow has a deliberate
+# exception that needs justifying.
+rules: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Release pipeline, CI, Docker, and supply-chain hardening
+
+Tightens every link in the release chain before v0.14.0 ships so the act of publishing itself does not undermine the correctness work that already landed.
+
+**`publish.yml`** no longer masks `cargo publish` failures with `|| echo "::warning::… already published or failed"`. A new pre-flight step dry-runs every crate in dependency order before any side-effecting publish; authentication, lockfile drift, and dependency-resolution issues now abort the workflow before any crate hits crates.io. Every actual publish passes `--locked`. The `workflow_dispatch` trigger keeps the dry-run rehearsal path; only `release: published` touches the real registry. The `Swatinem/rust-cache` step was removed to close a cache-poisoning vector against the signed artifacts.
+
+**`release-binaries.yml`** pins the toolchain through `dtolnay/rust-toolchain@... stable` with `targets:` set inline (replacing the unpinned `rustup update` plus follow-up `rustup target add`). After downloading the per-target archives, the release job generates a `SHA256SUMS` manifest and uploads it as a release asset, covered by the same `actions/attest-build-provenance` subject path as the archives. Consumers who do not pull the SLSA attestation can still verify download integrity against the manifest.
+
+**Workspace.** `rust-toolchain.toml` pins ambient `cargo` invocations to the MSRV of 1.88.0, so contributors who do not pass `+stable` build against the same Rust the MSRV CI job uses. A new `[profile.release]` block enables `lto = "thin"`, `codegen-units = 1`, and `strip = true`. The pin surfaced an existing 1.88.0 clippy / rustdoc backlog (collapsible-else, uninlined-format-args, duplicated `#[cfg(feature = "daemon-tls")]`, broken intra-doc links, unclosed `<host>` HTML tags); this release ships the cleanup so `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo doc --workspace --no-deps -D warnings -D rustdoc::broken-intra-doc-links` are gate-green.
+
+**CI.** The Sigma corpus regression job now fetches `SigmaHQ/sigma` at a pinned commit (bumped by editing `SIGMA_CORPUS_SHA` in `ci.yml`) instead of `master` tip, so an upstream rule edit cannot turn the workspace red without a deliberate commit here. The MSRV check gains `--all-targets` so a test- or example-only dependency that requires a newer Rust cannot slip past the MSRV gate. The coverage job uploads `lcov.info` as an artifact for external trackers. A new `doc` job runs `cargo doc --workspace --all-features --locked --no-deps` with the strict rustdoc gate so a future broken intra-doc link fails CI rather than landing silently.
+
+**Docker.** Both `cargo build` stages in the `Dockerfile` add `--locked`, and `rust-toolchain.toml` is part of the dependency-cache layer so the toolchain version is part of the layer's cache key. `.dockerignore` excludes `/fuzz`, `/tests`, `/docs`, `/docs-drafts`, `/site`, and `/benches` from the build context (root-anchored so per-crate `tests/` subdirectories are unaffected). The Grype vulnerability scan runs as a 2-leg matrix (`amd64` × `arm64`) so arch-specific CVEs cannot land on a release image unnoticed; SARIF uploads label findings by arch in the Security tab.
+
+**Supply chain.** `deny.toml` denies wildcard dependency versions (`wildcards = "deny"`), surfaces unmaintained-crate advisories via `unmaintained = "workspace"`, and grows a quarterly-review note plus "Last reviewed" date on the `RUSTSEC-2021-0153` ignore. The `audit` workflow now triggers on `deny.toml` and its own workflow file in addition to manifest and lockfile changes, and pulls `cargo-audit` from `taiki-e/install-action` prebuilds instead of compiling it from source on every invocation. Dependabot picks up two new ecosystems: `docker` against `/` (so a new digest for the pinned `rust:1-alpine` base image surfaces as a PR) and `npm` against `/editors/vscode` (so the extension's TypeScript / `@vscode/vsce` / eslint deps follow the same weekly batching as the Cargo deps).
+
 ### Runtime hardening: HTTP egress policy, body cap, hot-reload tuning, fail-closed dynamic sources (#167)
 
 Cluster of P0 hardening fixes for the daemon's HTTP surfaces and rule hot-reload. None of these were exploitable in a default deployment, but each silently produced behavior different from what the operator (or rule author) wrote, and all of them ship together before v0.14.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,13 @@ rust-version = "1.88.0"
 license = "MIT"
 repository = "https://github.com/timescale/rsigma"
 homepage = "https://github.com/timescale/rsigma"
+
+# Release profile knobs. `lto = "thin"` cuts ~10% off binary size at
+# roughly 1.5x compile cost; `codegen-units = 1` improves runtime perf
+# by giving the optimizer the whole module to look at; `strip = true`
+# drops debug symbols so the published archives stay small. The Docker
+# build runs `strip` separately and is unaffected by this profile.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache musl-dev
 WORKDIR /build
 
 # Layer 1: dependency compilation (cached unless manifests change)
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates/rsigma-parser/Cargo.toml crates/rsigma-parser/Cargo.toml
 COPY crates/rsigma-eval/Cargo.toml crates/rsigma-eval/Cargo.toml
 COPY crates/rsigma-convert/Cargo.toml crates/rsigma-convert/Cargo.toml
@@ -23,11 +23,11 @@ RUN mkdir -p crates/rsigma-parser/src crates/rsigma-eval/src \
              crates/rsigma-lsp/src/lib.rs \
     && echo 'fn main() {}' > crates/rsigma-cli/src/main.rs \
     && echo 'fn main() {}' > crates/rsigma-lsp/src/main.rs \
-    && cargo build --release --all-features -p rsigma 2>/dev/null || true
+    && cargo build --release --all-features --locked -p rsigma 2>/dev/null || true
 
 # Layer 2: full source build
 COPY . .
-RUN cargo build --release --all-features -p rsigma \
+RUN cargo build --release --all-features --locked -p rsigma \
     && strip target/release/rsigma
 
 # Runtime: bare minimum (zero CVEs, no shell, no package manager)

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -95,10 +95,7 @@ pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
     let backend = get_backend(&target, &options);
 
     if backend.requires_pipeline() && pipelines.is_empty() && !without_pipeline {
-        eprintln!(
-            "Backend '{}' requires a pipeline. Use -p or --without-pipeline.",
-            target
-        );
+        eprintln!("Backend '{target}' requires a pipeline. Use -p or --without-pipeline.");
         process::exit(crate::exit_code::CONFIG_ERROR);
     }
 

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -90,12 +90,14 @@ pub(crate) struct DaemonArgs {
     #[arg(long = "state-save-interval", default_value_t = config::defaults::STATE_SAVE_INTERVAL, value_parser = clap::value_parser!(u64).range(1..))]
     pub state_save_interval: u64,
 
-    /// Event input source. Supported schemes: stdin, http, nats://<host>:<port>/<subject>
+    /// Event input source. Supported schemes: `stdin`, `http`,
+    /// `nats://<host>:<port>/<subject>`.
     #[arg(long = "input", default_value = config::defaults::INPUT_SOURCE)]
     pub input: String,
 
     /// Detection output sink (can be repeated for fan-out).
-    /// Supported schemes: stdout, file://<path>, nats://<host>:<port>/<subject>
+    /// Supported schemes: `stdout`, `file://<path>`,
+    /// `nats://<host>:<port>/<subject>`.
     #[arg(long = "output", default_value = config::defaults::STDOUT_SINK)]
     pub output: Vec<String>,
 
@@ -114,8 +116,9 @@ pub(crate) struct DaemonArgs {
     pub drain_timeout: u64,
 
     /// Dead-letter queue target for events that fail processing.
-    /// Accepts same schemes as --output: stdout, file://<path>, nats://<host>:<port>/<subject>.
-    /// When not set, failed events are logged and discarded.
+    /// Accepts the same schemes as `--output`: `stdout`,
+    /// `file://<path>`, `nats://<host>:<port>/<subject>`. When not
+    /// set, failed events are logged and discarded.
     #[arg(long = "dlq")]
     pub dlq: Option<String>,
 

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -54,7 +54,7 @@ pub(crate) struct EvalArgs {
     pub jq: Option<String>,
 
     /// JSONPath (RFC 9535) query to extract the event payload.
-    /// Example: --jsonpath '$.event' or --jsonpath '$.records[*]'
+    /// Example: `--jsonpath '$.event'` or `--jsonpath '$.records[*]'`.
     #[arg(long = "jsonpath", conflicts_with = "jq")]
     pub jsonpath: Option<String>,
 

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -263,13 +263,7 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
     };
 
     println!(
-        "Checked {} file(s): {}, {} ({}, {}, {})",
-        total_files,
-        passed_colored,
-        failed_colored,
-        errors_colored,
-        warnings_colored,
-        infos_colored,
+        "Checked {total_files} file(s): {passed_colored}, {failed_colored} ({errors_colored}, {warnings_colored}, {infos_colored})",
     );
     tracing::info!(
         files = total_files,

--- a/crates/rsigma-cli/src/daemon/enrichment/config.rs
+++ b/crates/rsigma-cli/src/daemon/enrichment/config.rs
@@ -303,10 +303,11 @@ pub fn build_enrichers(file: EnrichersFile) -> Result<EnrichmentPipeline, Enrich
     build_enrichers_full(file, None, std::sync::Arc::new(NoopMetrics))
 }
 
-/// Like [`build_enrichers`] but accepts an optional shared
-/// [`SourceCache`] for `lookup` enrichers and a metrics hook the
-/// pipeline (and per-enricher cache lookups) report into. The daemon
-/// passes its Prometheus-backed `Metrics` here.
+/// Like the test-only `build_enrichers` shim above but accepts an
+/// optional shared [`SourceCache`] for `lookup` enrichers and a
+/// metrics hook the pipeline (and per-enricher cache lookups)
+/// report into. The daemon passes its Prometheus-backed `Metrics`
+/// here.
 pub fn build_enrichers_full(
     file: EnrichersFile,
     source_cache: Option<std::sync::Arc<SourceCache>>,
@@ -336,7 +337,7 @@ pub fn build_enrichers_full(
 /// Build a single [`Enricher`](rsigma_runtime::Enricher) from one YAML
 /// config block.
 ///
-/// Pulled out of [`build_enrichers`] so the loader's match on
+/// Pulled out of `build_enrichers_full` so the loader's match on
 /// `type_name` stays linear and so future primitives can be added by
 /// extending one match arm.
 fn build_one(
@@ -490,10 +491,10 @@ fn build_one(
     }
 }
 
-/// Build an [`ExtractExpr`] from `cfg.extract` + `cfg.extract_type`.
-/// `None` when no extract is configured. Defaults to `jq` when an
-/// extract expression is set without an explicit type, matching the
-/// pipeline-source convention.
+/// Build an [`ExtractExpr`](rsigma_eval::pipeline::sources::ExtractExpr)
+/// from `cfg.extract` + `cfg.extract_type`. `None` when no extract is
+/// configured. Defaults to `jq` when an extract expression is set
+/// without an explicit type, matching the pipeline-source convention.
 fn build_extract_expr(
     cfg: &EnricherConfig,
 ) -> Result<Option<rsigma_eval::pipeline::sources::ExtractExpr>, EnrichersConfigError> {

--- a/crates/rsigma-cli/src/daemon/store.rs
+++ b/crates/rsigma-cli/src/daemon/store.rs
@@ -29,8 +29,8 @@ pub struct SqliteStateStore {
 impl SqliteStateStore {
     /// Open (or create) a SQLite database at `path` and initialize the schema.
     pub fn open(path: &Path) -> Result<Self, String> {
-        let conn = rusqlite::Connection::open(path)
-            .map_err(|e| format!("open sqlite {:?}: {}", path, e))?;
+        let conn =
+            rusqlite::Connection::open(path).map_err(|e| format!("open sqlite {path:?}: {e}"))?;
 
         conn.execute_batch(
             r#"

--- a/crates/rsigma-cli/src/daemon/tls.rs
+++ b/crates/rsigma-cli/src/daemon/tls.rs
@@ -13,8 +13,6 @@
 //!
 //! Gated behind the `daemon-tls` Cargo feature.
 
-#![cfg(feature = "daemon-tls")]
-
 use std::io;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -130,52 +130,52 @@ enum Commands {
     },
 
     // ---- Deprecated flat aliases (hidden from `--help`, still functional) ----
-    /// [deprecated] Use `rsigma engine eval` instead
+    /// \[deprecated\] Use `rsigma engine eval` instead
     #[command(hide = true)]
     Eval(EvalArgs),
 
-    /// [deprecated] Use `rsigma engine daemon` instead
+    /// \[deprecated\] Use `rsigma engine daemon` instead
     #[cfg(feature = "daemon")]
     #[command(hide = true)]
     Daemon(DaemonArgs),
 
-    /// [deprecated] Use `rsigma rule parse` instead
+    /// \[deprecated\] Use `rsigma rule parse` instead
     #[command(hide = true)]
     Parse(ParseArgs),
 
-    /// [deprecated] Use `rsigma rule validate` instead
+    /// \[deprecated\] Use `rsigma rule validate` instead
     #[command(hide = true)]
     Validate(ValidateArgs),
 
-    /// [deprecated] Use `rsigma rule lint` instead
+    /// \[deprecated\] Use `rsigma rule lint` instead
     #[command(hide = true)]
     Lint(LintArgs),
 
-    /// [deprecated] Use `rsigma rule fields` instead
+    /// \[deprecated\] Use `rsigma rule fields` instead
     #[command(hide = true)]
     Fields(FieldsArgs),
 
-    /// [deprecated] Use `rsigma rule condition` instead
+    /// \[deprecated\] Use `rsigma rule condition` instead
     #[command(hide = true)]
     Condition(ConditionArgs),
 
-    /// [deprecated] Use `rsigma rule stdin` instead
+    /// \[deprecated\] Use `rsigma rule stdin` instead
     #[command(hide = true)]
     Stdin(StdinArgs),
 
-    /// [deprecated] Use `rsigma backend convert` instead
+    /// \[deprecated\] Use `rsigma backend convert` instead
     #[command(hide = true)]
     Convert(ConvertArgs),
 
-    /// [deprecated] Use `rsigma backend targets` instead
+    /// \[deprecated\] Use `rsigma backend targets` instead
     #[command(name = "list-targets", hide = true)]
     ListTargets,
 
-    /// [deprecated] Use `rsigma backend formats` instead
+    /// \[deprecated\] Use `rsigma backend formats` instead
     #[command(name = "list-formats", hide = true)]
     ListFormats(ListFormatsArgs),
 
-    /// [deprecated] Use `rsigma pipeline resolve` instead
+    /// \[deprecated\] Use `rsigma pipeline resolve` instead
     #[command(hide = true)]
     Resolve(ResolveArgs),
 }

--- a/crates/rsigma-cli/src/output/mod.rs
+++ b/crates/rsigma-cli/src/output/mod.rs
@@ -313,9 +313,9 @@ where
         first = false;
         let w = widths.get(i).copied().unwrap_or(0);
         if right_align.get(i).copied().unwrap_or(false) {
-            write!(out, "{cell:>w$}", w = w)?;
+            write!(out, "{cell:>w$}")?;
         } else {
-            write!(out, "{cell:<w$}", w = w)?;
+            write!(out, "{cell:<w$}")?;
         }
     }
     writeln!(out)

--- a/crates/rsigma-cli/tests/cli_daemon_nats.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_nats.rs
@@ -447,8 +447,7 @@ async fn daemon_nats_state_persists_source_position() {
     );
     assert!(
         seq.unwrap() >= 2,
-        "source_sequence should be >= 2 (processed 2 messages), got {:?}",
-        seq
+        "source_sequence should be >= 2 (processed 2 messages), got {seq:?}"
     );
 
     // Verify that a snapshot was actually saved

--- a/crates/rsigma-convert/src/backends/lynxdb/mod.rs
+++ b/crates/rsigma-convert/src/backends/lynxdb/mod.rs
@@ -356,8 +356,7 @@ impl Backend for LynxDbBackend {
             Modifier::Gte => "gte",
             _ => {
                 return Err(ConvertError::UnsupportedModifier(format!(
-                    "compare op {:?}",
-                    op
+                    "compare op {op:?}"
                 )));
             }
         };

--- a/crates/rsigma-convert/src/backends/test.rs
+++ b/crates/rsigma-convert/src/backends/test.rs
@@ -334,8 +334,7 @@ impl Backend for TextQueryTestBackend {
             Modifier::Gte => "gte",
             _ => {
                 return Err(ConvertError::UnsupportedModifier(format!(
-                    "compare op {:?}",
-                    op
+                    "compare op {op:?}"
                 )));
             }
         };

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -278,8 +278,8 @@ fn validate_condition_refs(
 ///
 /// This is the public entry point for one-shot rule evaluation. It does no
 /// bloom pre-filtering; every detection item is evaluated directly. Engines
-/// that maintain a [`crate::engine::bloom_index::FieldBloomIndex`] should
-/// instead call [`evaluate_rule_with_bloom`].
+/// that maintain a per-field bloom index should call the crate-private
+/// `evaluate_rule_with_bloom` variant via the `Engine` API instead.
 pub fn evaluate_rule(rule: &CompiledRule, event: &impl Event) -> Option<EvaluationResult> {
     evaluate_rule_with_bloom(rule, event, &crate::engine::bloom_index::NoBloom)
 }

--- a/crates/rsigma-eval/src/field_observer.rs
+++ b/crates/rsigma-eval/src/field_observer.rs
@@ -35,15 +35,14 @@
 //!
 //! # Coordinates
 //!
-//! - Iterate [`Event::field_keys`](crate::Event::field_keys) once per
-//!   event before evaluation. For JSON events this is a recursive
-//!   walk that allocates one `String` per leaf path (dot-joined paths
-//!   are not substrings of the source value); for flat formats like
-//!   `KvEvent` the override returns `Cow::Borrowed`. The cost is
-//!   acceptable in the opt-in diagnostic mode but is not free.
+//! - Iterate [`Event::field_keys`] once per event before evaluation.
+//!   For JSON events this is a recursive walk that allocates one
+//!   `String` per leaf path (dot-joined paths are not substrings of
+//!   the source value); for flat formats like `KvEvent` the override
+//!   returns `Cow::Borrowed`. The cost is acceptable in the opt-in
+//!   diagnostic mode but is not free.
 //! - Render the gap and broken-coverage signals by joining a
-//!   [`snapshot`](FieldObserver::snapshot) against a
-//!   [`RuleFieldSet`](crate::RuleFieldSet).
+//!   [`FieldObserver::snapshot`] against a [`RuleFieldSet`].
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -72,7 +71,7 @@ pub struct FieldObservationEntry {
 ///
 /// Returned by [`FieldObserver::snapshot`]; consumers (the daemon's
 /// HTTP handlers, the `engine eval` report writer) render coverage
-/// reports from this against a [`RuleFieldSet`](crate::RuleFieldSet).
+/// reports from this against a [`RuleFieldSet`].
 #[derive(Debug, Clone, Default)]
 pub struct FieldObservation {
     /// Per-field counters, sorted by descending count then ascending name.

--- a/crates/rsigma-eval/src/matcher/mod.rs
+++ b/crates/rsigma-eval/src/matcher/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Each `CompiledMatcher` variant is pre-compiled at rule load time.
 //! At evaluation time, `matches()` performs the comparison against an
-//! [`EventValue`] from the event with no dynamic dispatch or allocation.
+//! [`EventValue`](crate::event::EventValue) from the event with no
+//! dynamic dispatch or allocation.
 
 mod helpers;
 mod matching;

--- a/crates/rsigma-eval/src/pipeline/parsing.rs
+++ b/crates/rsigma-eval/src/pipeline/parsing.rs
@@ -760,9 +760,7 @@ fn parse_string_or_list_mapping(
                                 strings.push(s.to_string());
                             } else {
                                 log::warn!(
-                                    "non-string item in mapping list for key '{}': {:?}; skipping",
-                                    key,
-                                    item,
+                                    "non-string item in mapping list for key '{key}': {item:?}; skipping",
                                 );
                             }
                         }

--- a/crates/rsigma-parser/src/lint/rules/detection.rs
+++ b/crates/rsigma-parser/src/lint/rules/detection.rs
@@ -195,27 +195,25 @@ pub(crate) fn lint_detection_rule(
                         ),
                         format!("/tags/{i}"),
                     ));
-                } else {
-                    if let Some(ns) = tag.split('.').next()
-                        && !KNOWN_TAG_NAMESPACES.contains(&ns)
-                        && !extra_namespaces.iter().any(|n| n.as_str() == ns)
-                    {
-                        let mut seen = std::collections::HashSet::new();
-                        let known_list: Vec<&str> = KNOWN_TAG_NAMESPACES
-                            .iter()
-                            .copied()
-                            .chain(extra_namespaces.iter().map(String::as_str))
-                            .filter(|n| seen.insert(*n))
-                            .collect();
-                        warnings.push(warning(
-                            LintRule::UnknownTagNamespace,
-                            format!(
-                                "unknown tag namespace \"{ns}\", known namespaces: {}",
-                                known_list.join(", ")
-                            ),
-                            format!("/tags/{i}"),
-                        ));
-                    }
+                } else if let Some(ns) = tag.split('.').next()
+                    && !KNOWN_TAG_NAMESPACES.contains(&ns)
+                    && !extra_namespaces.iter().any(|n| n.as_str() == ns)
+                {
+                    let mut seen = std::collections::HashSet::new();
+                    let known_list: Vec<&str> = KNOWN_TAG_NAMESPACES
+                        .iter()
+                        .copied()
+                        .chain(extra_namespaces.iter().map(String::as_str))
+                        .filter(|n| seen.insert(*n))
+                        .collect();
+                    warnings.push(warning(
+                        LintRule::UnknownTagNamespace,
+                        format!(
+                            "unknown tag namespace \"{ns}\", known namespaces: {}",
+                            known_list.join(", ")
+                        ),
+                        format!("/tags/{i}"),
+                    ));
                 }
 
                 if !seen_tags.insert(tag.to_string()) {

--- a/crates/rsigma-runtime/src/enrichment/command.rs
+++ b/crates/rsigma-runtime/src/enrichment/command.rs
@@ -157,10 +157,7 @@ impl Enricher for CommandEnricher {
         if output.stdout.len() > MAX_COMMAND_STDOUT {
             return Err(EnrichError {
                 enricher_id: self.id.clone(),
-                kind: EnrichErrorKind::Fetch(format!(
-                    "stdout exceeded {} bytes",
-                    MAX_COMMAND_STDOUT
-                )),
+                kind: EnrichErrorKind::Fetch(format!("stdout exceeded {MAX_COMMAND_STDOUT} bytes")),
             });
         }
 

--- a/crates/rsigma-runtime/src/enrichment/http.rs
+++ b/crates/rsigma-runtime/src/enrichment/http.rs
@@ -110,7 +110,7 @@ impl HttpEnricher {
     /// Build a new enricher.
     ///
     /// `client` is shared at the process level. `cache` may be a
-    /// disabled cache ([`HttpResponseCache::new(Duration::from_secs(0))`])
+    /// disabled cache (`HttpResponseCache::new(Duration::from_secs(0))`)
     /// when `cache_ttl` is unset; the lookup path treats that as "always
     /// miss".
     #[allow(clippy::too_many_arguments)]

--- a/crates/rsigma-runtime/src/enrichment/mod.rs
+++ b/crates/rsigma-runtime/src/enrichment/mod.rs
@@ -1,11 +1,12 @@
 //! Post-evaluation enrichment for the rsigma daemon.
 //!
 //! Enrichment runs in the daemon's sink task, after `Engine::evaluate()` has
-//! produced a [`ProcessResult`] (a flat `Vec<EvaluationResult>`) and before
-//! that result is serialized to a sink. Each enricher inspects an
-//! [`EvaluationResult`], optionally fetches context (HTTP, command, source
-//! cache, pure template), and writes the result into
-//! `result.header.enrichments` under a configured `inject_field`.
+//! produced a [`ProcessResult`](rsigma_eval::ProcessResult) (a flat
+//! `Vec<EvaluationResult>`) and before that result is serialized to a sink.
+//! Each enricher inspects an [`EvaluationResult`], optionally fetches
+//! context (HTTP, command, source cache, pure template), and writes the
+//! result into `result.header.enrichments` under a configured
+//! `inject_field`.
 //!
 //! # Architecture
 //!
@@ -54,7 +55,10 @@ mod template;
 mod tests;
 
 pub use command::{CommandEnricher, OutputFormat};
-pub use http::{HttpEnricher, HttpEnricherClient, build_default_http_client};
+pub use http::{
+    DEFAULT_ENRICHER_MAX_RESPONSE_BYTES, HttpEnricher, HttpEnricherClient,
+    build_default_http_client,
+};
 pub use http_cache::{CacheKey, CacheOutcome, HttpResponseCache};
 pub use lookup::LookupEnricher;
 pub use scope::Scope;
@@ -329,8 +333,10 @@ impl EnrichmentPipeline {
     /// 5. Wraps each remaining `enrich()` call in
     ///    [`tokio::time::timeout`] using the enricher's timeout.
     /// 6. On error, applies the enricher's [`OnError`] policy.
-    /// 7. If any enricher in the chain returns
-    ///    [`EnrichOutcome::Drop`], the result is removed from the output.
+    /// 7. If any enricher in the chain returns the internal `Drop`
+    ///    outcome (via an enricher whose [`OnError`] policy is set
+    ///    to [`OnError::Drop`]), the result is removed from the
+    ///    output.
     ///
     /// The pipeline initializes `result.header.enrichments` to
     /// `Some(empty)` lazily on first successful injection, so the

--- a/crates/rsigma-runtime/src/enrichment/scope.rs
+++ b/crates/rsigma-runtime/src/enrichment/scope.rs
@@ -49,8 +49,8 @@ impl Scope {
     /// `rules` mixes exact rule IDs (anything without glob metacharacters)
     /// and rule-title globs (anything containing `*`, `?`, or `[`).
     /// `tags` mixes exact tags and prefix-wildcard patterns ending in
-    /// `.*` (e.g. `attack.*`). `levels` is a list of severity strings as
-    /// understood by [`Level::from_str`].
+    /// `.*` (e.g. `attack.*`). `levels` is a list of severity strings
+    /// as understood by `<rsigma_parser::Level as FromStr>::from_str`.
     ///
     /// Returns an error if any glob fails to compile or any level string
     /// fails to parse, so the daemon refuses to start with a malformed

--- a/crates/rsigma-runtime/src/pipeline_deprecation.rs
+++ b/crates/rsigma-runtime/src/pipeline_deprecation.rs
@@ -42,7 +42,9 @@ use std::sync::{Mutex, OnceLock};
 static SEEN_INLINE_SOURCES: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 
 /// Surface the pipeline-embedded `sources:` deprecation notice for one
-/// pipeline file. Idempotent per canonical path (see [`SEEN_INLINE_SOURCES`]).
+/// pipeline file. Idempotent per canonical path (dedup state lives in
+/// a process-wide `OnceLock<Mutex<HashSet<PathBuf>>>` private to this
+/// module).
 ///
 /// The warning is emitted via both `tracing::warn!` (for structured log
 /// aggregation, with `pipeline` and `path` fields) and `eprintln!` (for

--- a/crates/rsigma-runtime/src/sources/command.rs
+++ b/crates/rsigma-runtime/src/sources/command.rs
@@ -74,8 +74,7 @@ pub async fn resolve_command_with_limit(
                     return Err(SourceError {
                         source_id: String::new(),
                         kind: SourceErrorKind::ResourceLimit(format!(
-                            "command stdout exceeds {} byte limit",
-                            max_stdout_bytes
+                            "command stdout exceeds {max_stdout_bytes} byte limit"
                         )),
                     });
                 }

--- a/crates/rsigma-runtime/src/sources/http.rs
+++ b/crates/rsigma-runtime/src/sources/http.rs
@@ -131,8 +131,7 @@ pub(crate) async fn resolve_http_with_limit(
         return Err(SourceError {
             source_id: String::new(),
             kind: SourceErrorKind::ResourceLimit(format!(
-                "HTTP response Content-Length ({content_length} bytes) exceeds {} byte limit",
-                max_bytes
+                "HTTP response Content-Length ({content_length} bytes) exceeds {max_bytes} byte limit"
             )),
         });
     }
@@ -168,8 +167,7 @@ async fn read_body_capped(
             return Err(SourceError {
                 source_id: String::new(),
                 kind: SourceErrorKind::ResourceLimit(format!(
-                    "HTTP response body exceeds {} byte limit",
-                    max_bytes
+                    "HTTP response body exceeds {max_bytes} byte limit"
                 )),
             });
         }

--- a/crates/rsigma-runtime/src/sources/include.rs
+++ b/crates/rsigma-runtime/src/sources/include.rs
@@ -59,8 +59,7 @@ fn expand_includes_with_depth(
                 match &source.source_type {
                     SourceType::Http { .. } | SourceType::Nats { .. } => {
                         return Err(format!(
-                            "include references remote source '{}'; use --allow-remote-include to permit",
-                            source_id
+                            "include references remote source '{source_id}'; use --allow-remote-include to permit"
                         ));
                     }
                     _ => {}
@@ -74,8 +73,7 @@ fn expand_includes_with_depth(
                 for parsed_item in &items {
                     if matches!(parsed_item.transformation, Transformation::Include { .. }) {
                         return Err(format!(
-                            "included content from source '{}' contains nested include directives; recursive includes are not allowed (max depth 1)",
-                            source_id
+                            "included content from source '{source_id}' contains nested include directives; recursive includes are not allowed (max depth 1)"
                         ));
                     }
                 }

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -248,7 +248,9 @@ pub async fn resolve_all(
     resolve_all_with_state(resolver, sources, None).await
 }
 
-/// Like [`resolve_all`] but also updates a [`PipelineState`] with source resolution status.
+/// Like [`resolve_all`] but also updates a
+/// [`PipelineState`](rsigma_eval::pipeline::state::PipelineState) with
+/// source resolution status.
 pub async fn resolve_all_with_state(
     resolver: &dyn SourceResolver,
     sources: &[DynamicSource],

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,13 @@
 [advisories]
+# Surface unmaintained-crate advisories as warnings so they are visible
+# in the audit run without breaking CI; we cannot drop transitive
+# unmaintained deps unilaterally but we want to see them.
+unmaintained = "workspace"
 ignore = [
-    # encoding 0.2.33 (RUSTSEC-2021-0153) -- unmaintained, pulled transitively
-    # via evtx. No safe upgrade available; tracked for removal when evtx drops
-    # the encoding dependency.
+    # encoding 0.2.33 (RUSTSEC-2021-0153) -- unmaintained, pulled
+    # transitively via evtx. No safe upgrade available. Re-evaluate
+    # every quarter; remove this ignore once evtx drops the encoding
+    # dependency. Last reviewed: 2026-06-04.
     "RUSTSEC-2021-0153",
 ]
 
@@ -25,6 +30,10 @@ confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
+# Refuse wildcard dependencies. `version = "*"` in a workspace member
+# undermines lockfile reproducibility and makes supply-chain review
+# impossible. Use a concrete version or version range.
+wildcards = "deny"
 
 [sources]
 unknown-registry = "deny"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+# Pin every local and release build to the workspace MSRV.
+#
+# This file is honored by `rustup` when no explicit `+toolchain`
+# selector is on the command line. Contributors who run `cargo build`
+# or `cargo test` from a checkout get the same toolchain that the
+# MSRV CI job uses, so MSRV drift can be caught locally before a PR
+# hits CI. CI workflows explicitly select the channel they need
+# (`stable`, `nightly`, …) via `dtolnay/rust-toolchain`, so this file
+# only affects ambient invocations.
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

Tightens every link in the release chain before v0.14.0 ships so the act of publishing itself does not undermine the correctness work that already landed.

## Behavior changes

- **`publish.yml` no longer masks `cargo publish` failures.** Every step previously ended with `|| echo "::warning::… already published or failed"`, so auth, lockfile drift, and registry-index issues turned into yellow annotations instead of red runs. The mask is gone; each publish fails loud. A new pre-flight step dry-runs every crate in dependency order before any side-effecting publish, so a half-released set of crates cannot leave the workspace inconsistent on crates.io. Every publish now passes `--locked`. `workflow_dispatch` keeps the dry-run rehearsal path; only `release: published` touches crates.io. The `Swatinem/rust-cache` step on this workflow was removed to close a cache-poisoning vector against the signed artifacts.
- **`release-binaries.yml` pins the toolchain and ships `SHA256SUMS`.** The previous `rustup update` plus follow-up `rustup target add` is replaced by `dtolnay/rust-toolchain@... stable` with `targets:` inline, matching the rest of the repo's CI. After downloading the per-target archives, the release job generates a `SHA256SUMS` manifest and uploads it as a release asset; the manifest rides through the same `actions/attest-build-provenance` subject path as the archives, so consumers who do not pull the SLSA attestation can still verify download integrity.
- **Ambient builds pin to the workspace MSRV.** `rust-toolchain.toml` pins `cargo` / `cargo test` / `cargo clippy` invocations without `+<channel>` to Rust 1.88.0, so a contributor whose system stable is much newer still hits the same MSRV gate locally that CI enforces. CI workflows continue to pin their own channels explicitly.
- **A `[profile.release]` block trims binary size.** `lto = "thin"`, `codegen-units = 1`, `strip = true` ship in `Cargo.toml`. The Docker build's standalone `strip` becomes redundant but is left in place for the moment.
- **The 1.88.0 clippy / rustdoc backlog is paid down.** Pinning the MSRV and adding the doc gate surfaced existing lint debt: `collapsible_else_if`, `uninlined_format_args` across several files, a `duplicated_attribute` on the `daemon-tls` cfg gate, broken intra-doc links in `rsigma-eval` / `rsigma-runtime`, unclosed `<host>` HTML tags in CLI doc comments. All cleaned up with no `#[allow]` escape hatches; `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo doc --workspace --no-deps -D warnings -D rustdoc::broken-intra-doc-links` are gate-green.
- **CI gets a `doc` job, a wider MSRV check, an uploaded coverage report, and a pinned Sigma corpus.** `doc` runs `cargo doc --workspace --all-features --locked --no-deps` with the strict rustdoc gate; the MSRV check gains `--all-targets` so test- or example-only dependencies cannot drift past the MSRV; the coverage job uploads `lcov.info` as an artifact (Codecov / Coveralls / manual download); the Sigma-corpus regression job pins `SigmaHQ/sigma` to a specific commit (`SIGMA_CORPUS_SHA` in `ci.yml`) so an upstream rule edit cannot turn the workspace red without a deliberate bump here.
- **Docker builds are reproducible and scanned on every architecture.** Both `cargo build` stages in the `Dockerfile` add `--locked` and `rust-toolchain.toml` joins the dependency-cache layer. `.dockerignore` adds root-anchored entries for the workspace-root content that the daemon binary build does not need (`/fuzz`, `/tests`, `/docs`, `/site`, `/benches`, and the local drafts directory). The leading slash keeps per-crate `tests/` subdirectories reachable. The Grype scan runs as a 2-leg matrix (`amd64` × `arm64`); each SARIF upload labels itself `docker-<arch>` so the Security tab distinguishes findings.
- **Supply-chain gates tighten.** `deny.toml` denies wildcard dependency versions, surfaces unmaintained-crate advisories via `unmaintained = "workspace"`, and the `RUSTSEC-2021-0153` ignore grows a "Last reviewed" date plus a quarterly-review note. The `audit` workflow triggers on `deny.toml` and its own workflow file in addition to manifest/lockfile changes, and pulls `cargo-audit` from `taiki-e/install-action` prebuilds instead of compiling it from source every run. Dependabot picks up `docker` (against `/`, so base-image digest bumps surface as PRs) and `npm` (against `/editors/vscode`, so the extension's deps batch the same way Cargo's do).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --locked --no-deps`
- [x] `cargo deny check`
- [x] `cargo test --workspace --all-features -- --test-threads=1` — 1590 passed across 48 suites.
- [x] `zizmor --pedantic .github/workflows` — only one informational finding (`dtolnay/rust-toolchain` flagged as runner-bundled; intentional, matches the rest of the repo's CI).
- [x] `mkdocs build --strict` — clean.
- [ ] CI on this PR (the new `doc` job is the headline addition; the existing check / clippy / fmt / test / coverage / MSRV / Sigma-corpus / audit / deny jobs should all stay green).
- [ ] First release on `main` after merge will exercise the publish + release-binaries + docker workflows end to end.

## Out of scope for this PR

PR-smoke fuzzing on `fuzz/` changes, adding the missing `fuzz_eval_matcher_diff` target to the CI matrix and committing its seed corpus, and adding fuzz targets for `rsigma-convert` / `rsigma-cli` / `rsigma-lsp` are all worthwhile but they each carry their own design + timing decisions that do not block v0.14.0. They will ship as a follow-up PR.

`[workspace.lints]` opt-in across crates is also deferred: turning it on surfaces a separate lint backlog (notably `missing_docs` for the public library crates) that needs a focused triage pass.