### PR TITLE
feat(proto): portable Sigma IR protobuf interchange + conformance vectors

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,49 @@
+# Sigma portable IR (protobuf interchange)
+
+A language-neutral schema for a **post-pipeline, modifier-resolved, selector-resolved** Sigma rule. It is the single source of truth that an engine's internal HIR is generated from or conformance-locked against, and the wire message a remote backend (pySigma, RSigma, or any future engine) responds to.
+
+The schema reconciles the RSigma parser AST/HIR with pySigma's resolved types, conditions, modifiers, correlations, and filters, so both engines lower to and consume the same form.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `sigma_ir.proto` | The IR message schema: values, matchers, detections, conditions, rule/correlation/filter, metadata, and the `Pack` envelope. |
+| `sigma_backend.proto` | The `SigmaBackend` gRPC service (`Capabilities` + `Convert`). A thin transport over the message schema; a backend can run as a local subprocess or a remote endpoint. |
+| `conformance/` | Golden `(rule YAML -> canonical IR)` vectors that any implementation must reproduce. See `conformance/README.md`. |
+
+## Level
+
+The schema sits at the post-modifier, selector-resolved layer that both engines independently arrive at:
+
+- **pySigma** applies modifiers (turning `contains`/`re`/`cidr`/`fieldref`/`gt` into resolved `SigmaType` values) and expands selectors in `postprocess`.
+- **RSigma** lowers to its `IrMatcher`/`IrCondition` HIR.
+
+Consequences baked into the schema:
+
+- The wire IR is **fully modifier-resolved**: encoding modifiers (`base64`/`base64offset`/`wide`/`windash`) are applied before serialization, so no encoding logic ever crosses the wire (`base64offset`/`windash` become an `any_of` of resolved string matchers).
+- **Negation is a detection-item flag** (`IrDetectionItem.negated`), matching pySigma's general `neq`/`SigmaNegateModifier`, not a numeric operator.
+- **Selectors never cross the wire**; both engines expand them, so a consumer always sees a concrete boolean tree over named detections.
+
+## Conventions
+
+- Field numbers are stable once published; `reserved` ranges mark room for additive growth.
+- `oneof` is used wherever the source model is a sum type.
+- `oneof` arms avoid language keywords (`negation`/`conjunction`/`disjunction`/`boolean`) so generated code is clean in Python, Rust, and Go.
+- Placeholders (pySigma `%name%` and RSigma `${source.*}`) are modeled as string **parts**, a superset of a value-level deferred reference. pySigma emits resolved literals; RSigma may emit a `dynamic_ref`.
+
+## Compiling
+
+```sh
+# descriptor set (validation)
+protoc --proto_path=. --descriptor_set_out=/dev/null sigma_ir.proto sigma_backend.proto
+
+# language bindings (examples)
+protoc --proto_path=. --python_out=out sigma_ir.proto sigma_backend.proto
+# Rust via prost-build / tonic-build in build.rs
+# Go via protoc-gen-go / protoc-gen-go-grpc
+```
+
+## Status and home
+
+This lives on the `feat/portable-ir-proto` branch of the rsigma repo for now. The intent is to extract `proto/` into a neutral standalone `sigma-ir-schema` repo so a second implementation (pySigma) can vendor it credibly.

