### PR TITLE
fix(cli): build with `--no-default-features`

### DIFF
--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -8,6 +8,9 @@ mod lint;
 mod mcp;
 mod migrate_sources;
 mod parse;
+// `pipeline resolve` needs the async runtime + source resolver, which only
+// ship with the `daemon` feature.
+#[cfg(feature = "daemon")]
 mod resolve;
 mod validate;
 
@@ -23,5 +26,6 @@ pub(crate) use lint::{LintArgs, LintCounts, cmd_lint};
 pub(crate) use mcp::{McpCommands, dispatch_mcp};
 pub(crate) use migrate_sources::{MigrateSourcesArgs, cmd_migrate_sources};
 pub(crate) use parse::{ConditionArgs, ParseArgs, StdinArgs, cmd_condition, cmd_parse, cmd_stdin};
+#[cfg(feature = "daemon")]
 pub(crate) use resolve::{ResolveArgs, cmd_resolve};
 pub(crate) use validate::{ValidateArgs, cmd_validate};

--- a/crates/rsigma-cli/src/commands/validate.rs
+++ b/crates/rsigma-cli/src/commands/validate.rs
@@ -37,82 +37,26 @@ pub(crate) fn cmd_validate(args: ValidateArgs) {
         resolve_sources,
         source_files,
     } = args;
