### PR TITLE
feat(syslog): strip UTF-8 BOM from RFC 5424 messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
-### Strip the UTF-8 BOM from RFC 5424 syslog messages
+### Strip the UTF-8 BOM from RFC 5424 syslog messages (#187)
 
 RFC 5424 section 6.4 mandates that a UTF-8 `MSG` begin with a byte order mark (`U+FEFF`, bytes `EF BB BF`) as an encoding marker, not as content. `syslog_loose` preserves it verbatim, and `str::trim()` does not remove it (`U+FEFF` is not Unicode `White_Space`), so the BOM previously leaked into the parsed event: it corrupted the `_raw` field and anchored matchers (`startswith`, exact equality), and it blocked embedded-JSON detection because `serde_json` errors on a leading BOM, silently degrading a BOM-prefixed JSON payload to a key/value event.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma
 
 ## [Unreleased]
 
+### Strip the UTF-8 BOM from RFC 5424 syslog messages
+
+RFC 5424 section 6.4 mandates that a UTF-8 `MSG` begin with a byte order mark (`U+FEFF`, bytes `EF BB BF`) as an encoding marker, not as content. `syslog_loose` preserves it verbatim, and `str::trim()` does not remove it (`U+FEFF` is not Unicode `White_Space`), so the BOM previously leaked into the parsed event: it corrupted the `_raw` field and anchored matchers (`startswith`, exact equality), and it blocked embedded-JSON detection because `serde_json` errors on a leading BOM, silently degrading a BOM-prefixed JSON payload to a key/value event.
+
+- **The syslog adapter now strips a single leading BOM from the message body by default**, gated by a new `SyslogConfig.strip_bom` field (defaults to `true`).
+- **Opt out** with `rsigma engine eval --syslog-strip-bom false` / `rsigma engine daemon --syslog-strip-bom false`, or the `input.syslog_strip_bom` / `eval.syslog_strip_bom` config keys, to keep the message byte-for-byte.
+
 ### `rstix`: STIX 2.1 + TAXII 2.1 library crate, Phase 1 core foundation (#185)
 
 Introduces `rstix`, a new workspace library crate for native STIX 2.1 and TAXII 2.1 support. This first phase lands the core foundation only; the object model, serialization dispatch, pattern engine, validation pipeline, and graph/marking/store/TAXII runtime behaviours are deferred to later phases.

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -207,6 +207,7 @@ Unlike `engine eval`, the daemon stays alive after stdin reaches EOF and support
 | `--output` | repeatable | `["stdout"]` | Detection output sink (fan-out): `stdout`, `file://<path>`, `nats://<host>:<port>/<subject>` |
 | `--input-format` | string | `"auto"` | Input log format: `auto`, `json`, `syslog`, `plain`, `logfmt`\*, `cef`\* |
 | `--syslog-tz` | string | `"+00:00"` | Default timezone for RFC 3164 syslog (e.g. `+05:00`, `-08:00`) |
+| `--syslog-strip-bom` | bool | `true` | Strip a leading UTF-8 BOM from RFC 5424 syslog messages. Pass `false` to keep it byte-for-byte |
 | `--jq` | string | none | jq filter to extract event payload (conflicts with `--jsonpath`) |
 | `--jsonpath` | string | none | JSONPath (RFC 9535) query (conflicts with `--jq`) |
 | `--include-event` | flag | `false` | Include full event JSON in each detection match |
@@ -491,6 +492,7 @@ Evaluate JSON events against Sigma detection and correlation rules.
 | `--timestamp-field` | repeatable | `[]` | Event field(s) for timestamp extraction (prepended to the default list) |
 | `--input-format` | string | `"auto"` | Input log format: `auto`, `json`, `syslog`, `plain`, `logfmt`\*, `cef`\* |
 | `--syslog-tz` | string | `"+00:00"` | Default timezone for RFC 3164 syslog (e.g. `+05:00`, `-08:00`) |
