### PR TITLE
feat(mcp): add Streamable HTTP transport, bearer auth, TLS, and config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### MCP server: Streamable HTTP transport, bearer auth, and `mcp` config keys (#TBD)
+### MCP server: Streamable HTTP transport, bearer auth, and `mcp` config keys (#209)
 
 Adds a remote transport and configuration to the MCP server.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### MCP server: Streamable HTTP transport, bearer auth, and `mcp` config keys (#TBD)
+
+Adds a remote transport and configuration to the MCP server.
+
+- **Streamable HTTP transport.** `rsigma mcp serve --http <addr>` serves the MCP endpoint at `/mcp` over HTTP (stdio stays the default). Built on rmcp's `StreamableHttpService` mounted on axum.
+- **Bearer-token auth.** `--auth-token <token>` (or `RSIGMA_MCP_AUTH_TOKEN`) requires a static token on every request, compared in constant time; requests without it get `401`. The token is flag/env-only and never read from config files.
+- **TLS.** `--tls-cert`/`--tls-key` terminate TLS in-process using the daemon's rustls loader (requires the `daemon-tls` feature). Plaintext binds on non-loopback addresses are refused unless `--allow-plaintext`.
+- **Config keys.** A new `mcp` config section (`mcp.http_addr`, `mcp.lint_config`, `mcp.rules_dir`) is wired through `rsigma config init/validate/show/schema` and the `RSIGMA_MCP__*` environment layer. The auth token stays flag/env-only by design.
+
 ### MCP server: `rsigma mcp serve` and the `rsigma-mcp` crate (#208)
 
 A new [Model Context Protocol](https://modelcontextprotocol.io) server exposes the rsigma Sigma toolchain to AI agents (Cursor, Claude Code, ...) as structured tools. Instead of scraping CLI text, an agent calls typed tools and gets back JSON: ASTs, lint findings with spans and fix availability, evaluation matches, backend queries, and field inventories.

--- a/crates/rsigma-cli/src/commands/mcp.rs
+++ b/crates/rsigma-cli/src/commands/mcp.rs
@@ -1,9 +1,12 @@
 //! `rsigma mcp serve` — run the Model Context Protocol server.
 //!
-//! Exposes the rsigma toolchain to MCP-aware agents over stdio. The tool
-//! surface lives in the [`rsigma_mcp`] crate; this module owns the CLI flags
-//! and the tokio runtime, mirroring how `engine daemon` is wired.
+//! Exposes the rsigma toolchain to MCP-aware agents. stdio is the default
+//! transport; `--http <addr>` opts into the Streamable HTTP transport with
+//! optional bearer-token auth and TLS. The tool surface lives in the
+//! [`rsigma_mcp`] crate; this module owns the CLI flags and the tokio runtime,
+//! mirroring how `engine daemon` is wired.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
 
@@ -15,7 +18,7 @@ use crate::exit_code;
 /// `rsigma mcp <command>` subcommands.
 #[derive(Subcommand, Debug)]
 pub(crate) enum McpCommands {
-    /// Run the MCP server over stdio.
+    /// Run the MCP server (stdio by default; `--http` for Streamable HTTP).
     Serve(McpServeArgs),
 }
 
@@ -31,6 +34,34 @@ pub(crate) struct McpServeArgs {
     /// an agent reference rules by a path relative to a rules tree.
     #[arg(long = "rules-dir", value_name = "PATH")]
     pub rules_dir: Option<PathBuf>,
+
+    /// Serve over Streamable HTTP on this address (e.g. `127.0.0.1:9100`)
+    /// instead of stdio. The MCP endpoint is mounted at `/mcp`.
+    #[arg(long = "http", value_name = "ADDR")]
+    pub http: Option<SocketAddr>,
+
+    /// Require this bearer token on every HTTP request (sent as
+    /// `Authorization: Bearer <token>`). Also read from `RSIGMA_MCP_AUTH_TOKEN`.
+    /// Secrets stay flag/env-only and are never read from config files.
+    #[arg(
+        long = "auth-token",
+        env = "RSIGMA_MCP_AUTH_TOKEN",
+        value_name = "TOKEN"
+    )]
+    pub auth_token: Option<String>,
+
+    /// Allow binding plaintext HTTP on a non-loopback address without TLS.
+    #[arg(long = "allow-plaintext")]
+    pub allow_plaintext: bool,
+
+    /// TLS certificate (PEM) for the HTTP transport. Requires `--tls-key` and a
+    /// build with the `daemon-tls` feature.
+    #[arg(long = "tls-cert", value_name = "PATH", requires = "tls_key")]
+    pub tls_cert: Option<PathBuf>,
+
+    /// TLS private key (PEM) for the HTTP transport. Requires `--tls-cert`.
+    #[arg(long = "tls-key", value_name = "PATH", requires = "tls_cert")]
+    pub tls_key: Option<PathBuf>,
 }
 
 /// Dispatch `rsigma mcp <command>`.
