### PR TITLE
feat: gated match-detail enrichment for detection results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### Gated match-detail enrichment for detection results
+### Gated match-detail enrichment for detection results (#186)
 
 `matched_fields` entries can now explain *why* each field matched, gated behind a new opt-in verbosity level so the default wire shape is byte-for-byte unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to RSigma are documented in this file.
 Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
+## [Unreleased]
+
+### Gated match-detail enrichment for detection results
+
+`matched_fields` entries can now explain *why* each field matched, gated behind a new opt-in verbosity level so the default wire shape is byte-for-byte unchanged.
+
+- **New `MatchDetailLevel { Off, Summary, Full }`** on `rsigma-eval`, configured via `Engine::set_match_detail` (and the `CorrelationEngine` passthrough). `Off` is the default and preserves the historical `{field, value}` shape exactly; all new keys are `Option`/skipped on serialization, so existing sinks, the daemon NDJSON wire format, and the golden tests are unaffected unless a caller opts in.
+- **`Summary`** adds `selection` (the originating named detection), `matcher` (a new `MatcherKind` enum: `exact`, `contains`, `startswith`, `endswith`, `regex`, `one_of`, `cidr`, `numeric`, `exists`, `fieldref`, `null`, `bool`, `expand`, `timestamp`, `keyword`), and `case_sensitive`. **`Full`** additionally records `pattern`, the value the matcher tested against (truncated for very long pattern sets). Negated matchers set `negated: true`.
+- **Closed two long-standing reporting gaps** (visible only at `Summary`/`Full`, so `Off` is untouched): keyword detections, which previously contributed nothing to `matched_fields`, are now reported under the sentinel field `"keyword"`; and `null`-on-absent matches, previously invisible because the field had no value, are now reported with `value: null`.
+- **New `CompiledMatcher::describe()`** (returning `MatchDescriptor`) produces the structural description used to populate these fields. It runs only when a rule matches and only above `Off`, so the non-matching hot path is unchanged.
+- **CLI/runtime plumbing**: `rsigma engine eval --match-detail <off|summary|full>`, `rsigma engine daemon --match-detail <…>` plus the `daemon.engine.match_detail` config key, and `RuntimeEngine::set_match_detail` (carried across hot reloads).
+
 ## [0.14.0] - 2026-06-05
 
 **TL;DR**

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -254,6 +254,14 @@ pub(crate) struct DaemonArgs {
     #[arg(long = "bloom-prefilter")]
     pub bloom_prefilter: bool,
 
+    /// Match-detail verbosity for detection output: off (default),
+    /// summary, or full. `summary` adds the matcher kind, selection, and
+    /// case sensitivity (and reports keyword and absence matches); `full`
+    /// also records the matched pattern. Higher levels enlarge each
+    /// detection line; `off` keeps the historical `{ field, value }` shape.
+    #[arg(long = "match-detail", value_parser = ["off", "summary", "full"], default_value = "off")]
+    pub match_detail: String,
+
     /// Memory budget (in bytes) for the bloom index. Defaults to 1 MB
     /// (1048576). Lower the cap on memory-constrained deployments;
     /// raise it for very large rule sets where the default starts
@@ -476,6 +484,7 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         allow_remote_include,
         egress_policy,
         bloom_prefilter,
+        match_detail,
         bloom_max_bytes,
         observe_fields,
         observe_fields_max_keys,
@@ -583,6 +592,7 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         allow_remote_include,
         egress_policy,
         bloom_prefilter,
+        match_detail,
         bloom_max_bytes,
         observe_fields,
         observe_fields_max_keys,
@@ -797,6 +807,11 @@ fn apply_daemon_config(
         {
             args.bloom_prefilter = v;
         }
+        if !explicit("match_detail")
+            && let Some(v) = engine.match_detail
+        {
+            args.match_detail = v;
+        }
         if !explicit("bloom_max_bytes")
             && let Some(v) = engine.bloom_max_bytes
         {
@@ -883,6 +898,7 @@ fn run_daemon(
     allow_remote_include: bool,
     egress_policy: String,
     bloom_prefilter: bool,
+    match_detail: String,
     bloom_max_bytes: Option<usize>,
     observe_fields: bool,
     observe_fields_max_keys: usize,
@@ -991,12 +1007,18 @@ fn run_daemon(
         process::exit(exit_code::CONFIG_ERROR);
     });
 
+    // `value_parser` (and the config schema) restrict this to off/summary/full.
+    let match_detail = match_detail
+        .parse::<rsigma_eval::MatchDetailLevel>()
+        .unwrap_or(rsigma_eval::MatchDetailLevel::Off);
+
     let config = daemon::server::DaemonConfig {
         rules_path,
         pipelines,
         pipeline_paths: file_pipeline_paths,
         corr_config,
         include_event,
+        match_detail,
         pretty,
         api_addr: addr,
         event_filter,

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use clap::parser::ValueSource;
 use clap::{ArgMatches, Args};
 use rsigma_eval::{
-    CorrelationEngine, Engine, EvaluationResult, Event, FieldObserver, JsonEvent, Pipeline,
-    ResultBody, RuleFieldSet,
+    CorrelationEngine, Engine, EvaluationResult, Event, FieldObserver, JsonEvent, MatchDetailLevel,
+    Pipeline, ResultBody, RuleFieldSet,
 };
 use rsigma_parser::SigmaCollection;
 
@@ -79,6 +79,14 @@ pub(crate) struct EvalArgs {
     /// Equivalent to the `rsigma.include_event` custom attribute.
     #[arg(long = "include-event")]
     pub include_event: bool,
+
+    /// Match-detail verbosity for detection output.
+    ///   off     — field + value only (default; historical shape)
+    ///   summary — adds the matcher kind, selection, and case sensitivity,
+    ///             and reports keyword and absence matches
+    ///   full    — also records the matched pattern
+    #[arg(long = "match-detail", value_parser = ["off", "summary", "full"], default_value = "off")]
+    pub match_detail: String,
 
     /// Correlation event inclusion mode:
     ///   none  — don't include events (default, zero overhead)
@@ -283,6 +291,7 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
         action,
         no_detections,
         include_event,
+        match_detail,
         correlation_event_mode,
         max_correlation_events,
         timestamp_fields,
@@ -315,6 +324,11 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
     }
 
     let has_correlations = !collection.correlations.is_empty();
+
+    // `value_parser` restricts this to off/summary/full, so parsing cannot fail.
+    let match_detail = match_detail
+        .parse::<MatchDetailLevel>()
+        .unwrap_or(MatchDetailLevel::Off);
 
     let event_filter = crate::build_event_filter(jq, jsonpath);
 
@@ -362,6 +376,7 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
             &event_filter,
             corr_config,
             include_event,
+            match_detail,
             &input_format,
             &syslog_tz,
             bloom_prefilter,
@@ -379,6 +394,7 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
             &pipelines,
             &event_filter,
             include_event,
+            match_detail,
             &input_format,
             &syslog_tz,
             bloom_prefilter,
@@ -409,6 +425,7 @@ fn cmd_eval_with_correlations(
     event_filter: &EventFilter,
     config: rsigma_eval::CorrelationConfig,
     include_event: bool,
+    match_detail: MatchDetailLevel,
     input_format_str: &str,
     syslog_tz_str: &str,
     bloom_prefilter: bool,
@@ -418,6 +435,7 @@ fn cmd_eval_with_correlations(
 ) -> bool {
     let mut engine = CorrelationEngine::new(config);
     engine.set_include_event(include_event);
+    engine.set_match_detail(match_detail);
     if let Some(budget) = bloom_max_bytes {
         engine.set_bloom_max_bytes(budget);
     }
@@ -687,6 +705,7 @@ fn cmd_eval_detection_only(
     pipelines: &[Pipeline],
     event_filter: &EventFilter,
     include_event: bool,
+    match_detail: MatchDetailLevel,
     input_format_str: &str,
     syslog_tz_str: &str,
     bloom_prefilter: bool,
@@ -696,6 +715,7 @@ fn cmd_eval_detection_only(
 ) -> bool {
     let mut engine = Engine::new();
     engine.set_include_event(include_event);
+    engine.set_match_detail(match_detail);
     if let Some(budget) = bloom_max_bytes {
         engine.set_bloom_max_bytes(budget);
     }

--- a/crates/rsigma-cli/src/config/defaults.rs
+++ b/crates/rsigma-cli/src/config/defaults.rs
@@ -31,6 +31,9 @@ pub(crate) const STDOUT_SINK: &str = "stdout";
 /// (the classic SSRF targets) while leaving loopback and RFC1918 private
 /// addresses reachable so internal threat-intel APIs keep working.
 pub(crate) const EGRESS_POLICY: &str = "default";
+/// Default match-detail verbosity for detection output. `off` preserves the
+/// historical `{ field, value }` wire shape.
+pub(crate) const MATCH_DETAIL: &str = "off";
 /// Default minimum TLS version for the daemon API listener. Only consumed by
 /// the `--tls-min-version` flag, so it is gated on the same `daemon-tls`
 /// feature to avoid a dead-code warning in builds without it.
@@ -94,6 +97,7 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
                 observe_fields_max_keys: Some(OBSERVE_FIELDS_MAX_KEYS),
                 allow_remote_include: Some(false),
                 cross_rule_ac: Some(false),
+                match_detail: Some(MATCH_DETAIL.to_string()),
                 egress_policy: Some(EGRESS_POLICY.to_string()),
             }),
             nats: None,

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -319,6 +319,11 @@ pub(crate) struct EnginePartial {
     /// Cross-rule Aho-Corasick pre-filter. Ignored unless built with `daachorse-index`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cross_rule_ac: Option<bool>,
+    /// Match-detail verbosity for detection output: `off` (default),
+    /// `summary`, or `full`. Controls how much per-field match information
+    /// is attached to detection results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_detail: Option<String>,
     /// HTTP egress policy applied to dynamic-source and enrichment HTTP clients:
     /// `default` (block link-local + cloud metadata), `strict` (also block
     /// loopback + RFC1918 private), or `permissive` (allow everything).
@@ -337,6 +342,7 @@ impl Merge for EnginePartial {
                 .or(self.observe_fields_max_keys),
             allow_remote_include: over.allow_remote_include.or(self.allow_remote_include),
             cross_rule_ac: over.cross_rule_ac.or(self.cross_rule_ac),
+            match_detail: over.match_detail.or(self.match_detail),
             egress_policy: over.egress_policy.or(self.egress_policy),
         }
     }

--- a/crates/rsigma-cli/src/config/template.yaml
+++ b/crates/rsigma-cli/src/config/template.yaml
@@ -93,6 +93,10 @@ daemon:
   engine:
     # Enable bloom-filter pre-filtering of positive substring matchers.
     bloom_prefilter: false
+    # Match-detail verbosity for detection output: off (default), summary, full.
+    # summary adds the matcher kind/selection (and keyword/absence matches);
+    # full also records the matched pattern. off keeps the {field, value} shape.
+    match_detail: off
     # Memory budget (bytes) for the bloom index. No effect unless bloom_prefilter.
     # bloom_max_bytes: 1048576
     # Observe event field keys for coverage reporting.

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -10,7 +10,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
-use rsigma_eval::{CorrelationConfig, Pipeline, ProcessResult};
+use rsigma_eval::{CorrelationConfig, MatchDetailLevel, Pipeline, ProcessResult};
 use rsigma_runtime::{
     AckToken, EnrichmentPipeline, FieldObserver, FileSink, InputFormat, LogProcessor, MetricsHook,
     RawEvent, RuntimeEngine, Sink, StdinSource, StdoutSink, spawn_source,
@@ -102,6 +102,9 @@ pub struct DaemonConfig {
     /// Enable opt-in bloom-filter pre-filtering of positive substring
     /// matchers. Off by default; benefit is workload-dependent.
     pub bloom_prefilter: bool,
+    /// Match-detail verbosity forwarded to the inner detection engine.
+    /// `Off` by default (historical wire shape).
+    pub match_detail: MatchDetailLevel,
     /// Optional override for the bloom memory budget (bytes). `None` means
     /// the crate default (1 MB).
     pub bloom_max_bytes: Option<usize>,
@@ -168,6 +171,7 @@ pub async fn run_daemon(config: DaemonConfig) {
     );
     engine.set_pipeline_paths(config.pipeline_paths.clone());
     engine.set_allow_remote_include(config.allow_remote_include);
+    engine.set_match_detail(config.match_detail);
     engine.set_bloom_prefilter(config.bloom_prefilter);
     if let Some(budget) = config.bloom_max_bytes {
         engine.set_bloom_max_bytes(budget);

--- a/crates/rsigma-cli/tests/cli_eval.rs
+++ b/crates/rsigma-cli/tests/cli_eval.rs
@@ -101,6 +101,46 @@ fn eval_bloom_prefilter_flag_is_accepted() {
 }
 
 #[test]
+fn eval_match_detail_full_emits_matcher_and_pattern() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--match-detail",
+            "full",
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""matcher":"contains""#))
+        .stdout(predicate::str::contains(r#""pattern":"malware""#));
+}
+
+#[test]
+fn eval_match_detail_off_is_default_shape() {
+    // Without --match-detail (or with off), the enrichment keys must not
+    // appear, preserving the historical wire shape.
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    rsigma()
+        .args([
+            "engine",
+            "eval",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--event",
+            r#"{"CommandLine": "malware"}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("CommandLine"))
+        .stdout(predicate::str::contains(r#""matcher""#).not());
+}
+
+#[test]
 fn eval_bloom_prefilter_with_max_bytes() {
     // --bloom-max-bytes pairs with --bloom-prefilter; both must be accepted.
     let rule = temp_file(".yml", SIMPLE_RULE);

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -275,10 +275,21 @@ Accessors: `is_detection()` / `is_correlation()`, `as_detection() -> Option<&Det
 
 ### FieldMatch
 
-| Field | Type |
-|-------|------|
-| `field` | `String` |
-| `value` | `serde_json::Value` |
+| Field | Type | Description |
+|-------|------|-------------|
+| `field` | `String` | Field name that matched (`"keyword"` for keyword matches) |
+| `value` | `serde_json::Value` | Event value that triggered the match (`null` for absence matches) |
+| `selection` | `Option<String>` | Originating selection; populated above `MatchDetailLevel::Off` |
+| `matcher` | `Option<MatcherKind>` | Matcher kind that fired (e.g. `contains`, `regex`, `one_of`) |
+| `pattern` | `Option<String>` | Pattern the matcher tested against; `Full` level only, truncated |
+| `case_sensitive` | `Option<bool>` | Whether matching was case-sensitive, when meaningful |
+| `negated` | `bool` | `true` when the matcher was negated; omitted otherwise |
+
+The last five fields are populated by [`Engine::set_match_detail`]. The default
+`MatchDetailLevel::Off` records only `{field, value}` and skips the rest on
+serialization, so the wire shape is unchanged unless detail is enabled.
+`Summary` adds the descriptor fields and reports keyword and absence matches
+that `Off` omits; `Full` additionally records `pattern`.
 
 ### EventRef
 

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -34,7 +34,10 @@ use rsigma_parser::{
 use crate::error::{EvalError, Result};
 use crate::event::Event;
 use crate::matcher::{CompiledMatcher, sigma_string_to_regex};
-use crate::result::{DetectionBody, EvaluationResult, FieldMatch, ResultBody, RuleHeader};
+use crate::result::{
+    DetectionBody, EvaluationResult, FieldMatch, MatchDetailLevel, MatcherKind, ResultBody,
+    RuleHeader,
+};
 
 pub(crate) use helpers::yaml_to_json_map;
 use helpers::{
@@ -281,7 +284,12 @@ fn validate_condition_refs(
 /// that maintain a per-field bloom index should call the crate-private
 /// `evaluate_rule_with_bloom` variant via the `Engine` API instead.
 pub fn evaluate_rule(rule: &CompiledRule, event: &impl Event) -> Option<EvaluationResult> {
-    evaluate_rule_with_bloom(rule, event, &crate::engine::bloom_index::NoBloom)
+    evaluate_rule_with_bloom(
+        rule,
+        event,
+        &crate::engine::bloom_index::NoBloom,
+        MatchDetailLevel::Off,
+    )
 }
 
 /// Evaluate a compiled rule against an event with bloom pre-filtering.
@@ -295,6 +303,7 @@ pub(crate) fn evaluate_rule_with_bloom<E, B>(
     rule: &CompiledRule,
     event: &E,
     bloom: &B,
+    level: MatchDetailLevel,
 ) -> Option<EvaluationResult>
 where
     E: Event,
@@ -310,7 +319,7 @@ where
             bloom,
         ) {
             let matched_fields =
-                collect_field_matches(&matched_selections, &rule.detections, event);
+                collect_field_matches(&matched_selections, &rule.detections, event, level);
 
             let event_data = if rule.include_event {
                 Some(event.to_json())
@@ -1097,47 +1106,157 @@ where
     }
 }
 
-/// Collect field matches from matched selections for the MatchResult.
+/// Cap on the number of keyword-match entries recorded per keyword detection
+/// at `Summary` / `Full`. A single high-cardinality event (many string
+/// leaves) cannot blow up the output line.
+const MAX_KEYWORD_MATCHES: usize = 16;
+
+/// Collect field matches from matched selections for the detection result.
+///
+/// At [`MatchDetailLevel::Off`] this reproduces the historical behavior
+/// exactly: one `{ field, value }` entry per field-present `AllOf` item that
+/// matched, with keyword and absence matches omitted. At `Summary` / `Full`
+/// it attaches the matcher descriptor and reports the previously dropped
+/// keyword and `Null`-on-absent matches.
 fn collect_field_matches(
     selection_names: &[String],
     detections: &HashMap<String, CompiledDetection>,
     event: &impl Event,
+    level: MatchDetailLevel,
 ) -> Vec<FieldMatch> {
     let mut matches = Vec::new();
     for name in selection_names {
         if let Some(det) = detections.get(name) {
-            collect_detection_fields(det, event, &mut matches);
+            collect_detection_fields(name, det, event, level, &mut matches);
         }
     }
     matches
 }
 
 fn collect_detection_fields(
+    selection: &str,
     detection: &CompiledDetection,
     event: &impl Event,
+    level: MatchDetailLevel,
     out: &mut Vec<FieldMatch>,
 ) {
     match detection {
         CompiledDetection::AllOf(items) => {
             for item in items {
-                if let Some(field_name) = &item.field
-                    && let Some(value) = event.get_field(field_name)
-                    && item.matcher.matches(&value, event)
-                {
-                    out.push(FieldMatch {
-                        field: field_name.clone(),
-                        value: value.to_json(),
-                    });
+                match &item.field {
+                    Some(field_name) => {
+                        if let Some(value) = event.get_field(field_name) {
+                            if item.matcher.matches(&value, event) {
+                                out.push(make_field_match(
+                                    selection,
+                                    field_name,
+                                    value.to_json(),
+                                    &item.matcher,
+                                    level,
+                                ));
+                            }
+                        } else if level != MatchDetailLevel::Off
+                            && matches!(item.matcher, CompiledMatcher::Null)
+                        {
+                            // Field absent and matched by the `Null` matcher.
+                            // Never reported at `Off` (preserves wire shape).
+                            out.push(make_field_match(
+                                selection,
+                                field_name,
+                                serde_json::Value::Null,
+                                &item.matcher,
+                                level,
+                            ));
+                        }
+                    }
+                    None => {
+                        // Keyword item inside an `AllOf`. Only reported above `Off`.
+                        if level != MatchDetailLevel::Off {
+                            collect_keyword_matches(selection, &item.matcher, event, level, out);
+                        }
+                    }
                 }
             }
         }
         CompiledDetection::AnyOf(dets) => {
             for d in dets {
                 if eval_detection_with_bloom(d, event, &crate::engine::bloom_index::NoBloom) {
-                    collect_detection_fields(d, event, out);
+                    collect_detection_fields(selection, d, event, level, out);
                 }
             }
         }
-        CompiledDetection::Keywords(_) => {}
+        CompiledDetection::Keywords(matcher) => {
+            // Keyword detections produced no entries historically; only
+            // reported above `Off`.
+            if level != MatchDetailLevel::Off {
+                collect_keyword_matches(selection, matcher, event, level, out);
+            }
+        }
+    }
+}
+
+/// Build a [`FieldMatch`] at the requested detail level. `Off` yields the
+/// bare `{ field, value }` shape; `Summary` adds the matcher descriptor;
+/// `Full` additionally records the pattern.
+fn make_field_match(
+    selection: &str,
+    field: &str,
+    value: serde_json::Value,
+    matcher: &CompiledMatcher,
+    level: MatchDetailLevel,
+) -> FieldMatch {
+    match level {
+        MatchDetailLevel::Off => FieldMatch::new(field, value),
+        MatchDetailLevel::Summary | MatchDetailLevel::Full => {
+            let d = matcher.describe();
+            FieldMatch {
+                field: field.to_string(),
+                value,
+                selection: Some(selection.to_string()),
+                matcher: Some(d.kind),
+                pattern: if level == MatchDetailLevel::Full {
+                    d.pattern
+                } else {
+                    None
+                },
+                case_sensitive: d.case_sensitive,
+                negated: d.negated,
+            }
+        }
+    }
+}
+
+/// Record the individual event string values that satisfied a keyword
+/// matcher, capped at [`MAX_KEYWORD_MATCHES`]. Each entry uses the sentinel
+/// field name `"keyword"`.
+fn collect_keyword_matches(
+    selection: &str,
+    matcher: &CompiledMatcher,
+    event: &impl Event,
+    level: MatchDetailLevel,
+    out: &mut Vec<FieldMatch>,
+) {
+    let descriptor = matcher.describe();
+    let mut count = 0;
+    for s in event.all_string_values() {
+        if count >= MAX_KEYWORD_MATCHES {
+            break;
+        }
+        if matcher.matches_str(&s) {
+            count += 1;
+            out.push(FieldMatch {
+                field: "keyword".to_string(),
+                value: serde_json::Value::String(s.into_owned()),
+                selection: Some(selection.to_string()),
+                matcher: Some(MatcherKind::Keyword),
+                pattern: if level == MatchDetailLevel::Full {
+                    descriptor.pattern.clone()
+                } else {
+                    None
+                },
+                case_sensitive: descriptor.case_sensitive,
+                negated: descriptor.negated,
+            });
+        }
     }
 }

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -104,6 +104,12 @@ impl CorrelationEngine {
         self.engine.set_include_event(include);
     }
 
+    /// Forward to [`crate::Engine::set_match_detail`] on the inner detection
+    /// engine. Correlation detections inherit the level set here.
+    pub fn set_match_detail(&mut self, level: crate::result::MatchDetailLevel) {
+        self.engine.set_match_detail(level);
+    }
+
     /// Forward to [`crate::Engine::set_bloom_prefilter`] on the inner
     /// detection engine. Off by default; the optimization helps only on
     /// substring-heavy rule sets paired with mostly-non-matching events.

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -15,13 +15,11 @@ use rsigma_parser::{
     ConditionExpr, FilterRule, FilterRuleTarget, LogSource, SigmaCollection, SigmaRule,
 };
 
-use crate::compiler::{
-    CompiledRule, compile_detection, compile_rule, evaluate_rule, evaluate_rule_with_bloom,
-};
+use crate::compiler::{CompiledRule, compile_detection, compile_rule, evaluate_rule_with_bloom};
 use crate::error::{EvalError, Result};
 use crate::event::Event;
 use crate::pipeline::{Pipeline, apply_pipelines};
-use crate::result::EvaluationResult;
+use crate::result::{EvaluationResult, MatchDetailLevel};
 use crate::rule_index::RuleIndex;
 
 use bloom_index::{BloomCache, FieldBloomIndex};
@@ -69,6 +67,10 @@ pub struct Engine {
     /// Global override: include the full event JSON in all match results.
     /// When `true`, overrides per-rule `rsigma.include_event` custom attributes.
     include_event: bool,
+    /// Verbosity of the match detail recorded on detection results.
+    /// `Off` by default, which preserves the historical `{ field, value }`
+    /// wire shape. See [`Engine::set_match_detail`].
+    match_detail: MatchDetailLevel,
     /// Monotonic counter used to namespace injected filter detections,
     /// preventing key collisions when multiple filters share detection names.
     filter_counter: usize,
@@ -120,6 +122,7 @@ impl Engine {
             rules: Vec::new(),
             pipelines: Vec::new(),
             include_event: false,
+            match_detail: MatchDetailLevel::Off,
             filter_counter: 0,
             rule_index: RuleIndex::empty(),
             bloom_index: FieldBloomIndex::empty(),
@@ -140,6 +143,7 @@ impl Engine {
             rules: Vec::new(),
             pipelines: vec![pipeline],
             include_event: false,
+            match_detail: MatchDetailLevel::Off,
             filter_counter: 0,
             rule_index: RuleIndex::empty(),
             bloom_index: FieldBloomIndex::empty(),
@@ -234,6 +238,23 @@ impl Engine {
     /// the full event JSON regardless of per-rule custom attributes.
     pub fn set_include_event(&mut self, include: bool) {
         self.include_event = include;
+    }
+
+    /// Set the match-detail verbosity for detection results.
+    ///
+    /// `Off` (default) records each match as `{ field, value }`, identical to
+    /// pre-enrichment releases. `Summary` adds the originating selection, the
+    /// matcher kind, and case sensitivity, and reports keyword and absence
+    /// matches that `Off` omits. `Full` additionally records the pattern that
+    /// fired. The extra work runs only when a rule matches and only above
+    /// `Off`, so the default hot path is unchanged.
+    pub fn set_match_detail(&mut self, level: MatchDetailLevel) {
+        self.match_detail = level;
+    }
+
+    /// Returns the configured match-detail verbosity.
+    pub fn match_detail(&self) -> MatchDetailLevel {
+        self.match_detail
     }
 
     /// Add a pipeline to the engine.
@@ -564,7 +585,9 @@ impl Engine {
                 continue;
             }
             let rule = &self.rules[idx];
-            if let Some(mut m) = evaluate_rule(rule, event) {
+            if let Some(mut m) =
+                evaluate_rule_with_bloom(rule, event, &bloom_index::NoBloom, self.match_detail)
+            {
                 if self.include_event
                     && let Some(d) = m.as_detection_mut()
                     && d.event.is_none()
@@ -588,7 +611,7 @@ impl Engine {
                 continue;
             }
             let rule = &self.rules[idx];
-            if let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom) {
+            if let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom, self.match_detail) {
                 if self.include_event
                     && let Some(d) = m.as_detection_mut()
                     && d.event.is_none()
@@ -633,7 +656,8 @@ impl Engine {
             }
             let rule = &self.rules[idx];
             if logsource_matches(&rule.logsource, event_logsource)
-                && let Some(mut m) = evaluate_rule(rule, event)
+                && let Some(mut m) =
+                    evaluate_rule_with_bloom(rule, event, &bloom_index::NoBloom, self.match_detail)
             {
                 if self.include_event
                     && let Some(d) = m.as_detection_mut()
@@ -663,7 +687,8 @@ impl Engine {
             }
             let rule = &self.rules[idx];
             if logsource_matches(&rule.logsource, event_logsource)
-                && let Some(mut m) = evaluate_rule_with_bloom(rule, event, &bloom)
+                && let Some(mut m) =
+                    evaluate_rule_with_bloom(rule, event, &bloom, self.match_detail)
             {
                 if self.include_event
                     && let Some(d) = m.as_detection_mut()

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -573,9 +573,9 @@ impl Engine {
     }
 
     fn evaluate_no_bloom_path<E: Event>(&self, event: &E) -> Vec<EvaluationResult> {
-        // The public `evaluate_rule` is not generic over `BloomLookup`, so
-        // the no-bloom hot path lowers to straight-line code identical to
-        // the pre-bloom engine.
+        // Pass the zero-sized `NoBloom` lookup so this monomorphizes to the
+        // same straight-line code as the pre-bloom engine while still
+        // threading the configured match-detail level.
         let keep = self.cross_rule_ac_keep_mask(event);
         let mut results = Vec::new();
         for idx in self.rule_index.candidates(event) {

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -120,7 +120,7 @@ pub use error::{EvalError, Result};
 pub use event::{Event, EventValue, JsonEvent, KvEvent, MapEvent, PlainEvent};
 pub use field_observer::{FieldCoverage, FieldObservation, FieldObservationEntry, FieldObserver};
 pub use fields::{FieldOrigin, FieldSource, RuleFieldSet};
-pub use matcher::CompiledMatcher;
+pub use matcher::{CompiledMatcher, MatchDescriptor};
 pub use pipeline::{
     Pipeline, TransformationItem, apply_pipelines, apply_pipelines_with_state,
     builtin::{
@@ -130,6 +130,6 @@ pub use pipeline::{
     parse_transformation_items, validate_source_refs,
 };
 pub use result::{
-    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, ProcessResultExt, ResultBody,
-    RuleHeader,
+    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, MatchDetailLevel, MatcherKind,
+    ProcessResultExt, ResultBody, RuleHeader,
 };

--- a/crates/rsigma-eval/src/matcher/matching.rs
+++ b/crates/rsigma-eval/src/matcher/matching.rs
@@ -256,7 +256,7 @@ impl CompiledMatcher {
     /// Handles the string-matching subset of `CompiledMatcher`. Matchers that
     /// require a full `EventValue` (numeric comparisons, field refs, etc.)
     /// return `false` — those are never used in keyword detection.
-    pub(super) fn matches_str(&self, s: &str) -> bool {
+    pub(crate) fn matches_str(&self, s: &str) -> bool {
         match self {
             CompiledMatcher::Exact {
                 value: expected,

--- a/crates/rsigma-eval/src/matcher/mod.rs
+++ b/crates/rsigma-eval/src/matcher/mod.rs
@@ -14,7 +14,76 @@ use aho_corasick::AhoCorasick;
 use regex::{Regex, RegexSet};
 
 use crate::event::Event;
+use crate::result::MatcherKind;
 use ipnet::IpNet;
+
+/// Upper bound on the length of a `pattern` string recorded in match
+/// detail. Long Aho-Corasick / regex-set joins are truncated with an
+/// ellipsis so a single match cannot bloat the output line.
+const MAX_PATTERN_LEN: usize = 256;
+
+/// A structural description of a compiled matcher, used to populate the
+/// match-detail fields on a [`FieldMatch`](crate::result::FieldMatch).
+///
+/// Purely descriptive: it reports the matcher's shape and pattern, not
+/// which value matched. Composite matchers collapse to
+/// [`MatcherKind::OneOf`] with their child patterns joined.
+#[derive(Debug, Clone)]
+pub struct MatchDescriptor {
+    /// The matcher kind that fired.
+    pub kind: MatcherKind,
+    /// The pattern the matcher tested against, truncated to `MAX_PATTERN_LEN`.
+    pub pattern: Option<String>,
+    /// Whether matching was case-sensitive, when meaningful.
+    pub case_sensitive: Option<bool>,
+    /// Whether the matcher is negated.
+    pub negated: bool,
+}
+
+fn truncate_pattern(s: String) -> String {
+    if s.len() <= MAX_PATTERN_LEN {
+        return s;
+    }
+    let mut end = MAX_PATTERN_LEN.saturating_sub(3);
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = s[..end].to_string();
+    out.push_str("...");
+    out
+}
+
+fn numeric_descriptor(op: &str, n: f64) -> MatchDescriptor {
+    MatchDescriptor {
+        kind: MatcherKind::Numeric,
+        pattern: Some(format!("{op} {n}")),
+        case_sensitive: None,
+        negated: false,
+    }
+}
+
+fn join_child_patterns(children: &[CompiledMatcher]) -> String {
+    children
+        .iter()
+        .filter_map(|c| c.describe().pattern)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn expand_template_to_string(parts: &[ExpandPart]) -> String {
+    let mut s = String::new();
+    for part in parts {
+        match part {
+            ExpandPart::Literal(t) => s.push_str(t),
+            ExpandPart::Placeholder(name) => {
+                s.push('%');
+                s.push_str(name);
+                s.push('%');
+            }
+        }
+    }
+    s
+}
 
 /// A pre-compiled matcher for a single value comparison.
 ///
@@ -205,5 +274,229 @@ impl CompiledMatcher {
     #[inline]
     pub fn matches_keyword(&self, event: &impl Event) -> bool {
         event.any_string_value(&|s| self.matches_str(s))
+    }
+
+    /// Describe this matcher's shape for match-detail reporting.
+    ///
+    /// Runs only when assembling a detection result above
+    /// [`MatchDetailLevel::Off`](crate::result::MatchDetailLevel), never on
+    /// the matching hot path.
+    pub fn describe(&self) -> MatchDescriptor {
+        match self {
+            CompiledMatcher::Exact {
+                value,
+                case_insensitive,
+            } => MatchDescriptor {
+                kind: MatcherKind::Exact,
+                pattern: Some(truncate_pattern(value.clone())),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::Contains {
+                value,
+                case_insensitive,
+            } => MatchDescriptor {
+                kind: MatcherKind::Contains,
+                pattern: Some(truncate_pattern(value.clone())),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::StartsWith {
+                value,
+                case_insensitive,
+            } => MatchDescriptor {
+                kind: MatcherKind::StartsWith,
+                pattern: Some(truncate_pattern(value.clone())),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::EndsWith {
+                value,
+                case_insensitive,
+            } => MatchDescriptor {
+                kind: MatcherKind::EndsWith,
+                pattern: Some(truncate_pattern(value.clone())),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::Regex(re) => MatchDescriptor {
+                kind: MatcherKind::Regex,
+                pattern: Some(truncate_pattern(re.as_str().to_string())),
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::AhoCorasickSet {
+                needles,
+                case_insensitive,
+                ..
+            } => MatchDescriptor {
+                kind: MatcherKind::OneOf,
+                pattern: Some(truncate_pattern(needles.join(", "))),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::RegexSetMatch { set, .. } => MatchDescriptor {
+                kind: MatcherKind::OneOf,
+                pattern: Some(truncate_pattern(set.patterns().join(", "))),
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::Cidr(net) => MatchDescriptor {
+                kind: MatcherKind::Cidr,
+                pattern: Some(net.to_string()),
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::NumericEq(n) => numeric_descriptor("=", *n),
+            CompiledMatcher::NumericGt(n) => numeric_descriptor(">", *n),
+            CompiledMatcher::NumericGte(n) => numeric_descriptor(">=", *n),
+            CompiledMatcher::NumericLt(n) => numeric_descriptor("<", *n),
+            CompiledMatcher::NumericLte(n) => numeric_descriptor("<=", *n),
+            CompiledMatcher::Exists(expect) => MatchDescriptor {
+                kind: MatcherKind::Exists,
+                pattern: Some(expect.to_string()),
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::FieldRef {
+                field,
+                case_insensitive,
+            } => MatchDescriptor {
+                kind: MatcherKind::FieldRef,
+                pattern: Some(field.clone()),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::Null => MatchDescriptor {
+                kind: MatcherKind::Null,
+                pattern: None,
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::BoolEq(b) => MatchDescriptor {
+                kind: MatcherKind::Bool,
+                pattern: Some(b.to_string()),
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::Expand {
+                template,
+                case_insensitive,
+            } => MatchDescriptor {
+                kind: MatcherKind::Expand,
+                pattern: Some(truncate_pattern(expand_template_to_string(template))),
+                case_sensitive: Some(!case_insensitive),
+                negated: false,
+            },
+            CompiledMatcher::TimestampPart { inner, .. } => {
+                let inner_d = inner.describe();
+                MatchDescriptor {
+                    kind: MatcherKind::Timestamp,
+                    pattern: inner_d.pattern,
+                    case_sensitive: inner_d.case_sensitive,
+                    negated: inner_d.negated,
+                }
+            }
+            CompiledMatcher::Not(inner) => {
+                let mut d = inner.describe();
+                d.negated = !d.negated;
+                d
+            }
+            CompiledMatcher::AnyOf(ms) | CompiledMatcher::AllOf(ms) => MatchDescriptor {
+                kind: MatcherKind::OneOf,
+                pattern: Some(truncate_pattern(join_child_patterns(ms))),
+                case_sensitive: None,
+                negated: false,
+            },
+            CompiledMatcher::CaseInsensitiveGroup { children, .. } => MatchDescriptor {
+                kind: MatcherKind::OneOf,
+                pattern: Some(truncate_pattern(join_child_patterns(children))),
+                case_sensitive: Some(false),
+                negated: false,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod describe_tests {
+    use super::*;
+
+    #[test]
+    fn string_matchers_report_kind_pattern_and_case() {
+        let d = CompiledMatcher::Contains {
+            value: "abc".to_string(),
+            case_insensitive: true,
+        }
+        .describe();
+        assert_eq!(d.kind, MatcherKind::Contains);
+        assert_eq!(d.pattern.as_deref(), Some("abc"));
+        assert_eq!(d.case_sensitive, Some(false));
+        assert!(!d.negated);
+
+        let cased = CompiledMatcher::EndsWith {
+            value: "\\powershell.exe".to_string(),
+            case_insensitive: false,
+        }
+        .describe();
+        assert_eq!(cased.kind, MatcherKind::EndsWith);
+        assert_eq!(cased.case_sensitive, Some(true));
+    }
+
+    #[test]
+    fn numeric_exists_and_null_descriptors() {
+        let gt = CompiledMatcher::NumericGt(5.0).describe();
+        assert_eq!(gt.kind, MatcherKind::Numeric);
+        assert_eq!(gt.pattern.as_deref(), Some("> 5"));
+
+        let exists = CompiledMatcher::Exists(false).describe();
+        assert_eq!(exists.kind, MatcherKind::Exists);
+        assert_eq!(exists.pattern.as_deref(), Some("false"));
+
+        let null = CompiledMatcher::Null.describe();
+        assert_eq!(null.kind, MatcherKind::Null);
+        assert!(null.pattern.is_none());
+    }
+
+    #[test]
+    fn not_inverts_negated_flag_and_keeps_inner_kind() {
+        let inner = CompiledMatcher::Contains {
+            value: "evil".to_string(),
+            case_insensitive: true,
+        };
+        let d = CompiledMatcher::Not(Box::new(inner)).describe();
+        assert_eq!(d.kind, MatcherKind::Contains);
+        assert!(d.negated);
+        assert_eq!(d.pattern.as_deref(), Some("evil"));
+    }
+
+    #[test]
+    fn composite_collapses_to_one_of_with_joined_patterns() {
+        let d = CompiledMatcher::AnyOf(vec![
+            CompiledMatcher::Contains {
+                value: "foo".to_string(),
+                case_insensitive: true,
+            },
+            CompiledMatcher::Contains {
+                value: "bar".to_string(),
+                case_insensitive: true,
+            },
+        ])
+        .describe();
+        assert_eq!(d.kind, MatcherKind::OneOf);
+        assert_eq!(d.pattern.as_deref(), Some("foo, bar"));
+    }
+
+    #[test]
+    fn long_patterns_are_truncated() {
+        let long = "x".repeat(MAX_PATTERN_LEN * 2);
+        let d = CompiledMatcher::Contains {
+            value: long,
+            case_insensitive: true,
+        }
+        .describe();
+        let pattern = d.pattern.unwrap();
+        assert!(pattern.len() <= MAX_PATTERN_LEN);
+        assert!(pattern.ends_with("..."));
     }
 }

--- a/crates/rsigma-eval/src/result.rs
+++ b/crates/rsigma-eval/src/result.rs
@@ -162,13 +162,122 @@ pub struct CorrelationBody {
     pub event_refs: Option<Vec<EventRef>>,
 }
 
+/// Verbosity of the match detail attached to detection results.
+///
+/// Gates how much is recorded in each [`FieldMatch`]. `Off` is the default
+/// and produces the historical `{ field, value }` shape with no extra keys,
+/// so existing wire consumers are unaffected unless they opt in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MatchDetailLevel {
+    /// Historical behavior: only field-present matches, recorded as
+    /// `{ field, value }`. Keyword and absence matches are not reported.
+    #[default]
+    Off,
+    /// Adds the originating `selection`, the `matcher` kind, and
+    /// `case_sensitive`, and reports previously dropped keyword and
+    /// absence matches.
+    Summary,
+    /// Everything in `Summary` plus the `pattern` that fired.
+    Full,
+}
+
+impl MatchDetailLevel {
+    /// Lowercase wire name (`off` / `summary` / `full`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MatchDetailLevel::Off => "off",
+            MatchDetailLevel::Summary => "summary",
+            MatchDetailLevel::Full => "full",
+        }
+    }
+}
+
+impl std::str::FromStr for MatchDetailLevel {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "off" => Ok(MatchDetailLevel::Off),
+            "summary" => Ok(MatchDetailLevel::Summary),
+            "full" => Ok(MatchDetailLevel::Full),
+            other => Err(format!(
+                "invalid match-detail level: {other:?} (expected off, summary, or full)"
+            )),
+        }
+    }
+}
+
+/// The kind of matcher that produced a [`FieldMatch`].
+///
+/// Serialized lowercase. Composite and multi-pattern matchers
+/// (`AnyOf` / `AllOf` / Aho-Corasick / regex sets) collapse to `one_of`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MatcherKind {
+    Exact,
+    Contains,
+    StartsWith,
+    EndsWith,
+    Regex,
+    #[serde(rename = "one_of")]
+    OneOf,
+    Cidr,
+    Numeric,
+    Exists,
+    FieldRef,
+    Null,
+    Bool,
+    Expand,
+    Timestamp,
+    Keyword,
+}
+
+/// Serde helper: skip a `bool` field when it is `false`.
+#[inline]
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 /// A specific field match within a detection.
-#[derive(Debug, Clone, Serialize)]
+///
+/// The `field` and `value` keys are always present and preserve the
+/// historical wire shape. The remaining keys are populated only when the
+/// engine runs above [`MatchDetailLevel::Off`] and are skipped on
+/// serialization when empty, so the default output is byte-identical to
+/// pre-enrichment releases.
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct FieldMatch {
-    /// The field name that matched.
+    /// The field name that matched (`"keyword"` for keyword matches).
     pub field: String,
-    /// The event value that triggered the match.
+    /// The event value that triggered the match (`null` for absence matches).
     pub value: serde_json::Value,
+    /// The selection (named detection) the match came from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection: Option<String>,
+    /// The matcher kind that fired.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matcher: Option<MatcherKind>,
+    /// The pattern the matcher tested against (Full level only, truncated).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+    /// Whether the match was case-sensitive, when meaningful for the matcher.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub case_sensitive: Option<bool>,
+    /// Whether the matcher was negated (`|not` / inverted).
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub negated: bool,
+}
+
+impl FieldMatch {
+    /// Construct a bare match with only `field` and `value` set, matching
+    /// the historical (`MatchDetailLevel::Off`) shape.
+    pub fn new(field: impl Into<String>, value: serde_json::Value) -> Self {
+        FieldMatch {
+            field: field.into(),
+            value,
+            ..Default::default()
+        }
+    }
 }
 
 /// Convenience iterators over a slice of [`EvaluationResult`].
@@ -225,10 +334,10 @@ mod tests {
             header: header("Suspicious PowerShell"),
             body: ResultBody::Detection(DetectionBody {
                 matched_selections: vec!["selection".to_string()],
-                matched_fields: vec![FieldMatch {
-                    field: "CommandLine".to_string(),
-                    value: serde_json::json!("powershell -enc ..."),
-                }],
+                matched_fields: vec![FieldMatch::new(
+                    "CommandLine",
+                    serde_json::json!("powershell -enc ..."),
+                )],
                 event: None,
             }),
         };

--- a/crates/rsigma-eval/tests/match_detail.rs
+++ b/crates/rsigma-eval/tests/match_detail.rs
@@ -1,0 +1,163 @@
+//! End-to-end tests for the gated match-detail enrichment.
+//!
+//! Exercises `Engine::set_match_detail` across `Off` / `Summary` / `Full`,
+//! pinning the three behaviors that motivated the feature:
+//!
+//! 1. `Off` is byte-for-byte the historical shape (field + value only, no
+//!    keyword or absence entries).
+//! 2. `Summary` attaches the selection, matcher kind, and case sensitivity,
+//!    and reports the previously dropped keyword match.
+//! 3. `Full` additionally records the matched pattern.
+
+use rsigma_eval::event::JsonEvent;
+use rsigma_eval::{Engine, MatchDetailLevel, MatcherKind};
+use rsigma_parser::parse_sigma_yaml;
+use serde_json::json;
+
+const RULE: &str = r#"
+title: PS Encoded
+id: ps-enc
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection_img:
+        Image|endswith: \powershell.exe
+    selection_args:
+        CommandLine|contains: -enc
+    keywords:
+        - FromBase64String
+    condition: selection_img and selection_args and keywords
+level: high
+"#;
+
+fn engine_at(level: MatchDetailLevel) -> Engine {
+    let collection = parse_sigma_yaml(RULE).unwrap();
+    let mut engine = Engine::new();
+    engine.set_match_detail(level);
+    engine.add_collection(&collection).unwrap();
+    engine
+}
+
+fn matching_event() -> serde_json::Value {
+    json!({
+        "Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "CommandLine": "powershell -nop -enc ZWNobwo= ; FromBase64String(x)"
+    })
+}
+
+#[test]
+fn off_level_preserves_historical_shape() {
+    let engine = engine_at(MatchDetailLevel::Off);
+    let ev = matching_event();
+    let results = engine.evaluate(&JsonEvent::borrow(&ev));
+    assert_eq!(results.len(), 1);
+
+    let det = results[0].as_detection().unwrap();
+    // Only the two field selections contribute; the keyword selection does
+    // not, matching pre-enrichment behavior.
+    assert_eq!(det.matched_fields.len(), 2);
+    for fm in &det.matched_fields {
+        assert!(fm.selection.is_none());
+        assert!(fm.matcher.is_none());
+        assert!(fm.pattern.is_none());
+        assert!(fm.case_sensitive.is_none());
+        assert!(!fm.negated);
+    }
+    let fields: Vec<&str> = det
+        .matched_fields
+        .iter()
+        .map(|f| f.field.as_str())
+        .collect();
+    assert!(fields.contains(&"Image"));
+    assert!(fields.contains(&"CommandLine"));
+}
+
+#[test]
+fn summary_level_adds_descriptor_and_keyword_entry() {
+    let engine = engine_at(MatchDetailLevel::Summary);
+    let ev = matching_event();
+    let results = engine.evaluate(&JsonEvent::borrow(&ev));
+    assert_eq!(results.len(), 1);
+    let det = results[0].as_detection().unwrap();
+
+    let cmd = det
+        .matched_fields
+        .iter()
+        .find(|f| f.field == "CommandLine")
+        .expect("CommandLine match present");
+    assert_eq!(cmd.selection.as_deref(), Some("selection_args"));
+    assert_eq!(cmd.matcher, Some(MatcherKind::Contains));
+    assert_eq!(cmd.case_sensitive, Some(false));
+    // Summary withholds the pattern.
+    assert!(cmd.pattern.is_none());
+
+    // The keyword match, dropped entirely at Off, now appears.
+    let kw = det
+        .matched_fields
+        .iter()
+        .find(|f| f.matcher == Some(MatcherKind::Keyword))
+        .expect("keyword match present");
+    assert_eq!(kw.field, "keyword");
+    assert_eq!(kw.selection.as_deref(), Some("keywords"));
+}
+
+#[test]
+fn full_level_records_pattern() {
+    let engine = engine_at(MatchDetailLevel::Full);
+    let ev = matching_event();
+    let results = engine.evaluate(&JsonEvent::borrow(&ev));
+    let det = results[0].as_detection().unwrap();
+
+    let cmd = det
+        .matched_fields
+        .iter()
+        .find(|f| f.field == "CommandLine")
+        .expect("CommandLine match present");
+    assert_eq!(cmd.pattern.as_deref(), Some("-enc"));
+
+    let img = det
+        .matched_fields
+        .iter()
+        .find(|f| f.field == "Image")
+        .expect("Image match present");
+    assert_eq!(img.matcher, Some(MatcherKind::EndsWith));
+    assert_eq!(img.pattern.as_deref(), Some("\\powershell.exe"));
+}
+
+const NULL_RULE: &str = r#"
+title: Missing Image
+id: missing-image
+logsource:
+    category: process_creation
+detection:
+    selection:
+        Image: null
+    condition: selection
+level: low
+"#;
+
+#[test]
+fn null_on_absent_field_is_gated_by_level() {
+    let collection = parse_sigma_yaml(NULL_RULE).unwrap();
+    let ev = json!({ "CommandLine": "whoami" });
+
+    // Off: the absence match fires the rule but records no field entry.
+    let mut off = Engine::new();
+    off.add_collection(&collection).unwrap();
+    let off_res = off.evaluate(&JsonEvent::borrow(&ev));
+    assert_eq!(off_res.len(), 1);
+    assert!(off_res[0].as_detection().unwrap().matched_fields.is_empty());
+
+    // Summary: the absence match is reported with a null value.
+    let mut summary = Engine::new();
+    summary.set_match_detail(MatchDetailLevel::Summary);
+    summary.add_collection(&collection).unwrap();
+    let sum_res = summary.evaluate(&JsonEvent::borrow(&ev));
+    let det = sum_res[0].as_detection().unwrap();
+    assert_eq!(det.matched_fields.len(), 1);
+    let fm = &det.matched_fields[0];
+    assert_eq!(fm.field, "Image");
+    assert!(fm.value.is_null());
+    assert_eq!(fm.matcher, Some(MatcherKind::Null));
+}

--- a/crates/rsigma-eval/tests/wire_shape_golden.rs
+++ b/crates/rsigma-eval/tests/wire_shape_golden.rs
@@ -18,7 +18,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rsigma_eval::{
-    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, ResultBody, RuleHeader,
+    CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, MatcherKind, ResultBody,
+    RuleHeader,
 };
 use rsigma_parser::{CorrelationType, Level};
 
@@ -43,14 +44,14 @@ fn detection_golden_ndjson_line() {
         body: ResultBody::Detection(DetectionBody {
             matched_selections: vec!["selection_image".to_string(), "selection_args".to_string()],
             matched_fields: vec![
-                FieldMatch {
-                    field: "Image".to_string(),
-                    value: serde_json::json!("C:\\Windows\\System32\\powershell.exe"),
-                },
-                FieldMatch {
-                    field: "CommandLine".to_string(),
-                    value: serde_json::json!("powershell -nop -w hidden -enc JAB..."),
-                },
+                FieldMatch::new(
+                    "Image",
+                    serde_json::json!("C:\\Windows\\System32\\powershell.exe"),
+                ),
+                FieldMatch::new(
+                    "CommandLine",
+                    serde_json::json!("powershell -nop -w hidden -enc JAB..."),
+                ),
             ],
             event: None,
         }),
@@ -68,6 +69,87 @@ fn detection_golden_ndjson_line() {
     let parsed: serde_json::Value = serde_json::from_str(&actual).unwrap();
     assert!(parsed.get("matched_fields").is_some());
     assert!(parsed.get("correlation_type").is_none());
+}
+
+/// Wire-shape snapshot at `Summary`: enrichment fields appear after
+/// `field`/`value`, the keyword entry has no `pattern`, and `None`
+/// enrichment values are skipped.
+#[test]
+fn detection_summary_golden_ndjson_line() {
+    let result = EvaluationResult {
+        header: header("Suspicious PowerShell Encoded Command"),
+        body: ResultBody::Detection(DetectionBody {
+            matched_selections: vec!["selection_args".to_string(), "keywords".to_string()],
+            matched_fields: vec![
+                FieldMatch {
+                    field: "CommandLine".to_string(),
+                    value: serde_json::json!("powershell -nop -w hidden -enc JAB..."),
+                    selection: Some("selection_args".to_string()),
+                    matcher: Some(MatcherKind::Contains),
+                    pattern: None,
+                    case_sensitive: Some(false),
+                    negated: false,
+                },
+                FieldMatch {
+                    field: "keyword".to_string(),
+                    value: serde_json::json!("powershell -nop -w hidden -enc JAB..."),
+                    selection: Some("keywords".to_string()),
+                    matcher: Some(MatcherKind::Keyword),
+                    pattern: None,
+                    case_sensitive: None,
+                    negated: false,
+                },
+            ],
+            event: None,
+        }),
+    };
+
+    let actual = serde_json::to_string(&result).unwrap();
+    let expected = r#"{"rule_title":"Suspicious PowerShell Encoded Command","rule_id":"Suspicious PowerShell Encoded Command-id","level":"high","tags":["attack.execution","attack.t1059.001"],"matched_selections":["selection_args","keywords"],"matched_fields":[{"field":"CommandLine","value":"powershell -nop -w hidden -enc JAB...","selection":"selection_args","matcher":"contains","case_sensitive":false},{"field":"keyword","value":"powershell -nop -w hidden -enc JAB...","selection":"keywords","matcher":"keyword"}]}"#;
+    assert_eq!(
+        actual, expected,
+        "Summary detection wire shape drift. If intentional, update this golden and the CHANGELOG."
+    );
+}
+
+/// Wire-shape snapshot at `Full`: same as `Summary` plus the `pattern` key,
+/// and a negated entry emits `negated: true`.
+#[test]
+fn detection_full_golden_ndjson_line() {
+    let result = EvaluationResult {
+        header: header("Suspicious PowerShell Encoded Command"),
+        body: ResultBody::Detection(DetectionBody {
+            matched_selections: vec!["selection_args".to_string()],
+            matched_fields: vec![
+                FieldMatch {
+                    field: "CommandLine".to_string(),
+                    value: serde_json::json!("powershell -nop -w hidden -enc JAB..."),
+                    selection: Some("selection_args".to_string()),
+                    matcher: Some(MatcherKind::Contains),
+                    pattern: Some("-enc".to_string()),
+                    case_sensitive: Some(false),
+                    negated: false,
+                },
+                FieldMatch {
+                    field: "Image".to_string(),
+                    value: serde_json::json!("C:\\Windows\\notepad.exe"),
+                    selection: Some("selection_args".to_string()),
+                    matcher: Some(MatcherKind::EndsWith),
+                    pattern: Some("\\powershell.exe".to_string()),
+                    case_sensitive: Some(false),
+                    negated: true,
+                },
+            ],
+            event: None,
+        }),
+    };
+
+    let actual = serde_json::to_string(&result).unwrap();
+    let expected = r#"{"rule_title":"Suspicious PowerShell Encoded Command","rule_id":"Suspicious PowerShell Encoded Command-id","level":"high","tags":["attack.execution","attack.t1059.001"],"matched_selections":["selection_args"],"matched_fields":[{"field":"CommandLine","value":"powershell -nop -w hidden -enc JAB...","selection":"selection_args","matcher":"contains","pattern":"-enc","case_sensitive":false},{"field":"Image","value":"C:\\Windows\\notepad.exe","selection":"selection_args","matcher":"endswith","pattern":"\\powershell.exe","case_sensitive":false,"negated":true}]}"#;
+    assert_eq!(
+        actual, expected,
+        "Full detection wire shape drift. If intentional, update this golden and the CHANGELOG."
+    );
 }
 
 #[test]
@@ -173,10 +255,7 @@ fn detection_with_custom_attributes_emits_after_tags_before_body() {
         header: h,
         body: ResultBody::Detection(DetectionBody {
             matched_selections: vec!["selection".to_string()],
-            matched_fields: vec![FieldMatch {
-                field: "EventID".to_string(),
-                value: serde_json::json!(1),
-            }],
+            matched_fields: vec![FieldMatch::new("EventID", serde_json::json!(1))],
             event: None,
         }),
     };

--- a/crates/rsigma-runtime/src/engine.rs
+++ b/crates/rsigma-runtime/src/engine.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use rsigma_eval::event::Event;
 use rsigma_eval::{
-    CorrelationConfig, CorrelationEngine, CorrelationSnapshot, Engine, Pipeline, ProcessResult,
-    RuleFieldSet, parse_pipeline_file,
+    CorrelationConfig, CorrelationEngine, CorrelationSnapshot, Engine, MatchDetailLevel, Pipeline,
+    ProcessResult, RuleFieldSet, parse_pipeline_file,
 };
 use rsigma_parser::SigmaCollection;
 
@@ -28,6 +28,9 @@ pub struct RuntimeEngine {
     /// Optional override for the bloom memory budget in bytes. `None`
     /// means use the eval crate default.
     bloom_max_bytes: Option<usize>,
+    /// Match-detail verbosity forwarded to the inner detection engine on
+    /// every rule reload. `Off` by default (historical wire shape).
+    match_detail: MatchDetailLevel,
     /// Opt-in cross-rule Aho-Corasick pre-filter. Forwarded to the inner
     /// detection engine on every rule reload. Available behind the
     /// `daachorse-index` Cargo feature.
@@ -71,6 +74,7 @@ impl RuntimeEngine {
             allow_remote_include: false,
             bloom_prefilter: false,
             bloom_max_bytes: None,
+            match_detail: MatchDetailLevel::Off,
             #[cfg(feature = "daachorse-index")]
             cross_rule_ac: false,
             rule_field_set: Arc::new(ArcSwap::from_pointee(RuleFieldSet::default())),
@@ -112,6 +116,19 @@ impl RuntimeEngine {
     /// Return the configured bloom memory budget, if one was set.
     pub fn bloom_max_bytes(&self) -> Option<usize> {
         self.bloom_max_bytes
+    }
+
+    /// Set the match-detail verbosity on the inner detection engine.
+    /// `Off` by default. Applies on the next `load_rules()`; pre-load
+    /// callers should set this before calling `load_rules()`.
+    pub fn set_match_detail(&mut self, level: MatchDetailLevel) {
+        self.match_detail = level;
+    }
+
+    /// Return the current match-detail verbosity. Used by hot-reload to
+    /// carry the setting across a `RuntimeEngine` swap.
+    pub fn match_detail(&self) -> MatchDetailLevel {
+        self.match_detail
     }
 
     /// Enable or disable the cross-rule Aho-Corasick pre-filter on the
@@ -269,6 +286,7 @@ impl RuntimeEngine {
         if has_correlations {
             let mut engine = CorrelationEngine::new(self.corr_config.clone());
             engine.set_include_event(self.include_event);
+            engine.set_match_detail(self.match_detail);
             if let Some(budget) = self.bloom_max_bytes {
                 engine.set_bloom_max_bytes(budget);
             }
@@ -303,6 +321,7 @@ impl RuntimeEngine {
         } else {
             let mut engine = Engine::new();
             engine.set_include_event(self.include_event);
+            engine.set_match_detail(self.match_detail);
             if let Some(budget) = self.bloom_max_bytes {
                 engine.set_bloom_max_bytes(budget);
             }

--- a/crates/rsigma-runtime/src/enrichment/tests.rs
+++ b/crates/rsigma-runtime/src/enrichment/tests.rs
@@ -36,10 +36,10 @@ fn detection_result() -> EvaluationResult {
         },
         body: ResultBody::Detection(DetectionBody {
             matched_selections: vec!["selection".to_string()],
-            matched_fields: vec![FieldMatch {
-                field: "CommandLine".to_string(),
-                value: serde_json::json!("powershell -enc QQA="),
-            }],
+            matched_fields: vec![FieldMatch::new(
+                "CommandLine",
+                serde_json::json!("powershell -enc QQA="),
+            )],
             event: Some(serde_json::json!({"User": "alice", "Host": "dc01"})),
         }),
     }

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -310,6 +310,7 @@ impl LogProcessor {
         let allow_remote_include = old.allow_remote_include();
         let bloom_prefilter = old.bloom_prefilter();
         let bloom_max_bytes = old.bloom_max_bytes();
+        let match_detail = old.match_detail();
         #[cfg(feature = "daachorse-index")]
         let cross_rule_ac = old.cross_rule_ac();
         drop(old);
@@ -318,6 +319,7 @@ impl LogProcessor {
         let mut new_engine = RuntimeEngine::new(rules_path, pipelines, corr_config, include_event);
         new_engine.set_pipeline_paths(pipeline_paths);
         new_engine.set_allow_remote_include(allow_remote_include);
+        new_engine.set_match_detail(match_detail);
         new_engine.set_bloom_prefilter(bloom_prefilter);
         if let Some(budget) = bloom_max_bytes {
             new_engine.set_bloom_max_bytes(budget);

--- a/crates/rsigma-runtime/tests/enrichment_integration.rs
+++ b/crates/rsigma-runtime/tests/enrichment_integration.rs
@@ -91,10 +91,7 @@ fn detection(rule_id: &str, command_line: &str) -> EvaluationResult {
         },
         body: ResultBody::Detection(DetectionBody {
             matched_selections: vec!["selection".to_string()],
-            matched_fields: vec![FieldMatch {
-                field: "CommandLine".to_string(),
-                value: json!(command_line),
-            }],
+            matched_fields: vec![FieldMatch::new("CommandLine", json!(command_line))],
             event: None,
         }),
     }
@@ -146,10 +143,7 @@ async fn http_success_injects_full_response_object() {
     det.as_detection_mut()
         .unwrap()
         .matched_fields
-        .push(FieldMatch {
-            field: "HostName".to_string(),
-            value: json!("dc01"),
-        });
+        .push(FieldMatch::new("HostName", json!("dc01")));
 
     let enricher = Box::new(HttpEnricher::new(
         "asset_lookup".to_string(),
@@ -199,10 +193,7 @@ async fn http_template_renders_path_and_authorization_header() {
     det.as_detection_mut()
         .unwrap()
         .matched_fields
-        .push(FieldMatch {
-            field: "HostName".to_string(),
-            value: json!("dc01"),
-        });
+        .push(FieldMatch::new("HostName", json!("dc01")));
 
     let enricher = Box::new(HttpEnricher::new(
         "asset_lookup_with_auth".to_string(),

--- a/crates/rsigma-runtime/tests/enrichment_lookup.rs
+++ b/crates/rsigma-runtime/tests/enrichment_lookup.rs
@@ -35,10 +35,7 @@ fn detection_with_field(field: &str, value: serde_json::Value) -> EvaluationResu
         },
         body: ResultBody::Detection(DetectionBody {
             matched_selections: vec!["selection".to_string()],
-            matched_fields: vec![FieldMatch {
-                field: field.to_string(),
-                value,
-            }],
+            matched_fields: vec![FieldMatch::new(field, value)],
             event: None,
         }),
     }

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -48,6 +48,7 @@ For narrative coverage see [Streaming Detection](../../guide/streaming-detection
 | `--output <URL>` | `stdout` | Detection sink. Schemes: `stdout`, `file://<path>`, `nats://<host>:<port>/<subject>`. Repeatable for fan-out. |
 | `--dlq <URL>` | unset | Dead-letter queue for events that fail parsing or sink delivery. Same schemes as `--output`. When unset, failed events are logged and discarded. |
 | `--include-event` | off | Embed the full event JSON in every detection match. |
+| `--match-detail <LEVEL>` | `off` | Match-detail verbosity: `off` (field + value only), `summary` (adds matcher kind, selection, case sensitivity, and reports keyword/absence matches), or `full` (also records the matched pattern). Also settable via `daemon.engine.match_detail`. See [Evaluating Rules](../../guide/evaluating-rules.md#match-detail). |
 | `--pretty` | off | Pretty-print JSON output. |
 
 ### Pipelines and dynamic sources

--- a/docs/cli/engine/eval.md
+++ b/docs/cli/engine/eval.md
@@ -56,6 +56,7 @@ The global `--output-format` / `--color` / `--quiet` / `--no-stats` flags apply 
 | `--pretty` | off | Pretty-print JSON output. Kept for backwards compatibility; equivalent to `--output-format json` with pretty-printing on. |
 | `--no-detections` | off | Suppress detection output for rules that exist only to feed correlations (`generate: false`). |
 | `--include-event` | off | Embed the full event JSON in every `MatchResult`. Equivalent to setting `rsigma.include_event: "true"` per-rule. |
+| `--match-detail <LEVEL>` | `off` | Match-detail verbosity: `off` (field + value only), `summary` (adds matcher kind, selection, case sensitivity, and reports keyword/absence matches), or `full` (also records the matched pattern). See [Evaluating Rules](../../guide/evaluating-rules.md#match-detail). |
 
 ### Correlation behavior
 

--- a/docs/guide/evaluating-rules.md
+++ b/docs/guide/evaluating-rules.md
@@ -134,6 +134,37 @@ rsigma engine eval -r rules/ --include-event -e @events.ndjson
 
 For per-rule control, set the `rsigma.include_event` custom attribute on the rule (`"true"`/`"false"`). See [Custom Attributes](../reference/custom-attributes.md).
 
+## Match detail
+
+By default each entry in `matched_fields` is just `{field, value}`. Pass `--match-detail` to record why each field matched, which is useful when triaging a noisy rule or building a downstream UI:
+
+```bash
+rsigma engine eval -r rules/ --match-detail full -e '{"CommandLine": "cmd /c whoami"}'
+```
+
+There are three levels:
+
+| Level | What you get |
+|-------|--------------|
+| `off` (default) | `{field, value}` only. Byte-for-byte the historical shape. |
+| `summary` | Adds `selection` (the named detection it came from), `matcher` (the matcher kind, for example `contains` or `endswith`), and `case_sensitive`. Also reports matches that `off` drops entirely: keyword matches (under the sentinel field `"keyword"`) and absence matches (`value: null`). |
+| `full` | Everything in `summary` plus `pattern`, the value the matcher tested against (truncated for very long pattern sets). |
+
+A `full` entry looks like:
+
+```json
+{
+  "field": "CommandLine",
+  "value": "cmd /c whoami",
+  "selection": "selection",
+  "matcher": "contains",
+  "pattern": "whoami",
+  "case_sensitive": false
+}
+```
+
+Negated matchers add `"negated": true`. Higher levels enlarge each detection line and only run when a rule matches, so they cost nothing on the non-matching hot path. The daemon exposes the same control via `--match-detail` or the `daemon.engine.match_detail` config key.
+
 ## Input formats other than JSON
 
 `--input-format` accepts `auto` (the default), `json`, `syslog`, `plain`, and the feature-gated `logfmt`, `cef`. Auto-detect tries JSON, then syslog, then plain text:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,6 +61,7 @@ daemon:
     save_interval: 30
   engine:
     bloom_prefilter: false
+    match_detail: off
     observe_fields: false
     egress_policy: default
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `MatchDetailLevel { Off, Summary, Full }` to `rsigma-eval` so detection results can explain why each field matched. `Off` is the default and keeps the serialized `matched_fields` wire shape byte-for-byte identical, so existing sinks, the daemon NDJSON output, and the golden tests are unaffected unless a caller opts in.
- `Summary` adds the originating `selection`, the `matcher` kind (new `MatcherKind` enum), and `case_sensitive`, and reports two matches that were previously invisible: keyword matches (under the sentinel field `keyword`) and `null`-on-absent matches. `Full` additionally records the matched `pattern` (truncated for long pattern sets); negated matchers set `negated: true`.
- New `CompiledMatcher::describe()` builds the descriptor and runs only when a rule matches and only above `Off`, so the non-matching hot path is unchanged.
- Plumbed through `RuntimeEngine` (carried across hot reloads), `rsigma engine eval --match-detail`, `rsigma engine daemon --match-detail`, and the `daemon.engine.match_detail` config key.

## Wire shape

`Off` (default, unchanged):

```json
{"field":"CommandLine","value":"cmd /c whoami"}
```

`Full`:

```json
{"field":"CommandLine","value":"cmd /c whoami","selection":"selection","matcher":"contains","pattern":"whoami","case_sensitive":false}
```

## Test plan

- [x] `cargo test --workspace --all-features` (1647 passing)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `mkdocs build --strict`
- [x] New `tests/match_detail.rs` covers per-level engine behavior and the null-on-absent gating
- [x] `Off` golden lines unchanged; new `Summary`/`Full` golden lines added in `wire_shape_golden.rs`
- [x] `describe()` unit tests across matcher variants
- [x] CLI tests for `--match-detail` (full emits matcher/pattern; default omits the keys)