### PR TITLE
fix(ci): dry-run only the leaf crate in publish pre-flight

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,17 +39,19 @@ jobs:
       # that lands earlier could seed a tampered build cache). Publishing
       # happens once per release, so the cache miss is acceptable.
 
-      # Pre-flight: dry-run every crate in dependency order before any
-      # side-effecting publish. Catches authentication, dep-version, and
-      # manifest issues up front so a half-released set of crates cannot
-      # leave the workspace in an inconsistent state on crates.io.
-      - name: Pre-flight dry-run
-        run: |
-          for crate in rsigma-parser rsigma-eval rsigma-convert rsigma-runtime rsigma rsigma-lsp; do
-            echo "::group::cargo publish --dry-run -p ${crate}"
-            cargo publish --dry-run --locked -p "${crate}"
-            echo "::endgroup::"
-          done
+      # Pre-flight: dry-run only the crate that has no unpublished
+      # workspace dependencies. `cargo publish --dry-run` resolves every
+      # path dependency's version against the live crates.io index, so a
+      # dependent crate (e.g. rsigma-eval, which requires
+      # `rsigma-parser = "0.14.0"`) cannot be dry-run until its sibling's
+      # new version already exists on the registry. Dry-running
+      # rsigma-parser still smoke-tests packaging, the manifest, and
+      # lockfile state before any side-effecting upload; the dependent
+      # crates are validated by the sequential `--locked` publish below,
+      # each of which runs only after the crate it depends on has landed
+      # in the index.
+      - name: Pre-flight dry-run (rsigma-parser)
+        run: cargo publish --dry-run --locked -p rsigma-parser
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth


### PR DESCRIPTION
## Summary

The v0.14.0 `Publish to crates.io` run failed at the new pre-flight step ([run #16](https://github.com/timescale/rsigma/actions/runs/27007337338)), publishing nothing.

The `#168` hardening added a pre-flight that dry-runs every workspace crate in dependency order before any real publish. That is impossible on a version bump: `cargo publish --dry-run` resolves each crate's path-dependency versions against the live crates.io index, so dry-running `rsigma-eval` fails with `failed to select a version for the requirement rsigma-parser = "^0.14.0"` (`candidate versions found which didn't match: 0.13.0, …`) because `rsigma-parser 0.14.0` is not on the registry yet. This is a chicken-and-egg ordering issue, not a dependency cycle; the graph is a clean DAG.

This restricts the pre-flight to `rsigma-parser`, the only crate with no unpublished workspace dependencies. It still smoke-tests packaging, the manifest, and lockfile state before any side-effecting upload. The dependent crates are validated by the existing sequential `--locked` publish, each of which runs only after the crate it depends on has landed in the index (the path that shipped v0.2.0 through v0.13.0).

## Test plan

- [ ] `workflow_dispatch` on `Publish to crates.io` completes the pre-flight cleanly (dry-run rehearsal, no real upload).
- [ ] On re-cut of the `v0.14.0` release, the sequential publish lands all six crates in order.