@@ -40,9 +71,38 @@ pub(crate) fn dispatch_mcp(cmd: McpCommands) {
     }
 }
 
-/// Run the MCP server over stdio. Builds a multi-thread tokio runtime (same
-/// pattern as the daemon).
-pub(crate) fn cmd_mcp_serve(args: McpServeArgs) {
+/// Overlay the `mcp` config section (defaults < file < env) onto any flag the
+/// operator did not set explicitly. The auth token is intentionally excluded:
+/// secrets stay flag/env-only.
+fn apply_mcp_config(args: &mut McpServeArgs) {
+    let base = crate::config::load_and_merge(None);
+    let Some(mcp) = base.mcp else {
+        return;
+    };
+    if args.http.is_none()
+        && let Some(addr) = mcp.http_addr
+    {
+        match addr.parse::<SocketAddr>() {
+            Ok(parsed) => args.http = Some(parsed),
+            Err(e) => {
+                eprintln!("Invalid mcp.http_addr '{addr}' in config: {e}");
+                process::exit(exit_code::CONFIG_ERROR);
+            }
+        }
+    }
+    if args.lint_config.is_none() {
+        args.lint_config = mcp.lint_config;
+    }
+    if args.rules_dir.is_none() {
+        args.rules_dir = mcp.rules_dir;
+    }
+}
+
+/// Run the MCP server. Builds a multi-thread tokio runtime (same pattern as the
+/// daemon) and serves over stdio or, when `--http` is set, Streamable HTTP.
+pub(crate) fn cmd_mcp_serve(mut args: McpServeArgs) {
+    apply_mcp_config(&mut args);
+
     let lint_config = match &args.lint_config {
         Some(path) => match LintConfig::load(path) {
             Ok(config) => config,
@@ -67,8 +127,98 @@ pub(crate) fn cmd_mcp_serve(args: McpServeArgs) {
         }
     };
 
-    if let Err(e) = runtime.block_on(rsigma_mcp::serve_stdio(handler)) {
+    let result = match args.http {
+        None => runtime.block_on(rsigma_mcp::serve_stdio(handler)),
+        Some(addr) => runtime.block_on(serve_http_transport(handler, addr, &args)),
+    };
+
+    if let Err(e) = result {
         eprintln!("MCP server error: {e}");
         process::exit(exit_code::RULE_ERROR);
     }
+}
+
+/// Serve the Streamable HTTP transport (plaintext, or TLS when `daemon-tls` is
+/// compiled and cert/key are supplied).
+async fn serve_http_transport(
+    handler: rsigma_mcp::RsigmaMcp,
+    addr: SocketAddr,
+    args: &McpServeArgs,
+) -> anyhow::Result<()> {
+    let tls_requested = args.tls_cert.is_some();
+
+    if !tls_requested && !addr.ip().is_loopback() && !args.allow_plaintext {
+        anyhow::bail!(
+            "refusing to bind plaintext on non-loopback address {addr}; \
+             pass --tls-cert/--tls-key to enable TLS or --allow-plaintext to opt out \
+             (e.g. when terminating TLS at a sidecar proxy)"
+        );
+    }
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let auth = args.auth_token.clone();
+
+    if tls_requested {
+        return serve_http_tls(handler, listener, auth, addr, args).await;
+    }
+
+    eprintln!("MCP Streamable HTTP server listening on http://{addr}/mcp");
+    rsigma_mcp::serve_http(handler, listener, auth).await
+}
+
+/// TLS path: only available when the `daemon-tls` feature is compiled. Reuses
+/// the daemon's rustls loader and TLS-terminating axum listener.
+#[cfg(feature = "daemon-tls")]
+async fn serve_http_tls(
+    handler: rsigma_mcp::RsigmaMcp,
+    listener: tokio::net::TcpListener,
+    auth: Option<String>,
+    addr: SocketAddr,
+    args: &McpServeArgs,
+) -> anyhow::Result<()> {
+    use std::sync::Arc;
+
+    use crate::daemon::tls::{RustlsListener, TlsCliConfig, TlsState};
+
+    let cli = TlsCliConfig {
+        cert_path: args.tls_cert.clone().expect("tls_cert present"),
+        key_path: args.tls_key.clone().expect("tls_key present"),
+        key_password: None,
+        client_ca_path: None,
+        min_version: Default::default(),
+    };
+    let tls_state = TlsState::from_paths(cli).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let gauge = Arc::new(
+        prometheus::IntGauge::new(
+            "rsigma_mcp_tls_active_connections",
+            "Active TLS connections to the MCP HTTP server",
+        )
+        .expect("valid gauge"),
+    );
+    let tls_listener = RustlsListener::new(listener, tls_state.config, gauge);
+
+    eprintln!("MCP Streamable HTTP server listening on https://{addr}/mcp");
+
+    let router = rsigma_mcp::http_router(handler, auth);
+    axum::serve(tls_listener, router).await?;
+    Ok(())
+}
+
+/// Stub used when the binary is built without `daemon-tls`: TLS flags require
+/// that feature, so surface a clear error rather than silently falling back to
+/// plaintext.
+#[cfg(not(feature = "daemon-tls"))]
+async fn serve_http_tls(
+    _handler: rsigma_mcp::RsigmaMcp,
+    _listener: tokio::net::TcpListener,
+    _auth: Option<String>,
+    _addr: SocketAddr,
+    _args: &McpServeArgs,
+) -> anyhow::Result<()> {
+    anyhow::bail!(
+        "--tls-cert/--tls-key require a build with the `daemon-tls` feature; \
+         rebuild with `--features daemon-tls` or terminate TLS at a sidecar proxy \
+         and use --allow-plaintext"
+    )
 }

--- a/crates/rsigma-cli/src/config/defaults.rs
+++ b/crates/rsigma-cli/src/config/defaults.rs
@@ -118,5 +118,8 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
             syslog_strip_bom: Some(SYSLOG_STRIP_BOM),
             fail_on_detection: Some(false),
         }),
+        // The `mcp` section has no compiled defaults: stdio is the default
+        // transport, and the lint-config / rules-dir roots have no default.
+        mcp: None,
     }
 }

