### PR TITLE
fix(parser+cli): tighten diagnostic surfaces before v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Parser and CLI diagnostics: invalid metadata, output controls, panic-free migrate
+
+Tightens five small but visible cracks in the parser and CLI surface that all silently swallowed problems an operator was almost certainly trying to catch.
+
+**Invalid `status` / `level` and malformed `related:` entries are now surfaced.** `parse_detection_rule`, `parse_correlation_rule`, and `parse_filter_rule` previously coerced any unparseable `status:` or `level:` into a silent `None` (`get_str(m, "status").and_then(|s| s.parse().ok())`), and `parse_related` `filter_map`ped away any item that was not a mapping, was missing `id`/`type`, or carried an unknown `type`. A typo such as `status: stabel` or `type: derved` round-tripped to the in-memory rule with the field absent and no diagnostic. The parsers now thread a `&mut Vec<String>` for warnings, push index-qualified messages (`related[2] invalid type 'derved' (expected one of: derived, obsolete, merged, renamed, similar)`), and let `parse_sigma_yaml` extend `SigmaCollection.errors` with the result. Existing CLI surfaces (`rule parse`, `rule validate`, the "Loaded rules" path) already render `collection.errors`, so the new warnings flow through unchanged.
+
+**New `SigmaCollection` ergonomics.** Three helpers cover the "treat any error as failure" path that downstream callers were re-implementing each time: `SigmaCollection::has_errors()`, `SigmaCollection::error_count()`, and `SigmaCollection::into_result()` (consumes the collection and returns `Err(Vec<String>)` when anything failed, `Ok(self)` on a clean parse). The stale doc on the `errors` field that referenced a non-existent `collect_errors` flag is replaced with the actual contract.
+
+**`rule lint` honours `--quiet` and `--no-stats`.** Both global flags had no effect on the human renderer, so CI scrapers that piped only findings still got a "Loaded lint config: …" progress line on stderr and a "Checked N file(s): … passed, … failed" trailing summary on stdout. The summary block is now gated by `OutputCtx::show_stats()` and the config-load progress by `show_progress()`; findings still print under both flags. The structured `tracing::info!("Lint summary", …)` event continues to fire so log-based consumers still see the per-run totals.
+
+**Invalid `global.output_format` / `global.color` config values now warn instead of silently falling back.** A typo like `output_format: xml` or `color: rainbow` in the YAML config used to bypass the `OutputFormat::parse` / `ColorChoice::parse` filter, return `None`, and revert the operator to the TTY-aware defaults with no signal. A new `output::warn_invalid_global_output` wrapper between `config::discovered_global_output` and `OutputCtx::resolve` validates both strings, emits a stderr warning that lists the accepted alternatives, and strips the bad value so the resolver still falls back cleanly. The command itself still succeeds because the warning is informational.
+
+**`rule migrate-sources` no longer panics on a pipeline read race.** After writing the extracted `sources.yml`, the rewrite loop in `cmd_migrate_sources` re-read each pipeline file with `std::fs::read_to_string(path).unwrap()`. A file deleted between scan and rewrite (or a permission flip on a flaky filesystem) crashed the CLI. The read now matches the soft-error pattern the `std::fs::write` call below it already used: print a `warning:` line, skip the offending pipeline, and keep going. The extracted sources file is already on disk at that point, so a single unreadable pipeline does not invalidate the other rewrites.
+
 ### Release pipeline, CI, Docker, and supply-chain hardening
 
 Tightens every link in the release chain before v0.14.0 ships so the act of publishing itself does not undermine the correctness work that already landed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### Parser and CLI diagnostics: invalid metadata, output controls, panic-free migrate
+### Parser and CLI diagnostics: invalid metadata, output controls, panic-free migrate (#179)
 
 Tightens five small but visible cracks in the parser and CLI surface that all silently swallowed problems an operator was almost certainly trying to catch.
 

--- a/crates/rsigma-cli/src/commands/lint.rs
+++ b/crates/rsigma-cli/src/commands/lint.rs
@@ -80,8 +80,16 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
     } = args;
     let p = Painter::new(ctx.color);
 
-    // 0. Build lint config from file + CLI flags
-    let config = build_lint_config(&path, disable, lint_config_path, exclude, tag_namespaces);
+    // 0. Build lint config from file + CLI flags. `--quiet` suppresses
+    //    informational stderr from the config-loading layer below.
+    let config = build_lint_config(
+        &path,
+        disable,
+        lint_config_path,
+        exclude,
+        tag_namespaces,
+        ctx,
+    );
 
     // 1. Run built-in lint checks (with suppression)
     let results: Vec<FileLintResult> = if path.is_dir() {
@@ -225,49 +233,54 @@ pub(crate) fn cmd_lint(args: LintArgs, ctx: OutputCtx) -> LintCounts {
         }
     }
 
