### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to RSigma are documented in this file. Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
-## [Unreleased]
+## [0.15.0] - 2026-06-11
+
+**TL;DR**
+RSigma v0.15.0 is the "new conversion target and Sigma extensions" release:
+* Fibratus conversion backend: convert Sigma rules into Fibratus rule YAML for the first endpoint-sensor target, with a `fibratus_windows` field-mapping pipeline, idiomatic macro recognition, ATT&CK label flattening, and sequence-DSL correlation lowering (#191).
+* Array matching: `[any]`/`[all]`/`[all_or_empty]`/`[none]` object-scope blocks, implicit any-member matching, and positional indexing (`args[0]`, negative indices), evaluated in the engine and lowered to PostgreSQL JSONB (#159).
+* Declarable correlation window modes: `sliding`/`tumbling`/`session` windows plus a session `gap`, end to end across the parser, runtime evaluator, and PostgreSQL conversion, with pySigma-style `correlation_method` selection at convert time (#192).
+* `sigma-version`: an optional top-level spec-major attribute that gates breaking spec changes by the declared version (array matching now activates only at major `3`), plus cross-document reference lints (#188).
+* `rstix`: a new STIX 2.1 + TAXII 2.1 library crate; Phase 1 lands the core foundation (validated typed IDs, timestamps, deterministic SCO IDs, controlled vocabularies) (#185).
+* Gated match-detail enrichment: a new `MatchDetailLevel` (`off`/`summary`/`full`) that explains why each field matched, off by default so the default wire shape is byte-for-byte unchanged (#186).
+* RFC 5424 syslog now strips a leading UTF-8 BOM by default, fixing corrupted `_raw` fields, broken anchored matchers, and BOM-blocked embedded-JSON detection (#187).
+* Daemon shutdown fix: `SIGINT`/`SIGTERM` handlers are now installed before the API listener is announced, closing a startup race that could hard-kill the process instead of draining cleanly.
 
 ### Fixed
 
@@ -95,6 +106,8 @@ Introduces `rstix`, a new workspace library crate for native STIX 2.1 and TAXII 
 - **Closed two long-standing reporting gaps** (visible only at `Summary`/`Full`, so `Off` is untouched): keyword detections, which previously contributed nothing to `matched_fields`, are now reported under the sentinel field `"keyword"`; and `null`-on-absent matches, previously invisible because the field had no value, are now reported with `value: null`.
 - **New `CompiledMatcher::describe()`** (returning `MatchDescriptor`) produces the structural description used to populate these fields. It runs only when a rule matches and only above `Off`, so the non-matching hot path is unchanged.
 - **CLI/runtime plumbing**: `rsigma engine eval --match-detail <off|summary|full>`, `rsigma engine daemon --match-detail <…>` plus the `daemon.engine.match_detail` config key, and `RuntimeEngine::set_match_detail` (carried across hot reloads).
+
+[v0.14.0...v0.15.0](https://github.com/timescale/rsigma/compare/v0.14.0...v0.15.0)
 
 ## [0.14.0] - 2026-06-05
 
@@ -1702,6 +1715,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.15.0]: https://github.com/timescale/rsigma/releases/tag/v0.15.0
 [0.14.0]: https://github.com/timescale/rsigma/releases/tag/v0.14.0
 [0.13.0]: https://github.com/timescale/rsigma/releases/tag/v0.13.0
 [0.12.0]: https://github.com/timescale/rsigma/releases/tag/v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "assert_cmd",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "insta",
  "log",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "globset",
@@ -3983,7 +3983,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "phf",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -30,10 +30,10 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.14.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.14.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.14.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.15.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.15.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.15.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.15.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.14.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.15.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.15.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.15.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.14.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.15.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.15.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -19,8 +19,8 @@ evtx = ["dep:evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.14.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.14.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.15.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.15.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "globset",
  "log",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arc-swap",
  "async-trait",


### PR DESCRIPTION
## Summary

Release v0.15.0. Bumps the workspace from 0.14.0 to 0.15.0 (workspace package version plus all inter-crate path pins across the five dependent crates), syncs both `Cargo.lock` and `fuzz/Cargo.lock`, and finalizes [`CHANGELOG.md`](CHANGELOG.md) by promoting the `[Unreleased]` block to `[0.15.0] - 2026-06-11` with a TL;DR and the release reference link.

Headline framing: the "new conversion target and Sigma extensions" release.

- Fibratus conversion backend: Sigma to Fibratus rule YAML, `fibratus_windows` pipeline, idiomatic macros, ATT&CK label flattening, sequence-DSL correlation (#191).
- Array matching: `[any]`/`[all]`/`[all_or_empty]`/`[none]` blocks, implicit any-member, positional indexing, evaluated in-engine and lowered to PostgreSQL JSONB (#159).
- Declarable correlation window modes: `sliding`/`tumbling`/`session` plus a session `gap`, across parser, evaluator, and PostgreSQL conversion, with pySigma-style `correlation_method` selection (#192).
- `sigma-version`: top-level spec-major attribute gating breaking spec changes; array matching now activates only at major `3`, plus cross-document reference lints (#188).
- `rstix`: new STIX 2.1 + TAXII 2.1 library crate, Phase 1 core foundation (#185).
- Gated match-detail enrichment: `MatchDetailLevel` (off/summary/full), off by default so the wire shape is unchanged (#186).
- RFC 5424 syslog strips a leading UTF-8 BOM by default (#187).
- Daemon shutdown fix: signal handlers installed before the API listener is announced.

Full release notes: see the new `[0.15.0]` section in `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-features --locked` (lockfile/manifest consistency)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (CI)
- [x] `cargo test --workspace --all-features` (CI)
- [x] `mkdocs build --strict` (CI)
- [x] `cargo deny check` (CI)

This commit is a version/changelog bump only; no source changed since the last merge to `main`, so the heavier gates are left to CI.

## Post-merge

After merge, tag `v0.15.0` on `main` and create the GitHub Release using the `[0.15.0]` body verbatim. The `publish.yml`, `release-binaries.yml`, and `docker.yml` workflows fire on `release: published`.