--- a/proto/conformance/README.md
+++ b/proto/conformance/README.md
@@ -1,0 +1,48 @@
+# Conformance vectors
+
+Golden `(rule YAML -> canonical IR)` pairs. Serialization agreeing is necessary but not sufficient for portability: two engines must agree on **semantics** (modifier resolution order, default case-insensitivity, base64offset/windash expansion, selector expansion, the spec's ambiguous corners). These vectors pin that agreement.
+
+## Vector format
+
+Each file in `vectors/` is one vector:
+
+```json
+{
+  "name": "string-contains",
+  "description": "Human-readable explanation of what this pins.",
+  "message_type": "IrRule",         // IrRule | IrCorrelation | IrFilter
+  "input_yaml": "title: ...\n...",  // the Sigma document
+  "ir": { ...canonical IR as proto3 JSON... }
+}
+```
+
+- `ir` is **proto3 canonical JSON** for the `message_type`: lowerCamelCase field names, enum values as their string names (e.g. `"COMPARE_OP_GT"`), `oneof` as a single set key, `int64`/`uint64`/`sint64` as JSON strings, an empty message as `{}`.
+- Comparison is **structural**: an implementation parses both its own output and the vector's `ir` into the proto message and compares messages, so proto3's omission of default/zero-value fields is harmless.
+
+## `SigmaString.original`
+
+`original` is for round-trip and diagnostics, not semantics; the `parts` are authoritative. In these vectors `original` is the value **rendered with wildcards as literal `*` / `?`** (e.g. a `contains: whoami` renders `*whoami*`, and an escaped `\*` renders `\*`). Implementations should compare on `parts`, not `original`, unless they intend an exact round-trip.
+
+## Status (first cut, hand-authored)
+
+These are the **intended** canonical outputs, authored by hand from the schema and its reconciliation rules. They are not yet produced by a reference engine, because the pySigma IR emitter and the RSigma binding are downstream work. Once an emitter exists, regenerate these from the reference engine and treat any diff as a bug in the vector or the engine.
+
+Modifier expansions that are easy to get wrong (`base64offset`, `windash`) were computed with pySigma's exact algorithm, not eyeballed.
+
+## Coverage
+
+- Matchers: exact, contains, startswith, endswith, escaped-wildcard, regex (+flags), cidr, numeric compare, fieldref, exists, null, bool.
+- Value linking: `all` (AND) and the default value-list OR.
+- Expansions: `base64offset`, `windash`.
+- Detections/conditions: keywords, selector resolution, `and not`.
+- Top-level: an `event_count` correlation, a filter, a metadata-rich rule.
+
+Next: one vector per remaining correlation type, the `ArrayMatch`/`Conditional` extensions, `timestamp` part matching, and adversarial inputs (CJK/emoji values, very large integers, deeply nested conditions).
+
+## Validating a vector file against the schema
+
+```sh
+python3 -m venv .venv && .venv/bin/pip install protobuf
+protoc --proto_path=.. --python_out=/tmp/pb ../sigma_ir.proto
+# then json_format.ParseDict(vector["ir"], <message_type>()) must not raise
+```

--- a/proto/conformance/vectors/01-string-exact.json
+++ b/proto/conformance/vectors/01-string-exact.json
@@ -1,0 +1,28 @@
+{
+  "name": "string-exact",
+  "description": "Default full-value string match (case-insensitive). No modifier, no wildcards.",
+  "message_type": "IrRule",
+  "input_yaml": "title: String exact\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    Image: 'cmd.exe'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "String exact" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "Image",
+              "matcher": {
+                "stringMatch": {
+                  "value": { "parts": [ { "plain": "cmd.exe" } ], "original": "cmd.exe" },
+                  "hint": "STRING_MATCH_HINT_EXACT"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/02-string-contains.json
+++ b/proto/conformance/vectors/02-string-contains.json
@@ -1,0 +1,35 @@
+{
+  "name": "string-contains",
+  "description": "contains modifier inserts a leading and trailing multi-wildcard. hint records the intent.",
+  "message_type": "IrRule",
+  "input_yaml": "title: String contains\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    CommandLine|contains: 'whoami'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "String contains" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "stringMatch": {
+                  "value": {
+                    "parts": [
+                      { "wildcardMulti": {} },
+                      { "plain": "whoami" },
+                      { "wildcardMulti": {} }
+                    ],
+                    "original": "*whoami*"
+                  },
+                  "hint": "STRING_MATCH_HINT_CONTAINS"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/03-string-startswith.json
+++ b/proto/conformance/vectors/03-string-startswith.json
@@ -1,0 +1,34 @@
+{
+  "name": "string-startswith",
+  "description": "startswith modifier appends a trailing multi-wildcard.",
+  "message_type": "IrRule",
+  "input_yaml": "title: String startswith\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    Image|startswith: 'C:\\Windows\\System32'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "String startswith" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "Image",
+              "matcher": {
+                "stringMatch": {
+                  "value": {
+                    "parts": [
+                      { "plain": "C:\\Windows\\System32" },
+                      { "wildcardMulti": {} }
+                    ],
+                    "original": "C:\\Windows\\System32*"
+                  },
+                  "hint": "STRING_MATCH_HINT_STARTS_WITH"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/04-string-endswith.json
+++ b/proto/conformance/vectors/04-string-endswith.json
@@ -1,0 +1,34 @@
+{
+  "name": "string-endswith",
+  "description": "endswith modifier prepends a leading multi-wildcard. Canonical Image-endswith pattern; backslash before a non-special char stays literal.",
+  "message_type": "IrRule",
+  "input_yaml": "title: String endswith\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    Image|endswith: '\\cmd.exe'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "String endswith" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "Image",
+              "matcher": {
+                "stringMatch": {
+                  "value": {
+                    "parts": [
+                      { "wildcardMulti": {} },
+                      { "plain": "\\cmd.exe" }
+                    ],
+                    "original": "*\\cmd.exe"
+                  },
+                  "hint": "STRING_MATCH_HINT_ENDS_WITH"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/05-string-escaped-wildcard.json
+++ b/proto/conformance/vectors/05-string-escaped-wildcard.json
@@ -1,0 +1,31 @@
+{
+  "name": "string-escaped-wildcard",
+  "description": "Adversarial: an escaped \\* is a LITERAL asterisk, not a wildcard. So 'C:\\Windows\\*' is plain text with no wildcard parts. original renders the literal star re-escaped.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Escaped wildcard\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    Image: 'C:\\Windows\\*'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Escaped wildcard" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "Image",
+              "matcher": {
+                "stringMatch": {
+                  "value": {
+                    "parts": [ { "plain": "C:\\Windows*" } ],
+                    "original": "C:\\Windows\\*"
+                  },
+                  "hint": "STRING_MATCH_HINT_EXACT"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/06-regex-flags.json
+++ b/proto/conformance/vectors/06-regex-flags.json
@@ -1,0 +1,29 @@
+{
+  "name": "regex-flags",
+  "description": "re modifier yields a RegexMatch; trailing i and m modifiers set the ignorecase and multiline flags. Wildcards are NOT interpreted in regex values.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Regex with flags\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    CommandLine|re|i|m: 'foo.*bar'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Regex with flags" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "regex": {
+                  "pattern": "foo.*bar",
+                  "ignorecase": true,
+                  "multiline": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/07-cidr.json
+++ b/proto/conformance/vectors/07-cidr.json
@@ -1,0 +1,23 @@
+{
+  "name": "cidr",
+  "description": "cidr modifier yields a CidrMatch carrying the network as a string; the backend expands or matches it natively.",
+  "message_type": "IrRule",
+  "input_yaml": "title: CIDR match\nlogsource:\n  category: firewall\ndetection:\n  selection:\n    SourceIp|cidr: '10.0.0.0/8'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "CIDR match" },
+    "logsource": { "category": "firewall" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "SourceIp",
+              "matcher": { "cidr": { "network": "10.0.0.0/8" } }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/08-numeric-gt.json
+++ b/proto/conformance/vectors/08-numeric-gt.json
@@ -1,0 +1,28 @@
+{
+  "name": "numeric-gt",
+  "description": "gt modifier yields a numeric compare. A plain integer value (no modifier) would be COMPARE_OP_EQ. Note sint64 is encoded as a JSON string in proto3 JSON.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Numeric greater-than\nlogsource:\n  product: windows\n  service: security\ndetection:\n  selection:\n    EventID|gt: 4000\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Numeric greater-than" },
+    "logsource": { "product": "windows", "service": "security" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "EventID",
+              "matcher": {
+                "numeric": {
+                  "op": "COMPARE_OP_GT",
+                  "value": { "intValue": "4000" }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/09-fieldref.json
+++ b/proto/conformance/vectors/09-fieldref.json
@@ -1,0 +1,23 @@
+{
+  "name": "fieldref",
+  "description": "fieldref modifier compares one field against the value of another field rather than a literal.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Field reference\nlogsource:\n  category: file_event\n  product: windows\ndetection:\n  selection:\n    TargetFilename|fieldref: 'SourceFilename'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Field reference" },
+    "logsource": { "category": "file_event", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "TargetFilename",
+              "matcher": { "fieldRef": { "field": "SourceFilename" } }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/10-exists-null-bool.json
+++ b/proto/conformance/vectors/10-exists-null-bool.json
@@ -1,0 +1,22 @@
+{
+  "name": "exists-null-bool",
+  "description": "Three single-value matchers in one AND selection: field existence check, explicit null match, and a boolean value match.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Exists, null, bool\nlogsource:\n  category: registry_event\n  product: windows\ndetection:\n  selection:\n    Image|exists: true\n    TargetObject: null\n    Reversible: true\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Exists, null, bool" },
+    "logsource": { "category": "registry_event", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            { "field": "Image", "matcher": { "exists": { "exists": true } } },
+            { "field": "TargetObject", "matcher": { "null": {} } },
+            { "field": "Reversible", "matcher": { "boolean": { "value": true } } }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/11-value-linking.json
+++ b/proto/conformance/vectors/11-value-linking.json
@@ -1,0 +1,56 @@
+{
+  "name": "value-linking",
+  "description": "Value-list linking. sel_all uses |all so the two contains values are AND-linked (all_of). sel_any uses the default, so the two values are OR-linked (any_of).",
+  "message_type": "IrRule",
+  "input_yaml": "title: Value linking\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  sel_all:\n    CommandLine|contains|all:\n      - '-enc'\n      - '-noprofile'\n  sel_any:\n    CommandLine|contains:\n      - 'powershell'\n      - 'pwsh'\n  condition: sel_all and sel_any\n",
+  "ir": {
+    "metadata": { "title": "Value linking" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "sel_all": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "allOf": {
+                  "matchers": [
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "-enc" }, { "wildcardMulti": {} } ], "original": "*-enc*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "-noprofile" }, { "wildcardMulti": {} } ], "original": "*-noprofile*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "sel_any": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "anyOf": {
+                  "matchers": [
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "powershell" }, { "wildcardMulti": {} } ], "original": "*powershell*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "pwsh" }, { "wildcardMulti": {} } ], "original": "*pwsh*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [
+      {
+        "conjunction": {
+          "conditions": [
+            { "detectionRef": "sel_all" },
+            { "detectionRef": "sel_any" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/proto/conformance/vectors/12-base64offset.json
+++ b/proto/conformance/vectors/12-base64offset.json
@@ -1,0 +1,31 @@
+{
+  "name": "base64offset",
+  "description": "base64offset expands the value into three offset-aligned base64 encodings, OR-linked (any_of). Encodings computed with pySigma's exact algorithm (start_offsets=(0,2,3), end_offsets=(None,-3,-2)). The trailing |contains is the canonical real-world usage. Encoding modifiers are fully resolved on the wire; no base64 logic crosses it.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Base64 offset\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    CommandLine|base64offset|contains: 'cmd.exe'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Base64 offset" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "anyOf": {
+                  "matchers": [
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "Y21kLmV4Z" }, { "wildcardMulti": {} } ], "original": "*Y21kLmV4Z*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "NtZC5leG" }, { "wildcardMulti": {} } ], "original": "*NtZC5leG*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "jbWQuZXhl" }, { "wildcardMulti": {} } ], "original": "*jbWQuZXhl*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/13-windash.json
+++ b/proto/conformance/vectors/13-windash.json
@@ -1,0 +1,33 @@
+{
+  "name": "windash",
+  "description": "windash expands an interchangeable dash/slash at a word boundary into five forms (-, /, en-dash U+2013, em-dash U+2014, horizontal-bar U+2015), OR-linked. The trailing |contains wraps each. Expansion computed with pySigma's exact regex (\\B[-/]\\b) and replacement set.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Windash\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    CommandLine|windash|contains: '-encodedcommand'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Windash" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "anyOf": {
+                  "matchers": [
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "-encodedcommand" }, { "wildcardMulti": {} } ], "original": "*-encodedcommand*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "/encodedcommand" }, { "wildcardMulti": {} } ], "original": "*/encodedcommand*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "\u2013encodedcommand" }, { "wildcardMulti": {} } ], "original": "*\u2013encodedcommand*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "\u2014encodedcommand" }, { "wildcardMulti": {} } ], "original": "*\u2014encodedcommand*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } },
+                    { "stringMatch": { "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "\u2015encodedcommand" }, { "wildcardMulti": {} } ], "original": "*\u2015encodedcommand*" }, "hint": "STRING_MATCH_HINT_CONTAINS" } }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/14-keywords.json
+++ b/proto/conformance/vectors/14-keywords.json
@@ -1,0 +1,20 @@
+{
+  "name": "keywords",
+  "description": "Field-less keyword detection. The keywords arm carries an IrMatcher with no field; consumers apply full-text (substring) matching semantics. Hint left unspecified because keyword search semantics are the consumer's, not encoded as wildcards here.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Keyword search\nlogsource:\n  product: linux\ndetection:\n  keywords: 'mimikatz'\n  condition: keywords\n",
+  "ir": {
+    "metadata": { "title": "Keyword search" },
+    "logsource": { "product": "linux" },
+    "detections": {
+      "keywords": {
+        "keywords": {
+          "stringMatch": {
+            "value": { "parts": [ { "plain": "mimikatz" } ], "original": "mimikatz" }
+          }
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "keywords" } ]
+  }
+}

--- a/proto/conformance/vectors/15-selector-resolved.json
+++ b/proto/conformance/vectors/15-selector-resolved.json
@@ -1,0 +1,28 @@
+{
+  "name": "selector-resolved",
+  "description": "Selector '1 of selection_*' is resolved at lowering time into an explicit OR (disjunction) over the matching named detections. No selector ever crosses the wire.",
+  "message_type": "IrRule",
+  "input_yaml": "title: Selector resolution\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection_a:\n    EventID: 1\n  selection_b:\n    EventID: 2\n  condition: 1 of selection_*\n",
+  "ir": {
+    "metadata": { "title": "Selector resolution" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection_a": {
+        "allOf": { "items": [ { "field": "EventID", "matcher": { "numeric": { "op": "COMPARE_OP_EQ", "value": { "intValue": "1" } } } } ] }
+      },
+      "selection_b": {
+        "allOf": { "items": [ { "field": "EventID", "matcher": { "numeric": { "op": "COMPARE_OP_EQ", "value": { "intValue": "2" } } } } ] }
+      }
+    },
+    "conditions": [
+      {
+        "disjunction": {
+          "conditions": [
+            { "detectionRef": "selection_a" },
+            { "detectionRef": "selection_b" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/proto/conformance/vectors/16-correlation-event-count.json
+++ b/proto/conformance/vectors/16-correlation-event-count.json
@@ -1,0 +1,18 @@
+{
+  "name": "correlation-event-count",
+  "description": "An event_count correlation. timespan parsed to count/unit/seconds (original kept). Threshold condition with a single gte predicate. window defaults to sliding (omitted = WINDOW_MODE_UNSPECIFIED, treated as sliding). uint64 fields encode as JSON strings.",
+  "message_type": "IrCorrelation",
+  "input_yaml": "title: Multiple failed logins\ncorrelation:\n  type: event_count\n  rules:\n    - failed_login\n  group-by:\n    - User\n  timespan: 5m\n  condition:\n    gte: 10\n",
+  "ir": {
+    "metadata": { "title": "Multiple failed logins" },
+    "correlationType": "CORRELATION_TYPE_EVENT_COUNT",
+    "rules": [ "failed_login" ],
+    "groupBy": [ "User" ],
+    "timespan": { "count": "5", "unit": "TIME_UNIT_MINUTE", "seconds": "300", "original": "5m" },
+    "condition": {
+      "threshold": {
+        "predicates": [ { "op": "CONDITION_OPERATOR_GTE", "count": "10" } ]
+      }
+    }
+  }
+}

--- a/proto/conformance/vectors/17-filter.json
+++ b/proto/conformance/vectors/17-filter.json
@@ -1,0 +1,29 @@
+{
+  "name": "filter",
+  "description": "A global filter rule targeting specific rule IDs, with its own logsource, detections, and condition. The target is a FilterTarget.specific list ('any' would be the Empty arm).",
+  "message_type": "IrFilter",
+  "input_yaml": "title: Exclude admin baseline\nlogsource:\n  product: windows\nfilter:\n  rules:\n    - 0e2f7e1a-1111-2222-3333-444455556666\n  selection:\n    User: 'admin'\n  condition: selection\n",
+  "ir": {
+    "metadata": { "title": "Exclude admin baseline" },
+    "rules": { "specific": { "values": [ "0e2f7e1a-1111-2222-3333-444455556666" ] } },
+    "logsource": { "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "User",
+              "matcher": {
+                "stringMatch": {
+                  "value": { "parts": [ { "plain": "admin" } ], "original": "admin" },
+                  "hint": "STRING_MATCH_HINT_EXACT"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/conformance/vectors/18-condition-and-not.json
+++ b/proto/conformance/vectors/18-condition-and-not.json
@@ -1,0 +1,52 @@
+{
+  "name": "condition-and-not",
+  "description": "Boolean condition 'selection and not filter' lowers to a conjunction whose second arm is a negation of a detection reference. Negation here is a condition combinator (distinct from per-item negation / neq).",
+  "message_type": "IrRule",
+  "input_yaml": "title: And not\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n  selection:\n    Image|endswith: '\\rundll32.exe'\n  filter:\n    CommandLine|contains: 'legitimate'\n  condition: selection and not filter\n",
+  "ir": {
+    "metadata": { "title": "And not" },
+    "logsource": { "category": "process_creation", "product": "windows" },
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            {
+              "field": "Image",
+              "matcher": {
+                "stringMatch": {
+                  "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "\\rundll32.exe" } ], "original": "*\\rundll32.exe" },
+                  "hint": "STRING_MATCH_HINT_ENDS_WITH"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "filter": {
+        "allOf": {
+          "items": [
+            {
+              "field": "CommandLine",
+              "matcher": {
+                "stringMatch": {
+                  "value": { "parts": [ { "wildcardMulti": {} }, { "plain": "legitimate" }, { "wildcardMulti": {} } ], "original": "*legitimate*" },
+                  "hint": "STRING_MATCH_HINT_CONTAINS"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [
+      {
+        "conjunction": {
+          "conditions": [
+            { "detectionRef": "selection" },
+            { "negation": { "detectionRef": "filter" } }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/proto/conformance/vectors/19-metadata-superset.json
+++ b/proto/conformance/vectors/19-metadata-superset.json
@@ -1,0 +1,42 @@
+{
+  "name": "metadata-superset",
+  "description": "Exercises the IrRuleMetadata superset: id, status, level, author, date, references, tags, falsepositives, related, sigma_version, and custom_attributes (map<string, google.protobuf.Value> carrying a bool and a number). Also a per-item negated match (neq).",
+  "message_type": "IrRule",
+  "input_yaml": "title: Suspicious service install\nid: 0e2f7e1a-aaaa-bbbb-cccc-444455556666\nstatus: test\nlevel: high\nauthor: Jane Doe\ndate: 2026/06/13\nreferences:\n  - https://example.com/threat\ntags:\n  - attack.persistence\n  - attack.t1543.003\nfalsepositives:\n  - Legitimate software installs\nrelated:\n  - id: 11112222-3333-4444-5555-666677778888\n    type: derived\ndetection:\n  selection:\n    EventID: 7045\n    ServiceName|endswith|neq: '.sys'\n  condition: selection\n",
+  "ir": {
+    "metadata": {
+      "title": "Suspicious service install",
+      "id": "0e2f7e1a-aaaa-bbbb-cccc-444455556666",
+      "status": "STATUS_TEST",
+      "level": "LEVEL_HIGH",
+      "author": "Jane Doe",
+      "date": "2026/06/13",
+      "references": [ "https://example.com/threat" ],
+      "tags": [ "attack.persistence", "attack.t1543.003" ],
+      "falsepositives": [ "Legitimate software installs" ],
+      "related": [ { "id": "11112222-3333-4444-5555-666677778888", "relationType": "RELATION_TYPE_DERIVED" } ],
+      "customAttributes": { "rsigma.suppress": true, "risk_score": 75 }
+    },
+    "logsource": {},
+    "detections": {
+      "selection": {
+        "allOf": {
+          "items": [
+            { "field": "EventID", "matcher": { "numeric": { "op": "COMPARE_OP_EQ", "value": { "intValue": "7045" } } } },
+            {
+              "field": "ServiceName",
+              "negated": true,
+              "matcher": {
+                "stringMatch": {
+                  "value": { "parts": [ { "wildcardMulti": {} }, { "plain": ".sys" } ], "original": "*.sys" },
+                  "hint": "STRING_MATCH_HINT_ENDS_WITH"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "conditions": [ { "detectionRef": "selection" } ]
+  }
+}

--- a/proto/sigma_backend.proto
+++ b/proto/sigma_backend.proto
@@ -1,0 +1,56 @@
+// Remote Sigma backend service.
+//
+// A thin transport layer on top of sigma_ir.proto: a backend, written once,
+// responds to strongly typed messages so any engine (pySigma, RSigma, or a
+// future engine) can reuse it. The backend can run as a go-plugin-style local
+// subprocess or as a remote endpoint; both speak this contract.
+
+syntax = "proto3";
+
+package sigma.ir.v1;
+
+import "sigma_ir.proto";
+
+service SigmaBackend {
+  // What this backend supports, so an engine can fail fast on unsupported
+  // matcher/detection kinds rather than receiving wrong output.
+  rpc Capabilities(CapabilitiesRequest) returns (CapabilitiesResponse);
+
+  // Convert a pack into target queries.
+  rpc Convert(ConvertRequest) returns (ConvertResponse);
+}
+
+message CapabilitiesRequest {}
+
+message CapabilitiesResponse {
+  string backend_name = 1;
+  SchemaVersion max_schema_version = 2;
+  // Named output formats, e.g. "default", "siem_rule", "ndjson".
+  repeated string output_formats = 3;
+  // Capability tokens this backend understands, e.g. "ARRAY_MATCH",
+  // "CONDITIONAL", "QUERY_EXPR", "DYNAMIC_REF", "CORRELATION",
+  // "WINDOW_MODES".
+  repeated string capabilities = 4;
+}
+
+message ConvertRequest {
+  Pack pack = 1;
+  string output_format = 2; // empty => backend default
+  // Backend-specific knobs (e.g. index name, field prefix).
+  map<string, string> options = 3;
+}
+
+message ConvertResponse {
+  message RuleResult {
+    string rule_id = 1; // metadata.id or name
+    repeated string queries = 2;
+    // Set instead of queries when this rule cannot be expressed.
+    optional Unsupported unsupported = 3;
+  }
+  repeated RuleResult results = 1;
+}
+
+message Unsupported {
+  string rule_id = 1;
+  string reason = 2;
+}

--- a/proto/sigma_ir.proto
+++ b/proto/sigma_ir.proto
@@ -1,0 +1,464 @@
+// Sigma portable intermediate representation (IR).
+//
+// A language-neutral schema for a post-pipeline, modifier-resolved,
+// selector-resolved Sigma rule. It is the single source of truth that an
+// engine's internal HIR is generated from or conformance-locked against, and
+// the wire message a remote backend (pySigma, RSigma, or any future engine)
+// responds to.
+//
+// Level: this sits at the post-modifier, selector-resolved layer that both
+// pySigma (after modifier application + condition postprocess) and RSigma
+// (its planned IrMatcher/IrCondition HIR) independently arrive at.
+//
+// Conventions:
+//   * Field numbers are stable once published. `reserved` ranges mark room
+//     for additive growth.
+//   * oneof is used wherever the source model is a sum type, so an unknown
+//     arm round-trips as an unset field rather than coercing.
+//   * oneof field names avoid language keywords (negation/conjunction/
+//     disjunction/boolean) so generated code is clean in Python/Rust/Go.
+//   * Comparison of two encodings is by decoding to the message and comparing
+//     structurally; proto3 JSON default-value omission is therefore harmless.
+
+syntax = "proto3";
+
+package sigma.ir.v1;
+
+import "google/protobuf/struct.proto";
+
+option go_package = "github.com/sigma/ir/v1;sigmairv1";
+
+// ---------------------------------------------------------------------------
+// Schema + pack envelope
+// ---------------------------------------------------------------------------
+
+// Independent of any engine version. Bump major on a breaking field-number or
+// semantic change; minor on additive fields.
+message SchemaVersion {
+  uint32 major = 1;
+  uint32 minor = 2;
+}
+
+// A self-describing bundle of rules: the unit a pack file or a gRPC request
+// carries.
+message Pack {
+  SchemaVersion schema_version = 1;
+  // Free-form producer identity, e.g. "rsigma 0.14.0" or "pySigma 0.11.2".
+  string producer = 2;
+  // Static pipelines already applied at build time, so a load-time pipeline
+  // does not double-apply field mappings.
+  repeated string applied_pipelines = 3;
+  // True if any value still carries a dynamic_ref placeholder (needs
+  // specialization against a source cache before it can be compiled).
+  bool requires_specialization = 4;
+  // source_ids referenced by surviving dynamic_ref placeholders, so a loader
+  // fails fast when a required source is undeclared.
+  repeated string required_source_ids = 5;
+
+  repeated IrRule rules = 16;
+  repeated IrCorrelation correlations = 17;
+  repeated IrFilter filters = 18;
+
+  // reserved 6 to 15 for envelope growth; 19+ for new top-level doc kinds.
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+message Empty {}
+
+message SigmaString {
+  message Part {
+    oneof part {
+      string plain = 1;
+      Empty wildcard_multi = 2;   // '*'
+      Empty wildcard_single = 3;  // '?'
+      Placeholder placeholder = 4;
+    }
+  }
+  repeated Part parts = 1;
+  // Original raw value as authored, retained for round-trip and diagnostics.
+  string original = 2;
+}
+
+// A placeholder string-part. Resolved forms have already been substituted by
+// the producer; an unresolved placeholder survives as one of these.
+message Placeholder {
+  oneof kind {
+    // pySigma %name% style placeholder, resolved by a processing pipeline.
+    string name = 1;
+    // RSigma ${source.*} style deferred reference, resolved at load time.
+    DynamicSourceRef dynamic_ref = 2;
+  }
+}
+
+message DynamicSourceRef {
+  string source_id = 1;
+  ExtractExpr extract = 2; // optional
+}
+
+message ExtractExpr {
+  oneof expr {
+    string jq = 1;
+    string jsonpath = 2;
+    string cel = 3;
+  }
+}
+
+message IrNumber {
+  oneof value {
+    sint64 int_value = 1;   // preserves integers above 2^53
+    double double_value = 2;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Matchers (post-modifier semantic forms)
+// ---------------------------------------------------------------------------
+
+enum StringMatchHint {
+  STRING_MATCH_HINT_UNSPECIFIED = 0; // derive from wildcard positions
+  STRING_MATCH_HINT_EXACT = 1;
+  STRING_MATCH_HINT_CONTAINS = 2;
+  STRING_MATCH_HINT_STARTS_WITH = 3;
+  STRING_MATCH_HINT_ENDS_WITH = 4;
+}
+
+enum CompareOp {
+  COMPARE_OP_EQ = 0;
+  COMPARE_OP_LT = 1;
+  COMPARE_OP_LTE = 2;
+  COMPARE_OP_GT = 3;
+  COMPARE_OP_GTE = 4;
+}
+
+enum TimePart {
+  TIME_PART_UNSPECIFIED = 0;
+  TIME_PART_MINUTE = 1;
+  TIME_PART_HOUR = 2;
+  TIME_PART_DAY = 3;
+  TIME_PART_WEEK = 4;
+  TIME_PART_MONTH = 5;
+  TIME_PART_YEAR = 6;
+}
+
+message StringMatch {
+  SigmaString value = 1;     // wildcards encode contains/startswith/endswith
+  bool cased = 2;            // false = Sigma default case-insensitive
+  StringMatchHint hint = 3;  // advisory; `value` is authoritative
+}
+
+message RegexMatch {
+  string pattern = 1;
+  bool ignorecase = 2; // i
+  bool multiline = 3;  // m
+  bool dotall = 4;     // s
+}
+
+message CidrMatch { string network = 1; }
+
+message NumericMatch {
+  CompareOp op = 1;
+  IrNumber value = 2;
+}
+
+message FieldRefMatch {
+  string field = 1;
+  bool starts_with = 2;
+  bool ends_with = 3;
+  bool cased = 4;
+}
+
+message ExistsMatch { bool exists = 1; }
+message NullMatch {}
+message BoolMatch { bool value = 1; }
+
+message TimestampMatch {
+  TimePart part = 1;
+  IrMatcher inner = 2;
+}
+
+// pySigma SigmaQueryExpression: backend-specific late-stage injection.
+// Extension: consumers that do not advertise QUERY_EXPR reject this.
+message QueryExprMatch {
+  string expr = 1; // may contain a {field} placeholder
+  string id = 2;
+}
+
+message MatcherList { repeated IrMatcher matchers = 1; }
+
+message IrMatcher {
+  oneof matcher {
+    StringMatch string_match = 1;
+    RegexMatch regex = 2;
+    CidrMatch cidr = 3;
+    NumericMatch numeric = 4;
+    FieldRefMatch field_ref = 5;
+    ExistsMatch exists = 6;
+    NullMatch null = 7;
+    BoolMatch boolean = 8;
+    TimestampMatch timestamp = 9;
+
+    // Combinators (base64offset/windash expansions, value-linked groups).
+    MatcherList any_of = 10;
+    MatcherList all_of = 11;
+    IrMatcher negation = 12;
+
+    // Extensions (capability-gated).
+    QueryExprMatch query_expr = 13;
+  }
+  // reserved 14 to 31 for new matcher kinds.
+}
+
+// ---------------------------------------------------------------------------
+// Detections
+// ---------------------------------------------------------------------------
+
+message IrDetectionItem {
+  // Absent field => keyword/value match (against the array member or event).
+  optional string field = 1;
+  IrMatcher matcher = 2;
+  bool negated = 3; // pySigma detection_item.negated / RSigma neq
+}
+
+enum ArrayQuantifier {
+  ARRAY_QUANTIFIER_UNSPECIFIED = 0;
+  ARRAY_QUANTIFIER_ANY = 1;
+  ARRAY_QUANTIFIER_ALL = 2;
+  ARRAY_QUANTIFIER_ALL_OR_EMPTY = 3;
+  ARRAY_QUANTIFIER_NONE = 4;
+}
+
+message DetectionItemList { repeated IrDetectionItem items = 1; }
+message DetectionList { repeated IrDetection detections = 1; }
+
+// Extension: field[any]:/field[all]: object-scope matching (spec proposal).
+message ArrayMatch {
+  string field = 1;
+  ArrayQuantifier quantifier = 2;
+  IrDetection body = 3;
+}
+
+// Extension: explicit-condition object-scope body.
+message Conditional {
+  map<string, IrDetection> named = 1;
+  IrCondition condition = 2;
+}
+
+message IrDetection {
+  oneof detection {
+    DetectionItemList all_of = 1;   // AND-linked items (YAML mapping)
+    DetectionList any_of = 2;       // OR-linked sub-detections (YAML list)
+    IrMatcher keywords = 3;         // field-less keyword detection
+    DetectionList conjunction = 4;  // AND of heterogeneous sub-detections
+
+    // Extensions (spec proposal, capability-gated).
+    ArrayMatch array_match = 5;
+    Conditional conditional = 6;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conditions (selector-resolved boolean tree over named detections)
+// ---------------------------------------------------------------------------
+
+message ConditionList { repeated IrCondition conditions = 1; }
+
+message IrCondition {
+  oneof condition {
+    string detection_ref = 1;       // name of a detection in IrRule.detections
+    ConditionList conjunction = 2;  // AND
+    ConditionList disjunction = 3;  // OR
+    IrCondition negation = 4;       // NOT
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+enum Level {
+  LEVEL_UNSPECIFIED = 0;
+  LEVEL_INFORMATIONAL = 1;
+  LEVEL_LOW = 2;
+  LEVEL_MEDIUM = 3;
+  LEVEL_HIGH = 4;
+  LEVEL_CRITICAL = 5;
+}
+
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STATUS_STABLE = 1;
+  STATUS_TEST = 2;
+  STATUS_EXPERIMENTAL = 3;
+  STATUS_DEPRECATED = 4;
+  STATUS_UNSUPPORTED = 5;
+}
+
+enum RelationType {
+  RELATION_TYPE_UNSPECIFIED = 0;
+  RELATION_TYPE_DERIVED = 1;
+  RELATION_TYPE_OBSOLETE = 2;
+  RELATION_TYPE_MERGED = 3;
+  RELATION_TYPE_RENAMED = 4;
+  RELATION_TYPE_SIMILAR = 5;
+  RELATION_TYPE_CORRELATION = 6;
+}
+
+message Related {
+  string id = 1;
+  RelationType relation_type = 2;
+}
+
+message LogSource {
+  optional string category = 1;
+  optional string product = 2;
+  optional string service = 3;
+  optional string definition = 4;
+  map<string, string> custom = 5;
+}
+
+message IrRuleMetadata {
+  string title = 1;
+  optional string id = 2;
+  optional string name = 3;
+  optional Level level = 4;
+  optional Status status = 5;
+  optional string description = 6;
+  optional string author = 7;
+  optional string date = 8;     // YYYY-MM-DD or YYYY/MM/DD as authored
+  optional string modified = 9;
+  optional string taxonomy = 10;
+  optional string license = 11;
+  repeated string references = 12;
+  repeated string falsepositives = 13;
+  repeated string fields = 14;
+  repeated string tags = 15;
+  repeated string scope = 16;
+  repeated Related related = 17;
+  map<string, google.protobuf.Value> custom_attributes = 18;
+  // Only the spec MAJOR is meaningful (gates version-sensitive interpretation).
+  optional uint32 sigma_version = 19;
+}
+
+// ---------------------------------------------------------------------------
+// Detection rule
+// ---------------------------------------------------------------------------
+
+message IrRule {
+  IrRuleMetadata metadata = 1;
+  LogSource logsource = 2;
+  map<string, IrDetection> detections = 3;
+  repeated IrCondition conditions = 4;
+  // Optional raw condition string(s) for round-trip/debug only; consumers
+  // must use `conditions`, never re-parse this.
+  repeated string source_conditions = 5;
+}
+
+// ---------------------------------------------------------------------------
+// Correlation rule
+// ---------------------------------------------------------------------------
+
+enum TimeUnit {
+  TIME_UNIT_UNSPECIFIED = 0;
+  TIME_UNIT_SECOND = 1;
+  TIME_UNIT_MINUTE = 2;
+  TIME_UNIT_HOUR = 3;
+  TIME_UNIT_DAY = 4;
+  TIME_UNIT_WEEK = 5;
+  TIME_UNIT_MONTH = 6;
+  TIME_UNIT_YEAR = 7;
+}
+
+message Timespan {
+  uint64 count = 1;
+  TimeUnit unit = 2;
+  uint64 seconds = 3; // approximate for month/year
+  string original = 4;
+}
+
+enum CorrelationType {
+  CORRELATION_TYPE_UNSPECIFIED = 0;
+  CORRELATION_TYPE_EVENT_COUNT = 1;
+  CORRELATION_TYPE_VALUE_COUNT = 2;
+  CORRELATION_TYPE_TEMPORAL = 3;
+  CORRELATION_TYPE_TEMPORAL_ORDERED = 4;
+  CORRELATION_TYPE_VALUE_SUM = 5;
+  CORRELATION_TYPE_VALUE_AVG = 6;
+  CORRELATION_TYPE_VALUE_PERCENTILE = 7;
+  CORRELATION_TYPE_VALUE_MEDIAN = 8;
+}
+
+enum WindowMode {
+  WINDOW_MODE_UNSPECIFIED = 0; // treated as sliding
+  WINDOW_MODE_SLIDING = 1;
+  WINDOW_MODE_TUMBLING = 2;
+  WINDOW_MODE_SESSION = 3;
+}
+
+enum ConditionOperator {
+  CONDITION_OPERATOR_UNSPECIFIED = 0;
+  CONDITION_OPERATOR_LT = 1;
+  CONDITION_OPERATOR_LTE = 2;
+  CONDITION_OPERATOR_GT = 3;
+  CONDITION_OPERATOR_GTE = 4;
+  CONDITION_OPERATOR_EQ = 5;
+  CONDITION_OPERATOR_NEQ = 6;
+}
+
+message FieldAlias {
+  string alias = 1;
+  map<string, string> mapping = 2; // rule ref/name -> field name
+}
+
+message ThresholdCondition {
+  message Predicate {
+    ConditionOperator op = 1;
+    uint64 count = 2;
+  }
+  repeated Predicate predicates = 1; // all must hold (range support)
+  repeated string field = 2;         // for value_count and friends
+  optional uint32 percentile = 3;    // for value_percentile
+}
+
+message CorrelationCondition {
+  oneof condition {
+    ThresholdCondition threshold = 1;
+    IrCondition extended = 2; // boolean tree over rule references
+  }
+}
+
+message IrCorrelation {
+  IrRuleMetadata metadata = 1;
+  CorrelationType correlation_type = 2;
+  repeated string rules = 3;     // referenced rule ids/names
+  repeated string group_by = 4;
+  Timespan timespan = 5;
+  WindowMode window = 6;         // extension; default sliding
+  optional Timespan gap = 7;     // required when window = session
+  CorrelationCondition condition = 8;
+  repeated FieldAlias aliases = 9;
+  bool generate = 10;
+}
+
+// ---------------------------------------------------------------------------
+// Filter rule
+// ---------------------------------------------------------------------------
+
+message StringList { repeated string values = 1; }
+
+message FilterTarget {
+  oneof target {
+    Empty any = 1;
+    StringList specific = 2; // rule ids/names
+  }
+}
+
+message IrFilter {
+  IrRuleMetadata metadata = 1;
+  FilterTarget rules = 2;
+  optional LogSource logsource = 3;
+  map<string, IrDetection> detections = 4;
+  repeated IrCondition conditions = 5;
+}


### PR DESCRIPTION
## Why

Sigma backends are reimplemented per engine today: a Splunk/KQL/Elastic/etc. backend written for one engine has to be re-ported into RSigma and any future engine. This defines a shared, strongly typed message so a backend can be written once and reused across engines, including as a remote gRPC service. The message sits at the post-pipeline, modifier-resolved, selector-resolved layer that pySigma (after modifier application and condition postprocess) and RSigma (its HIR) independently arrive at, which is what makes a single schema faithful rather than forced. External/dynamic sources are converging across engines too (see [SigmaHQ/pySigma#470](https://github.com/SigmaHQ/pySigma/issues/470)), so they belong in the shared schema rather than as an engine-specific extension.

## Summary

- Adds `proto/sigma_ir.proto`, a language-neutral protobuf schema for a post-pipeline, modifier-resolved, selector-resolved Sigma rule: the wire message a remote backend responds to, and a single canonical form an engine's HIR can be generated from or conformance-locked against.
- Adds `proto/sigma_backend.proto`, a `SigmaBackend` gRPC service (`Capabilities` + `Convert`, with explicit `Unsupported` results) as the separable remote-backend transport over the schema.
- Adds 19 golden `(rule YAML -> canonical IR)` conformance vectors under `proto/conformance/vectors/`, plus READMEs documenting the schema, conventions, and vector format.
- Schema and docs only; no crate code changes. Built by reconciling the RSigma parser AST/HIR with pySigma's resolved types, conditions, modifiers, correlations, and filters, so both engines lower to and consume the same form.
- Records the intent to extract `proto/` into a neutral standalone schema repo so a second implementation can vendor it.

## Test plan

- [x] `protoc` (libprotoc 34.1) compiles `sigma_ir.proto` and `sigma_backend.proto` cleanly.
- [x] All 19 conformance vectors validate strictly against the schema (generated Python bindings + `json_format.ParseDict`, which rejects unknown fields).
- [x] `base64offset` / `windash` expansions in the vectors were computed with pySigma's exact algorithm, not hand-written.
- [ ] Reviewer: confirm the schema home (extract to a neutral repo vs keep in-tree).