+| `--syslog-strip-bom` | bool | `true` | Strip a leading UTF-8 BOM from RFC 5424 syslog messages. Pass `false` to keep it byte-for-byte |
 | `--fail-on-detection` | flag | `false` | Exit with code 1 when any detection or correlation fires. Useful for CI/CD pipelines |
 | `--bloom-prefilter` | flag | `false` | Enable bloom-filter pre-filtering of positive substring matchers (see `crates/rsigma-eval/README.md` for the trade-off) |
 | `--bloom-max-bytes` | integer | **1048576** | Memory budget for the bloom index (no effect without `--bloom-prefilter`) |

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -134,6 +134,13 @@ pub(crate) struct DaemonArgs {
     #[arg(long = "syslog-tz", default_value = config::defaults::SYSLOG_TZ)]
     pub syslog_tz: String,
 
+    /// Strip a leading UTF-8 BOM from RFC 5424 syslog messages. On by
+    /// default (RFC 5424 treats the BOM as an encoding marker, not content);
+    /// pass `--syslog-strip-bom false` to keep it. Only relevant for
+    /// syslog/auto input.
+    #[arg(long = "syslog-strip-bom", default_value_t = true, action = clap::ArgAction::Set)]
+    pub syslog_strip_bom: bool,
+
     /// NATS credentials file (.creds) for JWT + NKey authentication.
     /// Also reads from NATS_CREDS environment variable.
     #[cfg(feature = "daemon-nats")]
@@ -454,6 +461,7 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         dlq,
         input_format,
         syslog_tz,
+        syslog_strip_bom,
         #[cfg(feature = "daemon-nats")]
         nats_creds,
         #[cfg(feature = "daemon-nats")]
@@ -582,6 +590,7 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         dlq,
         input_format,
         syslog_tz,
+        syslog_strip_bom,
         state_restore_mode,
         #[cfg(feature = "daemon-nats")]
         nats_auth,
@@ -699,6 +708,11 @@ fn apply_daemon_config(
             && let Some(v) = input.syslog_tz
         {
             args.syslog_tz = v;
+        }
+        if !explicit("syslog_strip_bom")
+            && let Some(v) = input.syslog_strip_bom
+        {
+            args.syslog_strip_bom = v;
         }
         if !explicit("buffer_size")
             && let Some(v) = input.buffer_size
@@ -891,6 +905,7 @@ fn run_daemon(
     dlq: Option<String>,
     input_format: String,
     syslog_tz: String,
+    syslog_strip_bom: bool,
     state_restore_mode: daemon::server::StateRestoreMode,
     #[cfg(feature = "daemon-nats")] nats_auth: NatsAuthArgs,
     #[cfg(feature = "daemon-nats")] replay_policy: rsigma_runtime::ReplayPolicy,
@@ -939,7 +954,7 @@ fn run_daemon(
 
     let pipelines = crate::load_pipelines(&pipeline_paths);
     let event_filter = std::sync::Arc::new(crate::build_event_filter(jq, jsonpath));
-    let parsed_input_format = parse_input_format(&input_format, &syslog_tz);
+    let parsed_input_format = parse_input_format(&input_format, &syslog_tz, syslog_strip_bom);
 
     let corr_config = crate::build_correlation_config(
         suppress,
@@ -1066,7 +1081,11 @@ fn run_daemon(
 // Input format parsing
 // ---------------------------------------------------------------------------
 
-pub(crate) fn parse_input_format(format_str: &str, syslog_tz: &str) -> rsigma_runtime::InputFormat {
+pub(crate) fn parse_input_format(
+    format_str: &str,
+    syslog_tz: &str,
+    strip_bom: bool,
+) -> rsigma_runtime::InputFormat {
     use rsigma_runtime::InputFormat;
     use rsigma_runtime::input::SyslogConfig;
 
@@ -1075,10 +1094,12 @@ pub(crate) fn parse_input_format(format_str: &str, syslog_tz: &str) -> rsigma_ru
     match format_str {
         "auto" => InputFormat::Auto(SyslogConfig {
             default_tz_offset_secs: tz_secs,
+            strip_bom,
         }),
         "json" => InputFormat::Json,
         "syslog" => InputFormat::Syslog(SyslogConfig {
             default_tz_offset_secs: tz_secs,
+            strip_bom,
         }),
         "plain" => InputFormat::Plain,
         #[cfg(feature = "logfmt")]
@@ -1214,5 +1235,45 @@ mod tests {
         let base = partial("daemon:\n  rules: /file/rules\n");
         apply_daemon_config(&mut args, &matches, base);
         assert_eq!(args.rules.as_deref(), Some(Path::new("/file/rules")));
+    }
+
+    #[test]
+    fn parse_input_format_threads_strip_bom() {
+        use rsigma_runtime::InputFormat;
+        use rsigma_runtime::input::SyslogConfig;
+
+        assert_eq!(
+            parse_input_format("syslog", "+00:00", false),
+            InputFormat::Syslog(SyslogConfig {
+                default_tz_offset_secs: 0,
+                strip_bom: false,
+            })
+        );
+        assert_eq!(
+            parse_input_format("auto", "+00:00", true),
+            InputFormat::Auto(SyslogConfig {
+                default_tz_offset_secs: 0,
+                strip_bom: true,
+            })
+        );
+    }
+
+    #[test]
+    fn syslog_strip_bom_default_on_config_off_flag_wins() {
+        // Default (no flag, no file): stripping is on.
+        let (args, _) = parse(&["daemon", "--rules", "/r"]);
+        assert!(args.syslog_strip_bom);
+
+        // File disables it and the operator did not set the flag: file applies.
+        let (mut args, matches) = parse(&["daemon", "--rules", "/r"]);
+        let base = partial("daemon:\n  input:\n    syslog_strip_bom: false\n");
+        apply_daemon_config(&mut args, &matches, base);
+        assert!(!args.syslog_strip_bom);
+
+        // Explicit CLI flag wins over the file.
+        let (mut args, matches) = parse(&["daemon", "--rules", "/r", "--syslog-strip-bom", "true"]);
+        let base = partial("daemon:\n  input:\n    syslog_strip_bom: false\n");
+        apply_daemon_config(&mut args, &matches, base);
+        assert!(args.syslog_strip_bom);
     }
 }

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -121,6 +121,13 @@ pub(crate) struct EvalArgs {
     #[arg(long = "syslog-tz", default_value = "+00:00")]
     pub syslog_tz: String,
 
+    /// Strip a leading UTF-8 BOM from RFC 5424 syslog messages. On by
+    /// default (RFC 5424 treats the BOM as an encoding marker, not content);
+    /// pass `--syslog-strip-bom false` to keep it. Only relevant for
+    /// syslog/auto input.
+    #[arg(long = "syslog-strip-bom", default_value_t = true, action = clap::ArgAction::Set)]
+    pub syslog_strip_bom: bool,
+
     /// Exit with code 1 when any detection or correlation fires.
     /// Useful in CI/CD pipelines to fail a build on detection.
     #[arg(long = "fail-on-detection")]
@@ -268,6 +275,11 @@ fn overlay_eval_config(
         {
             args.syslog_tz = v;
         }
+        if !explicit("syslog_strip_bom")
+            && let Some(v) = eval.syslog_strip_bom
+        {
+            args.syslog_strip_bom = v;
+        }
         if !explicit("fail_on_detection")
             && let Some(v) = eval.fail_on_detection
         {
@@ -297,6 +309,7 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
         timestamp_fields,
         input_format,
         syslog_tz,
+        syslog_strip_bom,
         fail_on_detection: _,
         bloom_prefilter,
         bloom_max_bytes,
@@ -379,6 +392,7 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
             match_detail,
             &input_format,
             &syslog_tz,
+            syslog_strip_bom,
             bloom_prefilter,
             bloom_max_bytes,
             #[cfg(feature = "daachorse-index")]
@@ -397,6 +411,7 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
             match_detail,
             &input_format,
             &syslog_tz,
+            syslog_strip_bom,
             bloom_prefilter,
             bloom_max_bytes,
             #[cfg(feature = "daachorse-index")]
@@ -428,6 +443,7 @@ fn cmd_eval_with_correlations(
     match_detail: MatchDetailLevel,
     input_format_str: &str,
     syslog_tz_str: &str,
+    syslog_strip_bom: bool,
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
     #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
@@ -507,6 +523,7 @@ fn cmd_eval_with_correlations(
                 renderer,
                 input_format_str,
                 syslog_tz_str,
+                syslog_strip_bom,
                 observe,
             );
             if renderer.ctx().show_stats() {
@@ -536,6 +553,7 @@ fn cmd_eval_with_correlations(
                 renderer,
                 input_format_str,
                 syslog_tz_str,
+                syslog_strip_bom,
                 observe,
             );
             if renderer.ctx().show_stats() {
@@ -558,6 +576,7 @@ fn eval_stream_corr(
     renderer: &mut MatchRenderer,
     input_format_str: &str,
     syslog_tz_str: &str,
+    syslog_strip_bom: bool,
     observe: Option<&ObserveContext>,
 ) -> (u64, u64, u64) {
     let mut line_num = 0u64;
@@ -565,9 +584,10 @@ fn eval_stream_corr(
     let mut corr_count = 0u64;
 
     #[cfg(feature = "daemon")]
-    let format = crate::commands::parse_input_format(input_format_str, syslog_tz_str);
+    let format =
+        crate::commands::parse_input_format(input_format_str, syslog_tz_str, syslog_strip_bom);
     #[cfg(not(feature = "daemon"))]
-    let _ = (input_format_str, syslog_tz_str);
+    let _ = (input_format_str, syslog_tz_str, syslog_strip_bom);
 
     for line in reader.lines() {
         line_num += 1;
@@ -708,6 +728,7 @@ fn cmd_eval_detection_only(
     match_detail: MatchDetailLevel,
     input_format_str: &str,
     syslog_tz_str: &str,
+    syslog_strip_bom: bool,
     bloom_prefilter: bool,
     bloom_max_bytes: Option<usize>,
     #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
@@ -793,6 +814,7 @@ fn cmd_eval_detection_only(
                 renderer,
                 input_format_str,
                 syslog_tz_str,
+                syslog_strip_bom,
                 observe,
             );
             if renderer.ctx().show_stats() {
@@ -818,6 +840,7 @@ fn cmd_eval_detection_only(
                 renderer,
                 input_format_str,
                 syslog_tz_str,
+                syslog_strip_bom,
                 observe,
             );
             if renderer.ctx().show_stats() {
@@ -838,15 +861,17 @@ fn eval_stream_detect(
     renderer: &mut MatchRenderer,
     input_format_str: &str,
     syslog_tz_str: &str,
+    syslog_strip_bom: bool,
     observe: Option<&ObserveContext>,
 ) -> (u64, u64) {
     let mut line_num = 0u64;
     let mut match_count = 0u64;
 
     #[cfg(feature = "daemon")]
-    let format = crate::commands::parse_input_format(input_format_str, syslog_tz_str);
+    let format =
+        crate::commands::parse_input_format(input_format_str, syslog_tz_str, syslog_strip_bom);
     #[cfg(not(feature = "daemon"))]
-    let _ = (input_format_str, syslog_tz_str);
+    let _ = (input_format_str, syslog_tz_str, syslog_strip_bom);
 
     for line in reader.lines() {
         line_num += 1;
@@ -1375,5 +1400,24 @@ mod tests {
         let base = partial("eval:\n  rules: /file/rules\n");
         overlay_eval_config(&mut args, &matches, base);
         assert_eq!(args.rules.as_deref(), Some(Path::new("/file/rules")));
+    }
+
+    #[test]
+    fn syslog_strip_bom_default_on_config_off_flag_wins() {
+        // Default: stripping is on.
+        let (args, _) = parse(&["eval", "--rules", "/r"]);
+        assert!(args.syslog_strip_bom);
+
+        // File disables it and the flag is unset: file applies.
+        let (mut args, matches) = parse(&["eval", "--rules", "/r"]);
+        let base = partial("eval:\n  syslog_strip_bom: false\n");
+        overlay_eval_config(&mut args, &matches, base);
+        assert!(!args.syslog_strip_bom);
+
+        // Explicit CLI flag wins over the file.
+        let (mut args, matches) = parse(&["eval", "--rules", "/r", "--syslog-strip-bom", "true"]);
+        let base = partial("eval:\n  syslog_strip_bom: false\n");
+        overlay_eval_config(&mut args, &matches, base);
+        assert!(args.syslog_strip_bom);
     }
 }

--- a/crates/rsigma-cli/src/config/defaults.rs
+++ b/crates/rsigma-cli/src/config/defaults.rs
@@ -16,6 +16,7 @@ pub(crate) const API_ADDR: &str = "0.0.0.0:9090";
 pub(crate) const INPUT_SOURCE: &str = "stdin";
 pub(crate) const INPUT_FORMAT: &str = "auto";
 pub(crate) const SYSLOG_TZ: &str = "+00:00";
+pub(crate) const SYSLOG_STRIP_BOM: bool = true;
 pub(crate) const BUFFER_SIZE: usize = 10_000;
 pub(crate) const BATCH_SIZE: usize = 1;
 pub(crate) const DRAIN_TIMEOUT: u64 = 5;
@@ -65,6 +66,7 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
                 source: Some(INPUT_SOURCE.to_string()),
                 format: Some(INPUT_FORMAT.to_string()),
                 syslog_tz: Some(SYSLOG_TZ.to_string()),
+                syslog_strip_bom: Some(SYSLOG_STRIP_BOM),
                 buffer_size: Some(BUFFER_SIZE),
                 batch_size: Some(BATCH_SIZE),
                 jq: None,
@@ -107,6 +109,7 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
             pipelines: Some(Vec::new()),
             input_format: Some(INPUT_FORMAT.to_string()),
             syslog_tz: Some(SYSLOG_TZ.to_string()),
+            syslog_strip_bom: Some(SYSLOG_STRIP_BOM),
             fail_on_detection: Some(false),
         }),
     }

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -190,6 +190,9 @@ pub(crate) struct InputPartial {
     /// Default timezone offset for RFC 3164 syslog.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub syslog_tz: Option<String>,
+    /// Strip a leading UTF-8 BOM from RFC 5424 syslog messages (default true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syslog_strip_bom: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub buffer_size: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -208,6 +211,7 @@ impl Merge for InputPartial {
             source: over.source.or(self.source),
             format: over.format.or(self.format),
             syslog_tz: over.syslog_tz.or(self.syslog_tz),
+            syslog_strip_bom: over.syslog_strip_bom.or(self.syslog_strip_bom),
             buffer_size: over.buffer_size.or(self.buffer_size),
             batch_size: over.batch_size.or(self.batch_size),
             jq: over.jq.or(self.jq),
@@ -376,6 +380,9 @@ pub(crate) struct EvalPartial {
     pub input_format: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub syslog_tz: Option<String>,
+    /// Strip a leading UTF-8 BOM from RFC 5424 syslog messages (default true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syslog_strip_bom: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fail_on_detection: Option<bool>,
 }
@@ -387,6 +394,7 @@ impl Merge for EvalPartial {
             pipelines: over.pipelines.or(self.pipelines),
             input_format: over.input_format.or(self.input_format),
             syslog_tz: over.syslog_tz.or(self.syslog_tz),
+            syslog_strip_bom: over.syslog_strip_bom.or(self.syslog_strip_bom),
             fail_on_detection: over.fail_on_detection.or(self.fail_on_detection),
         }
     }

--- a/crates/rsigma-cli/src/config/template.yaml
+++ b/crates/rsigma-cli/src/config/template.yaml
@@ -48,6 +48,9 @@ daemon:
     format: auto
     # Default timezone offset for RFC 3164 syslog.
     syslog_tz: "+00:00"
+    # Strip a leading UTF-8 BOM from RFC 5424 syslog messages (RFC 5424 treats
+    # it as an encoding marker, not content). Set false to keep it byte-for-byte.
+    syslog_strip_bom: true
     # Channel capacity for source->engine and engine->sink queues.
     buffer_size: 10000
     # Max events processed per engine lock acquisition.
@@ -124,4 +127,6 @@ eval:
   # pipelines: [sysmon]
   input_format: auto
   syslog_tz: "+00:00"
+  # Strip a leading UTF-8 BOM from RFC 5424 syslog messages. Set false to keep it.
+  syslog_strip_bom: true
   fail_on_detection: false

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -777,6 +777,10 @@ mod config_default_drift {
             Some(defaults::SYSLOG_TZ)
         );
         assert_eq!(
+            daemon_default("syslog_strip_bom"),
+            Some(defaults::SYSLOG_STRIP_BOM.to_string())
+        );
+        assert_eq!(
             daemon_default("correlation_event_mode").as_deref(),
             Some(defaults::CORRELATION_EVENT_MODE)
         );

--- a/crates/rsigma-runtime/src/input/auto.rs
+++ b/crates/rsigma-runtime/src/input/auto.rs
@@ -124,11 +124,33 @@ mod tests {
     fn auto_detect_syslog_respects_config() {
         let config = SyslogConfig {
             default_tz_offset_secs: 5 * 3600,
+            ..SyslogConfig::default()
         };
         let decoded = auto_detect("<34>Oct 11 22:14:15 mymachine su: test", &config);
         assert!(matches!(
             decoded,
             EventInputDecoded::Kv(_) | EventInputDecoded::Json(_)
         ));
+    }
+
+    #[test]
+    fn auto_detect_syslog_strips_bom() {
+        // A BOM-prefixed RFC 5424 line still extracts structured fields, and
+        // the BOM does not leak into any string value.
+        let line =
+            "<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - \u{FEFF}an event";
+        let decoded = auto_detect(line, &cfg());
+        assert!(
+            matches!(
+                decoded,
+                EventInputDecoded::Kv(_) | EventInputDecoded::Json(_)
+            ),
+            "Expected Kv or Json for syslog, got Plain"
+        );
+        assert!(decoded.get_field("hostname").is_some());
+        assert!(
+            !decoded.any_string_value(&|s| s.starts_with('\u{FEFF}')),
+            "no string value should retain the BOM"
+        );
     }
 }

--- a/crates/rsigma-runtime/src/input/syslog.rs
+++ b/crates/rsigma-runtime/src/input/syslog.rs
@@ -17,11 +17,28 @@ use syslog_loose::Message;
 use super::EventInputDecoded;
 
 /// Configuration for the syslog adapter.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyslogConfig {
     /// Default timezone offset in seconds east of UTC for RFC 3164 messages
     /// that lack timezone information.
     pub default_tz_offset_secs: i32,
+    /// Strip a leading UTF-8 BOM (`U+FEFF`) from the syslog message body.
+    ///
+    /// RFC 5424 section 6.4 mandates that a UTF-8 `MSG` begin with a BOM as an
+    /// encoding marker, not as content. `syslog_loose` preserves it verbatim,
+    /// so without this the BOM leaks into `_raw` (breaking anchored matchers)
+    /// and blocks embedded-JSON detection (`serde_json` errors on a leading
+    /// BOM). Defaults to `true`; disable to keep the message byte-for-byte.
+    pub strip_bom: bool,
+}
+
+impl Default for SyslogConfig {
+    fn default() -> Self {
+        Self {
+            default_tz_offset_secs: 0,
+            strip_bom: true,
+        }
+    }
 }
 
 /// Parse a syslog line into an event.
@@ -40,12 +57,21 @@ pub fn parse_syslog(line: &str, config: &SyslogConfig) -> EventInputDecoded {
         syslog_loose::Variant::Either,
     );
 
-    build_event_from_message(&parsed)
+    build_event_from_message(&parsed, config.strip_bom)
 }
 
 /// Build an EventInputDecoded from a parsed syslog message.
-fn build_event_from_message(parsed: &Message<&str>) -> EventInputDecoded {
-    let msg_str = parsed.msg.trim();
+///
+/// When `strip_bom` is set, a single leading UTF-8 BOM (`U+FEFF`) is removed
+/// from the message body before JSON detection and `_raw` extraction. See
+/// [`SyslogConfig::strip_bom`].
+fn build_event_from_message(parsed: &Message<&str>, strip_bom: bool) -> EventInputDecoded {
+    let msg = if strip_bom {
+        parsed.msg.strip_prefix('\u{FEFF}').unwrap_or(parsed.msg)
+    } else {
+        parsed.msg
+    };
+    let msg_str = msg.trim();
 
     // Try to parse the message body as JSON.
     if let Ok(mut json_obj) = serde_json::from_str::<serde_json::Value>(msg_str)
@@ -214,9 +240,69 @@ mod tests {
     fn custom_timezone() {
         let config = SyslogConfig {
             default_tz_offset_secs: 5 * 3600, // UTC+5
+            ..SyslogConfig::default()
         };
         let line = "<34>Oct 11 22:14:15 mymachine su: test message";
         let decoded = parse_syslog(line, &config);
         assert!(decoded.any_string_value(&|s| s.contains("test message")));
+    }
+
+    #[test]
+    fn rfc5424_strips_bom() {
+        // RFC 5424 UTF-8 MSG begins with a BOM (U+FEFF) as an encoding marker.
+        let line =
+            "<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - \u{FEFF}an event";
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        let raw = decoded
+            .get_field("_raw")
+            .and_then(|v| v.as_str().map(|s| s.into_owned()))
+            .expect("_raw present");
+        assert!(!raw.starts_with('\u{FEFF}'), "BOM should be stripped");
+        assert_eq!(raw, "an event");
+    }
+
+    #[test]
+    fn rfc5424_bom_json_detected() {
+        // A BOM-prefixed JSON payload must still be detected as embedded JSON;
+        // serde_json errors on a leading BOM, so this would degrade to a
+        // KvEvent without the strip.
+        let line = "<134>1 2024-01-15T10:30:00Z docker01 myapp 9876 MSGID1 - \u{FEFF}{\"EventID\": 1, \"user\": \"admin\"}";
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        assert!(
+            matches!(decoded, EventInputDecoded::Json(_)),
+            "BOM-prefixed JSON should be parsed as JSON"
+        );
+        assert!(decoded.get_field("EventID").is_some());
+        assert!(decoded.get_field("user").is_some());
+        assert!(decoded.get_field("syslog_hostname").is_some());
+    }
+
+    #[test]
+    fn rfc5424_keep_bom_when_disabled() {
+        let config = SyslogConfig {
+            strip_bom: false,
+            ..SyslogConfig::default()
+        };
+        let line =
+            "<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - \u{FEFF}an event";
+        let decoded = parse_syslog(line, &config);
+        let raw = decoded
+            .get_field("_raw")
+            .and_then(|v| v.as_str().map(|s| s.into_owned()))
+            .expect("_raw present");
+        assert!(
+            raw.starts_with('\u{FEFF}'),
+            "BOM should be preserved when stripping is disabled"
+        );
+    }
+
+    #[test]
+    fn bom_only_message() {
+        // A message consisting solely of a BOM collapses to empty after the
+        // strip, so no _raw field is emitted.
+        let line = "<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - \u{FEFF}";
+        let decoded = parse_syslog(line, &SyslogConfig::default());
+        assert!(decoded.get_field("_raw").is_none());
+        assert!(decoded.get_field("hostname").is_some());
     }
 }

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -38,6 +38,7 @@ For narrative coverage see [Streaming Detection](../../guide/streaming-detection
 | `--input <URL>` | `stdin` | Event source. Schemes: `stdin`, `http` (accepts `POST /api/v1/events`), `nats://<host>:<port>/<subject>`. |
 | `--input-format <FORMAT>` | `auto` | Input log format: `auto`, `json`, `syslog`, `plain`. With features: `logfmt`, `cef`. |
 | `--syslog-tz <OFFSET>` | `+00:00` | Timezone offset for RFC 3164 syslog (`+HH:MM` or `-HH:MM`). |
+| `--syslog-strip-bom <BOOL>` | `true` | Strip a leading UTF-8 BOM (`U+FEFF`) from RFC 5424 syslog messages. RFC 5424 treats the BOM as an encoding marker, not content. Pass `--syslog-strip-bom false` to keep it byte-for-byte. |
 | `--jq <JQ>` | unset | `jq` filter to extract the event payload from each JSON object. Mutually exclusive with `--jsonpath`. |
 | `--jsonpath <JSONPATH>` | unset | JSONPath ([RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)) query to extract the event payload. |
 

--- a/docs/cli/engine/eval.md
+++ b/docs/cli/engine/eval.md
@@ -40,6 +40,7 @@ For a narrative tutorial see [Evaluating Rules](../../guide/evaluating-rules.md)
 | `--jsonpath <JSONPATH>` | unset | JSONPath ([RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)) query to extract the event payload. Example: `--jsonpath '$.event'`, `--jsonpath '$.records[*]'`. |
 | `--input-format <FORMAT>` | `auto` | Input log format: `auto`, `json`, `syslog`, `plain`. With the `logfmt` and `cef` features: also `logfmt`, `cef`. |
 | `--syslog-tz <OFFSET>` | `+00:00` | Timezone offset for RFC 3164 syslog parsing. Format: `+HH:MM` or `-HH:MM`. |
+| `--syslog-strip-bom <BOOL>` | `true` | Strip a leading UTF-8 BOM (`U+FEFF`) from RFC 5424 syslog messages. RFC 5424 treats the BOM as an encoding marker, not content. Pass `--syslog-strip-bom false` to keep it byte-for-byte. |
 
 ### Pipeline
 

--- a/docs/guide/input-formats.md
+++ b/docs/guide/input-formats.md
@@ -57,6 +57,16 @@ tail -f /var/log/syslog | rsigma engine eval -r rules/ --input-format syslog --s
 
 The value is a fixed offset (`+0530`, `-0800`). For ambiguity-free parsing, prefer RFC 5424 sources that carry the offset inline.
 
+### UTF-8 BOM handling
+
+RFC 5424 section 6.4 says a UTF-8 `MSG` should begin with a byte order mark (`U+FEFF`, bytes `EF BB BF`) as an encoding marker, not as content. RSigma strips a single leading BOM from the message body by default, so it does not leak into the `_raw` field, break anchored matchers (`startswith`, exact equality), or block embedded-JSON detection (a BOM-prefixed JSON payload is parsed as JSON rather than degrading to a raw string).
+
+To keep the message byte-for-byte instead, pass `--syslog-strip-bom false` (or set `input.syslog_strip_bom: false` / `eval.syslog_strip_bom: false` in the config file).
+
+```bash
+tail -f /var/log/syslog | rsigma engine eval -r rules/ --input-format syslog --syslog-strip-bom false
+```
+
 ### Auto-detect validation
 
 When `--input-format auto`, RSigma's syslog detection requires the line to parse cleanly with a facility, severity, and hostname before accepting. Random text that happens to begin with a number does not get misparsed.


### PR DESCRIPTION
## Summary

RFC 5424 section 6.4 mandates that a UTF-8 `MSG` begin with a byte order mark (`U+FEFF`, bytes `EF BB BF`) as an encoding marker, not as content. `syslog_loose` preserves it verbatim, and `str::trim()` does not remove it (`U+FEFF` is not Unicode `White_Space`), so the BOM leaked into the parsed event. It corrupted the `_raw` field and anchored matchers (`startswith`, exact equality), and it blocked embedded-JSON detection because `serde_json` errors on a leading BOM, silently degrading a BOM-prefixed JSON payload to a `KvEvent`.

- **Runtime**: the syslog adapter now strips a single leading BOM from the message body by default, gated by a new `SyslogConfig.strip_bom` field (manual `Default = true`, so `InputFormat::default()` strips).
- **CLI/config**: a value-taking `--syslog-strip-bom <BOOL>` flag (default true) on `engine eval` and `engine daemon`, plus the matching `input.syslog_strip_bom` / `eval.syslog_strip_bom` config keys. The flag and config key share one positive name to avoid double negatives; the drift-guard test pins the clap default to the config constant.
- **Docs**: input-formats guide subsection, eval/daemon CLI references, both CLI README tables, and a CHANGELOG entry.

Plan: `syslog_bom_stripping_92c3c69f`. Not a ranked roadmap Open item; tracked as a maintenance/quality fix.

## Test plan

- [x] `rfc5424_strips_bom`, `rfc5424_bom_json_detected` (embedded-JSON regression), `rfc5424_keep_bom_when_disabled`, `bom_only_message` in the syslog adapter
- [x] `auto_detect_syslog_strips_bom` in the auto-detect adapter
- [x] `parse_input_format_threads_strip_bom` plus eval/daemon overlay tests (default-on, config-off, explicit-flag-wins)
- [x] `cargo test -p rsigma-runtime -p rsigma --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `mkdocs build --strict`