### PR TITLE
feat(cli,fibratus): one rule file per rule for directory output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### `backend convert`: per-rule file output when `--output` is a directory
+### `backend convert`: per-rule file output when `--output` is a directory (#205)
 
 `rsigma backend convert` can now write one file per converted rule instead of a single concatenated stream. When `--output` points at a directory (an existing directory, or a path with a trailing separator that is created on demand), each rule is written to its own file named after a snake_case slug of the rule title, with the backend's native extension. This was prompted by Fibratus rule-deployment ergonomics: the engine loads one YAML rule per file from its `Rules/` directory, so the split output drops straight in without hand-separating the `---`-joined stream.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### `backend convert`: per-rule file output when `--output` is a directory
+
+`rsigma backend convert` can now write one file per converted rule instead of a single concatenated stream. When `--output` points at a directory (an existing directory, or a path with a trailing separator that is created on demand), each rule is written to its own file named after a snake_case slug of the rule title, with the backend's native extension. This was prompted by Fibratus rule-deployment ergonomics: the engine loads one YAML rule per file from its `Rules/` directory, so the split output drops straight in without hand-separating the `---`-joined stream.
+
+- **Naming.** File stems are a slug of the rule title (`Detect Whoami` becomes `detect_whoami`), falling back to the rule id and then a `rule` literal when the title slugifies to nothing. Colliding names get a numeric suffix (`same.yml`, `same_2.yml`) so two rules never overwrite each other. A rule that converts to several documents (for example a `temporal` correlation expanded with `-O temporal_permute=true`) keeps them together in its one file, finalized through the backend so the format-aware separators land inside.
+- **Extensions.** A new `Backend::output_file_extension` hook picks the per-rule extension: `yml` for the Fibratus YAML envelope (`txt` for its bare-expression `expr` format), `sql` for PostgreSQL, and `txt` by default. Single-file and stdout output are unchanged.
+- **Docs.** The Fibratus backend reference, the rule-conversion guide, and the README document the directory-output workflow (`rsigma backend convert rules/ -t fibratus -p fibratus_windows -o ./Rules/`).
+
 ### `rstix`: Phase 2 slice 1 — model skeleton and common properties
 
 Phase 2 (Data Model + Serialization) begins with slice 1 of ~7. This slice is not releasable on its own.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ rsigma backend convert rules/ -t lynxdb
 # Fibratus rule YAML for Windows EDR sensors
 rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows
 
+# Write one rule file per rule into a directory (drop straight into a Fibratus Rules/ folder)
+rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows -o ./Rules/
+
 # List all fields referenced by a ruleset
 rsigma rule fields -r rules/
 

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -160,6 +160,16 @@ pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
             if !skip_unsupported && !output_data.errors.is_empty() {
                 process::exit(crate::exit_code::RULE_ERROR);
             }
+            // When `--output` points at a directory (an existing directory or a
+            // path with a trailing separator), write one file per converted
+            // rule into it instead of a single concatenated stream. This lets
+            // operators drop the result straight into a target rules directory
+            // (e.g. a Fibratus `Rules/` folder) without splitting the output by
+            // hand.
+            if let Some(dir) = output.as_deref().filter(|p| is_directory_target(p)) {
+                write_split_output(backend.as_ref(), &output_data, &format, dir, &ctx);
+                return;
+            }
             // `--output-format json` wraps the queries in a JSON envelope.
             // The other structured formats (`ndjson`/`csv`/`tsv`/`table`)
             // make no sense for free-form query text -- warn once on stderr
@@ -303,5 +313,185 @@ fn write_output(content: &str, output: Option<&std::path::Path>) {
             }
         }
         None => println!("{content}"),