--- a/crates/rsigma-cli/src/config/mod.rs
+++ b/crates/rsigma-cli/src/config/mod.rs
@@ -219,7 +219,7 @@ fn load_file(path: &Path) -> Result<(RsigmaConfigPartial, Vec<String>), ConfigEr
             let message = if raw.contains("expected struct RsigmaConfigPartial") {
                 format!(
                     "top-level config must be a YAML mapping of sections \
-                 (global, daemon, eval); got {raw}"
+                 (global, daemon, eval, mcp); got {raw}"
                 )
             } else {
                 raw

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -43,6 +43,9 @@ pub(crate) struct RsigmaConfigPartial {
     /// `rsigma engine eval` settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eval: Option<EvalPartial>,
+    /// `rsigma mcp serve` settings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<McpPartial>,
 }
 
 impl Merge for RsigmaConfigPartial {
@@ -52,6 +55,7 @@ impl Merge for RsigmaConfigPartial {
             global: merge_opt(self.global, over.global),
             daemon: merge_opt(self.daemon, over.daemon),
             eval: merge_opt(self.eval, over.eval),
+            mcp: merge_opt(self.mcp, over.mcp),
         }
     }
 }
@@ -410,6 +414,32 @@ impl Merge for EvalPartial {
     }
 }
 
