### PR TITLE
Configurable correlation state caps: --max-state-entries and per-group --max-group-entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Configurable correlation state caps: `--max-state-entries` and a new per-group entry cap (#200)
+
+The correlation engine's memory bounds are now fully operator-configurable. Previously the global `(correlation, group-key)` entry cap (`max_state_entries`, default 100,000) was a library-only setting with no CLI surface, and nothing bounded the growth of a single group's window state, which grows with `timespan` x event rate on chatty groups.
+
+- **`--max-state-entries <N>`** on `engine eval` and `engine daemon` (config key `daemon.correlation.max_state_entries`) exposes the existing global hard cap. When reached, the stalest entries are evicted down to 90% capacity and a warning is logged, as before. A drift-guard test pins the CLI default to the engine's `CorrelationConfig` default across the two crates.
+- **`--max-group-entries <N>`** (config key `daemon.correlation.max_group_entries`, per-rule `rsigma.max_group_entries` custom attribute) is a new, opt-in cap on retained entries within a single group's window state: timestamps for `event_count`, `(timestamp, value)` pairs for `value_count` and the numeric aggregations, and per-referenced-rule hits for the temporal types. On overflow the oldest entries are dropped, which can only under-count (aggregates saturate; a correlation that needed the evicted entries may not fire). Session windows always keep their oldest entry as the span anchor, so truncation cannot silently extend the `timespan` cap. Unset means unbounded, the historical behavior, so existing deployments are unaffected.
+- **API.** `CorrelationConfig` gains `max_group_entries: Option<usize>`, `CompiledCorrelation` gains the matching per-rule override, and `WindowState` gains `truncate_oldest(cap, preserve_front)`. The per-rule attribute follows the same resolution order as the other `rsigma.*` correlation attributes: rule override wins over the engine default.
+- **Docs.** New flags documented on the `engine eval` and `engine daemon` CLI pages, the configuration file reference, the custom-attributes reference, the processing-pipelines attribute table, and the Performance Tuning guide's correlation-memory section (which also now states that the global cap bounds group count, not bytes within a group, and is global rather than per-rule).
+
 ### Correlation window-mode benchmarks: throughput and peak-memory stress suite (#199)
 
 Two new benchmark surfaces for the correlation window modes shipped in #192, prompted by the [SEP #214](https://github.com/SigmaHQ/sigma-specification/issues/214) discussion on memory becoming the bottleneck in stateful window correlation (high-cardinality group keys, long-lived sessions).

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -76,6 +76,18 @@ pub(crate) struct DaemonArgs {
     #[arg(long = "max-correlation-events", default_value_t = config::defaults::MAX_CORRELATION_EVENTS)]
     pub max_correlation_events: usize,
 
+    /// Hard cap on correlation state entries across all correlations and
+    /// group keys. When reached, the stalest entries are evicted down to
+    /// 90% capacity and a warning is logged.
+    #[arg(long = "max-state-entries", default_value_t = config::defaults::MAX_STATE_ENTRIES)]
+    pub max_state_entries: usize,
+
+    /// Cap on retained entries within a single correlation group's window
+    /// state. Bounds within-window growth of chatty groups; oldest entries
+    /// are dropped (session windows keep their span anchor). Unset = unbounded.
+    #[arg(long = "max-group-entries")]
+    pub max_group_entries: Option<usize>,
+
     /// Event field name(s) for timestamp extraction in correlations
     #[arg(long = "timestamp-field")]
     pub timestamp_fields: Vec<String>,
@@ -450,6 +462,8 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         no_detections,
         correlation_event_mode,
         max_correlation_events,
+        max_state_entries,
+        max_group_entries,
         timestamp_fields,
         state_db,
         state_save_interval,
@@ -578,6 +592,8 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         no_detections,
         correlation_event_mode,
         max_correlation_events,
+        max_state_entries,
+        max_group_entries,
         timestamp_fields,
         timestamp_fallback,
         state_db,
@@ -785,6 +801,16 @@ fn apply_daemon_config(
         {
             args.max_correlation_events = v;
         }
+        if !explicit("max_state_entries")
+            && let Some(v) = correlation.max_state_entries
+        {
+            args.max_state_entries = v;
+        }
+        if !explicit("max_group_entries")
+            && let Some(v) = correlation.max_group_entries
+        {
+            args.max_group_entries = Some(v);
+        }
         if !explicit("timestamp_fields")
             && let Some(v) = correlation.timestamp_fields
         {
@@ -893,6 +919,8 @@ fn run_daemon(
     no_detections: bool,
     correlation_event_mode: String,
     max_correlation_events: usize,
+    max_state_entries: usize,
+    max_group_entries: Option<usize>,
     timestamp_fields: Vec<String>,
     timestamp_fallback: String,
     state_db: Option<PathBuf>,
@@ -962,6 +990,8 @@ fn run_daemon(
         no_detections,
         correlation_event_mode,
         max_correlation_events,
+        max_state_entries,
+        max_group_entries,
         timestamp_fields,
         &timestamp_fallback,
     );

--- a/crates/rsigma-cli/src/commands/eval.rs
+++ b/crates/rsigma-cli/src/commands/eval.rs
@@ -102,6 +102,20 @@ pub(crate) struct EvalArgs {
     #[arg(long = "max-correlation-events", default_value = "10")]
     pub max_correlation_events: usize,
 
+    /// Hard cap on correlation state entries across all correlations and
+    /// group keys. When reached, the stalest entries are evicted down to
+    /// 90% capacity and a warning is logged.
+    #[arg(long = "max-state-entries", default_value_t = crate::config::defaults::MAX_STATE_ENTRIES, value_parser = clap::value_parser!(usize))]
+    pub max_state_entries: usize,
+
+    /// Cap on retained entries within a single correlation group's window
+    /// state (timestamps, value pairs, or per-rule hits). Bounds the
+    /// within-window growth of chatty groups; oldest entries are dropped
+    /// (session windows keep their span anchor). Unset = unbounded.
+    /// Equivalent to the `rsigma.max_group_entries` custom attribute.
+    #[arg(long = "max-group-entries")]
+    pub max_group_entries: Option<usize>,
+
     /// Event field name(s) to use for timestamp extraction in correlations.
     /// Can be specified multiple times; tried in order before built-in
     /// defaults (@timestamp, timestamp, EventTime, …).
@@ -306,6 +320,8 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
         match_detail,
         correlation_event_mode,
         max_correlation_events,
+        max_state_entries,
+        max_group_entries,
         timestamp_fields,
         input_format,
         syslog_tz,
@@ -353,6 +369,8 @@ pub(crate) fn cmd_eval(args: EvalArgs, ctx: OutputCtx) -> bool {
         no_detections,
         correlation_event_mode,
         max_correlation_events,
+        max_state_entries,
+        max_group_entries,
         timestamp_fields,
         "wallclock",
     );

--- a/crates/rsigma-cli/src/config/defaults.rs
+++ b/crates/rsigma-cli/src/config/defaults.rs
@@ -23,6 +23,10 @@ pub(crate) const DRAIN_TIMEOUT: u64 = 5;
 pub(crate) const CORRELATION_ACTION: &str = "alert";
 pub(crate) const CORRELATION_EVENT_MODE: &str = "none";
 pub(crate) const MAX_CORRELATION_EVENTS: usize = 10;
+/// Default hard cap on `(correlation, group-key)` state entries. Must match
+/// `CorrelationConfig::default().max_state_entries` in rsigma-eval; a
+/// drift-guard test pins the two together.
+pub(crate) const MAX_STATE_ENTRIES: usize = 100_000;
 pub(crate) const TIMESTAMP_FALLBACK: &str = "wallclock";
 pub(crate) const STATE_SAVE_INTERVAL: u64 = 30;
 pub(crate) const OBSERVE_FIELDS_MAX_KEYS: usize = 10_000;
@@ -84,6 +88,8 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
                 action: Some(CORRELATION_ACTION.to_string()),
                 event_mode: Some(CORRELATION_EVENT_MODE.to_string()),
                 max_events: Some(MAX_CORRELATION_EVENTS),
+                max_state_entries: Some(MAX_STATE_ENTRIES),
+                max_group_entries: None,
                 timestamp_fields: None,
                 timestamp_fallback: Some(TIMESTAMP_FALLBACK.to_string()),
                 no_detections: Some(false),

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -263,6 +263,14 @@ pub(crate) struct CorrelationPartial {
     pub event_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_events: Option<usize>,
+    /// Hard cap on `(correlation, group-key)` state entries before
+    /// stalest-first eviction (default 100,000).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_state_entries: Option<usize>,
+    /// Cap on retained entries within a single group's window state.
+    /// Unset means unbounded (the historical behavior).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_group_entries: Option<usize>,
     /// Extra event field names for timestamp extraction.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timestamp_fields: Option<Vec<String>>,
@@ -281,6 +289,8 @@ impl Merge for CorrelationPartial {
             action: over.action.or(self.action),
             event_mode: over.event_mode.or(self.event_mode),
             max_events: over.max_events.or(self.max_events),
+            max_state_entries: over.max_state_entries.or(self.max_state_entries),
+            max_group_entries: over.max_group_entries.or(self.max_group_entries),
             timestamp_fields: over.timestamp_fields.or(self.timestamp_fields),
             timestamp_fallback: over.timestamp_fallback.or(self.timestamp_fallback),
             no_detections: over.no_detections.or(self.no_detections),

--- a/crates/rsigma-cli/src/config/template.yaml
+++ b/crates/rsigma-cli/src/config/template.yaml
@@ -80,6 +80,12 @@ daemon:
     event_mode: none
     # Max events stored per correlation window group.
     max_events: 10
+    # Hard cap on correlation state entries across all correlations and
+    # group keys; stalest entries are evicted at the cap.
+    max_state_entries: 100000
+    # Cap on retained entries within a single group's window state.
+    # Unset = unbounded.
+    # max_group_entries: 10000
     # Extra event field names for timestamp extraction.
     # timestamp_fields: ["@timestamp"]
     # Behavior when no timestamp field is found: wallclock | skip

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -632,12 +632,15 @@ pub(crate) fn build_event_filter(jq: Option<String>, jsonpath: Option<String>) -
 }
 
 /// Build a `CorrelationConfig` from CLI arguments. Exits on parse errors.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_correlation_config(
     suppress: Option<String>,
     action: Option<String>,
     no_detections: bool,
     correlation_event_mode: String,
     max_correlation_events: usize,
+    max_state_entries: usize,
+    max_group_entries: Option<usize>,
     extra_timestamp_fields: Vec<String>,
     timestamp_fallback: &str,
 ) -> CorrelationConfig {
@@ -676,6 +679,8 @@ pub(crate) fn build_correlation_config(
         emit_detections: !no_detections,
         correlation_event_mode: event_mode,
         max_correlation_events,
+        max_state_entries,
+        max_group_entries,
         timestamp_fallback: ts_fallback,
         ..Default::default()
     };
@@ -805,12 +810,26 @@ mod config_default_drift {
             Some(defaults::MAX_CORRELATION_EVENTS.to_string())
         );
         assert_eq!(
+            daemon_default("max_state_entries"),
+            Some(defaults::MAX_STATE_ENTRIES.to_string())
+        );
+        assert_eq!(
             daemon_default("state_save_interval"),
             Some(defaults::STATE_SAVE_INTERVAL.to_string())
         );
         assert_eq!(
             daemon_default("observe_fields_max_keys"),
             Some(defaults::OBSERVE_FIELDS_MAX_KEYS.to_string())
+        );
+    }
+
+    /// The CLI default must match the engine's own `CorrelationConfig`
+    /// default; the two are defined in different crates.
+    #[test]
+    fn max_state_entries_matches_engine_default() {
+        assert_eq!(
+            defaults::MAX_STATE_ENTRIES,
+            CorrelationConfig::default().max_state_entries
         );
     }
 }

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -181,6 +181,7 @@ Stateful processing with sliding time windows, group-by aggregation, and all 8 c
 | `timestamp_fields` | `Vec<String>` | `["@timestamp", "timestamp", "EventTime", "TimeCreated", "eventTime"]` | Field names to try for timestamp extraction, in priority order |
 | `timestamp_fallback` | `TimestampFallback` | `WallClock` | `WallClock` (use `Utc::now()`) or `Skip` (skip event from correlation) |
 | `max_state_entries` | `usize` | `100,000` | Hard cap across all correlations and group keys |
+| `max_group_entries` | `Option<usize>` | `None` | Cap on retained entries within a single group's window state; `None` = unbounded. Oldest entries dropped on overflow (session windows keep their span anchor) |
 | `suppress` | `Option<u64>` | `None` | Default suppression window in seconds |
 | `action_on_match` | `CorrelationAction` | `Alert` | `Alert` (keep state) or `Reset` (clear window state) |
 | `emit_detections` | `bool` | `true` | Whether to emit detection-level matches for correlation-only rules |
@@ -431,6 +432,7 @@ Pipeline transformations can configure engine behavior via `SetCustomAttribute`,
 | `rsigma.include_event` | Embeds the full event JSON in detection output | `--include-event` | Per-rule |
 | `rsigma.correlation_event_mode` | Sets event inclusion mode (`full` or `refs`) | `--correlation-event-mode` | Per-correlation |
 | `rsigma.max_correlation_events` | Caps stored events per correlation window (integer) | `--max-correlation-events` | Per-correlation |
+| `rsigma.max_group_entries` | Caps retained entries within a single group's window state (integer, quoted) | `--max-group-entries` | Per-correlation |
 
 CLI flags and the library API always take precedence over pipeline attributes. Engine-level attributes (`timestamp_field`, `suppress`, `action`) are only applied when the CLI did not already set the corresponding flag. Per-correlation attributes override engine defaults for individual correlation rules.
 

--- a/crates/rsigma-eval/src/correlation/compiler.rs
+++ b/crates/rsigma-eval/src/correlation/compiler.rs
@@ -90,6 +90,12 @@ pub fn compile_correlation(rule: &CorrelationRule) -> Result<CompiledCorrelation
         .and_then(|v| v.as_str())
         .and_then(|s| s.parse::<usize>().ok());
 
+    let max_group_entries = rule
+        .custom_attributes
+        .get("rsigma.max_group_entries")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<usize>().ok());
+
     let custom_attributes = Arc::new(crate::compiler::yaml_to_json_map(&rule.custom_attributes));
 
     Ok(CompiledCorrelation {
@@ -111,6 +117,7 @@ pub fn compile_correlation(rule: &CorrelationRule) -> Result<CompiledCorrelation
         action,
         event_mode,
         max_events,
+        max_group_entries,
         custom_attributes,
     })
 }

--- a/crates/rsigma-eval/src/correlation/tests.rs
+++ b/crates/rsigma-eval/src/correlation/tests.rs
@@ -1069,3 +1069,95 @@ fn test_apply_window_open_session_caps_at_timespan() {
     assert_eq!(decision, WindowDecision::Reset);
     assert!(state.is_empty());
 }
+
+// =============================================================================
+// Per-group entry cap: WindowState::truncate_oldest
+// =============================================================================
+
+#[test]
+fn test_truncate_oldest_drops_oldest_entries() {
+    let mut state = WindowState::new_for(CorrelationType::EventCount);
+    for ts in 0..5 {
+        state.push_event_count(ts);
+    }
+    state.truncate_oldest(3, false);
+    // Oldest entries (0, 1) dropped; newest 3 retained.
+    assert_eq!(state.earliest_timestamp(), Some(2));
+    assert_eq!(state.latest_timestamp(), Some(4));
+}
+
+#[test]
+fn test_truncate_oldest_noop_under_cap() {
+    let mut state = WindowState::new_for(CorrelationType::EventCount);
+    state.push_event_count(1);
+    state.push_event_count(2);
+    state.truncate_oldest(3, false);
+    assert_eq!(state.earliest_timestamp(), Some(1));
+    assert_eq!(state.latest_timestamp(), Some(2));
+}
+
+#[test]
+fn test_truncate_oldest_preserve_front_keeps_session_anchor() {
+    let mut state = WindowState::new_for(CorrelationType::EventCount);
+    for ts in 0..5 {
+        state.push_event_count(ts);
+    }
+    state.truncate_oldest(3, true);
+    // The anchor (0) survives; the middle entries are dropped instead.
+    assert_eq!(state.earliest_timestamp(), Some(0));
+    assert_eq!(state.latest_timestamp(), Some(4));
+}
+
+#[test]
+fn test_truncate_oldest_cap_clamps_to_one() {
+    let mut state = WindowState::new_for(CorrelationType::EventCount);
+    for ts in 0..4 {
+        state.push_event_count(ts);
+    }
+    // A nonsensical cap of 0 is clamped to 1.
+    state.truncate_oldest(0, false);
+    assert_eq!(state.earliest_timestamp(), Some(3));
+    assert_eq!(state.latest_timestamp(), Some(3));
+}
+
+#[test]
+fn test_truncate_oldest_preserve_front_cap_one_keeps_anchor() {
+    let mut state = WindowState::new_for(CorrelationType::EventCount);
+    for ts in 0..4 {
+        state.push_event_count(ts);
+    }
+    state.truncate_oldest(1, true);
+    // Cap 1 with anchor preservation keeps exactly the anchor.
+    assert_eq!(state.earliest_timestamp(), Some(0));
+    assert_eq!(state.latest_timestamp(), Some(0));
+}
+
+#[test]
+fn test_truncate_oldest_value_count_drops_oldest_values() {
+    let mut state = WindowState::new_for(CorrelationType::ValueCount);
+    for (ts, v) in [(1, "a"), (2, "b"), (3, "c"), (4, "d")] {
+        state.push_value_count(ts, v.to_string());
+    }
+    state.truncate_oldest(2, false);
+    let cond = CompiledCondition {
+        field: Some(vec!["User".to_string()]),
+        predicates: vec![(ConditionOperator::Gte, 1.0)],
+        percentile: None,
+    };
+    // Only the two newest distinct values remain.
+    let value = state.check_condition(&cond, CorrelationType::ValueCount, &[], None);
+    assert_eq!(value, Some(2.0));
+}
+
+#[test]
+fn test_truncate_oldest_temporal_caps_each_rule_deque() {
+    let mut state = WindowState::new_for(CorrelationType::Temporal);
+    for ts in 0..5 {
+        state.push_temporal(ts, "rule_a");
+    }
+    state.push_temporal(10, "rule_b");
+    state.truncate_oldest(2, false);
+    // rule_a trimmed to its 2 newest hits; rule_b untouched (1 <= cap).
+    assert_eq!(state.earliest_timestamp(), Some(3));
+    assert_eq!(state.latest_timestamp(), Some(10));
+}

--- a/crates/rsigma-eval/src/correlation/types.rs
+++ b/crates/rsigma-eval/src/correlation/types.rs
@@ -48,6 +48,10 @@ pub struct CompiledCorrelation {
     /// Maximum events to store per window group for event inclusion.
     /// `None` means use the engine default (`CorrelationConfig.max_correlation_events`).
     pub max_events: Option<usize>,
+    /// Maximum retained entries within a single group's window state,
+    /// resolved from the `rsigma.max_group_entries` custom attribute.
+    /// `None` means use the engine default (`CorrelationConfig.max_group_entries`).
+    pub max_group_entries: Option<usize>,
     /// Custom attributes from the original Sigma correlation rule (merged).
     /// Wrapped in `Arc` so that per-match cloning is a pointer bump.
     pub custom_attributes: Arc<HashMap<String, serde_json::Value>>,

--- a/crates/rsigma-eval/src/correlation/window.rs
+++ b/crates/rsigma-eval/src/correlation/window.rs
@@ -118,6 +118,54 @@ impl WindowState {
         }
     }
 
+    /// Enforce a per-group entry cap by dropping the oldest entries.
+    ///
+    /// `cap` is the maximum number of retained entries (clamped to at least
+    /// 1). For temporal state the cap applies to each referenced rule's hit
+    /// deque independently, since the deques are what grow with event rate.
+    ///
+    /// When `preserve_front` is set (session windows), the oldest entry is
+    /// kept and truncation happens behind it: the front entry anchors the
+    /// session's total-span cap (`timespan`), so dropping it would silently
+    /// let the session extend past the cap. Truncation can only under-count;
+    /// it never extends a window.
+    pub fn truncate_oldest(&mut self, cap: usize, preserve_front: bool) {
+        let cap = cap.max(1);
+
+        fn truncate_deque<T>(deque: &mut VecDeque<T>, cap: usize, preserve_front: bool) {
+            if deque.len() <= cap {
+                return;
+            }
+            if preserve_front {
+                let anchor = deque.pop_front().expect("len > cap >= 1");
+                // Keep the anchor plus the newest cap - 1 entries.
+                let excess = deque.len() - (cap - 1);
+                deque.drain(..excess);
+                deque.push_front(anchor);
+            } else {
+                let excess = deque.len() - cap;
+                deque.drain(..excess);
+            }
+        }
+
+        match self {
+            WindowState::EventCount { timestamps } => {
+                truncate_deque(timestamps, cap, preserve_front);
+            }
+            WindowState::ValueCount { entries } => {
+                truncate_deque(entries, cap, preserve_front);
+            }
+            WindowState::Temporal { rule_hits } => {
+                for timestamps in rule_hits.values_mut() {
+                    truncate_deque(timestamps, cap, preserve_front);
+                }
+            }
+            WindowState::NumericAgg { entries } => {
+                truncate_deque(entries, cap, preserve_front);
+            }
+        }
+    }
+
     /// Clear all entries from the window state (used by `CorrelationAction::Reset`).
     pub fn clear(&mut self) {
         match self {

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -635,6 +635,13 @@ impl CorrelationEngine {
             .unwrap_or(self.config.max_correlation_events)
     }
 
+    /// Resolve the per-group window-state entry cap for a given correlation.
+    /// `None` means unbounded.
+    fn resolve_max_group_entries(&self, corr_idx: usize) -> Option<usize> {
+        let corr = &self.correlations[corr_idx];
+        corr.max_group_entries.or(self.config.max_group_entries)
+    }
+
     /// Update a single correlation's state and check its condition.
     fn update_correlation(
         &mut self,
@@ -658,6 +665,7 @@ impl CorrelationEngine {
         let action = corr.action.unwrap_or(self.config.action_on_match);
         let event_mode = self.resolve_event_mode(corr_idx);
         let max_events = self.resolve_max_events(corr_idx);
+        let max_group_entries = self.resolve_max_group_entries(corr_idx);
 
         // Determine the rule_ref strings for alias resolution and temporal tracking.
         let mut ref_strs: Vec<&str> = Vec::new();
@@ -718,6 +726,13 @@ impl CorrelationEngine {
                     state.push_numeric(ts, n);
                 }
             }
+        }
+
+        // Enforce the per-group entry cap. Session windows keep their oldest
+        // entry as the span anchor so truncation cannot silently extend the
+        // `timespan` cap.
+        if let Some(cap) = max_group_entries {
+            state.truncate_oldest(cap, window_mode == WindowMode::Session);
         }
 
         // Push event into buffer based on event mode. Keep the buffer's retained
@@ -908,6 +923,12 @@ impl CorrelationEngine {
                     _ => {
                         state.push_event_count(ts);
                     }
+                }
+
+                // Same per-group cap as the direct path; session windows
+                // keep the span anchor.
+                if let Some(cap) = corr.max_group_entries.or(self.config.max_group_entries) {
+                    state.truncate_oldest(cap, window_mode == WindowMode::Session);
                 }
 
                 let fired = state.check_condition(

--- a/crates/rsigma-eval/src/correlation_engine/tests.rs
+++ b/crates/rsigma-eval/src/correlation_engine/tests.rs
@@ -536,6 +536,147 @@ fn test_evict_expired_drops_stale_session_group() {
 }
 
 // =========================================================================
+// Per-group entry cap (max_group_entries)
+// =========================================================================
+
+fn windowed_engine_with_group_cap(window_lines: &str, cap: usize) -> CorrelationEngine {
+    let collection = parse_sigma_yaml(&window_mode_yaml(window_lines)).unwrap();
+    let config = CorrelationConfig {
+        max_group_entries: Some(cap),
+        ..Default::default()
+    };
+    let mut engine = CorrelationEngine::new(config);
+    engine.add_collection(&collection).unwrap();
+    engine
+}
+
+#[test]
+fn test_max_group_entries_caps_event_count() {
+    // Cap of 2 retained entries: the gte-3 threshold can never be met,
+    // no matter how many events land in the window.
+    let mut engine = windowed_engine_with_group_cap("    timespan: 100s", 2);
+    let v = json!({"action": "click", "User": "admin"});
+    let event = JsonEvent::borrow(&v);
+    let mut fired = 0;
+    for ts in 0..10 {
+        fired += engine.process_event_at(&event, ts).correlation_count();
+    }
+    assert_eq!(fired, 0);
+
+    // Control: the same stream without a cap fires.
+    let mut engine = windowed_engine("    timespan: 100s");
+    let mut fired = 0;
+    for ts in 0..10 {
+        fired += engine.process_event_at(&event, ts).correlation_count();
+    }
+    assert!(fired > 0);
+}
+
+#[test]
+fn test_max_group_entries_session_keeps_span_anchor() {
+    // Cap of 2 on a session window (gap 10s, span cap 20s). Truncation must
+    // keep the session's oldest entry: if the anchor were dropped, the span
+    // would be measured from a later event and the t=24 arrival would extend
+    // the session (24-9=15s <= 20s) instead of resetting it (24-0=24s > 20s),
+    // letting the count reach the gte-3 threshold.
+    let mut engine =
+        windowed_engine_with_group_cap("    window: session\n    gap: 10s\n    timespan: 20s", 2);
+    let v = json!({"action": "click", "User": "admin"});
+    let event = JsonEvent::borrow(&v);
+    let mut fired = 0;
+    for ts in [0, 5, 9, 16, 24] {
+        fired += engine.process_event_at(&event, ts).correlation_count();
+    }
+    assert_eq!(fired, 0);
+}
+
+#[test]
+fn test_rsigma_max_group_entries_attribute_overrides_engine_default() {
+    // The per-correlation `rsigma.max_group_entries` custom attribute wins
+    // over the engine-level default (here: unbounded engine, capped rule).
+    let yaml = r#"
+title: Base
+id: base-cap
+logsource:
+    category: test
+detection:
+    selection:
+        action: click
+    condition: selection
+---
+title: Capped Clicks
+id: corr-cap
+rsigma.max_group_entries: '2'
+correlation:
+    type: event_count
+    rules:
+        - base-cap
+    group-by:
+        - User
+    timespan: 100s
+    condition:
+        gte: 3
+level: medium
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let v = json!({"action": "click", "User": "admin"});
+    let event = JsonEvent::borrow(&v);
+    let mut fired = 0;
+    for ts in 0..10 {
+        fired += engine.process_event_at(&event, ts).correlation_count();
+    }
+    assert_eq!(fired, 0);
+}
+
+#[test]
+fn test_max_group_entries_value_count_saturates_distinct() {
+    // value_count with a cap of 2: at most 2 distinct values retained, so a
+    // gte-3 distinct threshold cannot fire.
+    let yaml = r#"
+title: Login
+id: base-vc-cap
+logsource:
+    category: test
+detection:
+    selection:
+        action: login
+    condition: selection
+---
+title: Many Users
+id: corr-vc-cap
+correlation:
+    type: value_count
+    rules:
+        - base-vc-cap
+    group-by:
+        - Host
+    timespan: 100s
+    condition:
+        field: User
+        gte: 3
+level: medium
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let config = CorrelationConfig {
+        max_group_entries: Some(2),
+        ..Default::default()
+    };
+    let mut engine = CorrelationEngine::new(config);
+    engine.add_collection(&collection).unwrap();
+
+    let mut fired = 0;
+    for (ts, user) in [(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e")] {
+        let v = json!({"action": "login", "Host": "srv01", "User": user});
+        let event = JsonEvent::borrow(&v);
+        fired += engine.process_event_at(&event, ts).correlation_count();
+    }
+    assert_eq!(fired, 0);
+}
+
+// =========================================================================
 // Value count correlation
 // =========================================================================
 

--- a/crates/rsigma-eval/src/correlation_engine/types.rs
+++ b/crates/rsigma-eval/src/correlation_engine/types.rs
@@ -117,6 +117,23 @@ pub struct CorrelationConfig {
     /// Default: 100_000.
     pub max_state_entries: usize,
 
+    /// Maximum number of retained entries within a single group's window
+    /// state (timestamps for `event_count`, `(timestamp, value)` pairs for
+    /// `value_count` and the numeric aggregations, per-rule hits for
+    /// temporal types). Bounds the within-window growth that
+    /// `max_state_entries` does not: a group's deque otherwise grows with
+    /// `timespan` x event rate.
+    ///
+    /// When the cap is exceeded the oldest entries are dropped, which can
+    /// only under-count (aggregates saturate; correlations that would have
+    /// fired on evicted entries may not). Session windows always keep their
+    /// oldest entry as the span anchor so truncation cannot silently extend
+    /// the `timespan` cap.
+    ///
+    /// `None` (default) means unbounded, preserving existing behavior.
+    /// Can be overridden per-correlation via `rsigma.max_group_entries`.
+    pub max_group_entries: Option<usize>,
+
     /// Default suppression window in seconds.
     ///
     /// After a correlation fires for a `(correlation, group_key)`, suppress
@@ -167,6 +184,7 @@ impl Default for CorrelationConfig {
             ],
             timestamp_fallback: TimestampFallback::default(),
             max_state_entries: 100_000,
+            max_group_entries: None,
             suppress: None,
             action_on_match: CorrelationAction::default(),
             emit_detections: true,

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -103,6 +103,8 @@ See [TLS deployment](../../reference/security.md#tls-termination-for-the-api-lis
 | `--no-detections` | off | Suppress detection output for correlation-only base rules. |
 | `--correlation-event-mode <MODE>` | `none` | `none`, `full` (deflate-compressed full bodies), `refs` (timestamp + ID only). |
 | `--max-correlation-events <N>` | `10` | Cap on stored events per correlation window. |
+| `--max-state-entries <N>` | `100000` | Hard cap on correlation state entries across all correlations and group keys. When reached, the stalest entries are evicted to 90% capacity and a warning is logged. |
+| `--max-group-entries <N>` | unset | Cap on retained entries within a single correlation group's window state. Bounds within-window growth of chatty groups; oldest entries are dropped (session windows keep their span anchor). Unset = unbounded. |
 | `--timestamp-field <FIELD>` | unset | Field name to prepend to the timestamp extraction list. Repeatable. |
 | `--timestamp-fallback <MODE>` | `wallclock` | Behavior when no timestamp is found: `wallclock` (use wall clock time) or `skip` (skip correlation state for that event). Use `skip` for forensic replay. |
 

--- a/docs/cli/engine/eval.md
+++ b/docs/cli/engine/eval.md
@@ -67,6 +67,8 @@ The global `--output-format` / `--color` / `--quiet` / `--no-stats` flags apply 
 | `--action <ACTION>` | `alert` | Post-fire action for correlations: `alert` (keep state, re-alert on next match) or `reset` (clear window state). |
 | `--correlation-event-mode <MODE>` | `none` | Whether to embed contributing events in correlation output: `none`, `full` (deflate-compressed full bodies), `refs` (timestamp + ID only). |
 | `--max-correlation-events <N>` | `10` | Cap on stored events per correlation window when `--correlation-event-mode` is not `none`. Oldest evicted. |
+| `--max-state-entries <N>` | `100000` | Hard cap on correlation state entries across all correlations and group keys. When reached, the stalest entries are evicted to 90% capacity and a warning is logged. |
+| `--max-group-entries <N>` | unset | Cap on retained entries within a single correlation group's window state. Bounds within-window growth of chatty groups; oldest entries are dropped (session windows keep their span anchor). Unset = unbounded. Equivalent to the `rsigma.max_group_entries` custom attribute. |
 | `--timestamp-field <FIELD>` | unset | Field name to prepend to the timestamp extraction priority list. Default list: `@timestamp`, `timestamp`, `EventTime`, `TimeCreated`, `eventTime`. Repeatable. |
 
 ### Performance (advanced)

--- a/docs/guide/evaluating-rules.md
+++ b/docs/guide/evaluating-rules.md
@@ -105,6 +105,8 @@ rsigma engine eval -r rules/ --correlation-event-mode full --max-correlation-eve
 | `--no-detections` | Drop detection-level output, only emit correlation results. |
 | `--correlation-event-mode <none,full,refs>` | Whether to include contributing events in correlation output: `none` (zero overhead), `full` (deflate-compressed bodies), `refs` (timestamp + ID only). |
 | `--max-correlation-events N` | Cap the number of events stored per correlation window. Default 10. |
+| `--max-state-entries N` | Hard cap on correlation state entries across all correlations and group keys. Default 100,000. |
+| `--max-group-entries N` | Cap on retained entries within a single group's window state. Unset = unbounded. |
 | `--timestamp-field FIELD` | Add a field name to the front of the timestamp extraction list (default `@timestamp`, `timestamp`, `EventTime`, `TimeCreated`, `eventTime`). |
 
 For continuous correlation that survives restarts, switch to [streaming detection](streaming-detection.md) where state is persisted to SQLite.

--- a/docs/guide/performance-tuning.md
+++ b/docs/guide/performance-tuning.md
@@ -132,16 +132,16 @@ The trade-off: a higher `--batch-size` increases tail latency (an event waits up
 
 ## Memory pressure and correlation state
 
-Correlation state lives in memory unless `--state-db` writes periodic snapshots to SQLite. The hard cap is `max_state_entries`, default 100,000 `(correlation, group-key)` entries across all correlation rules. When the cap is hit, the engine evicts the stalest 10% and emits a warning.
+Correlation state lives in memory unless `--state-db` writes periodic snapshots to SQLite. The hard cap is `max_state_entries`, default 100,000 `(correlation, group-key)` entries across all correlation rules, settable with `--max-state-entries` (or `daemon.correlation.max_state_entries` in the config file). When the cap is hit, the engine evicts the stalest 10% and emits a warning.
 
-The cap bounds the number of groups, not bytes. Within a live group, the window state grows with `timespan` x event rate: 8 bytes per in-window event for `event_count`, 16 for the numeric aggregations (`value_sum`/`value_avg`/`value_percentile`/`value_median`), and roughly 32 bytes plus the value string for `value_count`. The measured shape (see [Benchmarks](../benchmarks.md#window-mode-memory-stress-0150)): 1M unique session keys against the default cap peaked at 39.8 MiB, and a fully chatty `event_count` workload (100 groups sustaining 1 event/s through a 2h session cap) held 6.3 MiB. A live but quiet session group costs ~256 bytes, dominated by the group-key strings.
+The cap bounds the number of groups, not the bytes within one. A single group's window state grows with `timespan` x event rate: 8 bytes per in-window event for `event_count`, 16 for the numeric aggregations (`value_sum`/`value_avg`/`value_percentile`/`value_median`), and roughly 32 bytes plus the value string for `value_count`. `--max-group-entries` (or the per-rule `rsigma.max_group_entries` custom attribute) caps that within-window growth; when a group exceeds it, the oldest entries are dropped, which can only under-count. Session windows always keep their oldest entry as the span anchor so truncation cannot silently extend the `timespan` cap. Unset means unbounded, the historical behavior. The measured shape (see [Benchmarks](../benchmarks.md#window-mode-memory-stress-0150)): 1M unique session keys against the default cap peaked at 39.8 MiB, and a fully chatty `event_count` workload (100 groups sustaining 1 event/s through a 2h session cap) held 6.3 MiB. A live but quiet session group costs ~256 bytes, dominated by the group-key strings.
 
 Window modes (`sliding`/`tumbling`/`session`) have identical per-event cost; they differ only in how long entries are retained. `tumbling` resets per-group state at each bucket boundary and is the cheapest under sustained load; `session` retains everything between the first event and the `timespan` cap, so it is the mode to watch on chatty groups.
 
 Two workload shapes deserve attention:
 
-- **`value_count` with high-cardinality values.** Every `(timestamp, value)` pair is retained for the window, and the distinct count is recomputed per event over the whole window — O(window size) per event. At 1,800 distinct values per window, measured throughput drops from ~1.1M to 63K events/s. CPU collapses before memory does. Prefer `event_count` where distinctness is not actually required, or shorten the window.
-- **Group-key cardinality floods.** Under cap pressure the stalest groups are evicted first, so a burst of unique keys can push a slow-burning session out of state before it completes. The eviction warning in the log is the tripwire; raise `max_state_entries` if the warning fires during legitimate traffic.
+- **`value_count` with high-cardinality values.** Every `(timestamp, value)` pair is retained for the window, and the distinct count is recomputed per event over the whole window — O(window size) per event. At 1,800 distinct values per window, measured throughput drops from ~1.1M to 63K events/s. CPU collapses before memory does. Prefer `event_count` where distinctness is not actually required, shorten the window, or set `--max-group-entries` to bound the retained pairs.
+- **Group-key cardinality floods.** Under cap pressure the stalest groups are evicted first, so a burst of unique keys can push a slow-burning session out of state before it completes. The eviction warning in the log is the tripwire; raise `--max-state-entries` if the warning fires during legitimate traffic.
 
 Watch:
 
@@ -151,6 +151,8 @@ Watch:
 Tune by:
 
 - Lowering the per-correlation window (`timespan: 5m` instead of `1h`) so older state expires faster.
+- Setting `--max-group-entries` (or `rsigma.max_group_entries` per-rule) to cap within-window growth on chatty groups, e.g. `value_count` rules over high-rate telemetry.
+- Lowering `--max-state-entries` on memory-constrained deployments, or raising it when the eviction warning fires during legitimate high-cardinality traffic.
 - Setting `--max-correlation-events 5` (or via `rsigma.max_correlation_events` per-rule) to cap the per-window event list.
 - Setting `--correlation-event-mode refs` to store lightweight references instead of full event bodies. `refs` mode keeps timestamps and event IDs only; `full` retains the deflate-compressed event JSON. `none` (the default) keeps no events.
 
@@ -188,7 +190,7 @@ Replace the synthetic Criterion inputs with rules and events that mirror your ow
 | Eval latency too high at 5k+ pure-substring rules | `--cross-rule-ac` (needs the `daachorse-index` build). |
 | Eval latency too high on substring-heavy rules with mostly-non-matching events | `--bloom-prefilter`. |
 | Daemon queue depth (`rsigma_input_queue_depth`) climbing under load | Raise `--batch-size` to 64 or 128, then `--buffer-size` to absorb bursts. |
-| `rsigma_correlation_state_entries` near 100k and growing | Shorter `timespan`, lower `max_correlation_events`, or `--correlation-event-mode refs`. |
+| `rsigma_correlation_state_entries` near 100k and growing | Shorter `timespan`, `--max-group-entries`, lower `max_correlation_events`, or `--correlation-event-mode refs`. Raise `--max-state-entries` if the traffic is legitimately high-cardinality. |
 | `rsigma_back_pressure_events_total` increasing rapidly | Upstream input is faster than the engine. Raise `--batch-size`, scale horizontally with NATS consumer groups (see [NATS Streaming](nats-streaming.md#consumer-groups)), or shed load upstream. |
 | Tail latency too high after raising `--batch-size` | Lower the batch size; the trade-off has reached the wrong side of the curve. |
 

--- a/docs/guide/processing-pipelines.md
+++ b/docs/guide/processing-pipelines.md
@@ -181,6 +181,7 @@ Transformations can write per-rule attributes that the engine and backends read.
 | `rsigma.include_event` | detection engine | Embed the full event JSON in detection output for this rule. |
 | `rsigma.correlation_event_mode` | correlation engine | `none`, `full`, `refs` for one rule. |
 | `rsigma.max_correlation_events` | correlation engine | Per-window event cap for one rule. |
+| `rsigma.max_group_entries` | correlation engine | Per-group window-state entry cap for one rule. |
 | `postgres.table` | PostgreSQL backend | Override the target table for one rule. |
 | `postgres.schema` | PostgreSQL backend | Override the schema. |
 | `postgres.database` | PostgreSQL backend | Override the database. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -57,6 +57,8 @@ daemon:
     action: alert
     event_mode: none
     max_events: 10
+    max_state_entries: 100000   # hard cap across all correlations and groups
+    # max_group_entries: 10000  # per-group window-state cap; unset = unbounded
   state:
     save_interval: 30
   engine:

--- a/docs/reference/custom-attributes.md
+++ b/docs/reference/custom-attributes.md
@@ -17,6 +17,7 @@ CLI flags and library API calls always take precedence over `custom_attributes` 
 | `rsigma.include_event` | Embed the full event JSON in detection output for this rule. `"true"` or `"false"`. | `--include-event` | Per-rule |
 | `rsigma.correlation_event_mode` | Correlation event inclusion: `none`, `full` (deflate-compressed bodies), `refs` (timestamp + ID only). | `--correlation-event-mode` | Per-correlation |
 | `rsigma.max_correlation_events` | Cap on events stored per correlation window for this rule. Integer. | `--max-correlation-events` | Per-correlation |
+| `rsigma.max_group_entries` | Cap on retained entries within a single group's window state for this rule (timestamps, value pairs, or per-rule hits). Oldest entries are dropped; session windows keep their span anchor. Integer, quoted. | `--max-group-entries` | Per-correlation |
 
 ### Example: keep full events for a brute-force rule, default for everything else
 


### PR DESCRIPTION
## Summary

Follow-up to the window-mode memory analysis (#199): the `max_state_entries` hard cap bounds the number of `(correlation, group-key)` entries but not the bytes within one group, whose window state grows with `timespan` x event rate. This PR makes both bounds operator-configurable.

- **`--max-state-entries <N>`** on `engine eval` and `engine daemon` (config key `daemon.correlation.max_state_entries`) exposes the existing global cap, previously a library-only setting. Eviction behavior is unchanged: stalest entries drop to 90% capacity with a warning. A drift-guard test pins the CLI default to the engine's `CorrelationConfig::default()` across the two crates.
- **`--max-group-entries <N>`** (config key `daemon.correlation.max_group_entries`, per-rule `rsigma.max_group_entries` custom attribute) is a new opt-in cap on retained entries within a single group's window state: timestamps for `event_count`, `(timestamp, value)` pairs for `value_count` and the numeric aggregations, per-referenced-rule hits for temporal types. On overflow the oldest entries are dropped, which can only under-count. Session windows always keep their oldest entry as the span anchor, so truncation cannot silently extend the `timespan` cap (covered by a dedicated test that would fire spuriously if the anchor were dropped). Unset = unbounded, so existing deployments are unaffected.
- **API**: `CorrelationConfig.max_group_entries`, the matching `CompiledCorrelation` per-rule override, and `WindowState::truncate_oldest(cap, preserve_front)`. Enforced in both the direct and chained correlation paths.
- **Docs**: CLI pages for both commands, configuration reference + config-init template, custom-attributes reference, processing-pipelines attribute table, and the Performance Tuning correlation-memory section (which now states the global cap is across all rules, not per rule, and what each cap does and does not bound).

## Test plan

- [x] 7 new unit tests for `truncate_oldest` (plain, anchor-preserving, clamp, value_count, temporal per-deque)
- [x] 4 new engine tests: event_count cap with uncapped control, session anchor preservation end to end, `rsigma.max_group_entries` override, value_count distinct saturation
- [x] Drift guards: clap daemon default for `max_state_entries` matches `config::defaults`, and the CLI constant matches the engine default
- [x] `cargo test -p rsigma-eval -p rsigma --all-features`: 988 passed
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `mkdocs build --strict` passes
- [x] CI multi-OS matrix