### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to RSigma are documented in this file.
 Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
-## [Unreleased]
+## [0.14.0] - 2026-06-05
+
+**TL;DR**
+RSigma v0.14.0 is the "layered config, structured output, and correctness/hardening" release:
+* Layered YAML configuration with explicit precedence (flag > env > project > user > system > default) plus a new `rsigma config` group (`init`, `validate`, `show`, `schema`, `path`, `reload`).
+* Structured output everywhere: a global `--output-format <json|ndjson|table|csv|tsv>` selector with a TTY-aware default, plus global `--color`, `--quiet`, and `--no-stats`.
+* Custom linter tag namespaces via a repeatable `--tag-namespace` flag and a `tag_namespaces` config key, so organisation-specific tags no longer force disabling `unknown_tag_namespace` wholesale, thanks to @fwosar.
+* Sigma correctness: multi-field `value_count` composite keys, compile-time rejection of multi-field numeric aggregations, empty `value_median` returns `None`, cross-crate detection-name selector consistency, and convert-side rejection of modifiers it cannot express.
+* Runtime hardening: a category-based HTTP egress policy (SSRF/cloud-metadata defense applied at DNS resolution), a 10 MiB enricher response cap, hot-reload that preserves engine tuning, and fail-closed dynamic-source resolution.
+* Evaluator and parser robustness: compile-time rejection of conflicting detection-modifier combinations, allocation-free `JsonEvent` dot-path traversal, and CLI diagnostics that stop silently swallowing invalid `status` / `level` / `related:` metadata.
+* Detached dynamic sources: pipeline-embedded `sources:` now warns louder on stderr and through the daemon hot-reload path.
+* Release pipeline, CI, Docker, and supply-chain hardening before publish, two batched Dependabot rollups, and a docs-accuracy sweep across the site.
 
 ### Documentation accuracy: TLS, feature flags, metric and lint counts, CLI surface, endpoint inventory, benchmark freshness (#181)
 
@@ -1598,6 +1609,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.14.0]: https://github.com/timescale/rsigma/releases/tag/v0.14.0
 [0.13.0]: https://github.com/timescale/rsigma/releases/tag/v0.13.0
 [0.12.0]: https://github.com/timescale/rsigma/releases/tag/v0.12.0
 [0.11.0]: https://github.com/timescale/rsigma/releases/tag/v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "assert_cmd",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "insta",
  "log",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "globset",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -30,10 +30,10 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.13.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.13.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.13.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.14.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.14.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.14.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.13.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.14.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.13.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.14.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -19,8 +19,8 @@ evtx = ["dep:evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.13.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.13.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.14.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "globset",
  "log",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arc-swap",
  "async-trait",


### PR DESCRIPTION
## Summary

Release v0.14.0. Bumps the workspace from 0.13.0 to 0.14.0 (workspace package version plus all inter-crate path pins across the five dependent crates), syncs both `Cargo.lock` and `fuzz/Cargo.lock`, and finalizes [`CHANGELOG.md`](CHANGELOG.md) by promoting the `[Unreleased]` block to `[0.14.0] - 2026-06-05` with a TL;DR and the release reference link.

Headline framing: the "layered config, structured output, and correctness/hardening" release.

- Layered YAML configuration plus the `rsigma config` group (#152).
- TTY-aware structured output: global `--output-format`, `--color`, `--quiet`, `--no-stats` (#157).
- Custom linter tag namespaces via `--tag-namespace` and `tag_namespaces` (#161, #162).
- Sigma correctness: multi-field correlations, empty median, unsupported convert modifiers (#166).
- Runtime hardening: HTTP egress policy, enricher body cap, hot-reload tuning, fail-closed dynamic sources (#167).
- Eval and convert internals: conflicting-modifier validation, dot-path perf, golden routing (#180).
- Parser and CLI diagnostics: invalid metadata, output controls, panic-free migrate (#179).
- Louder pipeline-embedded `sources:` deprecation (#140).
- Release pipeline, CI, Docker, and supply-chain hardening, plus dependency batches (#156, #178) and a docs-accuracy sweep (#181).

Full release notes: see the new `[0.14.0]` section in `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-features --locked` (lockfile/manifest consistency)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (CI)
- [ ] `cargo test --workspace --all-features` (CI)
- [ ] `mkdocs build --strict` (CI)
- [ ] `cargo deny check` (CI)

This commit is a version/changelog bump only; no source changed since the last merge to `main`, so the heavier gates are left to CI.

## Post-merge

After merge, tag `v0.14.0` on `main` and create the GitHub Release using the `[0.14.0]` body verbatim. The `publish.yml`, `release-binaries.yml`, and `docker.yml` workflows fire on `release: published`.