+    }
+}
+
+/// True when the `--output` target should be treated as a directory to fill
+/// with one file per rule rather than a single file to write the whole stream
+/// to.
+///
+/// An existing directory always qualifies. A path with a trailing separator
+/// signals directory intent even before the directory exists (rsync-style), so
+/// `-o rules/` splits while `-o rules.yml` writes a single file.
+fn is_directory_target(path: &std::path::Path) -> bool {
+    if path.is_dir() {
+        return true;
+    }
+    let s = path.as_os_str().to_string_lossy();
+    s.ends_with('/') || s.ends_with(std::path::MAIN_SEPARATOR)
+}
+
+/// Write one file per converted rule into `dir`, naming each file after the
+/// rule and giving it the backend's per-rule extension (`.yml` for Fibratus,
+/// `.sql` for PostgreSQL, ...). Each rule's own conversion result (which may
+/// itself be several documents, e.g. correlation permutations) is finalized
+/// through the backend so format-aware separators land inside the file.
+fn write_split_output(
+    backend: &dyn rsigma_convert::Backend,
+    output_data: &rsigma_convert::ConversionOutput,
+    format: &str,
+    dir: &std::path::Path,
+    ctx: &OutputCtx,
+) {
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        eprintln!("Error creating output directory {}: {e}", dir.display());
+        process::exit(crate::exit_code::CONFIG_ERROR);
+    }
+
+    let ext = backend.output_file_extension(format);
+    let mut used_names = std::collections::HashSet::new();
+    let mut written = 0usize;
+
+    for result in &output_data.queries {
+        let content = backend
+            .finalize_output(result.queries.clone(), format)
+            .unwrap_or_else(|e| {
+                eprintln!(
+                    "Output finalization failed for rule '{}': {e}",
+                    result.rule_title
+                );
+                process::exit(crate::exit_code::RULE_ERROR);
+            });
+        if content.trim().is_empty() {
+            continue;
+        }
+
+        let filename = rule_filename(
+            &result.rule_title,
+            result.rule_id.as_deref(),
+            ext,
+            &mut used_names,
+        );
+        let path = dir.join(&filename);
+        let content = if content.ends_with('\n') {
+            content
+        } else {
+            format!("{content}\n")
+        };
+        if let Err(e) = std::fs::write(&path, &content) {
+            eprintln!("Error writing to {}: {e}", path.display());
+            process::exit(crate::exit_code::CONFIG_ERROR);
+        }
+        written += 1;
+    }
+
+    if ctx.show_progress() {
+        eprintln!("Wrote {written} rule file(s) to {}", dir.display());
+    }
+}
+
+/// Build a unique, filesystem-safe file name for a converted rule.
+///
+/// The base name is a slug of the rule title (the human-readable key the
+/// upstream Fibratus rules library names its files after); the rule id, then a
+/// `rule` literal, are fallbacks when the title slugifies to nothing. Names
+/// already taken in this run get a numeric suffix so two rules with the same
+/// title never overwrite each other.
+fn rule_filename(
+    title: &str,
+    id: Option<&str>,
+    ext: &str,
+    used: &mut std::collections::HashSet<String>,
+) -> String {
+    let mut base = slugify(title);
+    if base.is_empty() {
+        base = id
+            .map(slugify)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_default();
+    }
+    if base.is_empty() {
+        base = "rule".to_string();
+    }
+
+    let mut candidate = format!("{base}.{ext}");
+    let mut counter = 2usize;
+    while !used.insert(candidate.clone()) {
+        candidate = format!("{base}_{counter}.{ext}");
+        counter += 1;
+    }
+    candidate
+}
+
+/// Lowercase a string and collapse every run of non-alphanumeric characters
+/// into a single `_`, trimming leading and trailing underscores. Produces the
+/// snake_case file stems the upstream Fibratus rules library uses.
+fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_underscore = false;
+    for ch in s.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_underscore = false;
+        } else if !prev_underscore {
+            out.push('_');
+            prev_underscore = true;
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn slugify_makes_snake_case_stems() {
+        assert_eq!(slugify("Detect Whoami"), "detect_whoami");
+        assert_eq!(
+            slugify("Suspicious cmd.exe via Explorer!"),
+            "suspicious_cmd_exe_via_explorer"
+        );
+        assert_eq!(slugify("  leading/trailing  "), "leading_trailing");
+        assert_eq!(slugify("---"), "");
+    }
+
+    #[test]
+    fn rule_filename_uses_title_slug_and_extension() {
+        let mut used = HashSet::new();
+        assert_eq!(
+            rule_filename("Detect Whoami", Some("abc"), "yml", &mut used),
+            "detect_whoami.yml"
+        );
+    }
+
+    #[test]
+    fn rule_filename_falls_back_to_id_then_rule() {
+        let mut used = HashSet::new();
+        assert_eq!(
+            rule_filename(
+                "!!!",
+                Some("00000000-0000-0000-0000-000000000100"),
+                "yml",
+                &mut used
+            ),
+            "00000000_0000_0000_0000_000000000100.yml"
+        );
+        assert_eq!(rule_filename("???", None, "sql", &mut used), "rule.sql");
+    }
+
+    #[test]
+    fn rule_filename_dedupes_collisions() {
+        let mut used = HashSet::new();
+        assert_eq!(rule_filename("Same", None, "yml", &mut used), "same.yml");
+        assert_eq!(rule_filename("Same", None, "yml", &mut used), "same_2.yml");
+        assert_eq!(rule_filename("Same", None, "yml", &mut used), "same_3.yml");
+    }
+
+    #[test]
+    fn directory_target_detects_trailing_separator() {
+        assert!(is_directory_target(std::path::Path::new("rules/")));
+        assert!(!is_directory_target(std::path::Path::new("rules.yml")));
     }
 }