-    let mut pipelines = crate::load_pipelines(&pipeline_paths);
-
-    // Load and resolve external sources alongside pipeline-embedded ones
-    let external_sources = if !source_files.is_empty() {
-        match rsigma_runtime::sources::registry::load_external_sources(&source_files) {
-            Ok(ext) => ext.into_iter().map(|(s, _)| s).collect::<Vec<_>>(),
-            Err(e) => {
-                eprintln!("Error loading external sources: {e}");
-                process::exit(crate::exit_code::CONFIG_ERROR);
-            }
+    // Dynamic source resolution (`--resolve-sources` / `--source`) needs the
+    // async runtime + source resolver, which ship with the `daemon` feature.
+    #[cfg(feature = "daemon")]
+    let pipelines = resolve_validate_sources(
+        crate::load_pipelines(&pipeline_paths),
+        resolve_sources,
+        &source_files,
+    );
+    #[cfg(not(feature = "daemon"))]
+    let pipelines = {
+        let loaded = crate::load_pipelines(&pipeline_paths);
+        if resolve_sources || !source_files.is_empty() {
+            eprintln!(
+                "error: --resolve-sources/--source require the `daemon` feature; \
+                 rebuild with `--features daemon`"
+            );
+            process::exit(crate::exit_code::CONFIG_ERROR);
         }
-    } else {
-        Vec::new()
+        loaded
     };
-
-    if resolve_sources {
-        let has_dynamic = pipelines.iter().any(|p| p.is_dynamic()) || !external_sources.is_empty();
-        if has_dynamic {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap_or_else(|e| {
-                    eprintln!("Failed to create async runtime for source resolution: {e}");
-                    process::exit(crate::exit_code::CONFIG_ERROR);
-                });
-
-            let resolver = rsigma_runtime::DefaultSourceResolver::new();
-            let mut resolved_pipelines = Vec::with_capacity(pipelines.len());
-            let mut source_errors: Vec<String> = Vec::new();
-
-            // Resolve external sources first so they populate the cache
-            if !external_sources.is_empty()
-                && let Err(e) = rt.block_on(rsigma_runtime::sources::resolve_all(
-                    &resolver,
-                    &external_sources,
-                ))
-            {
-                source_errors.push(format!("external sources: {e}"));
-            }
-
-            for pipeline in &pipelines {
-                if pipeline.is_dynamic() {
-                    match rt.block_on(rsigma_runtime::sources::resolve_all(
-                        &resolver,
-                        &pipeline.sources,
-                    )) {
-                        Ok(resolved_data) => {
-                            let expanded =
-                                rsigma_runtime::sources::template::TemplateExpander::expand(
-                                    pipeline,
-                                    &resolved_data,
-                                );
-                            resolved_pipelines.push(expanded);
-                        }
-                        Err(e) => {
-                            source_errors.push(format!("pipeline '{}': {e}", pipeline.name));
-                            resolved_pipelines.push(pipeline.clone());
-                        }
-                    }
-                } else {
-                    resolved_pipelines.push(pipeline.clone());
-                }
-            }
-
-            if !source_errors.is_empty() {
-                eprintln!("Source resolution errors:");
-                for err in &source_errors {
-                    eprintln!("  - {err}");
-                }
-                process::exit(crate::exit_code::CONFIG_ERROR);
-            }
-
-            pipelines = resolved_pipelines;
-            println!("  Sources resolved:  OK");
-        }
-    }
 
     match parse_sigma_directory(&path) {
         Ok(collection) => {
@@ -187,4 +131,92 @@ pub(crate) fn cmd_validate(args: ValidateArgs) {
             process::exit(crate::exit_code::RULE_ERROR);
         }
     }
+}
+
+/// Load external sources and, when `--resolve-sources` is set, resolve every
+/// dynamic pipeline and external source, returning the expanded pipelines.
+/// Exits with `CONFIG_ERROR` on a load or resolution failure.
+#[cfg(feature = "daemon")]
+fn resolve_validate_sources(
+    mut pipelines: Vec<rsigma_eval::Pipeline>,
+    resolve_sources: bool,
+    source_files: &[PathBuf],
+) -> Vec<rsigma_eval::Pipeline> {
+    // Load external sources alongside pipeline-embedded ones (validating that
+    // the source files parse, regardless of whether we resolve them).
+    let external_sources = if !source_files.is_empty() {
+        match rsigma_runtime::sources::registry::load_external_sources(source_files) {
+            Ok(ext) => ext.into_iter().map(|(s, _)| s).collect::<Vec<_>>(),
+            Err(e) => {
+                eprintln!("Error loading external sources: {e}");
+                process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    if resolve_sources {
+        let has_dynamic = pipelines.iter().any(|p| p.is_dynamic()) || !external_sources.is_empty();
+        if has_dynamic {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap_or_else(|e| {
+                    eprintln!("Failed to create async runtime for source resolution: {e}");
+                    process::exit(crate::exit_code::CONFIG_ERROR);
+                });
+
+            let resolver = rsigma_runtime::DefaultSourceResolver::new();
+            let mut resolved_pipelines = Vec::with_capacity(pipelines.len());
+            let mut source_errors: Vec<String> = Vec::new();
+
+            // Resolve external sources first so they populate the cache
+            if !external_sources.is_empty()
+                && let Err(e) = rt.block_on(rsigma_runtime::sources::resolve_all(
+                    &resolver,
+                    &external_sources,
+                ))
+            {
+                source_errors.push(format!("external sources: {e}"));
+            }
+
+            for pipeline in &pipelines {
+                if pipeline.is_dynamic() {
+                    match rt.block_on(rsigma_runtime::sources::resolve_all(
+                        &resolver,
+                        &pipeline.sources,
+                    )) {
+                        Ok(resolved_data) => {
+                            let expanded =
+                                rsigma_runtime::sources::template::TemplateExpander::expand(
+                                    pipeline,
+                                    &resolved_data,
+                                );
+                            resolved_pipelines.push(expanded);
+                        }
+                        Err(e) => {
+                            source_errors.push(format!("pipeline '{}': {e}", pipeline.name));
+                            resolved_pipelines.push(pipeline.clone());
+                        }
+                    }
+                } else {
+                    resolved_pipelines.push(pipeline.clone());
+                }
+            }
+
+            if !source_errors.is_empty() {
+                eprintln!("Source resolution errors:");
+                for err in &source_errors {
+                    eprintln!("  - {err}");
+                }
+                process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+
+            pipelines = resolved_pipelines;
+            println!("  Sources resolved:  OK");
+        }
+    }
+
+    pipelines
 }

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -12,8 +12,13 @@ use std::process;
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use commands::{
     ConditionArgs, ConvertArgs, EvalArgs, FieldsArgs, LintArgs, LintCounts, ListFormatsArgs,
-    MigrateSourcesArgs, ParseArgs, ResolveArgs, StdinArgs, ValidateArgs,
+    MigrateSourcesArgs, ParseArgs, StdinArgs, ValidateArgs,
 };
+// `pipeline resolve` resolves dynamic sources, which needs the async runtime
+// (tokio) and the source resolver from rsigma-runtime. Both ship with the
+// `daemon` feature, so the command is gated on it.
+#[cfg(feature = "daemon")]
+use commands::ResolveArgs;
 #[cfg(feature = "daemon")]
 use commands::{DaemonArgs, cmd_daemon};
 #[cfg(feature = "mcp")]
@@ -120,6 +125,7 @@ enum Commands {
     },
 
     /// Pipeline tooling (resolve dynamic sources, …)
+    #[cfg(feature = "daemon")]
     Pipeline {
         #[command(subcommand)]
         cmd: PipelineCommands,
@@ -185,6 +191,7 @@ enum Commands {
     ListFormats(ListFormatsArgs),
 
     /// \[deprecated\] Use `rsigma pipeline resolve` instead
+    #[cfg(feature = "daemon")]
     #[command(hide = true)]
     Resolve(ResolveArgs),
 }
@@ -236,6 +243,7 @@ enum BackendCommands {
     Formats(ListFormatsArgs),
 }
 
+#[cfg(feature = "daemon")]
 #[derive(Subcommand)]
 enum PipelineCommands {
     /// Resolve dynamic pipeline sources and display their data
@@ -336,6 +344,7 @@ fn dispatch(command: Commands, matches: &ArgMatches, ctx: output::OutputCtx) {
         Commands::Engine { cmd } => dispatch_engine(cmd, matches, ctx),
         Commands::Rule { cmd } => dispatch_rule(cmd, ctx),
         Commands::Backend { cmd } => dispatch_backend(cmd, ctx),
+        #[cfg(feature = "daemon")]
         Commands::Pipeline { cmd } => dispatch_pipeline(cmd),
         #[cfg(feature = "mcp")]
         Commands::Mcp { cmd } => dispatch_mcp(cmd),
@@ -393,6 +402,7 @@ fn dispatch(command: Commands, matches: &ArgMatches, ctx: output::OutputCtx) {
             deprecation_warn("list-formats", "backend formats");
             commands::cmd_list_formats(target);
         }
+        #[cfg(feature = "daemon")]
         Commands::Resolve(args) => {
             deprecation_warn("resolve", "pipeline resolve");
             commands::cmd_resolve(args);
@@ -440,6 +450,7 @@ fn dispatch_backend(cmd: BackendCommands, ctx: output::OutputCtx) {
     }
 }
 
+#[cfg(feature = "daemon")]
 fn dispatch_pipeline(cmd: PipelineCommands) {
     match cmd {
         PipelineCommands::Resolve(args) => commands::cmd_resolve(args),
@@ -530,6 +541,10 @@ pub(crate) fn load_pipelines(paths: &[PathBuf]) -> Vec<Pipeline> {
                             p.sources.iter().map(|s| s.id.as_str()).collect();
                         eprintln!("  dynamic source(s): {}", source_ids.join(", "));
                     }
+                    // The inline-sources deprecation warning lives in
+                    // rsigma-runtime, which is only linked with the `daemon`
+                    // feature. Builds without it cannot resolve sources anyway.
+                    #[cfg(feature = "daemon")]
                     if !p.sources.is_empty() {
                         rsigma_runtime::warn_pipeline_inline_sources(path, &p.name);
                     }

--- a/crates/rsigma-cli/tests/cli_daemon.rs
+++ b/crates/rsigma-cli/tests/cli_daemon.rs
@@ -1,5 +1,7 @@
 //! Integration tests for daemon state persistence and streaming pipeline.
 
+#![cfg(feature = "daemon")]
+
 mod common;
 
 use common::{SIMPLE_RULE, rsigma, temp_file};


### PR DESCRIPTION
## Summary

- `pipeline resolve` and `rule validate --resolve-sources` resolve dynamic sources, which needs the async runtime (`tokio`) and the source resolver from `rsigma-runtime`. Both ship only with the `daemon` feature, but the command wiring referenced `rsigma_runtime` and `tokio` unconditionally, so `cargo build --no-default-features` failed to compile (CI only ever builds `--all-features`, `--features mcp`, and the default, so this was untested).
- Gate the `pipeline` command group, the `resolve` module, the inline-sources deprecation warning in `load_pipelines`, and the `rule validate` source-resolution path behind the `daemon` feature. Without it, `rule validate --resolve-sources`/`--source` exits with a clear "rebuild with --features daemon" message instead of failing the build.
- Gate the `cli_daemon` integration test file behind `daemon`, matching the other daemon test files (it was the only one missing the gate).

Daemon-enabled behavior (the default and `--all-features` builds) is unchanged.

## Test plan

- [x] `cargo build -p rsigma --no-default-features`
- [x] `cargo clippy -p rsigma --no-default-features --all-targets -- -D warnings`
- [x] same for `--no-default-features --features evtx|logfmt|cef` (the combos that pull `rsigma-runtime` without `daemon`)
- [x] `cargo clippy -p rsigma --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rsigma --all-features --test cli_validate --test cli_daemon_dynamic` (the `--resolve-sources` path is behavior-preserving)