-    // 7. Summary
-    let passed = total_files - failed_files;
-    let separator = "─".repeat(60);
-    println!("{}", p.dim(&separator));
+    // 7. Summary. Gated by `ctx.show_stats()` so `--quiet` / `--no-stats`
+    //    skip the separator and the human "Checked N file(s)..." line.
+    //    The structured `tracing::info!` summary still fires for log
+    //    consumers because it is not part of the human output stream.
+    if ctx.show_stats() {
+        let passed = total_files - failed_files;
+        let separator = "─".repeat(60);
+        println!("{}", p.dim(&separator));
 
-    let passed_str = format!("{passed} passed");
-    let failed_str = format!("{failed_files} failed");
-    let errors_str = format!("{total_errors} error(s)");
-    let warnings_str = format!("{total_warnings} warning(s)");
-    let infos_str = format!("{total_infos} info(s)");
+        let passed_str = format!("{passed} passed");
+        let failed_str = format!("{failed_files} failed");
+        let errors_str = format!("{total_errors} error(s)");
+        let warnings_str = format!("{total_warnings} warning(s)");
+        let infos_str = format!("{total_infos} info(s)");
 
-    let passed_colored = if passed > 0 {
-        p.green_bold(&passed_str)
-    } else {
-        p.dim(&passed_str)
-    };
-    let failed_colored = if failed_files > 0 {
-        p.red_bold(&failed_str)
-    } else {
-        p.dim(&failed_str)
-    };
-    let errors_colored = if total_errors > 0 {
-        p.red(&errors_str)
-    } else {
-        p.dim(&errors_str)
-    };
-    let warnings_colored = if total_warnings > 0 {
-        p.yellow(&warnings_str)
-    } else {
-        p.dim(&warnings_str)
-    };
-    let infos_colored = if total_infos > 0 {
-        p.blue(&infos_str)
-    } else {
-        p.dim(&infos_str)
-    };
+        let passed_colored = if passed > 0 {
+            p.green_bold(&passed_str)
+        } else {
+            p.dim(&passed_str)
+        };
+        let failed_colored = if failed_files > 0 {
+            p.red_bold(&failed_str)
+        } else {
+            p.dim(&failed_str)
+        };
+        let errors_colored = if total_errors > 0 {
+            p.red(&errors_str)
+        } else {
+            p.dim(&errors_str)
+        };
+        let warnings_colored = if total_warnings > 0 {
+            p.yellow(&warnings_str)
+        } else {
+            p.dim(&warnings_str)
+        };
+        let infos_colored = if total_infos > 0 {
+            p.blue(&infos_str)
+        } else {
+            p.dim(&infos_str)
+        };
 
-    println!(
-        "Checked {total_files} file(s): {passed_colored}, {failed_colored} ({errors_colored}, {warnings_colored}, {infos_colored})",
-    );
+        println!(
+            "Checked {total_files} file(s): {passed_colored}, {failed_colored} ({errors_colored}, {warnings_colored}, {infos_colored})",
+        );
+    }
     tracing::info!(
         files = total_files,
-        passed,
+        passed = total_files - failed_files,
         failed = failed_files,
         errors = total_errors,
         warnings = total_warnings,
@@ -566,12 +579,17 @@ fn build_lint_config(
     lint_config_path: Option<PathBuf>,
     exclude: Vec<String>,
     tag_namespaces: Vec<String>,
+    ctx: OutputCtx,
 ) -> LintConfig {
-    // Load config file
+    // Operator-facing progress lines ("Loaded lint config: …") are
+    // pure informational and respect `--quiet` via `show_progress()`.
+    // Errors and warnings (failed load, bad config) always print.
     let mut config = if let Some(explicit) = lint_config_path {
         match LintConfig::load(&explicit) {
             Ok(c) => {
-                eprintln!("Loaded lint config: {}", explicit.display());
+                if ctx.show_progress() {
+                    eprintln!("Loaded lint config: {}", explicit.display());
+                }
                 c
             }
             Err(e) => {
@@ -582,7 +600,9 @@ fn build_lint_config(
     } else if let Some(found) = LintConfig::find_in_ancestors(path) {
         match LintConfig::load(&found) {
             Ok(c) => {
-                eprintln!("Loaded lint config: {}", found.display());
+                if ctx.show_progress() {
+                    eprintln!("Loaded lint config: {}", found.display());
+                }
                 c
             }
             Err(e) => {

--- a/crates/rsigma-cli/src/commands/migrate_sources.rs
+++ b/crates/rsigma-cli/src/commands/migrate_sources.rs
@@ -179,13 +179,26 @@ pub(crate) fn cmd_migrate_sources(args: MigrateSourcesArgs) {
         _ => unreachable!(),
     }
 
-    // Rewrite pipeline files with sources: block removed
+    // Rewrite pipeline files with sources: block removed. A read failure
+    // here (file deleted between scan and rewrite, permission flip, …)
+    // used to panic the CLI; report the failure on stderr and keep
+    // processing the remaining pipelines, matching the soft-error
+    // behaviour the rewrite step itself already uses.
     for path in &pipeline_files {
-        let content = std::fs::read_to_string(path).unwrap();
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "warning: could not re-read {} to strip sources: {e}",
+                    path.display()
+                );
+                continue;
+            }
+        };
         let stripped = remove_sources_block(&content);
         if stripped != content {
             if let Err(e) = std::fs::write(path, &stripped) {
-                eprintln!("Warning: could not rewrite {}: {e}", path.display());
+                eprintln!("warning: could not rewrite {}: {e}", path.display());
             } else {
                 eprintln!("Removed sources: block from {}", path.display());
             }

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -270,6 +270,7 @@ fn main() {
     // but before any command runs. The same precedence model that drives
     // --log-format applies here: flag > env > file > default.
     let (cfg_format, cfg_color) = config::discovered_global_output(cfg_override.as_deref());
+    let (cfg_format, cfg_color) = output::warn_invalid_global_output(cfg_format, cfg_color);
     let stdout_is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
     let ctx = output::OutputCtx::resolve(
         cli.output_format,

--- a/crates/rsigma-cli/src/output/mod.rs
+++ b/crates/rsigma-cli/src/output/mod.rs
@@ -130,6 +130,51 @@ impl Default for OutputCtx {
     }
 }
 
+/// Sanitize the raw `global.output_format` and `global.color` values
+/// pulled from a config file before they reach [`OutputCtx::resolve`].
+///
+/// Both values previously round-tripped through
+/// `OutputFormat::parse` / `ColorChoice::parse`, with a `None` from
+/// the parser silently falling through to the default. That meant a
+/// typo such as `output_format: xml` was silently ignored: the
+/// effective format reverted to the TTY-aware default and the
+/// operator had no way to discover the mistake short of reading the
+/// source. This wrapper warns on stderr for each unrecognized value
+/// and strips it from the return so callers fall through cleanly.
+///
+/// Returns the sanitized strings: any input that does not parse is
+/// replaced with `None`. The original strings are accepted by value
+/// so the call site can pass `cfg_format` directly without an extra
+/// clone.
+pub(crate) fn warn_invalid_global_output(
+    output_format: Option<String>,
+    color: Option<String>,
+) -> (Option<String>, Option<String>) {
+    let format = output_format.and_then(|s| match OutputFormat::parse(&s) {
+        Some(_) => Some(s),
+        None => {
+            eprintln!(
+                "warning: invalid global.output_format '{s}' \
+                 (expected one of: json, ndjson, table, csv, tsv); \
+                 falling back to default"
+            );
+            None
+        }
+    });
+    let color = color.and_then(|s| match ColorChoice::parse(&s) {
+        Some(_) => Some(s),
+        None => {
+            eprintln!(
+                "warning: invalid global.color '{s}' \
+                 (expected one of: auto, always, never); \
+                 falling back to default"
+            );
+            None
+        }
+    });
+    (format, color)
+}
+
 impl OutputCtx {
     /// Resolve the effective `OutputCtx` from layered inputs.
     ///
@@ -583,5 +628,42 @@ mod tests {
         let r = Row { name: "rule", n: 3 };
         assert_eq!(Row::headers(), &["NAME", "N"]);
         assert_eq!(r.row(), vec!["rule".to_string(), "3".to_string()]);
+    }
+
+    #[test]
+    fn warn_invalid_global_output_keeps_recognized_values() {
+        // Valid strings pass through untouched. The function is only
+        // responsible for filtering out unrecognized values; the actual
+        // parsing happens later in `OutputCtx::resolve`.
+        let (f, c) = warn_invalid_global_output(Some("ndjson".into()), Some("always".into()));
+        assert_eq!(f.as_deref(), Some("ndjson"));
+        assert_eq!(c.as_deref(), Some("always"));
+    }
+
+    #[test]
+    fn warn_invalid_global_output_strips_unrecognized_format() {
+        // An invalid format string is replaced with `None` so the
+        // downstream resolver falls back to its TTY-aware default
+        // instead of silently keeping the misconfigured value.
+        let (f, c) = warn_invalid_global_output(Some("xml".into()), None);
+        assert!(f.is_none());
+        assert!(c.is_none());
+    }
+
+    #[test]
+    fn warn_invalid_global_output_strips_unrecognized_color() {
+        let (f, c) = warn_invalid_global_output(None, Some("rainbow".into()));
+        assert!(f.is_none());
+        assert!(c.is_none());
+    }
+
+    #[test]
+    fn warn_invalid_global_output_passes_through_none() {
+        // The common case (no global override in the config file) must
+        // not introduce a phantom warning. With both inputs `None`
+        // there is nothing to validate and both outputs are `None`.
+        let (f, c) = warn_invalid_global_output(None, None);
+        assert!(f.is_none());
+        assert!(c.is_none());
     }
 }

--- a/crates/rsigma-cli/tests/cli_config.rs
+++ b/crates/rsigma-cli/tests/cli_config.rs
@@ -258,3 +258,76 @@ fn daemon_rejects_invalid_egress_policy_value() {
         .failure()
         .stderr(predicate::str::contains("egress-policy"));
 }
+
+#[cfg(feature = "daemon")]
+#[test]
+fn invalid_global_output_format_in_config_warns_then_falls_back() {
+    // Bad `global.output_format` used to be ignored silently. Now the
+    // CLI prints a stderr warning and reverts to the TTY-aware
+    // default. The command itself still succeeds because the bad
+    // value is treated as "unset" by `warn_invalid_global_output`.
+    // Use `engine daemon --dry-run` because it accepts `--config` and
+    // exits without trying to bind any sockets.
+    let cfg = temp_file(
+        ".yaml",
+        "global:\n  output_format: xml\ndaemon:\n  rules: /tmp/myrules\n",
+    );
+    rsigma()
+        .args([
+            "engine",
+            "daemon",
+            "--config",
+            cfg.path().to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("invalid global.output_format 'xml'")
+                .and(predicate::str::contains("falling back to default")),
+        );
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn invalid_global_color_in_config_warns_then_falls_back() {
+    let cfg = temp_file(
+        ".yaml",
+        "global:\n  color: rainbow\ndaemon:\n  rules: /tmp/myrules\n",
+    );
+    rsigma()
+        .args([
+            "engine",
+            "daemon",
+            "--config",
+            cfg.path().to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("invalid global.color 'rainbow'"));
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn valid_global_output_in_config_emits_no_warning() {
+    let cfg = temp_file(
+        ".yaml",
+        "global:\n  output_format: ndjson\n  color: never\ndaemon:\n  rules: /tmp/myrules\n",
+    );
+    rsigma()
+        .args([
+            "engine",
+            "daemon",
+            "--config",
+            cfg.path().to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("invalid global.output_format")
+                .not()
+                .and(predicate::str::contains("invalid global.color").not()),
+        );
+}

--- a/crates/rsigma-cli/tests/cli_lint.rs
+++ b/crates/rsigma-cli/tests/cli_lint.rs
@@ -510,3 +510,39 @@ detection:
         "duplicate tag should be removed"
     );
 }
+
+#[test]
+fn lint_quiet_suppresses_summary_and_config_progress() {
+    let rule = temp_file(".yml", LINT_INVALID_LEVEL);
+    rsigma()
+        .args(["--quiet", "rule", "lint", rule.path().to_str().unwrap()])
+        .assert()
+        .stdout(
+            predicate::str::contains("Checked")
+                .not()
+                .and(predicate::str::contains("file(s):").not()),
+        )
+        .stderr(predicate::str::contains("Loaded lint config").not());
+}
+
+#[test]
+fn lint_no_stats_suppresses_summary_but_keeps_findings() {
+    let rule = temp_file(".yml", LINT_INVALID_LEVEL);
+    rsigma()
+        .args(["--no-stats", "rule", "lint", rule.path().to_str().unwrap()])
+        .assert()
+        .stdout(
+            predicate::str::contains("Checked")
+                .not()
+                .and(predicate::str::contains("invalid_level")),
+        );
+}
+
+#[test]
+fn lint_quiet_still_emits_findings() {
+    let rule = temp_file(".yml", LINT_INVALID_LEVEL);
+    rsigma()
+        .args(["--quiet", "rule", "lint", rule.path().to_str().unwrap()])
+        .assert()
+        .stdout(predicate::str::contains("invalid_level"));
+}

--- a/crates/rsigma-parser/src/ast.rs
+++ b/crates/rsigma-parser/src/ast.rs
@@ -689,7 +689,15 @@ pub struct SigmaCollection {
     pub rules: Vec<SigmaRule>,
     pub correlations: Vec<CorrelationRule>,
     pub filters: Vec<FilterRule>,
-    /// Parsing errors that were collected (when `collect_errors` is true).
+    /// Per-document parse errors accumulated while building the
+    /// collection. Populated by [`parse_sigma_yaml`](crate::parse_sigma_yaml)
+    /// and friends; one entry per document the parser could not
+    /// produce a [`SigmaRule`], [`CorrelationRule`], or [`FilterRule`]
+    /// from. The collection is still returned on `Ok(_)` so callers
+    /// can decide whether a partial parse is acceptable; the
+    /// [`SigmaCollection::has_errors`] / [`SigmaCollection::error_count`]
+    /// / [`SigmaCollection::into_result`] helpers cover the common
+    /// "treat any error as a failure" path.
     #[serde(skip)]
     pub errors: Vec<String>,
 }
@@ -711,6 +719,32 @@ impl SigmaCollection {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// True when the parser recorded one or more per-document parse
+    /// errors while building this collection.
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    /// Number of per-document parse errors recorded while building
+    /// this collection. Equivalent to `self.errors.len()`.
+    pub fn error_count(&self) -> usize {
+        self.errors.len()
+    }
+
+    /// Promote the accumulated errors to a hard failure. Returns the
+    /// collection when [`SigmaCollection::has_errors`] is false;
+    /// otherwise returns the collection's [`errors`](Self::errors) so
+    /// callers can format them. The original collection is consumed
+    /// either way so the success path can move out of `self` without
+    /// re-cloning the documents.
+    pub fn into_result(self) -> Result<Self, Vec<String>> {
+        if self.has_errors() {
+            Err(self.errors)
+        } else {
+            Ok(self)
+        }
     }
 }
 

--- a/crates/rsigma-parser/src/parser/correlation.rs
+++ b/crates/rsigma-parser/src/parser/correlation.rs
@@ -7,7 +7,9 @@ use crate::condition::parse_condition;
 use crate::error::{Result, SigmaParserError};
 use crate::value::Timespan;
 
-use super::{collect_custom_attributes, get_str, get_str_list, parse_related, val_key};
+use super::{
+    collect_custom_attributes, get_str, get_str_list, parse_enum_with_warn, parse_related, val_key,
+};
 
 // =============================================================================
 // Correlation Rule Parsing
@@ -15,8 +17,15 @@ use super::{collect_custom_attributes, get_str, get_str_list, parse_related, val
 
 /// Parse a correlation rule from a YAML value.
 ///
+/// `warnings` receives non-fatal issues (invalid `status` / `level`
+/// values, malformed `related:` entries); see
+/// [`parse_detection_rule`](super::detection::parse_detection_rule).
+///
 /// Reference: pySigma correlations.py SigmaCorrelationRule.from_dict
-pub(super) fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
+pub(super) fn parse_correlation_rule(
+    value: &Value,
+    warnings: &mut Vec<String>,
+) -> Result<CorrelationRule> {
     let m = value
         .as_mapping()
         .ok_or_else(|| SigmaParserError::InvalidCorrelation("Expected a YAML mapping".into()))?;
@@ -109,19 +118,19 @@ pub(super) fn parse_correlation_rule(value: &Value) -> Result<CorrelationRule> {
         title,
         id: get_str(m, "id").map(|s| s.to_string()),
         name: get_str(m, "name").map(|s| s.to_string()),
-        status: get_str(m, "status").and_then(|s| s.parse().ok()),
+        status: parse_enum_with_warn(get_str(m, "status"), "status", warnings),
         description: get_str(m, "description").map(|s| s.to_string()),
         author: get_str(m, "author").map(|s| s.to_string()),
         date: get_str(m, "date").map(|s| s.to_string()),
         modified: get_str(m, "modified").map(|s| s.to_string()),
-        related: parse_related(m.get(val_key("related"))),
+        related: parse_related(m.get(val_key("related")), warnings),
         references: get_str_list(m, "references"),
         taxonomy: get_str(m, "taxonomy").map(|s| s.to_string()),
         license: get_str(m, "license").map(|s| s.to_string()),
         tags: get_str_list(m, "tags"),
         fields: get_str_list(m, "fields"),
         falsepositives: get_str_list(m, "falsepositives"),
-        level: get_str(m, "level").and_then(|s| s.parse().ok()),
+        level: parse_enum_with_warn(get_str(m, "level"), "level", warnings),
         scope: get_str_list(m, "scope"),
         correlation_type,
         rules,

--- a/crates/rsigma-parser/src/parser/detection.rs
+++ b/crates/rsigma-parser/src/parser/detection.rs
@@ -8,7 +8,8 @@ use crate::error::{Result, SigmaParserError};
 use crate::value::SigmaValue;
 
 use super::{
-    collect_custom_attributes, get_str, get_str_list, parse_logsource, parse_related, val_key,
+    collect_custom_attributes, get_str, get_str_list, parse_enum_with_warn, parse_logsource,
+    parse_related, val_key,
 };
 
 // =============================================================================
@@ -17,8 +18,16 @@ use super::{
 
 /// Parse a detection rule from a YAML value.
 ///
+/// `warnings` receives non-fatal issues that would otherwise be
+/// silently swallowed (invalid `status` / `level` values, malformed
+/// `related:` entries). The parser still returns `Ok(rule)` for
+/// these so a single typo does not invalidate the whole document.
+///
 /// Reference: pySigma rule.py SigmaRule.from_yaml / from_dict
-pub(super) fn parse_detection_rule(value: &Value) -> Result<SigmaRule> {
+pub(super) fn parse_detection_rule(
+    value: &Value,
+    warnings: &mut Vec<String>,
+) -> Result<SigmaRule> {
     let m = value
         .as_mapping()
         .ok_or_else(|| SigmaParserError::InvalidRule("Expected a YAML mapping".into()))?;
@@ -72,9 +81,9 @@ pub(super) fn parse_detection_rule(value: &Value) -> Result<SigmaRule> {
         detection,
         id: get_str(m, "id").map(|s| s.to_string()),
         name: get_str(m, "name").map(|s| s.to_string()),
-        related: parse_related(m.get(val_key("related"))),
+        related: parse_related(m.get(val_key("related")), warnings),
         taxonomy: get_str(m, "taxonomy").map(|s| s.to_string()),
-        status: get_str(m, "status").and_then(|s| s.parse().ok()),
+        status: parse_enum_with_warn(get_str(m, "status"), "status", warnings),
         description: get_str(m, "description").map(|s| s.to_string()),
         license: get_str(m, "license").map(|s| s.to_string()),
         author: get_str(m, "author").map(|s| s.to_string()),
@@ -83,7 +92,7 @@ pub(super) fn parse_detection_rule(value: &Value) -> Result<SigmaRule> {
         modified: get_str(m, "modified").map(|s| s.to_string()),
         fields: get_str_list(m, "fields"),
         falsepositives: get_str_list(m, "falsepositives"),
-        level: get_str(m, "level").and_then(|s| s.parse().ok()),
+        level: parse_enum_with_warn(get_str(m, "level"), "level", warnings),
         tags: get_str_list(m, "tags"),
         scope: get_str_list(m, "scope"),
         custom_attributes,

--- a/crates/rsigma-parser/src/parser/detection.rs
+++ b/crates/rsigma-parser/src/parser/detection.rs
@@ -24,10 +24,7 @@ use super::{
 /// these so a single typo does not invalidate the whole document.
 ///
 /// Reference: pySigma rule.py SigmaRule.from_yaml / from_dict
-pub(super) fn parse_detection_rule(
-    value: &Value,
-    warnings: &mut Vec<String>,
-) -> Result<SigmaRule> {
+pub(super) fn parse_detection_rule(value: &Value, warnings: &mut Vec<String>) -> Result<SigmaRule> {
     let m = value
         .as_mapping()
         .ok_or_else(|| SigmaParserError::InvalidRule("Expected a YAML mapping".into()))?;

--- a/crates/rsigma-parser/src/parser/filter.rs
+++ b/crates/rsigma-parser/src/parser/filter.rs
@@ -5,7 +5,8 @@ use crate::error::{Result, SigmaParserError};
 
 use super::detection::parse_detections;
 use super::{
-    collect_custom_attributes, get_str, get_str_list, parse_logsource, parse_related, val_key,
+    collect_custom_attributes, get_str, get_str_list, parse_enum_with_warn, parse_logsource,
+    parse_related, val_key,
 };
 
 // =============================================================================
@@ -13,7 +14,11 @@ use super::{
 // =============================================================================
 
 /// Parse a filter rule from a YAML value.
-pub(super) fn parse_filter_rule(value: &Value) -> Result<FilterRule> {
+///
+/// `warnings` receives non-fatal issues (invalid `status` / `level`
+/// values, malformed `related:` entries); see
+/// [`parse_detection_rule`](super::detection::parse_detection_rule).
+pub(super) fn parse_filter_rule(value: &Value, warnings: &mut Vec<String>) -> Result<FilterRule> {
     let m = value
         .as_mapping()
         .ok_or_else(|| SigmaParserError::InvalidRule("Expected a YAML mapping".into()))?;
@@ -97,18 +102,18 @@ pub(super) fn parse_filter_rule(value: &Value) -> Result<FilterRule> {
         id: get_str(m, "id").map(|s| s.to_string()),
         name: get_str(m, "name").map(|s| s.to_string()),
         taxonomy: get_str(m, "taxonomy").map(|s| s.to_string()),
-        status: get_str(m, "status").and_then(|s| s.parse().ok()),
+        status: parse_enum_with_warn(get_str(m, "status"), "status", warnings),
         description: get_str(m, "description").map(|s| s.to_string()),
         author: get_str(m, "author").map(|s| s.to_string()),
         date: get_str(m, "date").map(|s| s.to_string()),
         modified: get_str(m, "modified").map(|s| s.to_string()),
-        related: parse_related(m.get(val_key("related"))),
+        related: parse_related(m.get(val_key("related")), warnings),
         license: get_str(m, "license").map(|s| s.to_string()),
         references: get_str_list(m, "references"),
         tags: get_str_list(m, "tags"),
         fields: get_str_list(m, "fields"),
         falsepositives: get_str_list(m, "falsepositives"),
-        level: get_str(m, "level").and_then(|s| s.parse().ok()),
+        level: parse_enum_with_warn(get_str(m, "level"), "level", warnings),
         scope: get_str_list(m, "scope"),
         logsource,
         rules,

--- a/crates/rsigma-parser/src/parser/mod.rs
+++ b/crates/rsigma-parser/src/parser/mod.rs
@@ -100,7 +100,10 @@ pub fn parse_sigma_yaml(yaml: &str) -> Result<SigmaCollection> {
 
                         previous = Some(final_val.clone());
 
-                        match parse_document(&final_val) {
+                        let mut doc_warnings: Vec<String> = Vec::new();
+                        let parsed = parse_document(&final_val, &mut doc_warnings);
+                        collection.errors.extend(doc_warnings);
+                        match parsed {
                             Ok(doc) => match doc {
                                 SigmaDocument::Rule(rule) => collection.rules.push(*rule),
                                 SigmaDocument::Correlation(corr) => {
@@ -139,7 +142,10 @@ pub fn parse_sigma_yaml(yaml: &str) -> Result<SigmaCollection> {
         previous = Some(merged.clone());
 
         // Determine document type and parse
-        match parse_document(&merged) {
+        let mut doc_warnings: Vec<String> = Vec::new();
+        let parsed = parse_document(&merged, &mut doc_warnings);
+        collection.errors.extend(doc_warnings);
+        match parsed {
             Ok(doc) => match doc {
                 SigmaDocument::Rule(rule) => collection.rules.push(*rule),
                 SigmaDocument::Correlation(corr) => collection.correlations.push(corr),
@@ -201,17 +207,17 @@ pub fn parse_sigma_directory(dir: &Path) -> Result<SigmaCollection> {
 /// Parse a single YAML value into the appropriate Sigma document type.
 ///
 /// Reference: pySigma collection.py from_dicts — checks for 'correlation' and 'filter' keys
-fn parse_document(value: &Value) -> Result<SigmaDocument> {
+fn parse_document(value: &Value, warnings: &mut Vec<String>) -> Result<SigmaDocument> {
     let mapping = value
         .as_mapping()
         .ok_or_else(|| SigmaParserError::InvalidRule("Document is not a YAML mapping".into()))?;
 
     if mapping.contains_key(Value::String("correlation".into())) {
-        correlation::parse_correlation_rule(value).map(SigmaDocument::Correlation)
+        correlation::parse_correlation_rule(value, warnings).map(SigmaDocument::Correlation)
     } else if mapping.contains_key(Value::String("filter".into())) {
-        filter::parse_filter_rule(value).map(SigmaDocument::Filter)
+        filter::parse_filter_rule(value, warnings).map(SigmaDocument::Filter)
     } else {
-        detection::parse_detection_rule(value).map(|r| SigmaDocument::Rule(Box::new(r)))
+        detection::parse_detection_rule(value, warnings).map(|r| SigmaDocument::Rule(Box::new(r)))
     }
 }
 
@@ -289,20 +295,74 @@ pub(super) fn parse_logsource(value: &Value) -> Result<LogSource> {
     })
 }
 
-pub(super) fn parse_related(value: Option<&Value>) -> Vec<Related> {
-    let Some(Value::Sequence(seq)) = value else {
+/// Parse a `related:` list. Surfaces invalid entries through
+/// `warnings` instead of silently dropping them so a typo in
+/// `type: derved` (a misspelt `derived`) shows up in
+/// `SigmaCollection.errors` rather than being absent without trace.
+pub(super) fn parse_related(value: Option<&Value>, warnings: &mut Vec<String>) -> Vec<Related> {
+    let Some(seq_val) = value else {
+        return Vec::new();
+    };
+    let Some(seq) = seq_val.as_sequence() else {
+        warnings.push(format!(
+            "'related' must be a sequence of mappings, got: {seq_val:?}"
+        ));
         return Vec::new();
     };
 
     seq.iter()
-        .filter_map(|item| {
-            let m = item.as_mapping()?;
-            let id = get_str(m, "id")?.to_string();
-            let type_str = get_str(m, "type")?;
-            let relation_type = type_str.parse().ok()?;
+        .enumerate()
+        .filter_map(|(i, item)| {
+            let Some(m) = item.as_mapping() else {
+                warnings.push(format!("related[{i}] is not a mapping: {item:?}"));
+                return None;
+            };
+            let id = match get_str(m, "id") {
+                Some(s) => s.to_string(),
+                None => {
+                    warnings.push(format!("related[{i}] missing 'id'"));
+                    return None;
+                }
+            };
+            let type_str = match get_str(m, "type") {
+                Some(s) => s,
+                None => {
+                    warnings.push(format!("related[{i}] missing 'type'"));
+                    return None;
+                }
+            };
+            let relation_type = match type_str.parse() {
+                Ok(t) => t,
+                Err(_) => {
+                    warnings.push(format!(
+                        "related[{i}] invalid type '{type_str}' (expected one of: \
+                         derived, obsolete, merged, renamed, similar)"
+                    ));
+                    return None;
+                }
+            };
             Some(Related { id, relation_type })
         })
         .collect()
+}
+
+/// Parse a string value into an enum, pushing a warning into
+/// `warnings` when the value is present but does not parse. Returns
+/// `None` for both "absent" and "invalid", matching the previous
+/// silent `parse().ok()` contract for downstream consumers.
+pub(super) fn parse_enum_with_warn<T: std::str::FromStr>(
+    raw: Option<&str>,
+    field: &str,
+    warnings: &mut Vec<String>,
+) -> Option<T> {
+    let raw = raw?;
+    match raw.parse() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            warnings.push(format!("invalid {field}: '{raw}'"));
+            None
+        }
+    }
 }
 
 pub(super) fn val_key(s: &str) -> Value {

--- a/crates/rsigma-parser/src/parser/tests.rs
+++ b/crates/rsigma-parser/src/parser/tests.rs
@@ -1435,6 +1435,119 @@ detection:
 }
 
 #[test]
+fn parse_surfaces_invalid_status_value() {
+    let yaml = r#"
+title: Bogus status
+logsource:
+    product: test
+status: bogus
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(c.rules.len(), 1, "rule should still be accepted");
+    assert!(c.rules[0].status.is_none(), "invalid status must be None");
+    assert!(
+        c.errors.iter().any(|e| e.contains("invalid status")
+            && e.contains("'bogus'")),
+        "warning should mention invalid status; got {:?}",
+        c.errors
+    );
+}
+
+#[test]
+fn parse_surfaces_invalid_level_value() {
+    let yaml = r#"
+title: Bogus level
+logsource:
+    product: test
+level: cataclysmic
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(c.rules.len(), 1);
+    assert!(c.rules[0].level.is_none());
+    assert!(
+        c.errors.iter().any(|e| e.contains("invalid level")
+            && e.contains("'cataclysmic'")),
+        "warning should mention invalid level; got {:?}",
+        c.errors
+    );
+}
+
+#[test]
+fn parse_surfaces_invalid_related_entries() {
+    // Three intentional defects: a non-mapping entry, a missing
+    // `id`, and an unknown `type`. The valid trailing entry must
+    // still survive so a partial parse remains useful.
+    let yaml = r#"
+title: Mixed related
+logsource:
+    product: test
+related:
+    - "not-a-mapping"
+    - type: derived
+    - id: 11111111-2222-3333-4444-555555555555
+      type: derved
+    - id: 99999999-8888-7777-6666-555555555555
+      type: derived
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(c.rules.len(), 1);
+    let related = &c.rules[0].related;
+    assert_eq!(
+        related.len(),
+        1,
+        "only the well-formed related entry should be retained"
+    );
+
+    let errs = &c.errors;
+    assert!(
+        errs.iter().any(|e| e.contains("related[0]") && e.contains("not a mapping")),
+        "should warn about the string entry; got {errs:?}"
+    );
+    assert!(
+        errs.iter().any(|e| e.contains("related[1]") && e.contains("missing 'id'")),
+        "should warn about the missing id; got {errs:?}"
+    );
+    assert!(
+        errs.iter().any(|e| e.contains("related[2]") && e.contains("invalid type 'derved'")),
+        "should warn about the unknown type; got {errs:?}"
+    );
+}
+
+#[test]
+fn parse_surfaces_invalid_related_top_level_shape() {
+    let yaml = r#"
+title: Wrong-shape related
+logsource:
+    product: test
+related: "should be a sequence"
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    assert_eq!(c.rules.len(), 1);
+    assert!(c.rules[0].related.is_empty());
+    assert!(
+        c.errors.iter().any(|e| e.contains("'related' must be a sequence")),
+        "should warn about the wrong-shape related field; got {:?}",
+        c.errors
+    );
+}
+
+#[test]
 fn sigma_collection_into_result_returns_ok_when_clean() {
     let yaml = r#"
 title: Clean Rule

--- a/crates/rsigma-parser/src/parser/tests.rs
+++ b/crates/rsigma-parser/src/parser/tests.rs
@@ -1450,8 +1450,9 @@ detection:
     assert_eq!(c.rules.len(), 1, "rule should still be accepted");
     assert!(c.rules[0].status.is_none(), "invalid status must be None");
     assert!(
-        c.errors.iter().any(|e| e.contains("invalid status")
-            && e.contains("'bogus'")),
+        c.errors
+            .iter()
+            .any(|e| e.contains("invalid status") && e.contains("'bogus'")),
         "warning should mention invalid status; got {:?}",
         c.errors
     );
@@ -1473,8 +1474,9 @@ detection:
     assert_eq!(c.rules.len(), 1);
     assert!(c.rules[0].level.is_none());
     assert!(
-        c.errors.iter().any(|e| e.contains("invalid level")
-            && e.contains("'cataclysmic'")),
+        c.errors
+            .iter()
+            .any(|e| e.contains("invalid level") && e.contains("'cataclysmic'")),
         "warning should mention invalid level; got {:?}",
         c.errors
     );
@@ -1512,15 +1514,18 @@ detection:
 
     let errs = &c.errors;
     assert!(
-        errs.iter().any(|e| e.contains("related[0]") && e.contains("not a mapping")),
+        errs.iter()
+            .any(|e| e.contains("related[0]") && e.contains("not a mapping")),
         "should warn about the string entry; got {errs:?}"
     );
     assert!(
-        errs.iter().any(|e| e.contains("related[1]") && e.contains("missing 'id'")),
+        errs.iter()
+            .any(|e| e.contains("related[1]") && e.contains("missing 'id'")),
         "should warn about the missing id; got {errs:?}"
     );
     assert!(
-        errs.iter().any(|e| e.contains("related[2]") && e.contains("invalid type 'derved'")),
+        errs.iter()
+            .any(|e| e.contains("related[2]") && e.contains("invalid type 'derved'")),
         "should warn about the unknown type; got {errs:?}"
     );
 }
@@ -1541,7 +1546,9 @@ detection:
     assert_eq!(c.rules.len(), 1);
     assert!(c.rules[0].related.is_empty());
     assert!(
-        c.errors.iter().any(|e| e.contains("'related' must be a sequence")),
+        c.errors
+            .iter()
+            .any(|e| e.contains("'related' must be a sequence")),
         "should warn about the wrong-shape related field; got {:?}",
         c.errors
     );

--- a/crates/rsigma-parser/src/parser/tests.rs
+++ b/crates/rsigma-parser/src/parser/tests.rs
@@ -1394,3 +1394,61 @@ fn deep_merge_succeeds_at_reasonable_depth() {
     let result = super::deep_merge(nested_map(10), nested_map(10));
     assert!(result.is_ok());
 }
+
+#[test]
+fn sigma_collection_has_errors_and_error_count_are_consistent() {
+    // Per-document parse failures land in `collection.errors` rather
+    // than aborting the whole parse, so the helpers must agree with
+    // the underlying vec.
+    let yaml = r#"
+action: repeat
+title: Orphan
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    assert!(c.has_errors());
+    assert_eq!(c.error_count(), c.errors.len());
+    assert_eq!(c.error_count(), 1);
+}
+
+#[test]
+fn sigma_collection_into_result_promotes_errors_to_err() {
+    let yaml = r#"
+action: repeat
+title: Orphan
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    match c.into_result() {
+        Ok(_) => panic!("collection with errors must surface as Err"),
+        Err(errors) => {
+            assert_eq!(errors.len(), 1);
+            assert!(errors[0].contains("without a previous document"));
+        }
+    }
+}
+
+#[test]
+fn sigma_collection_into_result_returns_ok_when_clean() {
+    let yaml = r#"
+title: Clean Rule
+logsource:
+    product: test
+detection:
+    selection:
+        Field: value
+    condition: selection
+"#;
+    let c = parse_sigma_yaml(yaml).unwrap();
+    let promoted = c
+        .into_result()
+        .expect("clean collection should round-trip through into_result");
+    assert_eq!(promoted.rules.len(), 1);
+    assert!(!promoted.has_errors());
+}


### PR DESCRIPTION
## Summary

Five small but visible diagnostic gaps that all silently swallowed problems an operator was almost certainly trying to catch. Each lands as its own commit so review can focus on the behaviour change rather than chasing the wiring.

## Behaviour changes

### Parser: invalid status / level / related entries now surface in `SigmaCollection.errors`

`parse_detection_rule`, `parse_correlation_rule`, and `parse_filter_rule` previously coerced any unparseable `status:` or `level:` into a silent `None` (`get_str(m, "status").and_then(|s| s.parse().ok())`), and `parse_related` `filter_map`-dropped any item that was not a mapping, was missing `id` / `type`, or carried an unknown `type`. A typo such as `status: stabel` or `type: derved` round-tripped to the in-memory rule with the field absent and no diagnostic. The parsers now thread `&mut Vec<String>` for warnings and push index-qualified messages, e.g. `related[2] invalid type 'derved' (expected one of: derived, obsolete, merged, renamed, similar)`. `parse_sigma_yaml` extends `SigmaCollection.errors` with the result before matching on the parse outcome. All three rule parsers remain `pub(super)`, so the signature change is contained inside the parser module; existing CLI surfaces (`rule parse`, `rule validate`, the "Loaded rules" path in `main.rs`) already render `collection.errors`, so the new warnings flow through unchanged.

### Parser: three new `SigmaCollection` helpers

`SigmaCollection::has_errors()`, `SigmaCollection::error_count()`, and `SigmaCollection::into_result()` cover the "treat any error as failure" path that downstream callers were re-implementing each time. `into_result()` consumes the collection and returns `Err(Vec<String>)` when anything failed, `Ok(self)` on a clean parse. The stale doc on the `errors` field that referenced a non-existent `collect_errors` flag is replaced with the actual contract.

### CLI: `rule lint` honours `--quiet` and `--no-stats`

Both global flags had no effect on the human renderer, so CI scrapers that piped only findings still got a `Loaded lint config: ...` progress line on stderr and a `Checked N file(s): ... passed, ... failed` trailing summary on stdout. The summary block is now gated by `OutputCtx::show_stats()` and the config-load progress by `show_progress()`; findings still print under both flags. The structured `tracing::info!("Lint summary", ...)` event continues to fire so log-based consumers still see the per-run totals.

### CLI: invalid `global.output_format` / `global.color` config values warn instead of silently falling back

A typo like `output_format: xml` or `color: rainbow` in the YAML config used to bypass the `OutputFormat::parse` / `ColorChoice::parse` filter, return `None`, and revert the operator to the TTY-aware defaults with no signal. A new `output::warn_invalid_global_output` wrapper between `config::discovered_global_output` and `OutputCtx::resolve` validates both strings, emits a stderr warning that lists the accepted alternatives, and strips the bad value so the resolver still falls back cleanly. The command itself still succeeds because the warning is informational.

### CLI: `rule migrate-sources` no longer panics on a pipeline read race

After writing the extracted `sources.yml`, the rewrite loop in `cmd_migrate_sources` re-read each pipeline file with `std::fs::read_to_string(path).unwrap()`. A file deleted between scan and rewrite (or a permission flip on a flaky filesystem) crashed the CLI. The read now matches the soft-error pattern the `std::fs::write` call below it already used: print a `warning:` line, skip the offending pipeline, and keep going. The extracted sources file is already on disk at that point, so a single unreadable pipeline does not invalidate the other rewrites.

## Deliberately deferred

- The delimited-writer paths in `output/mod.rs` (`render_table`, `DelimitedWriter::push`) still swallow `io::Error` with `let _ = ...`. Wiring EPIPE through cleanly needs a process-wide SIGPIPE handler or a new `libc` dependency and is larger than this PR's scope.
- The "central `CliError` handler" item from the parser/CLI cluster is not in this PR; the existing `process::exit` call sites still scattered across `commands/` are the right surface for a follow-up.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (1607 passed)
- [x] `RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --no-deps`
- [x] New parser tests: `parse_surfaces_invalid_status_value`, `parse_surfaces_invalid_level_value`, `parse_surfaces_invalid_related_entries`, `parse_surfaces_invalid_related_top_level_shape`, `sigma_collection_has_errors_and_error_count_are_consistent`, `sigma_collection_into_result_promotes_errors_to_err`, `sigma_collection_into_result_returns_ok_when_clean`
- [x] New CLI integration tests: `lint_quiet_suppresses_summary_and_config_progress`, `lint_no_stats_suppresses_summary_but_keeps_findings`, `lint_quiet_still_emits_findings`, `invalid_global_output_format_in_config_warns_then_falls_back`, `invalid_global_color_in_config_warns_then_falls_back`, `valid_global_output_in_config_emits_no_warning`
- [x] New `output::tests`: `warn_invalid_global_output_keeps_recognized_values`, `warn_invalid_global_output_strips_unrecognized_format`, `warn_invalid_global_output_strips_unrecognized_color`, `warn_invalid_global_output_passes_through_none`