+/// `mcp serve` settings. The auth token is deliberately absent: secrets stay
+/// flag/env-only (`--auth-token` / `RSIGMA_MCP_AUTH_TOKEN`).
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct McpPartial {
+    /// Bind address for the Streamable HTTP transport (maps to `--http`).
+    /// Unset means stdio.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_addr: Option<String>,
+    /// Lint config file applied by the `lint_rules` tool (maps to `--lint-config`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lint_config: Option<PathBuf>,
+    /// Default root for relative path-based tool calls (maps to `--rules-dir`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rules_dir: Option<PathBuf>,
+}
+
+impl Merge for McpPartial {
+    fn merge(self, over: Self) -> Self {
+        Self {
+            http_addr: over.http_addr.or(self.http_addr),
+            lint_config: over.lint_config.or(self.lint_config),
+            rules_dir: over.rules_dir.or(self.rules_dir),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -448,6 +478,21 @@ mod tests {
             Some("127.0.0.1:8080".into())
         );
         assert_eq!(merged.version, Some(1));
+    }
+
+    #[test]
+    fn mcp_section_parses_and_merges() {
+        let base: RsigmaConfigPartial = yaml_serde::from_str(
+            "mcp:\n  http_addr: 127.0.0.1:9100\n  rules_dir: /etc/rsigma/rules\n",
+        )
+        .expect("parses mcp section");
+        let over: RsigmaConfigPartial =
+            yaml_serde::from_str("mcp:\n  rules_dir: /override/rules\n").expect("parses override");
+        let merged = base.merge(over);
+        let mcp = merged.mcp.expect("mcp section");
+        // higher layer wins per-field; untouched fields are preserved
+        assert_eq!(mcp.http_addr.as_deref(), Some("127.0.0.1:9100"));
+        assert_eq!(mcp.rules_dir, Some(PathBuf::from("/override/rules")));
     }
 
     #[test]

--- a/crates/rsigma-cli/src/config/template.yaml
+++ b/crates/rsigma-cli/src/config/template.yaml
@@ -136,3 +136,13 @@ eval:
   # Strip a leading UTF-8 BOM from RFC 5424 syslog messages. Set false to keep it.
   syslog_strip_bom: true
   fail_on_detection: false
+
+# `rsigma mcp serve` settings. The auth token is NOT configurable here by
+# design; supply it via --auth-token or RSIGMA_MCP_AUTH_TOKEN.
+mcp:
+  # Bind address for the Streamable HTTP transport (`--http`). Unset = stdio.
+  # http_addr: 127.0.0.1:9100
+  # Lint config file applied by the lint_rules tool (`--lint-config`).
+  # lint_config: .rsigma-lint.yml
+  # Default root for relative path-based tool calls (`--rules-dir`).
+  # rules_dir: ./rules

--- a/crates/rsigma-mcp/src/http.rs
+++ b/crates/rsigma-mcp/src/http.rs
@@ -1,0 +1,98 @@
+//! Streamable HTTP transport for the MCP server.
+//!
+//! Mounts the rmcp [`StreamableHttpService`] on an axum router at `/mcp`, with
+//! optional static bearer-token authentication enforced as a middleware layer.
+//! TLS termination is the caller's responsibility (the CLI reuses the daemon's
+//! rustls listener); this module produces the router and a plaintext serve
+//! helper.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{Request, State};
+use axum::http::{StatusCode, header::AUTHORIZATION};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use rmcp::transport::streamable_http_server::StreamableHttpService;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+
+use crate::RsigmaMcp;
+
+/// Build the axum router exposing the MCP service at `/mcp`.
+///
+/// When `auth_token` is `Some`, every request must carry a matching
+/// `Authorization: Bearer <token>` header or receive `401 Unauthorized`.
+pub fn http_router(handler: RsigmaMcp, auth_token: Option<String>) -> Router {
+    let service = StreamableHttpService::new(
+        move || Ok(handler.clone()),
+        Arc::new(LocalSessionManager::default()),
+        Default::default(),
+    );
+
+    let mut router = Router::new().nest_service("/mcp", service);
+    if let Some(token) = auth_token {
+        router = router.layer(middleware::from_fn_with_state(Arc::new(token), bearer_auth));
+    }
+    router
+}
+
+/// Serve the MCP HTTP router on `listener` (plaintext). The caller owns the
+/// tokio runtime; for TLS, build [`http_router`] and serve it over a
+/// TLS-terminating [`axum::serve::Listener`] instead.
+pub async fn serve_http(
+    handler: RsigmaMcp,
+    listener: tokio::net::TcpListener,
+    auth_token: Option<String>,
+) -> anyhow::Result<()> {
+    let router = http_router(handler, auth_token);
+    axum::serve(listener, router).await?;
+    Ok(())
+}
+
+/// Bearer-token auth middleware. Compares the presented token to the configured
+/// one in constant time and returns `401` on any mismatch or absence.
+async fn bearer_auth(
+    State(expected): State<Arc<String>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let authorized = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|t| constant_time_eq(t.as_bytes(), expected.as_bytes()))
+        .unwrap_or(false);
+
+    if authorized {
+        next.run(request).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "missing or invalid bearer token").into_response()
+    }
+}
+
+/// Constant-time byte comparison so token checks do not leak the matched prefix
+/// length via timing. (The overall length is not secret for a bearer token.)
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::constant_time_eq;
+
+    #[test]
+    fn constant_time_eq_matches() {
+        assert!(constant_time_eq(b"secret", b"secret"));
+        assert!(!constant_time_eq(b"secret", b"secrey"));
+        assert!(!constant_time_eq(b"secret", b"secretx"));
+        assert!(!constant_time_eq(b"", b"x"));
+    }
+}