--- a/crates/rsigma-cli/tests/cli_convert.rs
+++ b/crates/rsigma-cli/tests/cli_convert.rs
@@ -389,6 +389,80 @@ fn convert_to_file_output() {
     assert_snapshot!(content, @r#"SELECT * FROM security_events WHERE "CommandLine" ILIKE '%whoami%'"#);
 }
 
+#[test]
+fn convert_split_writes_one_file_per_rule() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("rule_a.yml"), SIMPLE_DETECTION).unwrap();
+    let second_rule = r#"
+title: Detect Ipconfig
+id: 00000000-0000-0000-0000-000000000101
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'ipconfig'
+    condition: selection
+level: low
+"#;
+    std::fs::write(dir.path().join("rule_b.yml"), second_rule).unwrap();
+
+    let out_dir = TempDir::new().unwrap();
+    rsigma()
+        .args([
+            "backend",
+            "convert",
+            dir.path().to_str().unwrap(),
+            "--target",
+            "fibratus",
+            "-p",
+            "fibratus_windows",
+            "--output",
+            out_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let whoami = std::fs::read_to_string(out_dir.path().join("detect_whoami.yml")).unwrap();
+    assert!(whoami.starts_with("name: Detect Whoami\n"));
+    assert!(whoami.contains("ps.cmdline icontains 'whoami'"));
+    assert!(!whoami.contains("ipconfig"));
+
+    let ipconfig = std::fs::read_to_string(out_dir.path().join("detect_ipconfig.yml")).unwrap();
+    assert!(ipconfig.starts_with("name: Detect Ipconfig\n"));
+    assert!(ipconfig.contains("ps.cmdline icontains 'ipconfig'"));
+    assert!(!ipconfig.contains("whoami"));
+}
+
+#[test]
+fn convert_split_creates_directory_from_trailing_separator() {
+    let rule = temp_file(".yml", SIMPLE_DETECTION);
+    let parent = TempDir::new().unwrap();
+    // A path with a trailing separator that does not exist yet is treated as a
+    // directory and created.
+    let out_dir = parent.path().join("Rules");
+    let mut out_arg = out_dir.to_str().unwrap().to_string();
+    out_arg.push(std::path::MAIN_SEPARATOR);
+
+    rsigma()
+        .args([
+            "backend",
+            "convert",
+            rule.path().to_str().unwrap(),
+            "--target",
+            "fibratus",
+            "-p",
+            "fibratus_windows",
+            "--output",
+            &out_arg,
+        ])
+        .assert()
+        .success();
+
+    assert!(out_dir.join("detect_whoami.yml").is_file());
+}
+
 // ---------------------------------------------------------------------------
 // list-targets / list-formats
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-convert/src/backend.rs
+++ b/crates/rsigma-convert/src/backend.rs
@@ -240,6 +240,19 @@ pub trait Backend: Send + Sync {
 
     fn finalize_output(&self, queries: Vec<String>, output_format: &str) -> Result<String>;
 
+    /// File extension (no leading dot) for per-rule output files when
+    /// `rsigma backend convert` writes one file per rule into a directory.
+    ///
+    /// The default is `txt`; backends override it so the split files land
+    /// with the extension their target loader expects (`sql` for
+    /// PostgreSQL, `yml` for Fibratus rule YAML). The `output_format`
+    /// argument lets a backend pick a different extension per format (e.g.
+    /// Fibratus emits `.txt` for the bare-expression `expr` format and
+    /// `.yml` for the YAML rule envelope).
+    fn output_file_extension(&self, _output_format: &str) -> &str {
+        "txt"
+    }
+
     // --- Correlation rule conversion (optional) ---
 
     fn supports_correlation(&self) -> bool {

--- a/crates/rsigma-convert/src/backends/fibratus/mod.rs
+++ b/crates/rsigma-convert/src/backends/fibratus/mod.rs
@@ -834,6 +834,16 @@ impl Backend for FibratusBackend {
         }
     }
 
+    fn output_file_extension(&self, output_format: &str) -> &str {
+        // The YAML envelope formats drop into a Fibratus `Rules/` directory
+        // as `.yml` files the loader picks up directly; the bare-expression
+        // `expr` format is plain text with no envelope.
+        match output_format {
+            "expr" => "txt",
+            _ => "yml",
+        }
+    }
+
     fn finalize_output(&self, queries: Vec<String>, output_format: &str) -> Result<String> {
         match output_format {
             "expr" => Ok(queries.join("\n")),

--- a/crates/rsigma-convert/src/backends/postgres/mod.rs
+++ b/crates/rsigma-convert/src/backends/postgres/mod.rs
@@ -594,6 +594,10 @@ impl Backend for PostgresBackend {
         false
     }
 
+    fn output_file_extension(&self, _output_format: &str) -> &str {
+        "sql"
+    }
+
     // --- Detection rule conversion ---
 
     fn convert_rule(

--- a/docs/developers/adding-backends.md
+++ b/docs/developers/adding-backends.md
@@ -106,6 +106,8 @@ impl Backend for SplunkBackend {
 }
 ```
 
+Optional: override `output_file_extension` so the per-rule files `rsigma backend convert` writes when `--output` is a directory get the extension your target loader expects (`"sql"`, `"yml"`, ...). It defaults to `"txt"` and takes the output format so a backend can vary it per format.
+
 Step 4: re-export from `lib.rs` so embedders can use the backend type directly.
 
 ```rust

--- a/docs/guide/rule-conversion.md
+++ b/docs/guide/rule-conversion.md
@@ -347,6 +347,12 @@ rsigma backend convert rules/windows/process_creation/ -t fibratus -p fibratus_w
 
 Two output formats: `default` (also aliased as `yaml`/`rule`) emits a complete YAML rule document per Sigma rule with the `name`/`id`/`description`/`labels`/`condition`/`min-engine-version`/`action` envelope, with `---` separators when multiple rules are converted at once. `expr` strips the envelope and emits only the bare filter expression for piping into ad-hoc Fibratus commands.
 
+Because Fibratus loads one rule per file from its `Rules/` directory, point `--output` at a directory to get a separate `<title-slug>.yml` file per rule instead of one combined stream, ready to drop straight into the sensor:
+
+```bash
+rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows -o ./Rules/
+```
+
 Backend options (`-O key=value`):
 
 ```bash
@@ -404,6 +410,12 @@ rsigma backend convert rules/ -t postgres -f view \
     --skip-unsupported \
     -o /var/lib/rsigma/sql/views.sql
 psql -f /var/lib/rsigma/sql/views.sql
+```
+
+When `-o` names a directory (an existing directory, or a path ending in a separator that is created on demand) the converter writes one file per rule into it instead of a single combined file. Each file is named after a snake_case slug of the rule title and gets the backend's native extension (`.yml` for Fibratus, `.sql` for PostgreSQL). This is the easiest way to populate a sensor's rule directory, such as a Fibratus `Rules/` folder:
+
+```bash
+rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows -o ./Rules/
 ```
 
 ## Workflow: from rules to a Grafana dashboard

--- a/docs/reference/backends/fibratus.md
+++ b/docs/reference/backends/fibratus.md
@@ -150,6 +150,16 @@ Filter expression only, no YAML envelope. Useful for piping into ad-hoc Fibratus
 spawn_process and ps.exe iendswith '\\cmd.exe' and ps.parent.exe iendswith '\\explorer.exe' and ps.cmdline icontains 'whoami'
 ```
 
+## One file per rule
+
+Fibratus loads one YAML rule per file from its `Rules/` directory, so the backend can write a separate file per converted rule instead of a single `---`-separated stream. This happens automatically when `--output` points at a directory: an existing directory, or a path with a trailing separator (which is created on demand). Each rule lands in `<title-slug>.yml`, ready to drop straight into the sensor:
+
+```sh
+rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows -o ./Rules/
+```
+
+File stems are a snake_case slug of the rule title (`Detect Whoami` becomes `detect_whoami.yml`), matching the upstream rules-library naming style; the rule id and then a `rule` literal are fallbacks when a title slugifies to nothing, and colliding names get a numeric suffix (`same.yml`, `same_2.yml`) so no rule overwrites another. A rule that converts to several documents (a `temporal` correlation expanded with `-O temporal_permute=true`, for example) keeps them together in its one file. Without a directory `--output`, the behavior is unchanged: the whole stream goes to stdout or to the single file you name.
+
 ## Correlation rules
 
 Fibratus 1.10+ uses an inline DSL inside `condition:` for stateful sequences; the backend lowers Sigma correlation rules to that DSL. Coverage matrix:


### PR DESCRIPTION
## Summary

Addresses PR review feedback that the Fibratus backend should emit a separate YAML file per Sigma rule rather than one combined `---`-joined stream, so converted rules drop straight into a Fibratus `Rules/` directory.

- `backend convert` now writes one file per converted rule when `--output` points at a directory: an existing directory, or a path with a trailing separator that is created on demand. Single-file and stdout output are unchanged (passing a directory to `-o` previously just errored on write, so this is purely additive).
- Files are named after a snake_case slug of the rule title (`Detect Whoami` -> `detect_whoami.yml`), falling back to the rule id and then a `rule` literal, with numeric-suffix de-duping so no rule overwrites another. A rule that converts to several documents (for example a `temporal` correlation expanded with `-O temporal_permute=true`) keeps them together in its one file, finalized through the backend so the format-aware separators land inside.
- New `Backend::output_file_extension(format)` hook picks the per-rule extension: `yml` for the Fibratus YAML envelope (`txt` for its bare-expression `expr` format), `sql` for PostgreSQL, `txt` by default.

```bash
rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows -o ./Rules/
```

Docs updated: Fibratus backend reference, rule-conversion guide, README, the adding-backends developer note, and a CHANGELOG entry.

## Test plan

- [x] Unit tests for `slugify`, `rule_filename` (title/id/`rule` fallbacks, collision de-dupe), and directory-target detection.
- [x] CLI integration tests: one file per rule into a directory; directory created from a trailing separator.
- [x] `cargo fmt --all -- --check`, `cargo clippy` with `-Dwarnings`, full test suites for both crates (628 passed).
- [x] `mkdocs build --strict`.
- [x] Manual end-to-end run confirming file naming and content.