### PR TITLE
Window-mode correlation benchmarks: throughput and peak-memory stress suite

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -26,6 +26,7 @@ cargo bench
 cargo bench -p rsigma-parser --bench parse
 cargo bench -p rsigma-eval --bench eval
 cargo bench -p rsigma-eval --bench correlation
+cargo bench -p rsigma-eval --bench correlation_memory   # peak-heap stress (not Criterion)
 cargo bench -p rsigma-runtime --bench runtime_throughput
 cargo bench -p rsigma-runtime --bench dynamic_pipelines
 
@@ -218,6 +219,46 @@ Run with `cargo bench -p rsigma-eval --features daachorse-index --bench eval -- 
 | 10,000 | 7.97 ms | 1.25 Melem/s |
 | 50,000 | 41.5 ms | 1.20 Melem/s |
 
+### Window Modes: sliding vs tumbling vs session (0.15.0)
+
+Apple M4 Pro, macOS, release build, 2026-06-12. Identical `event_count` workload for all three modes: 10,000 events across 1,000 group keys, one event per group per 10s tick, 1h window, 10m session gap. The window decision in `apply_window_open` is O(1) (deque front/back inspection), so the three modes cost the same per event.
+
+| Window mode | Time (median) | Throughput |
+|-------------|---------------|------------|
+| `sliding` (default) | 7.25 ms | 1.38 Melem/s |
+| `tumbling` | 6.69 ms | 1.49 Melem/s |
+| `session` | 6.74 ms | 1.48 Melem/s |
+
+Run with `cargo bench -p rsigma-eval --bench correlation -- correlation_window_modes`.
+
+### Window-Mode Memory Stress (0.15.0)
+
+Apple M4 Pro, macOS, release build, 2026-06-12. The `correlation_memory` bench is not a Criterion suite: it installs a counting global allocator and reports **peak** and **settled** heap deltas over the engine baseline, isolating window-state maintenance (alert thresholds are unreachable; event construction is excluded from the deltas). It reproduces the two scenarios from the [SEP #214](https://github.com/SigmaHQ/sigma-specification/issues/214) discussion on memory becoming the bottleneck in stateful window correlation.
+
+**A. High-cardinality session windows** (one event per unique key, `event_count`, gap 5m, cap 2h) — exercises the `max_state_entries` hard cap and stalest-first eviction:
+
+| Configuration | Throughput | Peak heap | Settled | Live groups |
+|---------------|-----------:|----------:|--------:|------------:|
+| 100k keys, default cap (100k) | 789 Kelem/s | 20.5 MiB | 17.7 MiB | 100,000 |
+| 1M keys, default cap (100k) | 898 Kelem/s | 39.8 MiB | 22.4 MiB | capped |
+| 1M keys, cap raised to 2M | 805 Kelem/s | 327.4 MiB | 243.8 MiB | 1,000,000 |
+
+A live session group costs ~256 B settled, dominated by the `GroupKey` heap strings rather than the timestamps. Throughput under active eviction is the highest of the three runs because the state map stays small; the eviction sort is amortized over the 10% headroom the cap reclaims.
+
+**B. Long-lived chatty sessions** (groups emitting continuously inside an open session; gap never exceeded, so the per-group deque grows to timespan/interval entries):
+
+| Workload | Throughput | Peak heap | Bytes/in-window event |
+|----------|-----------:|----------:|----------------------:|
+| `event_count` session, 1k groups @ 30s (240 ev/window) | 1.16 Melem/s | 2.2 MiB | 8 B |
+| `event_count` sliding, 1k groups @ 30s (240 ev/window) | 1.14 Melem/s | 2.2 MiB | 8 B |
+| `value_count` session, 1k groups @ 30s, distinct strings | 324 Kelem/s | 21.1 MiB | ~92 B |
+| `event_count` session, 100 groups @ 1 ev/s (7,200 ev/window) | 1.13 Melem/s | 6.3 MiB | 9 B |
+| `value_count` session, 100 groups @ 1 ev/s, distinct (1,800 ev/window) | 63 Kelem/s | 16.0 MiB | ~93 B |
+
+**C. Mode comparison** (10k groups, 1M events, 1h window): sliding 1.10 Melem/s, tumbling 1.06 Melem/s, session 1.06 Melem/s — all 6.6 MiB peak. Memory differences between modes come only from how long entries are retained, not from per-event overhead.
+
+Run with `cargo bench -p rsigma-eval --bench correlation_memory` (about half a minute total).
+
 ---
 
 ## Runtime (`rsigma-runtime`)
@@ -333,6 +374,9 @@ Full pipeline: resolve source, expand templates, apply value_placeholders, evalu
 - **Runtime overhead is negative**: LogProcessor with JSON batching is actually faster than raw Engine evaluation due to batch-level optimizations and format-aware parsing.
 - **Rule count scales well**: Increasing from 100 to 1000 rules has minimal per-event cost increase (~50%) thanks to indexed field matching.
 - **Correlation is efficient**: Temporal correlations (2.1M elem/s) are 2x faster than event-count correlations (1.05M elem/s), and both scale linearly with events.
+- **Window modes cost the same per event**: sliding, tumbling, and session all run at ~1.4-1.5 Melem/s on an identical workload. The window decision is O(1); choosing `session` over `sliding` is free at evaluation time.
+- **Correlation memory is bounded by entry count, not bytes**: the `max_state_entries` cap (default 100k) held 1M unique session keys to a 39.8 MiB peak via stalest-first eviction. Within the cap, per-group deques grow with timespan x event rate: 8 B per in-window event for `event_count`, ~92 B for `value_count` with distinct string values.
+- **`value_count` distinct counting is the correlation bottleneck**: the distinct count is recomputed per event over the whole window (O(W) per event), so throughput drops from ~1.1 Melem/s to 63 Kelem/s at 1,800 distinct values per window — CPU collapses before memory does. Prefer shorter windows or `event_count` where distinctness is not required.
 - **Template expansion is negligible**: Even with 20 vars, expansion adds < 10 us. Not a bottleneck.
 - **JSONPath is the fastest extraction language**: Roughly 2x faster than JQ for comparable filter operations on dynamic source data.
 - **CEL has high overhead**: ~160x slower than JSONPath for list filtering due to interpretation overhead. Best suited for simple field access or small datasets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Correlation window-mode benchmarks: throughput and peak-memory stress suite (#TBD)
+### Correlation window-mode benchmarks: throughput and peak-memory stress suite (#199)
 
 Two new benchmark surfaces for the correlation window modes shipped in #192, prompted by the [SEP #214](https://github.com/SigmaHQ/sigma-specification/issues/214) discussion on memory becoming the bottleneck in stateful window correlation (high-cardinality group keys, long-lived sessions).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to RSigma are documented in this file. Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
+## [Unreleased]
+
+### Correlation window-mode benchmarks: throughput and peak-memory stress suite (#TBD)
+
+Two new benchmark surfaces for the correlation window modes shipped in #192, prompted by the [SEP #214](https://github.com/SigmaHQ/sigma-specification/issues/214) discussion on memory becoming the bottleneck in stateful window correlation (high-cardinality group keys, long-lived sessions).
+
+- **`correlation_window_modes` Criterion group** (`cargo bench -p rsigma-eval --bench correlation -- correlation_window_modes`): sliding vs tumbling vs session on an identical `event_count` workload. All three modes run at ~1.4-1.5 Melem/s — the window decision in `apply_window_open` is O(1), so declaring `window: session` is free at evaluation time.
+- **`correlation_memory` bench target** (`cargo bench -p rsigma-eval --bench correlation_memory`): not a Criterion suite — it installs a counting global allocator and reports peak/settled heap deltas, which Criterion cannot observe. Three scenario families: high-cardinality session keys against the `max_state_entries` cap (1M unique keys held to a 39.8 MiB peak by stalest-first eviction; ~256 B per live session group uncapped), long-lived chatty sessions (8 B per in-window `event_count` event; `value_count` with distinct strings costs ~92 B per event and drops to 63 Kelem/s at 1,800 distinct values per window because the distinct count is recomputed per event), and a three-mode comparison on identical load (identical memory and throughput).
+- **Documentation**: results recorded in `BENCHMARKS.md` (new Window Modes and Window-Mode Memory Stress sections plus Key Observations); the Performance Tuning guide's correlation-memory section now documents what the cap does and does not bound, per-event state costs by correlation type, the `value_count` distinct-count hot spot, and the cardinality-flood eviction caveat — and fixes a long-standing inaccuracy (the `max_state_entries` cap is global across all correlation rules, not per rule). The streaming-detection guide links the window-mode semantics to the measured numbers, and the developer testing guide documents the non-Criterion bench target.
+
 ## [0.15.0] - 2026-06-11
 
 **TL;DR**

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -44,6 +44,12 @@ harness = false
 name = "correlation"
 harness = false
 
+# Not a Criterion bench: measures peak heap via a counting global allocator
+# (window-mode memory stress). Prints an aligned results table.
+[[bench]]
+name = "correlation_memory"
+harness = false
+
 [[bench]]
 name = "result_serialize"
 harness = false

--- a/crates/rsigma-eval/benches/correlation.rs
+++ b/crates/rsigma-eval/benches/correlation.rs
@@ -288,6 +288,94 @@ level: high
 }
 
 // ---------------------------------------------------------------------------
+// Benchmark: window modes (sliding vs tumbling vs session)
+// ---------------------------------------------------------------------------
+
+fn bench_correlation_window_modes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("correlation_window_modes");
+    group.sample_size(20);
+
+    // Identical workload for all three modes: 10k events spread over 1k
+    // group keys, one event per group per 10s tick, 1h window. The session
+    // gap (10m) exceeds the tick interval so sessions stay open until the
+    // timespan cap, matching the sliding window's retention.
+    let yaml_for = |window_block: &str| {
+        format!(
+            r#"
+title: Base Rule
+id: bench-base-001
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+    condition: selection
+level: low
+---
+title: Window Mode Corr
+id: corr-window-001
+correlation:
+    type: event_count
+    rules:
+        - bench-base-001
+    group-by:
+        - User
+    timespan: 3600s
+{window_block}    condition:
+        gte: 1000000
+level: high
+"#
+        )
+    };
+
+    let n_events = 10_000usize;
+    let n_groups = 1_000usize;
+    let event_values: Vec<serde_json::Value> = (0..n_groups)
+        .map(|g| {
+            serde_json::json!({
+                "EventType": "process_create",
+                "User": format!("user_{g:04}"),
+                "CommandLine": "whoami",
+            })
+        })
+        .collect();
+    let events: Vec<JsonEvent> = event_values.iter().map(JsonEvent::borrow).collect();
+
+    for (mode, window_block) in [
+        ("sliding", ""),
+        ("tumbling", "    window: tumbling\n"),
+        ("session", "    window: session\n    gap: 600s\n"),
+    ] {
+        let yaml = yaml_for(window_block);
+        let collection = parse_sigma_yaml(&yaml).unwrap();
+
+        group.throughput(criterion::Throughput::Elements(n_events as u64));
+
+        group.bench_with_input(BenchmarkId::new("mode", mode), &events, |b, events| {
+            b.iter_with_setup(
+                || {
+                    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+                    engine.add_collection(&collection).unwrap();
+                    engine
+                },
+                |mut engine| {
+                    let base_ts = 1_000_000i64;
+                    for i in 0..n_events {
+                        let event = &events[i % n_groups];
+                        // One event per group per 10s tick.
+                        let ts = base_ts + (i / n_groups) as i64 * 10;
+                        let result = engine.process_event_at(black_box(event), ts);
+                        black_box(&result);
+                    }
+                },
+            );
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Criterion harness
 // ---------------------------------------------------------------------------
 
@@ -298,5 +386,6 @@ criterion_group!(
     bench_correlation_throughput,
     bench_correlation_batch,
     bench_correlation_state_pressure,
+    bench_correlation_window_modes,
 );
 criterion_main!(benches);

--- a/crates/rsigma-eval/benches/correlation_memory.rs
+++ b/crates/rsigma-eval/benches/correlation_memory.rs
@@ -1,0 +1,410 @@
+//! Memory and throughput stress bench for correlation window modes.
+//!
+//! Unlike the Criterion suites, this target measures **peak heap** via a
+//! counting global allocator, which Criterion cannot observe. It exercises
+//! the two scenarios from the SEP #214 discussion on memory becoming the
+//! bottleneck in stateful window correlation:
+//!
+//! - high-cardinality group keys (does the `max_state_entries` cap hold?), and
+//! - long-lived chatty sessions (how do per-group deques grow within a window?).
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p rsigma-eval --bench correlation_memory
+//! ```
+//!
+//! The full run takes roughly half a minute in release mode. Results print as
+//! an aligned table; "peak" and "settled" are heap deltas over the engine
+//! baseline (rules loaded, no events processed), so event construction and
+//! engine setup are excluded. Alert conditions are set unreachably high so the
+//! numbers isolate window-state maintenance rather than alert emission.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use rsigma_eval::{CorrelationConfig, CorrelationEngine, JsonEvent, ProcessResultExt};
+use rsigma_parser::parse_sigma_yaml;
+
+// ---------------------------------------------------------------------------
+// Counting allocator: tracks live and peak heap bytes
+// ---------------------------------------------------------------------------
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            let live = LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        p
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            if new_size >= layout.size() {
+                let grow = new_size - layout.size();
+                let live = LIVE.fetch_add(grow, Ordering::Relaxed) + grow;
+                PEAK.fetch_max(live, Ordering::Relaxed);
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOC: CountingAlloc = CountingAlloc;
+
+fn live_bytes() -> usize {
+    LIVE.load(Ordering::Relaxed)
+}
+
+fn reset_peak() {
+    PEAK.store(live_bytes(), Ordering::Relaxed);
+}
+
+fn peak_bytes() -> usize {
+    PEAK.load(Ordering::Relaxed)
+}
+
+fn mib(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+// ---------------------------------------------------------------------------
+// Rule and engine construction
+// ---------------------------------------------------------------------------
+
+/// Build a two-document collection: one base detection rule plus one
+/// correlation rule with the requested type and window mode. The alert
+/// threshold is unreachable so runs measure state maintenance only.
+fn rules_yaml(corr_type: &str, window: &str, timespan: &str, gap: Option<&str>) -> String {
+    let window_block = match window {
+        // Sliding is the default; omit the keys to exercise the default path.
+        "sliding" => String::new(),
+        "session" => format!(
+            "    window: session\n    gap: {}\n",
+            gap.expect("session window requires a gap")
+        ),
+        other => format!("    window: {other}\n"),
+    };
+    let field_block = if corr_type == "value_count" {
+        "        field: CommandLine\n"
+    } else {
+        ""
+    };
+    format!(
+        r#"title: Base Rule
+id: membench-base-001
+logsource:
+    product: windows
+detection:
+    selection:
+        EventType: 'process_create'
+    condition: selection
+level: low
+---
+title: Window Memory Bench Corr
+id: membench-corr-001
+correlation:
+    type: {corr_type}
+    rules:
+        - membench-base-001
+    group-by:
+        - User
+    timespan: {timespan}
+{window_block}    condition:
+{field_block}        gte: 1000000
+level: high
+"#
+    )
+}
+
+fn engine_for(yaml: &str, max_state_entries: usize) -> CorrelationEngine {
+    let collection = parse_sigma_yaml(yaml).expect("bench rules parse");
+    let config = CorrelationConfig {
+        max_state_entries,
+        ..Default::default()
+    };
+    let mut engine = CorrelationEngine::new(config);
+    engine
+        .add_collection(&collection)
+        .expect("bench rules load");
+    engine
+}
+
+// ---------------------------------------------------------------------------
+// Measurement plumbing
+// ---------------------------------------------------------------------------
+
+struct RunStats {
+    events: usize,
+    secs: f64,
+    peak_delta: usize,
+    settled_delta: usize,
+    groups: usize,
+    alerts: usize,
+}
+
+fn report(name: &str, s: &RunStats) {
+    println!(
+        "{name:<62} {:>9.0} ev/s  peak {:>7.1} MiB  settled {:>7.1} MiB  groups {:>9}  alerts {:>5}",
+        s.events as f64 / s.secs,
+        mib(s.peak_delta),
+        mib(s.settled_delta),
+        s.groups,
+        s.alerts,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A: high-cardinality group keys
+//
+// One event per unique user key, session window. Exercises the
+// `max_state_entries` hard cap and the stalest-first eviction path.
+// ---------------------------------------------------------------------------
+
+fn scenario_cardinality(n_keys: usize, max_state_entries: usize) -> RunStats {
+    let yaml = rules_yaml("event_count", "session", "2h", Some("5m"));
+    let mut engine = engine_for(&yaml, max_state_entries);
+
+    let baseline = live_bytes();
+    reset_peak();
+    let start = Instant::now();
+    let mut alerts = 0usize;
+
+    let base_ts = 1_000_000_000i64;
+    for i in 0..n_keys {
+        let v = serde_json::json!({
+            "EventType": "process_create",
+            "User": format!("user_{i:08}"),
+            "CommandLine": "whoami /all",
+            "Image": "C:\\Windows\\System32\\whoami.exe",
+        });
+        let event = JsonEvent::borrow(&v);
+        let result = engine.process_event_at(&event, base_ts + i as i64);
+        alerts += result.correlation_count();
+    }
+
+    RunStats {
+        events: n_keys,
+        secs: start.elapsed().as_secs_f64(),
+        peak_delta: peak_bytes().saturating_sub(baseline),
+        settled_delta: live_bytes().saturating_sub(baseline),
+        groups: engine.state_count(),
+        alerts,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B: long-lived chatty sessions
+//
+// `n_groups` hosts each emit one event every `interval_secs`, interleaved,
+// for `duration_secs` of stream time. With gap > interval the session never
+// closes from inactivity; it only rolls over at the `timespan` cap, so the
+// per-group deque grows to timespan / interval entries.
+// ---------------------------------------------------------------------------
+
+struct ChattySpec {
+    corr_type: &'static str,
+    window: &'static str,
+    n_groups: usize,
+    interval_secs: i64,
+    duration_secs: i64,
+    timespan: &'static str,
+    gap: Option<&'static str>,
+    /// When true, every `CommandLine` value is distinct: the worst case for
+    /// `value_count`, which stores each `(timestamp, value)` pair.
+    distinct_values: bool,
+}
+
+fn scenario_chatty(spec: &ChattySpec) -> RunStats {
+    let yaml = rules_yaml(spec.corr_type, spec.window, spec.timespan, spec.gap);
+    let mut engine = engine_for(&yaml, 1_000_000);
+
+    let users: Vec<String> = (0..spec.n_groups).map(|i| format!("host_{i:06}")).collect();
+
+    let baseline = live_bytes();
+    reset_peak();
+    let start = Instant::now();
+    let mut alerts = 0usize;
+    let mut events = 0usize;
+
+    let base_ts = 1_000_000_000i64;
+    let ticks = spec.duration_secs / spec.interval_secs;
+    for t in 0..ticks {
+        let ts = base_ts + t * spec.interval_secs;
+        for (g, user) in users.iter().enumerate() {
+            let cmd = if spec.distinct_values {
+                format!(
+                    "cmd_{t}_{g} --with-realistic-arguments --target 10.0.0.{}",
+                    g % 255
+                )
+            } else {
+                "whoami /all".to_string()
+            };
+            let v = serde_json::json!({
+                "EventType": "process_create",
+                "User": user,
+                "CommandLine": cmd,
+            });
+            let event = JsonEvent::borrow(&v);
+            let result = engine.process_event_at(&event, ts);
+            alerts += result.correlation_count();
+            events += 1;
+        }
+    }
+
+    RunStats {
+        events,
+        secs: start.elapsed().as_secs_f64(),
+        peak_delta: peak_bytes().saturating_sub(baseline),
+        settled_delta: live_bytes().saturating_sub(baseline),
+        groups: engine.state_count(),
+        alerts,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario C: identical workload across the three window modes
+// ---------------------------------------------------------------------------
+
+fn scenario_mode(window: &'static str) -> RunStats {
+    scenario_chatty(&ChattySpec {
+        corr_type: "event_count",
+        window,
+        n_groups: 10_000,
+        interval_secs: 100,
+        duration_secs: 10_000, // 100 ticks x 10k groups = 1M events
+        timespan: "1h",
+        gap: if window == "session" {
+            Some("10m")
+        } else {
+            None
+        },
+        distinct_values: false,
+    })
+}
+
+fn main() {
+    println!(
+        "\n=== A. High-cardinality session windows (1 event/key, event_count, gap 5m, cap 2h) ==="
+    );
+    for &(n_keys, cap, label) in &[
+        (100_000usize, 100_000usize, "100k keys, default cap 100k"),
+        (
+            1_000_000,
+            100_000,
+            "1M keys, default cap 100k (eviction active)",
+        ),
+        (
+            1_000_000,
+            2_000_000,
+            "1M keys, cap raised to 2M (no eviction)",
+        ),
+    ] {
+        let stats = scenario_cardinality(n_keys, cap);
+        report(&format!("session  {label}"), &stats);
+    }
+
+    println!("\n=== B. Long-lived chatty sessions ===");
+    let stats = scenario_chatty(&ChattySpec {
+        corr_type: "event_count",
+        window: "session",
+        n_groups: 1_000,
+        interval_secs: 30,
+        duration_secs: 4 * 3600,
+        timespan: "2h",
+        gap: Some("5m"),
+        distinct_values: false,
+    });
+    report(
+        "event_count session  1k groups @ 30s (240 ev/window)",
+        &stats,
+    );
+
+    let stats = scenario_chatty(&ChattySpec {
+        corr_type: "event_count",
+        window: "sliding",
+        n_groups: 1_000,
+        interval_secs: 30,
+        duration_secs: 4 * 3600,
+        timespan: "2h",
+        gap: None,
+        distinct_values: false,
+    });
+    report(
+        "event_count sliding  1k groups @ 30s (240 ev/window)",
+        &stats,
+    );
+
+    let stats = scenario_chatty(&ChattySpec {
+        corr_type: "value_count",
+        window: "session",
+        n_groups: 1_000,
+        interval_secs: 30,
+        duration_secs: 4 * 3600,
+        timespan: "2h",
+        gap: Some("5m"),
+        distinct_values: true,
+    });
+    report(
+        "value_count session  1k groups @ 30s, distinct strings",
+        &stats,
+    );
+
+    let stats = scenario_chatty(&ChattySpec {
+        corr_type: "event_count",
+        window: "session",
+        n_groups: 100,
+        interval_secs: 1,
+        duration_secs: 4 * 3600,
+        timespan: "2h",
+        gap: Some("5m"),
+        distinct_values: false,
+    });
+    report(
+        "event_count session  100 groups @ 1 ev/s (7200 ev/window)",
+        &stats,
+    );
+
+    // Scaled down (1h stream, 30m cap) so the full bench stays under a minute:
+    // the distinct-count check is O(window) per event, so this case is slow by
+    // nature -- that is the finding, not an accident of the bench.
+    let stats = scenario_chatty(&ChattySpec {
+        corr_type: "value_count",
+        window: "session",
+        n_groups: 100,
+        interval_secs: 1,
+        duration_secs: 3600,
+        timespan: "30m",
+        gap: Some("5m"),
+        distinct_values: true,
+    });
+    report(
+        "value_count session  100 groups @ 1 ev/s, distinct (1800/window)",
+        &stats,
+    );
+
+    println!("\n=== C. Mode comparison, identical workload (10k groups, 1M events, 1h window) ===");
+    for mode in ["sliding", "tumbling", "session"] {
+        let stats = scenario_mode(mode);
+        report(&format!("{mode:<8} 10k groups, 100 ev/group"), &stats);
+    }
+
+    println!();
+}

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -189,6 +189,12 @@ cargo bench -p rsigma-parser -- parse
 cargo bench -p rsigma-runtime -- runtime_throughput
 ```
 
+One bench target is not a Criterion suite: `correlation_memory` installs a counting global allocator and reports peak/settled heap for correlation window-state stress scenarios (high-cardinality group keys, long-lived chatty sessions), which Criterion cannot measure. It prints an aligned table and finishes in about half a minute:
+
+```bash
+cargo bench -p rsigma-eval --bench correlation_memory
+```
+
 Benchmarks are not gated in CI. The numbers in [Benchmarks](../benchmarks.md) come from a manual run on the development workstation; if a PR makes a hot-path change, attach a before/after Criterion summary in the PR description.
 
 ## Tips

--- a/docs/guide/performance-tuning.md
+++ b/docs/guide/performance-tuning.md
@@ -132,7 +132,16 @@ The trade-off: a higher `--batch-size` increases tail latency (an event waits up
 
 ## Memory pressure and correlation state
 
-Correlation state lives in memory unless `--state-db` writes periodic snapshots to SQLite. The hard cap is `max_state_entries`, default 100,000 entries per correlation rule. When the cap is hit, the engine evicts the stalest 10% and emits a warning.
+Correlation state lives in memory unless `--state-db` writes periodic snapshots to SQLite. The hard cap is `max_state_entries`, default 100,000 `(correlation, group-key)` entries across all correlation rules. When the cap is hit, the engine evicts the stalest 10% and emits a warning.
+
+The cap bounds the number of groups, not bytes. Within a live group, the window state grows with `timespan` x event rate: 8 bytes per in-window event for `event_count`, 16 for the numeric aggregations (`value_sum`/`value_avg`/`value_percentile`/`value_median`), and roughly 32 bytes plus the value string for `value_count`. The measured shape (see [Benchmarks](../benchmarks.md#window-mode-memory-stress-0150)): 1M unique session keys against the default cap peaked at 39.8 MiB, and a fully chatty `event_count` workload (100 groups sustaining 1 event/s through a 2h session cap) held 6.3 MiB. A live but quiet session group costs ~256 bytes, dominated by the group-key strings.
+
+Window modes (`sliding`/`tumbling`/`session`) have identical per-event cost; they differ only in how long entries are retained. `tumbling` resets per-group state at each bucket boundary and is the cheapest under sustained load; `session` retains everything between the first event and the `timespan` cap, so it is the mode to watch on chatty groups.
+
+Two workload shapes deserve attention:
+
+- **`value_count` with high-cardinality values.** Every `(timestamp, value)` pair is retained for the window, and the distinct count is recomputed per event over the whole window — O(window size) per event. At 1,800 distinct values per window, measured throughput drops from ~1.1M to 63K events/s. CPU collapses before memory does. Prefer `event_count` where distinctness is not actually required, or shorten the window.
+- **Group-key cardinality floods.** Under cap pressure the stalest groups are evicted first, so a burst of unique keys can push a slow-burning session out of state before it completes. The eviction warning in the log is the tripwire; raise `max_state_entries` if the warning fires during legitimate traffic.
 
 Watch:
 

--- a/docs/guide/streaming-detection.md
+++ b/docs/guide/streaming-detection.md
@@ -109,6 +109,8 @@ The `rsigma.*` spelling wins if both appear. The engine reads the resolved value
 
 Window decisions follow arrival order, the same contract as the existing sliding window: the engine reasons about the events currently retained per group, not a global watermark. One asymmetry is deliberate: a tumbling window discards a late event that belongs to an earlier, already-passed bucket rather than letting it reset the active bucket, so out-of-order stragglers cannot wipe an accumulating count. Window bookkeeping is derived from the per-group timestamps already tracked, so persisted state (`--state-db`) stays compatible and survives upgrades.
 
+All three modes have the same per-event cost (the window decision is O(1)), so choosing `session` over `sliding` is free at evaluation time; what differs is how long state is retained per group. See [Performance Tuning](performance-tuning.md#memory-pressure-and-correlation-state) for the memory characteristics and the [Benchmarks](../benchmarks.md#window-mode-memory-stress-0150) page for measured numbers under high-cardinality and long-lived-session stress.
+
 ## Output sinks
 
 The `--output` flag is repeatable, which gives you fan-out for free. Each match is cloned to every configured sink via a bounded mpsc channel:


### PR DESCRIPTION
## Summary

Follow-up to #192 (correlation window modes), prompted by the [SEP #214](https://github.com/SigmaHQ/sigma-specification/issues/214) discussion: the maintainer noted that sliding/session correlation in high-cardinality scenarios with long-lived sessions tends to hit a memory bottleneck. This PR adds benchmarks that measure exactly that, and documents the results.

- **`correlation_window_modes` Criterion group** (`benches/correlation.rs`): sliding vs tumbling vs session on an identical `event_count` workload. All three run at ~1.4-1.5 Melem/s; the window decision in `apply_window_open` is O(1), so declaring `window: session` is free at evaluation time.
- **`correlation_memory` bench target** (new, `harness = false`, not Criterion): installs a counting global allocator and reports peak/settled heap deltas, which Criterion cannot observe. Scenarios: high-cardinality session keys against the `max_state_entries` cap (1M unique keys held to 39.8 MiB peak by stalest-first eviction; ~256 B per live group uncapped), long-lived chatty sessions (8 B per in-window `event_count` event; `value_count` with distinct strings costs ~92 B/event and collapses to 63 Kelem/s at 1,800 distinct values per window because the distinct count is recomputed per event, O(W)), and a three-mode comparison. Full run is about half a minute.
- **Docs**: `BENCHMARKS.md` gains Window Modes + Window-Mode Memory Stress sections and Key Observations bullets; the Performance Tuning guide documents what the cap does and does not bound, per-event state costs by correlation type, the `value_count` hot spot, and the cardinality-flood eviction caveat, and fixes a pre-existing inaccuracy (`max_state_entries` is global, not per correlation rule); Streaming Detection links the window semantics to the numbers; the developer testing guide documents the non-Criterion target.

## Test plan

- [x] `cargo bench -p rsigma-eval --bench correlation_memory` runs clean (~15 s) and reproduces the documented numbers on Apple M4 Pro
- [x] `cargo bench -p rsigma-eval --bench correlation -- correlation_window_modes` runs clean
- [x] `cargo fmt --all` and `cargo clippy -p rsigma-eval --benches --all-features -- -D warnings` pass
- [x] `mkdocs build --strict` passes
- [x] CI (multi-OS test matrix; no library code changed, benches and docs only)