--- a/crates/rsigma-mcp/src/lib.rs
+++ b/crates/rsigma-mcp/src/lib.rs
@@ -11,9 +11,13 @@
 //! handlers are thin synchronous wrappers over the underlying rsigma crates,
 //! which keeps stdout reserved for the transport (all diagnostics go to stderr).
 
+#[cfg(feature = "http")]
+mod http;
 mod input;
 mod tools;
 
+#[cfg(feature = "http")]
+pub use http::{http_router, serve_http};
 pub use tools::RsigmaMcp;
 
 use rmcp::ServiceExt;

--- a/crates/rsigma-mcp/tests/http.rs
+++ b/crates/rsigma-mcp/tests/http.rs
@@ -1,0 +1,93 @@
+//! Integration tests for the Streamable HTTP transport and bearer auth.
+//!
+//! Only compiled with the `http` feature (which the workspace `--all-features`
+//! gate enables).
+#![cfg(feature = "http")]
+
+use std::time::Duration;
+
+use rmcp::ServiceExt;
+use rmcp::transport::StreamableHttpClientTransport;
+use rsigma_mcp::RsigmaMcp;
+
+/// Install a process-default rustls crypto provider. Under `--all-features`
+/// both aws-lc-rs and ring are in the dependency graph, so rustls has no
+/// unambiguous default and the reqwest client the rmcp transport builds would
+/// otherwise panic with "No provider set". Idempotent.
+fn ensure_crypto_provider() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+/// Bind an ephemeral port and spawn the MCP HTTP server on it, returning the
+/// bound address once it is listening.
+async fn spawn_server(auth: Option<String>) -> std::net::SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = rsigma_mcp::serve_http(RsigmaMcp::default(), listener, auth).await;
+    });
+    // Give the spawned server a moment to start accepting.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    addr
+}
+
+#[tokio::test]
+async fn http_tools_list_round_trip() {
+    ensure_crypto_provider();
+    let addr = spawn_server(None).await;
+    let transport = StreamableHttpClientTransport::from_uri(format!("http://{addr}/mcp"));
+    let client = ().serve(transport).await.expect("client connect");
+
+    let tools = client.list_all_tools().await.expect("list tools");
+    assert_eq!(tools.len(), 11, "expected 11 tools over HTTP");
+
+    client.cancel().await.ok();
+}
+
+#[tokio::test]
+async fn http_bearer_auth_401_and_200() {
+    ensure_crypto_provider();
+    let token = "s3cr3t-token";
+    let addr = spawn_server(Some(token.to_string())).await;
+    let url = format!("http://{addr}/mcp");
+    let http = reqwest::Client::new();
+
+    let init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
+
+    // No token -> the bearer middleware rejects before the MCP service.
+    let resp = http
+        .post(&url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(init_body)
+        .send()
+        .await
+        .expect("request sends");
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // Correct token -> request passes the middleware (the MCP service handles
+    // it; the status is no longer 401).
+    let resp = http
+        .post(&url)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(init_body)
+        .send()
+        .await
+        .expect("request sends");
+    assert_ne!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "request with a valid token must not be 401"
+    );
+    assert!(
+        resp.status().is_success(),
+        "request with a valid token should be handled: got {}",
+        resp.status()
+    );
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,6 +86,7 @@ Run [`rsigma config init`](../cli/config/init.md) to scaffold a full, commented 
 | `daemon.nats` | `engine daemon` | Non-secret NATS knobs (e.g. `consumer_group`). Secrets stay env-only. Inert unless built with `daemon-nats`. |
 | `daemon.engine.cross_rule_ac` | `engine daemon` | Inert unless built with `daachorse-index`. |
 | `eval` | `engine eval` | Mirrors the eval flag surface. |
+| `mcp` | `mcp serve` | `mcp.http_addr` (the `--http` bind address; unset means stdio), `mcp.lint_config`, and `mcp.rules_dir`. The auth token is secret and stays flag/env-only. Inert unless built with the `mcp` feature. |
 
 ### Secrets policy
 
@@ -107,6 +108,7 @@ Two parallel schemes are honoured:
     | `RSIGMA_DAEMON__API__ADDR=127.0.0.1:9090` | `daemon.api.addr` |
     | `RSIGMA_DAEMON__INPUT__BUFFER_SIZE=20000` | `daemon.input.buffer_size` |
     | `RSIGMA_GLOBAL__LOG_FORMAT=json` | `global.log_format` |
+    | `RSIGMA_MCP__HTTP_ADDR=127.0.0.1:9100` | `mcp.http_addr` |
 
 2. **Legacy clap-bound names** with a single underscore (`NATS_CREDS`, `RSIGMA_CONSUMER_GROUP`, `RSIGMA_TLS_KEY_PASSWORD`). These continue to work at the flag layer and are listed in [Environment Variables](environment-variables.md). Secrets are *only* readable this way.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -16,7 +16,8 @@ Every variable here has a corresponding `--flag` that takes precedence.
 | `RSIGMA_GLOBAL__OUTPUT_FORMAT` | `json`/`ndjson`/`table`/`csv`/`tsv` | unset | All | Default value for `--output-format`. See [Output Formats](output.md). |
 | `RSIGMA_GLOBAL__COLOR` | `auto`/`always`/`never` | unset | All | Default value for `--color`. |
 | `XDG_CONFIG_HOME` | path | `~/.config` | All | Honoured when locating the user config (`$XDG_CONFIG_HOME/rsigma/config.yaml`). See [Configuration discovery](configuration.md#discovery). |
-| `RSIGMA_<SECTION>__<KEY>` | YAML scalar | unset | `engine daemon`, `engine eval` | Uniform env layer for non-secret config keys (e.g. `RSIGMA_DAEMON__API__ADDR`, `RSIGMA_GLOBAL__LOG_FORMAT`). See [Configuration: environment layer](configuration.md#environment-layer). |
+| `RSIGMA_<SECTION>__<KEY>` | YAML scalar | unset | `engine daemon`, `engine eval`, `mcp serve` | Uniform env layer for non-secret config keys (e.g. `RSIGMA_DAEMON__API__ADDR`, `RSIGMA_GLOBAL__LOG_FORMAT`, `RSIGMA_MCP__HTTP_ADDR`). See [Configuration: environment layer](configuration.md#environment-layer). |
+| `RSIGMA_MCP_AUTH_TOKEN` | string | unset | `mcp serve --http` | Static bearer token required on every HTTP request (`Authorization: Bearer <token>`). Equivalent to `--auth-token`. Secret: flag/env only, never read from config files. |
 | `RSIGMA_CONSUMER_GROUP` | string | unset | `engine daemon` with `--input nats://` | NATS JetStream consumer group name. Equivalent to `--consumer-group`. Multiple daemons sharing the same group name load-balance across a single durable pull consumer. |
 | `RSIGMA_TLS_KEY_PASSWORD` | string | unset | `engine daemon` with `--tls-key` | Password for an encrypted TLS key. Currently rejected at startup; reserved for a future release. |
 | `NATS_CREDS` | path to `.creds` file | unset | `engine daemon` with NATS source or sink | NATS credentials file (JWT + NKey). Equivalent to `--nats-creds`. |


### PR DESCRIPTION
## Summary

Adds a remote transport and configuration to the MCP server (the stdio server from #208); stdio stays the default.

- **Streamable HTTP transport.** `rsigma mcp serve --http <addr>` serves the MCP endpoint at `/mcp` over HTTP, built on rmcp's `StreamableHttpService` mounted on axum (behind the `mcp` feature, which enables `rsigma-mcp/http`).
- **Bearer-token auth.** `--auth-token <token>` (or `RSIGMA_MCP_AUTH_TOKEN`) is required on every request and compared in constant time; requests without it get `401`. The token is flag/env-only and never read from config files.
- **TLS.** `--tls-cert`/`--tls-key` terminate TLS in-process using the daemon's rustls loader (requires the `daemon-tls` feature). Plaintext binds on non-loopback addresses are refused unless `--allow-plaintext`.
- **Config keys.** A new `mcp` config section (`mcp.http_addr`, `mcp.lint_config`, `mcp.rules_dir`) wired through `rsigma config init/validate/show/schema` and the `RSIGMA_MCP__*` environment layer. The auth token stays flag/env-only by design.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo check -p rsigma` (default build, `mcp` opted out)
- [x] `cargo test -p rsigma-mcp --all-features` (34 tests, including the HTTP integration suite: `tools/list`, 401 without token, 200 with token)
- [x] `mkdocs build --strict`