### PR TITLE
feat(cli): add `rule backtest` corpus-replay harness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Golden test outputs are compared byte-for-byte against tool output, which is
+# always LF. Pin them to LF so a Windows checkout does not rewrite them to CRLF.
+crates/rsigma-cli/tests/golden/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### `rule backtest`: corpus replay with per-rule expectations (#TBD)
+
+A new `rsigma rule backtest` subcommand replays an event corpus against a ruleset and diffs the per-rule fire counts against declared expectations, the per-rule fixture harness that `engine eval --fail-on-detection` could not provide (that check is corpus-global and passes when any rule fires).
+
+- **Corpus replay.** `--corpus` takes a file or a directory walked recursively, with extension dispatch (`.ndjson`/`.jsonl` as NDJSON, `.evtx` via the evtx feature, everything else through `--input-format`). Correlation state is reset per corpus file so each file is an independent time slice.
+- **Expectations.** An optional `--expectations` YAML asserts per rule (by id or title): `at_least`, `at_most`, or `exactly`, optionally scoped to one corpus file. A rule that fires with no covering expectation is surfaced as a potential false positive, governed by `--unexpected` (`fail`/`warn`/`ignore`).
+- **Reports.** The report renders through the shared output layer (`table`, `json`, `ndjson`/`csv`/`tsv` per-rule rows) and can be written to `--report` (JSON) and `--junit` (a hand-rolled JUnit XML, no new dependency). It carries per-rule fires, a per-corpus-file breakdown, the unexpected-fire set, and a per-logsource false-positive-density rollup.
+- **Exit codes** follow the house scheme: `0` all expectations met, `1` a failed expectation or a policy-failing unexpected fire, `2` unreadable rules, `3` a bad expectations file or corpus path.
+- **Config.** A `backtest` section (`rules`, `corpus`, `expectations`, `unexpected`, `pipelines`, and the syslog input knobs) flows through `rsigma config init/validate/show/schema`, the `RSIGMA_BACKTEST__*` environment layer, `--config`, and `--dry-run`.
+- **Internal.** The format-aware eval stream loop moved into a shared `commands::eval_stream` module so `engine eval` and `rule backtest` cannot drift on input parsing; eval behavior is unchanged.
+
 ### `rstix`: Phase 2 — STIX meta objects (#213)
 
 Phase 2 adds STIX meta objects (not releasable on its own until `StixObject` dispatch and `Bundle` parsing land).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### `rule backtest`: corpus replay with per-rule expectations (#TBD)
+### `rule backtest`: corpus replay with per-rule expectations (#216)
 
 A new `rsigma rule backtest` subcommand replays an event corpus against a ruleset and diffs the per-rule fire counts against declared expectations, the per-rule fixture harness that `engine eval --fail-on-detection` could not provide (that check is corpus-global and passes when any rule fires).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For rule quality and editor integration, a built-in linter validates rules again
 * **Processing pipelines:** Use pySigma-compatible processing pipelines for field mapping, transformations, conditions, and finalizers
 * **Dynamic pipelines:** Populate any pipeline value from external sources (HTTP, files, commands, NATS) with template expansion, auto-refresh, and data extraction via jq, JSONPath, or CEL
 * **Post-evaluation enrichment:** Inject contextual data (asset info, IP reputation, identity, GeoIP, runbook URLs, ...) into detection and correlation results via four primitives (`template`, `lookup`, `http`, `command`) with kind-aware template namespaces, response cache, scope filtering, and hot-reload
+* **Corpus backtesting:** Replay an event corpus against a ruleset with `rule backtest`, diffing per-rule fire counts against declared expectations (positive/negative fixtures, bounded noise budgets), flagging uncovered fires as potential false positives, and emitting a JSON or JUnit XML report for CI
 * **Rule conversion:** Convert rules into backend-native query strings via a pluggable backend trait (PostgreSQL/TimescaleDB SQL, LynxDB SPL2, Fibratus rule YAML for EDR sensors)
 * **Eval prefilters:** Use optional prefilters for large rule sets, including a bloom filter for substring matchers (`--bloom-prefilter`) and cross-rule Aho-Corasick index for whole-rule pruning (`--cross-rule-ac`, requires `daachorse-index` feature)
 * **Field observability:** Opt-in `--observe-fields` mode on both `engine daemon` (live, exposed over `GET /api/v1/fields*` with Prometheus counters) and `engine eval` (one-shot JSON report at end-of-run, ideal for CI gap analysis) surfaces which event fields no rule references (gap signal) and which rule fields have never appeared in an event (broken-coverage signal); same JSON shape across runtimes
@@ -319,6 +320,9 @@ rsigma rule fields -r rules/
 
 # Show fields after pipeline mapping
 rsigma rule fields -r rules/ -p ecs.yml --json
+
+# Backtest a corpus against per-rule expectations (CI fixture harness)
+rsigma rule backtest -r rules/ --corpus ci/corpus/ --expectations ci/expectations.yml
 
 # List available backends and formats
 rsigma backend targets

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -63,7 +63,7 @@ These flags work with every subcommand, mirroring how `--log-format` does, and t
 
 ## Subcommands
 
-Commands are grouped into four noun-led groups: `engine` (eval / daemon), `rule` (parse / validate / lint / fields / condition / stdin), `backend` (convert / targets / formats), and `pipeline` (resolve).
+Commands are grouped into four noun-led groups: `engine` (eval / daemon), `rule` (parse / validate / lint / fields / backtest / condition / stdin), `backend` (convert / targets / formats), and `pipeline` (resolve).
 
 ### Migrating from the old flat commands
 
@@ -110,7 +110,7 @@ rsigma config path
 rsigma config reload
 ```
 
-`engine daemon` and `engine eval` also support `--config <PATH>` (load only that file) and `--dry-run` (print the effective section and exit `0`).
+`engine daemon`, `engine eval`, and `rule backtest` also support `--config <PATH>` (load only that file) and `--dry-run` (print the effective section and exit `0`).
 
 Discovery walks: `/etc/rsigma/config.yaml` → `~/.config/rsigma/config.yaml` → nearest `.rsigmarc` (walked up from CWD) → `./rsigma.yaml`. Override with `--config`. The full schema, environment-variable scheme (`RSIGMA_<SECTION>__<KEY>`), and secrets policy live in the [Configuration Reference](https://timescale.github.io/rsigma/reference/configuration/).
 
@@ -767,6 +767,34 @@ rsigma rule fields -r rules/ --json | jq '.fields[] | select(.sources[] == "dete
 **Table output** writes field data to stdout and a summary line to stderr, so you can pipe the table or redirect it without mixing in summary text.
 
 **JSON output** includes a `summary` object (rule/correlation/filter counts, unique fields, pipelines applied), a `fields` array, and when pipelines are applied, a `pipeline_mappings` array showing each field name transformation.
+
+### `rule backtest`: Replay a corpus and diff per-rule fires against expectations
+
+Walks an event corpus (a file or a directory, recursively), evaluates every record, tallies per-rule and per-corpus-file fire counts, and diffs them against an optional expectations file. It is the per-rule fixture harness: a positive fixture can require a rule to fire at least once, a negative fixture can require a rule to fire exactly zero times, and any rule that fires without a covering expectation is surfaced as a potential false positive.
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `--rules` / `-r` | path | required | Sigma rule file or directory (or `backtest.rules` in a config file) |
+| `--corpus` | repeatable | required | Corpus file or directory; `.ndjson`/`.jsonl` as NDJSON, `.evtx` via the evtx feature, else `--input-format` |
+| `--expectations` | path | none | Expectations YAML (per-rule assertions); without it, backtest prints per-rule stats only |
+| `--unexpected` | string | `warn` | Policy for an uncovered fire: `fail`, `warn`, `ignore`. Overrides the expectations-file default |
+| `--pipeline` / `-p` | repeatable | `[]` | Processing pipeline(s) to apply |
+| `--junit` | path | none | Write a JUnit XML report |
+| `--report` | path | none | Write the full JSON report to a file |
+
+```bash
+# Assert a fixture suite against expectations
+rsigma rule backtest -r rules/ --corpus ci/corpus/ --expectations ci/expectations.yml
+
+# Fail CI on any uncovered fire and emit a JUnit report
+rsigma rule backtest -r rules/ --corpus ci/benign/ \
+    --expectations ci/expectations.yml --unexpected fail --junit backtest.xml
+
+# Per-rule statistics with no expectations
+rsigma rule backtest -r rules/ --corpus samples/ --output-format json | jq '.rules'
+```
+
+Exit codes: `0` all expectations met, `1` a failed expectation (or an uncovered fire under `--unexpected fail`), `2` unreadable rules, `3` a bad expectations file or missing corpus path. The full flag table, expectations schema, and report shape are in the [`rule backtest` reference](https://timescale.github.io/rsigma/cli/rule/backtest/).
 
 ### `pipeline resolve`: Test dynamic source resolution
 

--- a/crates/rsigma-cli/src/commands/backtest/expectations.rs
+++ b/crates/rsigma-cli/src/commands/backtest/expectations.rs
@@ -1,0 +1,387 @@
+//! Expectations file: schema, validation, and rule-reference resolution.
+//!
+//! An expectations file declares, per rule, how many times it must fire over
+//! the corpus (and optionally within a single corpus file). It is plain YAML
+//! deserialized into typed structs; there is no hand-rolled parsing. Every
+//! shape error here is a configuration error (exit code 3): a malformed file,
+//! a conflicting bound, an ambiguous rule title, or a reference to a rule that
+//! is not in the loaded ruleset.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rsigma_parser::SigmaCollection;
+use serde::{Deserialize, Serialize};
+
+/// Policy for a detection/correlation that fires without a covering
+/// expectation (a potential false positive on a known-benign corpus).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum UnexpectedPolicy {
+    /// Treat an unexpected fire as a failure: exit 1 and emit a JUnit failure
+    /// for each unexpected rule.
+    Fail,
+    /// Report unexpected fires but leave the exit code unchanged (default).
+    #[default]
+    Warn,
+    /// Do not surface unexpected fires on the human report or in the exit code.
+    Ignore,
+}
+
+impl UnexpectedPolicy {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            UnexpectedPolicy::Fail => "fail",
+            UnexpectedPolicy::Warn => "warn",
+            UnexpectedPolicy::Ignore => "ignore",
+        }
+    }
+
+    /// Parse the wire value used by `--unexpected` and `backtest.unexpected`.
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "fail" => Some(UnexpectedPolicy::Fail),
+            "warn" => Some(UnexpectedPolicy::Warn),
+            "ignore" => Some(UnexpectedPolicy::Ignore),
+            _ => None,
+        }
+    }
+}
+
+/// Raw expectations document as it appears on disk.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExpectationsFile {
+    #[serde(default)]
+    defaults: Defaults,
+    #[serde(default)]
+    expectations: Vec<RawExpectation>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Defaults {
+    /// File-level default policy. `None` means the file did not set one, so a
+    /// higher layer (CLI flag, config, or the built-in `warn`) decides.
+    #[serde(default)]
+    unexpected_detections: Option<UnexpectedPolicy>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawExpectation {
+    /// Rule id (preferred) or exact title.
+    rule: String,
+    /// Optional corpus-file scope: a path relative to the `--corpus` root.
+    #[serde(default)]
+    corpus: Option<String>,
+    #[serde(default)]
+    at_least: Option<u64>,
+    #[serde(default)]
+    at_most: Option<u64>,
+    #[serde(default)]
+    exactly: Option<u64>,
+}
+
+/// A validated fire-count bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Bound {
+    /// The rule must fire exactly this many times.
+    Exactly(u64),
+    /// The rule fire count must fall within `[at_least, at_most]`; either end
+    /// may be open.
+    Range {
+        at_least: Option<u64>,
+        at_most: Option<u64>,
+    },
+}
+
+impl Bound {
+    /// Whether `actual` satisfies this bound.
+    pub(crate) fn satisfied_by(&self, actual: u64) -> bool {
+        match self {
+            Bound::Exactly(n) => actual == *n,
+            Bound::Range { at_least, at_most } => {
+                at_least.is_none_or(|l| actual >= l) && at_most.is_none_or(|u| actual <= u)
+            }
+        }
+    }
+
+    /// A short human description used in reports (e.g. `exactly 0`, `>= 3`,
+    /// `3..=10`).
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Bound::Exactly(n) => format!("exactly {n}"),
+            Bound::Range {
+                at_least: Some(l),
+                at_most: Some(u),
+            } => format!("{l}..={u}"),
+            Bound::Range {
+                at_least: Some(l),
+                at_most: None,
+            } => format!(">= {l}"),
+            Bound::Range {
+                at_least: None,
+                at_most: Some(u),
+            } => format!("<= {u}"),
+            // Validation rejects an all-open range, so this is unreachable in
+            // practice; describe it defensively rather than panicking.
+            Bound::Range {
+                at_least: None,
+                at_most: None,
+            } => "any".to_string(),
+        }
+    }
+}
+
+/// A fully resolved expectation, ready to diff against accumulated fires.
+#[derive(Debug, Clone)]
+pub(crate) struct Expectation {
+    /// The original reference string from the file (id or title).
+    pub reference: String,
+    /// The resolved rule key: `rule_id` if the rule has one, else its title.
+    /// This matches the key the accumulator derives from each result.
+    pub rule_key: String,
+    /// Optional corpus-file scope (path relative to the `--corpus` root).
+    pub corpus: Option<String>,
+    pub bound: Bound,
+}
+
+/// The resolved expectations plus the file-level default policy.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedExpectations {
+    /// File-level `defaults.unexpected_detections`, if the file set one.
+    pub file_default_policy: Option<UnexpectedPolicy>,
+    pub expectations: Vec<Expectation>,
+}
+
+/// Read an expectations file and resolve every rule reference against the
+/// loaded collection. Returns a configuration-error message on any problem.
+pub(crate) fn load_and_resolve(
+    path: &Path,
+    collection: &SigmaCollection,
+) -> Result<ResolvedExpectations, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read expectations file {}: {e}", path.display()))?;
+    let file: ExpectationsFile = yaml_serde::from_str(&content)
+        .map_err(|e| format!("could not parse expectations file {}: {e}", path.display()))?;
+    resolve(file, collection)
+}
+
+/// Resolve a parsed expectations document against the collection.
+fn resolve(
+    file: ExpectationsFile,
+    collection: &SigmaCollection,
+) -> Result<ResolvedExpectations, String> {
+    let index = RuleIndex::build(collection);
+
+    let mut expectations = Vec::with_capacity(file.expectations.len());
+    for raw in file.expectations {
+        let bound = validate_bound(&raw)?;
+        let rule_key = index.resolve(&raw.rule)?;
+        expectations.push(Expectation {
+            reference: raw.rule,
+            rule_key,
+            corpus: raw.corpus,
+            bound,
+        });
+    }
+
+    Ok(ResolvedExpectations {
+        file_default_policy: file.defaults.unexpected_detections,
+        expectations,
+    })
+}
+
+/// Validate the count fields of a single raw expectation into a [`Bound`].
+fn validate_bound(raw: &RawExpectation) -> Result<Bound, String> {
+    match (raw.exactly, raw.at_least, raw.at_most) {
+        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(format!(
+            "expectation for '{}': `exactly` cannot be combined with `at_least`/`at_most`",
+            raw.rule
+        )),
+        (Some(n), None, None) => Ok(Bound::Exactly(n)),
+        (None, None, None) => Err(format!(
+            "expectation for '{}': set one of `exactly`, `at_least`, or `at_most`",
+            raw.rule
+        )),
+        (None, at_least, at_most) => {
+            if let (Some(l), Some(u)) = (at_least, at_most)
+                && l > u
+            {
+                return Err(format!(
+                    "expectation for '{}': at_least ({l}) is greater than at_most ({u})",
+                    raw.rule
+                ));
+            }
+            Ok(Bound::Range { at_least, at_most })
+        }
+    }
+}
+
+/// Lookup tables from rule references to the accumulator key.
+///
+/// `by_id` maps an id directly to its key. `by_title` maps a title to the set
+/// of keys that carry it, so a duplicate title resolves to an ambiguity error
+/// rather than silently picking one.
+struct RuleIndex {
+    by_id: HashMap<String, String>,
+    by_title: HashMap<String, Vec<String>>,
+}
+
+impl RuleIndex {
+    fn build(collection: &SigmaCollection) -> Self {
+        let mut by_id: HashMap<String, String> = HashMap::new();
+        let mut by_title: HashMap<String, Vec<String>> = HashMap::new();
+
+        let mut insert = |id: Option<&str>, title: &str| {
+            let key = id.unwrap_or(title).to_string();
+            if let Some(id) = id {
+                by_id.insert(id.to_string(), key.clone());
+            }
+            by_title.entry(title.to_string()).or_default().push(key);
+        };
+
+        for rule in &collection.rules {
+            insert(rule.id.as_deref(), &rule.title);
+        }
+        for corr in &collection.correlations {
+            insert(corr.id.as_deref(), &corr.title);
+        }
+
+        Self { by_id, by_title }
+    }
+
+    /// Resolve a reference (id preferred, then title) to its accumulator key.
+    fn resolve(&self, reference: &str) -> Result<String, String> {
+        if let Some(key) = self.by_id.get(reference) {
+            return Ok(key.clone());
+        }
+        match self.by_title.get(reference).map(Vec::as_slice) {
+            Some([key]) => Ok(key.clone()),
+            Some(keys) if keys.len() > 1 => Err(format!(
+                "expectation references ambiguous title '{reference}' ({} rules share it); \
+                 reference it by rule id instead",
+                keys.len()
+            )),
+            _ => Err(format!(
+                "expectation references rule '{reference}', which is not in the loaded ruleset"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_parser::parse_sigma_yaml;
+
+    const RULES: &str = r#"
+title: Suspicious Whoami Execution
+id: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\whoami.exe'
+    condition: selection
+level: low
+"#;
+
+    fn collection() -> SigmaCollection {
+        parse_sigma_yaml(RULES).expect("rules parse")
+    }
+
+    fn parse(yaml: &str) -> Result<ResolvedExpectations, String> {
+        let file: ExpectationsFile = yaml_serde::from_str(yaml).map_err(|e| e.to_string())?;
+        resolve(file, &collection())
+    }
+
+    #[test]
+    fn resolves_by_id() {
+        let r = parse(
+            "expectations:\n  - rule: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5\n    at_least: 1\n",
+        )
+        .expect("resolves");
+        assert_eq!(r.expectations.len(), 1);
+        assert_eq!(
+            r.expectations[0].rule_key,
+            "5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5"
+        );
+        assert!(matches!(
+            r.expectations[0].bound,
+            Bound::Range {
+                at_least: Some(1),
+                at_most: None
+            }
+        ));
+    }
+
+    #[test]
+    fn resolves_by_title_to_id_key() {
+        // Referenced by title, but the key is the rule id because the rule has one.
+        let r = parse("expectations:\n  - rule: Suspicious Whoami Execution\n    exactly: 0\n")
+            .expect("resolves");
+        assert_eq!(
+            r.expectations[0].rule_key,
+            "5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5"
+        );
+        assert!(matches!(r.expectations[0].bound, Bound::Exactly(0)));
+    }
+
+    #[test]
+    fn unknown_rule_is_error() {
+        let err = parse("expectations:\n  - rule: No Such Rule\n    at_least: 1\n").unwrap_err();
+        assert!(err.contains("not in the loaded ruleset"), "{err}");
+    }
+
+    #[test]
+    fn conflicting_bounds_is_error() {
+        let err = parse(
+            "expectations:\n  - rule: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5\n    exactly: 1\n    at_least: 2\n",
+        )
+        .unwrap_err();
+        assert!(err.contains("cannot be combined"), "{err}");
+    }
+
+    #[test]
+    fn empty_bounds_is_error() {
+        let err =
+            parse("expectations:\n  - rule: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5\n").unwrap_err();
+        assert!(err.contains("set one of"), "{err}");
+    }
+
+    #[test]
+    fn inverted_range_is_error() {
+        let err = parse(
+            "expectations:\n  - rule: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5\n    at_least: 10\n    at_most: 3\n",
+        )
+        .unwrap_err();
+        assert!(err.contains("greater than"), "{err}");
+    }
+
+    #[test]
+    fn bound_satisfaction() {
+        assert!(Bound::Exactly(0).satisfied_by(0));
+        assert!(!Bound::Exactly(0).satisfied_by(1));
+        let range = Bound::Range {
+            at_least: Some(3),
+            at_most: Some(10),
+        };
+        assert!(!range.satisfied_by(2));
+        assert!(range.satisfied_by(3));
+        assert!(range.satisfied_by(10));
+        assert!(!range.satisfied_by(11));
+    }
+
+    #[test]
+    fn file_default_policy_is_captured() {
+        let r = parse("defaults:\n  unexpected_detections: fail\nexpectations: []\n")
+            .expect("resolves");
+        assert_eq!(r.file_default_policy, Some(UnexpectedPolicy::Fail));
+        let r = parse("expectations: []\n").expect("resolves");
+        assert_eq!(r.file_default_policy, None);
+    }
+}

--- a/crates/rsigma-cli/src/commands/backtest/mod.rs
+++ b/crates/rsigma-cli/src/commands/backtest/mod.rs
@@ -1,0 +1,565 @@
+//! `rsigma rule backtest`: replay an event corpus against a ruleset, diff the
+//! per-rule fire counts against declared expectations, and emit a CI-native
+//! report.
+//!
+//! Backtest sits on top of the shared event stream loop (`commands::eval_stream`)
+//! so it parses corpus input exactly as `engine eval` does. The difference is
+//! the per-result action: instead of rendering each match, backtest accumulates
+//! per-rule and per-corpus-file counters, then diffs them against an optional
+//! expectations file. Correlation state is reset per corpus file (each file is
+//! an independent time slice; carrying window state across files would produce
+//! phantom correlations).
+
+mod expectations;
+mod report;
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::time::Instant;
+
+use clap::parser::ValueSource;
+use clap::{ArgMatches, Args};
+use rsigma_eval::{CorrelationConfig, CorrelationEngine, Engine, EvaluationResult, Pipeline};
+use rsigma_parser::SigmaCollection;
+
+#[cfg(feature = "evtx")]
+use super::eval_stream::stream_evtx_events;
+use super::eval_stream::{CorrelationProcessor, DetectionProcessor, EventProcessor, stream_events};
+use crate::config;
+use crate::exit_code;
+use crate::output::OutputCtx;
+use expectations::{ResolvedExpectations, UnexpectedPolicy};
+use report::{Accumulator, Report, result_key};
+
+/// Arguments for `rsigma rule backtest`.
+#[derive(Args, Debug)]
+pub(crate) struct BacktestArgs {
+    /// Path to a YAML config file. Overrides config-file discovery.
+    /// CLI flags still take precedence over config-file values.
+    #[arg(long = "config", value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Print the effective config (defaults < file < env) and exit.
+    #[arg(long = "dry-run")]
+    pub dry_run: bool,
+
+    /// Path to a Sigma rule file or directory of rules.
+    /// Required unless supplied via `backtest.rules` in the config file.
+    #[arg(short, long)]
+    pub rules: Option<PathBuf>,
+
+    /// Event corpus: a file or a directory walked recursively. Repeatable.
+    /// Extension dispatch: `.ndjson`/`.jsonl` as NDJSON, `.evtx` via the
+    /// feature-gated adapter, everything else through `--input-format`.
+    /// Required unless supplied via `backtest.corpus` in the config file.
+    #[arg(long = "corpus", value_name = "PATH")]
+    pub corpus: Vec<PathBuf>,
+
+    /// Expectations YAML (per-rule fire-count assertions). Without it, backtest
+    /// still runs and reports per-rule statistics; it just has nothing to diff.
+    #[arg(long = "expectations", value_name = "PATH")]
+    pub expectations: Option<PathBuf>,
+
+    /// What an unmatched fire (a rule firing with no covering expectation)
+    /// means: `fail`, `warn`, or `ignore`. Overrides the file-level default.
+    #[arg(long = "unexpected", value_parser = ["fail", "warn", "ignore"])]
+    pub unexpected: Option<String>,
+
+    /// Processing pipeline(s) to apply. Accepts builtin names (ecs_windows,
+    /// sysmon) or YAML file paths. Repeatable.
+    #[arg(short = 'p', long = "pipeline")]
+    pub pipelines: Vec<PathBuf>,
+
+    /// jq filter to extract the event payload from each JSON object.
+    #[arg(long = "jq", conflicts_with = "jsonpath")]
+    pub jq: Option<String>,
+
+    /// JSONPath (RFC 9535) query to extract the event payload.
+    #[arg(long = "jsonpath", conflicts_with = "jq")]
+    pub jsonpath: Option<String>,
+
+    /// Input log format for non-NDJSON corpus files.
+    /// auto: try JSON, then syslog, then plain (default).
+    #[arg(long = "input-format", default_value = "auto")]
+    pub input_format: String,
+
+    /// Default timezone offset for RFC 3164 syslog (e.g. +05:00, -08:00).
+    #[arg(long = "syslog-tz", default_value = "+00:00")]
+    pub syslog_tz: String,
+
+    /// Strip a leading UTF-8 BOM from RFC 5424 syslog messages. On by default.
+    #[arg(long = "syslog-strip-bom", default_value_t = true, action = clap::ArgAction::Set)]
+    pub syslog_strip_bom: bool,
+
+    /// Write a JUnit XML report (one test case per expectation, plus one per
+    /// unexpected-firing rule under the `fail` policy).
+    #[arg(long = "junit", value_name = "PATH")]
+    pub junit: Option<PathBuf>,
+
+    /// Write the full JSON report to a file regardless of the stdout format.
+    #[arg(long = "report", value_name = "PATH")]
+    pub report: Option<PathBuf>,
+}
+
+/// Overlay the `backtest` config section (defaults < file < env) onto `args`
+/// for any flag the operator did not set explicitly, then handle `--dry-run`.
+pub(crate) fn apply_backtest_config(args: &mut BacktestArgs, matches: &ArgMatches) {
+    let base = config::load_and_merge(args.config.as_deref());
+    if args.dry_run {
+        config::print_dry_run("backtest", &base);
+        process::exit(exit_code::SUCCESS);
+    }
+    overlay_backtest_config(args, matches, base);
+}
+
+/// Pure overlay of the resolved `backtest` section onto `args` (no disk
+/// access), split out from [`apply_backtest_config`] so it can be unit-tested.
+fn overlay_backtest_config(
+    args: &mut BacktestArgs,
+    matches: &ArgMatches,
+    base: config::RsigmaConfigPartial,
+) {
+    let explicit = |id: &str| {
+        matches!(
+            matches.value_source(id),
+            Some(ValueSource::CommandLine | ValueSource::EnvVariable)
+        )
+    };
+
+    if let Some(bt) = base.backtest {
+        if !explicit("rules")
+            && let Some(v) = bt.rules
+        {
+            args.rules = Some(v);
+        }
+        if !explicit("corpus")
+            && let Some(v) = bt.corpus
+        {
+            args.corpus = v;
+        }
+        if !explicit("expectations")
+            && let Some(v) = bt.expectations
+        {
+            args.expectations = Some(v);
+        }
+        // `--unexpected` has no clap default, so `is_none` means the operator
+        // did not set it on the command line; let the config layer fill it.
+        if args.unexpected.is_none()
+            && let Some(v) = bt.unexpected
+        {
+            args.unexpected = Some(v);
+        }
+        if !explicit("pipelines")
+            && let Some(v) = bt.pipelines
+        {
+            args.pipelines = v;
+        }
+        if !explicit("input_format")
+            && let Some(v) = bt.input_format
+        {
+            args.input_format = v;
+        }
+        if !explicit("syslog_tz")
+            && let Some(v) = bt.syslog_tz
+        {
+            args.syslog_tz = v;
+        }
+        if !explicit("syslog_strip_bom")
+            && let Some(v) = bt.syslog_strip_bom
+        {
+            args.syslog_strip_bom = v;
+        }
+    }
+}
+
+/// Run the backtest. Returns the process exit code (0 pass, 1 findings,
+/// 2 rule error, 3 config error). Rule and config errors exit directly.
+pub(crate) fn cmd_backtest(args: BacktestArgs, ctx: OutputCtx) -> i32 {
+    let Some(rules_path) = args.rules.clone() else {
+        eprintln!("error: no rules path; set --rules or backtest.rules in the config file");
+        return exit_code::CONFIG_ERROR;
+    };
+    if args.corpus.is_empty() {
+        eprintln!("error: no corpus; set --corpus or backtest.corpus in the config file");
+        return exit_code::CONFIG_ERROR;
+    }
+
+    // `load_collection` exits with RULE_ERROR if the rules cannot be parsed.
+    let collection = crate::load_collection(&rules_path);
+    let pipelines = crate::load_pipelines(&args.pipelines);
+    let event_filter = crate::build_event_filter(args.jq.clone(), args.jsonpath.clone());
+
+    let resolved = match &args.expectations {
+        Some(path) => match expectations::load_and_resolve(path, &collection) {
+            Ok(r) => Some(r),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return exit_code::CONFIG_ERROR;
+            }
+        },
+        None => None,
+    };
+
+    let policy = match resolve_policy(args.unexpected.as_deref(), resolved.as_ref()) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return exit_code::CONFIG_ERROR;
+        }
+    };
+
+    let report = match run(
+        &args,
+        collection,
+        &pipelines,
+        &event_filter,
+        resolved,
+        policy,
+    ) {
+        Ok(report) => report,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return exit_code::CONFIG_ERROR;
+        }
+    };
+
+    report.render(&ctx, args.report.as_deref(), args.junit.as_deref());
+    report.exit_code()
+}
+
+/// Effective unexpected policy: CLI/config flag > expectations-file default >
+/// the built-in `warn`.
+fn resolve_policy(
+    cli_or_config: Option<&str>,
+    resolved: Option<&ResolvedExpectations>,
+) -> Result<UnexpectedPolicy, String> {
+    if let Some(s) = cli_or_config {
+        return UnexpectedPolicy::parse(s).ok_or_else(|| {
+            format!("invalid unexpected policy '{s}' (expected fail, warn, ignore)")
+        });
+    }
+    if let Some(p) = resolved.and_then(|r| r.file_default_policy) {
+        return Ok(p);
+    }
+    Ok(UnexpectedPolicy::default())
+}
+
+/// Walk the corpus, evaluate each file with fresh correlation state, and build
+/// the report.
+fn run(
+    args: &BacktestArgs,
+    collection: SigmaCollection,
+    pipelines: &[Pipeline],
+    event_filter: &crate::EventFilter,
+    resolved: Option<ResolvedExpectations>,
+    policy: UnexpectedPolicy,
+) -> Result<Report, String> {
+    let corpus_files = collect_corpus_files(&args.corpus)?;
+    if corpus_files.is_empty() {
+        eprintln!("warning: no corpus files found under the given --corpus path(s)");
+    }
+
+    let has_correlations = !collection.correlations.is_empty();
+    let mut acc = Accumulator::new();
+    let start = Instant::now();
+
+    // Detection-only rulesets are stateless, so one compiled engine is reused
+    // across files. With correlations, the engine is rebuilt per file to reset
+    // window state (the engine exposes no in-place state reset).
+    let detection_engine =
+        (!has_correlations).then(|| build_detection_engine(&collection, pipelines));
+
+    for cf in &corpus_files {
+        acc.note_file();
+        let events = if has_correlations {
+            let mut engine = build_correlation_engine(&collection, pipelines);
+            let mut processor = CorrelationProcessor {
+                engine: &mut engine,
+            };
+            stream_corpus_file(cf, &mut processor, event_filter, args, &mut acc)
+        } else {
+            let engine = detection_engine.as_ref().expect("detection engine built");
+            let mut processor = DetectionProcessor { engine };
+            stream_corpus_file(cf, &mut processor, event_filter, args, &mut acc)
+        };
+        acc.add_events(events);
+    }
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+    Ok(Report::build(
+        acc,
+        &collection,
+        resolved.as_ref(),
+        policy,
+        duration_ms,
+    ))
+}
+
+/// Stream a single corpus file through `processor`, recording each fire under
+/// the file's relative key. Returns the number of events read.
+fn stream_corpus_file<P: EventProcessor>(
+    cf: &CorpusFile,
+    processor: &mut P,
+    event_filter: &crate::EventFilter,
+    args: &BacktestArgs,
+    acc: &mut Accumulator,
+) -> u64 {
+    let file_key = cf.key.clone();
+    let mut on_result = |m: &EvaluationResult| {
+        let key = result_key(m).to_string();
+        acc.record(&key, &file_key);
+    };
+
+    match cf.kind {
+        CorpusKind::Evtx => {
+            #[cfg(feature = "evtx")]
+            {
+                stream_evtx_events(&cf.path, event_filter, None, processor, &mut on_result)
+            }
+            #[cfg(not(feature = "evtx"))]
+            {
+                eprintln!(
+                    "warning: skipping EVTX corpus file {} (built without the evtx feature)",
+                    cf.path.display()
+                );
+                0
+            }
+        }
+        CorpusKind::Ndjson | CorpusKind::Other => {
+            let format = match cf.kind {
+                CorpusKind::Ndjson => "json",
+                _ => args.input_format.as_str(),
+            };
+            let file = match File::open(&cf.path) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Error opening corpus file '{}': {e}", cf.path.display());
+                    return 0;
+                }
+            };
+            stream_events(
+                BufReader::new(file),
+                event_filter,
+                format,
+                &args.syslog_tz,
+                args.syslog_strip_bom,
+                None,
+                processor,
+                &mut on_result,
+            )
+        }
+    }
+}
+
+fn build_detection_engine(collection: &SigmaCollection, pipelines: &[Pipeline]) -> Engine {
+    let mut engine = Engine::new();
+    for p in pipelines {
+        engine.add_pipeline(p.clone());
+    }
+    if let Err(e) = engine.add_collection(collection) {
+        eprintln!("Error compiling rules: {e}");
+        process::exit(exit_code::RULE_ERROR);
+    }
+    engine
+}
+
+fn build_correlation_engine(
+    collection: &SigmaCollection,
+    pipelines: &[Pipeline],
+) -> CorrelationEngine {
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    for p in pipelines {
+        engine.add_pipeline(p.clone());
+    }
+    if let Err(e) = engine.add_collection(collection) {
+        eprintln!("Error compiling rules: {e}");
+        process::exit(exit_code::RULE_ERROR);
+    }
+    engine
+}
+
+// ---------------------------------------------------------------------------
+// Corpus traversal
+// ---------------------------------------------------------------------------
+
+/// How a corpus file is parsed, decided by its extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CorpusKind {
+    /// `.ndjson` / `.jsonl`: forced JSON parsing.
+    Ndjson,
+    /// `.evtx`: the feature-gated Windows Event Log adapter.
+    Evtx,
+    /// Anything else: parsed through `--input-format`.
+    Other,
+}
+
+/// A discovered corpus file plus its report key (path relative to the
+/// `--corpus` root, with `/` separators for cross-platform stability).
+#[derive(Debug)]
+struct CorpusFile {
+    key: String,
+    path: PathBuf,
+    kind: CorpusKind,
+}
+
+fn classify(path: &Path) -> CorpusKind {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("ndjson" | "jsonl") => CorpusKind::Ndjson,
+        Some("evtx") => CorpusKind::Evtx,
+        _ => CorpusKind::Other,
+    }
+}
+
+/// Resolve the `--corpus` roots into a sorted list of files. A root may be a
+/// single file or a directory walked recursively.
+fn collect_corpus_files(roots: &[PathBuf]) -> Result<Vec<CorpusFile>, String> {
+    let mut out = Vec::new();
+    for root in roots {
+        if !root.exists() {
+            return Err(format!("corpus path not found: {}", root.display()));
+        }
+        if root.is_file() {
+            let key = root
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .unwrap_or_else(|| root.to_string_lossy().into_owned());
+            out.push(CorpusFile {
+                key,
+                kind: classify(root),
+                path: root.clone(),
+            });
+        } else if root.is_dir() {
+            walk_dir(root, root, &mut out)?;
+        }
+    }
+    out.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(out)
+}
+
+fn walk_dir(root: &Path, dir: &Path, out: &mut Vec<CorpusFile>) -> Result<(), String> {
+    let read = std::fs::read_dir(dir)
+        .map_err(|e| format!("could not read corpus directory {}: {e}", dir.display()))?;
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|e| {
+            format!(
+                "could not read corpus directory entry in {}: {e}",
+                dir.display()
+            )
+        })?;
+        paths.push(entry.path());
+    }
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            walk_dir(root, &path, out)?;
+        } else if path.is_file() {
+            let rel = path.strip_prefix(root).unwrap_or(&path);
+            let key = rel
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            out.push(CorpusFile {
+                key,
+                kind: classify(&path),
+                path,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Command, FromArgMatches};
+
+    fn parse(argv: &[&str]) -> (BacktestArgs, ArgMatches) {
+        let cmd = BacktestArgs::augment_args(Command::new("backtest"));
+        let matches = cmd.get_matches_from(argv);
+        let args = BacktestArgs::from_arg_matches(&matches).expect("valid args");
+        (args, matches)
+    }
+
+    fn partial(yaml: &str) -> config::RsigmaConfigPartial {
+        yaml_serde::from_str(yaml).expect("valid partial")
+    }
+
+    #[test]
+    fn cli_flag_beats_config_file() {
+        let (mut args, matches) = parse(&["backtest", "--rules", "/cli/rules"]);
+        let base = partial("backtest:\n  rules: /file/rules\n  unexpected: fail\n");
+        overlay_backtest_config(&mut args, &matches, base);
+        assert_eq!(args.rules.as_deref(), Some(Path::new("/cli/rules")));
+        // The config fills the unset unexpected policy.
+        assert_eq!(args.unexpected.as_deref(), Some("fail"));
+    }
+
+    #[test]
+    fn config_fills_unset_corpus() {
+        let (mut args, matches) = parse(&["backtest", "--rules", "/r"]);
+        let base = partial("backtest:\n  corpus:\n    - /file/corpus\n");
+        overlay_backtest_config(&mut args, &matches, base);
+        assert_eq!(args.corpus, vec![PathBuf::from("/file/corpus")]);
+    }
+
+    #[test]
+    fn cli_unexpected_beats_config() {
+        let (mut args, matches) = parse(&["backtest", "--rules", "/r", "--unexpected", "ignore"]);
+        let base = partial("backtest:\n  unexpected: fail\n");
+        overlay_backtest_config(&mut args, &matches, base);
+        assert_eq!(args.unexpected.as_deref(), Some("ignore"));
+    }
+
+    #[test]
+    fn policy_precedence_cli_over_file_default() {
+        let r = ResolvedExpectations {
+            file_default_policy: Some(UnexpectedPolicy::Fail),
+            expectations: Vec::new(),
+        };
+        assert_eq!(
+            resolve_policy(Some("ignore"), Some(&r)).unwrap(),
+            UnexpectedPolicy::Ignore
+        );
+        // No CLI/config flag falls back to the file default.
+        assert_eq!(
+            resolve_policy(None, Some(&r)).unwrap(),
+            UnexpectedPolicy::Fail
+        );
+        // No file default falls back to warn.
+        assert_eq!(resolve_policy(None, None).unwrap(), UnexpectedPolicy::Warn);
+    }
+
+    #[test]
+    fn classify_by_extension() {
+        assert_eq!(classify(Path::new("a.ndjson")), CorpusKind::Ndjson);
+        assert_eq!(classify(Path::new("a.jsonl")), CorpusKind::Ndjson);
+        assert_eq!(classify(Path::new("a.evtx")), CorpusKind::Evtx);
+        assert_eq!(classify(Path::new("a.log")), CorpusKind::Other);
+        assert_eq!(classify(Path::new("noext")), CorpusKind::Other);
+    }
+
+    #[test]
+    fn corpus_walk_is_sorted_and_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("b.ndjson"), "{}").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub").join("a.ndjson"), "{}").unwrap();
+
+        let files = collect_corpus_files(&[dir.path().to_path_buf()]).unwrap();
+        let keys: Vec<&str> = files.iter().map(|f| f.key.as_str()).collect();
+        assert_eq!(keys, vec!["b.ndjson", "sub/a.ndjson"]);
+    }
+
+    #[test]
+    fn missing_corpus_path_is_error() {
+        let err = collect_corpus_files(&[PathBuf::from("/no/such/corpus/path")]).unwrap_err();
+        assert!(err.contains("not found"), "{err}");
+    }
+}

--- a/crates/rsigma-cli/src/commands/backtest/report.rs
+++ b/crates/rsigma-cli/src/commands/backtest/report.rs
@@ -1,0 +1,836 @@
+//! Backtest accumulation, expected-vs-actual diff, and report rendering.
+//!
+//! The accumulator tallies per-rule and per-corpus-file fire counts as events
+//! stream through the engine. [`Report::build`] turns those tallies plus the
+//! resolved expectations into a stable, serializable document: the expectation
+//! diff, per-rule statistics, the set of unexpected fires (the false-positive
+//! signal on a known-benign corpus), and a per-logsource rollup of those
+//! unexpected fires.
+//!
+//! The document renders through the shared [`OutputCtx`] layer (table for a
+//! TTY, `json` for the full document, `ndjson`/`csv`/`tsv` for per-rule rows)
+//! and, optionally, to a hand-rolled JUnit XML file for CI annotation.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::Path;
+
+use rsigma_eval::EvaluationResult;
+use rsigma_parser::{LogSource, SigmaCollection};
+use serde::Serialize;
+
+use super::expectations::{ResolvedExpectations, UnexpectedPolicy};
+use crate::exit_code;
+use crate::output::{
+    DelimitedWriter, OutputCtx, OutputFormat, Painter, Tabular, render_json, render_ndjson,
+};
+
+/// Accumulator key for a result: the rule id when present, else its title.
+/// Mirrors how detection and correlation results populate their header, so an
+/// expectation resolved to the same key lines up with what fired.
+pub(crate) fn result_key(result: &EvaluationResult) -> &str {
+    result
+        .header
+        .rule_id
+        .as_deref()
+        .unwrap_or(&result.header.rule_title)
+}
+
+/// Compact logsource projection used throughout the report.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct LogSourceView {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    product: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service: Option<String>,
+}
+
+impl LogSourceView {
+    fn from_logsource(ls: &LogSource) -> Option<Self> {
+        if ls.category.is_none() && ls.product.is_none() && ls.service.is_none() {
+            return None;
+        }
+        Some(Self {
+            category: ls.category.clone(),
+            product: ls.product.clone(),
+            service: ls.service.clone(),
+        })
+    }
+
+    /// A stable one-line label (`product/category/service`) used for grouping
+    /// and table cells. `(none)` when no component is set (e.g. correlations).
+    fn label(view: &Option<Self>) -> String {
+        let Some(v) = view else {
+            return "(none)".to_string();
+        };
+        let parts: Vec<&str> = [
+            v.product.as_deref(),
+            v.category.as_deref(),
+            v.service.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        if parts.is_empty() {
+            "(none)".to_string()
+        } else {
+            parts.join("/")
+        }
+    }
+}
+
+/// Per-rule metadata pulled from the loaded collection (the engine result does
+/// not carry logsource, so it is resolved here by key).
+struct RuleMeta {
+    id: Option<String>,
+    title: String,
+    level: Option<String>,
+    logsource: Option<LogSourceView>,
+}
+
+fn collect_rule_meta(collection: &SigmaCollection) -> BTreeMap<String, RuleMeta> {
+    let mut meta = BTreeMap::new();
+    for rule in &collection.rules {
+        let key = rule.id.clone().unwrap_or_else(|| rule.title.clone());
+        meta.insert(
+            key,
+            RuleMeta {
+                id: rule.id.clone(),
+                title: rule.title.clone(),
+                level: rule.level.map(|l| l.as_str().to_string()),
+                logsource: LogSourceView::from_logsource(&rule.logsource),
+            },
+        );
+    }
+    for corr in &collection.correlations {
+        let key = corr.id.clone().unwrap_or_else(|| corr.title.clone());
+        meta.insert(
+            key,
+            RuleMeta {
+                id: corr.id.clone(),
+                title: corr.title.clone(),
+                level: corr.level.map(|l| l.as_str().to_string()),
+                // Correlation rules have no logsource of their own.
+                logsource: None,
+            },
+        );
+    }
+    meta
+}
+
+/// Running tally of fires, keyed by rule and by (rule, corpus file).
+pub(crate) struct Accumulator {
+    total: HashMap<String, u64>,
+    by_file: HashMap<String, BTreeMap<String, u64>>,
+    events_processed: u64,
+    corpus_files: u64,
+}
+
+impl Accumulator {
+    pub(crate) fn new() -> Self {
+        Self {
+            total: HashMap::new(),
+            by_file: HashMap::new(),
+            events_processed: 0,
+            corpus_files: 0,
+        }
+    }
+
+    /// Record one fire of `key` observed while processing `file`.
+    pub(crate) fn record(&mut self, key: &str, file: &str) {
+        *self.total.entry(key.to_string()).or_default() += 1;
+        *self
+            .by_file
+            .entry(key.to_string())
+            .or_default()
+            .entry(file.to_string())
+            .or_default() += 1;
+    }
+
+    pub(crate) fn add_events(&mut self, n: u64) {
+        self.events_processed += n;
+    }
+
+    pub(crate) fn note_file(&mut self) {
+        self.corpus_files += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Serializable report document
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+struct Summary {
+    corpus_files: u64,
+    events_processed: u64,
+    rules_loaded: u64,
+    expectations_total: u64,
+    expectations_passed: u64,
+    expectations_failed: u64,
+    unexpected_rules: u64,
+    unexpected_fires: u64,
+    unexpected_policy: String,
+    duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ExpectationResult {
+    /// The original reference (id or title) from the file.
+    rule: String,
+    rule_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
+    bound: String,
+    actual: u64,
+    pass: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RuleStat {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rule_id: Option<String>,
+    rule_title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    level: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logsource: Option<LogSourceView>,
+    fires: u64,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    by_file: BTreeMap<String, u64>,
+}
+
+const RULE_HEADERS: &[&str] = &["RULE_ID", "TITLE", "LEVEL", "LOGSOURCE", "FIRES"];
+
+impl Tabular for RuleStat {
+    fn headers() -> &'static [&'static str] {
+        RULE_HEADERS
+    }
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.rule_id.clone().unwrap_or_else(|| "-".to_string()),
+            self.rule_title.clone(),
+            self.level.clone().unwrap_or_else(|| "-".to_string()),
+            LogSourceView::label(&self.logsource),
+            self.fires.to_string(),
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct UnexpectedStat {
+    rule_key: String,
+    rule_title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    level: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logsource: Option<LogSourceView>,
+    fires: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LogSourceRollup {
+    logsource: String,
+    unexpected_fires: u64,
+    rules: Vec<String>,
+}
+
+/// The full backtest report document.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Report {
+    summary: Summary,
+    expectations: Vec<ExpectationResult>,
+    rules: Vec<RuleStat>,
+    unexpected: Vec<UnexpectedStat>,
+    by_logsource: Vec<LogSourceRollup>,
+    /// Effective policy, retained for exit-code and rendering decisions; not
+    /// part of the serialized shape (it appears as `summary.unexpected_policy`).
+    #[serde(skip)]
+    policy: UnexpectedPolicy,
+}
+
+impl Report {
+    /// Build the report from the accumulated tallies and resolved expectations.
+    pub(crate) fn build(
+        acc: Accumulator,
+        collection: &SigmaCollection,
+        resolved: Option<&ResolvedExpectations>,
+        policy: UnexpectedPolicy,
+        duration_ms: u64,
+    ) -> Self {
+        let meta = collect_rule_meta(collection);
+        let rules_loaded = (collection.rules.len() + collection.correlations.len()) as u64;
+
+        let empty = Vec::new();
+        let expectations_in = resolved.map(|r| &r.expectations).unwrap_or(&empty);
+        let has_expectations = !expectations_in.is_empty();
+
+        // Expectation diff (in file order for stable output).
+        let mut expectations = Vec::with_capacity(expectations_in.len());
+        let mut expected_keys: HashSet<&str> = HashSet::new();
+        let mut passed = 0u64;
+        for exp in expectations_in {
+            expected_keys.insert(exp.rule_key.as_str());
+            let actual = match &exp.corpus {
+                Some(scope) => acc
+                    .by_file
+                    .get(&exp.rule_key)
+                    .and_then(|m| m.get(scope))
+                    .copied()
+                    .unwrap_or(0),
+                None => acc.total.get(&exp.rule_key).copied().unwrap_or(0),
+            };
+            let pass = exp.bound.satisfied_by(actual);
+            if pass {
+                passed += 1;
+            }
+            expectations.push(ExpectationResult {
+                rule: exp.reference.clone(),
+                rule_key: exp.rule_key.clone(),
+                scope: exp.corpus.clone(),
+                bound: exp.bound.describe(),
+                actual,
+                pass,
+            });
+        }
+        let failed = expectations.len() as u64 - passed;
+
+        // Unexpected fires only make sense when there is something to diff:
+        // with no expectations every fire would otherwise look "uncovered".
+        let mut unexpected = Vec::new();
+        if has_expectations {
+            let mut fired: Vec<(&String, &u64)> = acc
+                .total
+                .iter()
+                .filter(|(key, fires)| **fires > 0 && !expected_keys.contains(key.as_str()))
+                .collect();
+            fired.sort_by(|a, b| a.0.cmp(b.0));
+            for (key, fires) in fired {
+                let (title, level, logsource) = match meta.get(key) {
+                    Some(m) => (m.title.clone(), m.level.clone(), m.logsource.clone()),
+                    None => (key.clone(), None, None),
+                };
+                unexpected.push(UnexpectedStat {
+                    rule_key: key.clone(),
+                    rule_title: title,
+                    level,
+                    logsource,
+                    fires: *fires,
+                });
+            }
+        }
+        let unexpected_rules = unexpected.len() as u64;
+        let unexpected_fires: u64 = unexpected.iter().map(|u| u.fires).sum();
+
+        // Per-rule stats: every rule that fired plus every rule referenced by
+        // an expectation (so an asserted-but-silent rule still appears).
+        let mut keys: BTreeSet<&str> = BTreeSet::new();
+        for (key, fires) in &acc.total {
+            if *fires > 0 {
+                keys.insert(key.as_str());
+            }
+        }
+        for key in &expected_keys {
+            keys.insert(key);
+        }
+        let mut rules = Vec::with_capacity(keys.len());
+        for key in keys {
+            let by_file = acc.by_file.get(key).cloned().unwrap_or_default();
+            let fires = acc.total.get(key).copied().unwrap_or(0);
+            let stat = match meta.get(key) {
+                Some(m) => RuleStat {
+                    rule_id: m.id.clone(),
+                    rule_title: m.title.clone(),
+                    level: m.level.clone(),
+                    logsource: m.logsource.clone(),
+                    fires,
+                    by_file,
+                },
+                None => RuleStat {
+                    rule_id: None,
+                    rule_title: key.to_string(),
+                    level: None,
+                    logsource: None,
+                    fires,
+                    by_file,
+                },
+            };
+            rules.push(stat);
+        }
+
+        let by_logsource = rollup_by_logsource(&unexpected);
+
+        let summary = Summary {
+            corpus_files: acc.corpus_files,
+            events_processed: acc.events_processed,
+            rules_loaded,
+            expectations_total: expectations.len() as u64,
+            expectations_passed: passed,
+            expectations_failed: failed,
+            unexpected_rules,
+            unexpected_fires,
+            unexpected_policy: policy.as_str().to_string(),
+            duration_ms,
+        };
+
+        Report {
+            summary,
+            expectations,
+            rules,
+            unexpected,
+            by_logsource,
+            policy,
+        }
+    }
+
+    /// House exit code: findings (1) on any failed expectation, or on
+    /// unexpected fires under the `fail` policy; success (0) otherwise.
+    pub(crate) fn exit_code(&self) -> i32 {
+        if self.summary.expectations_failed > 0 {
+            return exit_code::FINDINGS;
+        }
+        if self.policy == UnexpectedPolicy::Fail && self.summary.unexpected_rules > 0 {
+            return exit_code::FINDINGS;
+        }
+        exit_code::SUCCESS
+    }
+
+    /// Render to stdout in the selected format, plus optional `--report` JSON
+    /// and `--junit` XML side files.
+    pub(crate) fn render(
+        &self,
+        ctx: &OutputCtx,
+        report_path: Option<&Path>,
+        junit_path: Option<&Path>,
+    ) {
+        if let Some(path) = report_path
+            && let Err(e) = write_string_file(path, &self.to_pretty_json())
+        {
+            eprintln!("Failed to write report to {}: {e}", path.display());
+        }
+
+        match ctx.format {
+            OutputFormat::Json => render_json(self, ctx.pretty_json()),
+            OutputFormat::Ndjson => {
+                for rule in &self.rules {
+                    render_ndjson(rule);
+                }
+            }
+            OutputFormat::Csv => self.render_delimited(','),
+            OutputFormat::Tsv => self.render_delimited('\t'),
+            OutputFormat::Table => self.render_human(ctx),
+        }
+
+        if let Some(path) = junit_path
+            && let Err(e) = write_string_file(path, &self.to_junit_xml())
+        {
+            eprintln!("Failed to write JUnit report to {}: {e}", path.display());
+        }
+
+        // For machine formats the human summary is not on stdout, so emit a
+        // one-line recap on stderr (the table view already shows it).
+        if ctx.format != OutputFormat::Table && ctx.show_stats() {
+            eprintln!("{}", self.stderr_summary());
+        }
+    }
+
+    fn render_delimited(&self, sep: char) {
+        let mut writer = DelimitedWriter::new(sep, RuleStat::headers());
+        for rule in &self.rules {
+            writer.push(&rule.row());
+        }
+    }
+
+    fn stderr_summary(&self) -> String {
+        let s = &self.summary;
+        format!(
+            "Backtest: {} corpus files, {} events, {}/{} expectations passed, \
+             {} unexpected fires across {} rules (policy: {}).",
+            s.corpus_files,
+            s.events_processed,
+            s.expectations_passed,
+            s.expectations_total,
+            s.unexpected_fires,
+            s.unexpected_rules,
+            s.unexpected_policy,
+        )
+    }
+
+    fn to_pretty_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    // -- Human (table) rendering --------------------------------------------
+
+    fn render_human(&self, ctx: &OutputCtx) {
+        let p = Painter::new(ctx.color);
+        let s = &self.summary;
+
+        println!("{}", p.bold("Backtest summary"));
+        println!("  corpus files:  {}", s.corpus_files);
+        println!("  events:        {}", s.events_processed);
+        println!("  rules loaded:  {}", s.rules_loaded);
+        println!(
+            "  expectations:  {} passed, {} failed",
+            s.expectations_passed, s.expectations_failed
+        );
+        if self.policy != UnexpectedPolicy::Ignore {
+            println!(
+                "  unexpected:    {} rules, {} fires (policy: {})",
+                s.unexpected_rules, s.unexpected_fires, s.unexpected_policy
+            );
+        }
+
+        if !self.expectations.is_empty() {
+            println!("\n{}", p.bold("Expectations"));
+            for e in &self.expectations {
+                let tag = if e.pass {
+                    p.green_bold("PASS")
+                } else {
+                    p.red_bold("FAIL")
+                };
+                let scope = match &e.scope {
+                    Some(s) => format!(" [{s}]"),
+                    None => String::new(),
+                };
+                println!(
+                    "  {tag}  {}{scope}  expected {}, got {}",
+                    e.rule, e.bound, e.actual
+                );
+            }
+        }
+
+        if !self.rules.is_empty() {
+            println!("\n{}", p.bold("Rule fires"));
+            crate::output::render_table(&self.rules);
+        }
+
+        if self.policy != UnexpectedPolicy::Ignore && !self.unexpected.is_empty() {
+            println!("\n{}", p.bold("Unexpected fires"));
+            for u in &self.unexpected {
+                println!(
+                    "  {}  {} ({} fires)",
+                    p.yellow(&u.rule_title),
+                    LogSourceView::label(&u.logsource),
+                    u.fires
+                );
+            }
+
+            if !self.by_logsource.is_empty() {
+                println!("\n{}", p.bold("Unexpected fires by logsource"));
+                for r in &self.by_logsource {
+                    println!("  {}  {} fires", r.logsource, r.unexpected_fires);
+                }
+            }
+        }
+    }
+
+    // -- JUnit XML rendering -------------------------------------------------
+
+    /// Render a JUnit report: one test case per expectation, plus one per
+    /// unexpected-firing rule when the policy is `fail`. The shape is fixed and
+    /// hand-rolled (no new dependency), matching the repo's `DelimitedWriter`
+    /// precedent. `time` attributes are intentionally omitted so the output is
+    /// deterministic.
+    fn to_junit_xml(&self) -> String {
+        struct Case {
+            name: String,
+            classname: &'static str,
+            failure: Option<String>,
+        }
+
+        let mut cases: Vec<Case> = Vec::new();
+        for e in &self.expectations {
+            let name = match &e.scope {
+                Some(s) => format!("{} [{}]", e.rule, s),
+                None => e.rule.clone(),
+            };
+            let failure = (!e.pass).then(|| format!("expected {}, got {}", e.bound, e.actual));
+            cases.push(Case {
+                name,
+                classname: "rsigma.backtest.expectations",
+                failure,
+            });
+        }
+        if self.policy == UnexpectedPolicy::Fail {
+            for u in &self.unexpected {
+                cases.push(Case {
+                    name: u.rule_title.clone(),
+                    classname: "rsigma.backtest.unexpected",
+                    failure: Some(format!(
+                        "unexpected {} fires with no covering expectation",
+                        u.fires
+                    )),
+                });
+            }
+        }
+
+        let total = cases.len();
+        let failures = cases.iter().filter(|c| c.failure.is_some()).count();
+
+        let mut out = String::new();
+        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        out.push_str(&format!(
+            "<testsuites tests=\"{total}\" failures=\"{failures}\">\n"
+        ));
+        out.push_str(&format!(
+            "  <testsuite name=\"rsigma backtest\" tests=\"{total}\" failures=\"{failures}\">\n"
+        ));
+        for c in &cases {
+            let name = xml_escape(&c.name);
+            match &c.failure {
+                None => out.push_str(&format!(
+                    "    <testcase name=\"{name}\" classname=\"{}\"/>\n",
+                    c.classname
+                )),
+                Some(msg) => {
+                    let msg = xml_escape(msg);
+                    out.push_str(&format!(
+                        "    <testcase name=\"{name}\" classname=\"{}\">\n",
+                        c.classname
+                    ));
+                    out.push_str(&format!(
+                        "      <failure message=\"{msg}\">{msg}</failure>\n"
+                    ));
+                    out.push_str("    </testcase>\n");
+                }
+            }
+        }
+        out.push_str("  </testsuite>\n");
+        out.push_str("</testsuites>\n");
+        out
+    }
+}
+
+/// Group unexpected fires by their rule logsource, the per-logsource
+/// false-positive-density view.
+fn rollup_by_logsource(unexpected: &[UnexpectedStat]) -> Vec<LogSourceRollup> {
+    let mut groups: BTreeMap<String, (u64, Vec<String>)> = BTreeMap::new();
+    for u in unexpected {
+        let label = LogSourceView::label(&u.logsource);
+        let entry = groups.entry(label).or_default();
+        entry.0 += u.fires;
+        entry.1.push(u.rule_key.clone());
+    }
+    groups
+        .into_iter()
+        .map(|(logsource, (unexpected_fires, mut rules))| {
+            rules.sort();
+            LogSourceRollup {
+                logsource,
+                unexpected_fires,
+                rules,
+            }
+        })
+        .collect()
+}
+
+/// Escape the five XML predefined entities for use in element text and
+/// double-quoted attribute values alike.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn write_string_file(path: &Path, contents: &str) -> io::Result<()> {
+    let mut file = File::create(path)?;
+    file.write_all(contents.as_bytes())?;
+    if !contents.ends_with('\n') {
+        file.write_all(b"\n")?;
+    }
+    file.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::backtest::expectations::{Bound, Expectation};
+
+    fn rules() -> SigmaCollection {
+        let yaml = r#"
+title: Whoami
+id: 11111111-1111-1111-1111-111111111111
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\whoami.exe'
+    condition: selection
+level: low
+---
+title: Netstat
+id: 22222222-2222-2222-2222-222222222222
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\netstat.exe'
+    condition: selection
+level: informational
+"#;
+        rsigma_parser::parse_sigma_yaml(yaml).expect("rules parse")
+    }
+
+    fn resolved(exps: Vec<Expectation>, policy: Option<UnexpectedPolicy>) -> ResolvedExpectations {
+        ResolvedExpectations {
+            file_default_policy: policy,
+            expectations: exps,
+        }
+    }
+
+    fn exp(key: &str, scope: Option<&str>, bound: Bound) -> Expectation {
+        Expectation {
+            reference: key.to_string(),
+            rule_key: key.to_string(),
+            corpus: scope.map(str::to_string),
+            bound,
+        }
+    }
+
+    #[test]
+    fn expectation_pass_and_fail() {
+        let mut acc = Accumulator::new();
+        acc.note_file();
+        acc.add_events(3);
+        acc.record("11111111-1111-1111-1111-111111111111", "a.ndjson");
+        acc.record("11111111-1111-1111-1111-111111111111", "a.ndjson");
+
+        let r = resolved(
+            vec![
+                exp(
+                    "11111111-1111-1111-1111-111111111111",
+                    None,
+                    Bound::Range {
+                        at_least: Some(1),
+                        at_most: None,
+                    },
+                ),
+                exp(
+                    "22222222-2222-2222-2222-222222222222",
+                    None,
+                    Bound::Range {
+                        at_least: Some(1),
+                        at_most: None,
+                    },
+                ),
+            ],
+            None,
+        );
+        let report = Report::build(acc, &rules(), Some(&r), UnexpectedPolicy::Warn, 0);
+        assert_eq!(report.summary.expectations_passed, 1);
+        assert_eq!(report.summary.expectations_failed, 1);
+        assert_eq!(report.exit_code(), exit_code::FINDINGS);
+    }
+
+    #[test]
+    fn scoped_expectation_counts_one_file() {
+        let mut acc = Accumulator::new();
+        acc.record("11111111-1111-1111-1111-111111111111", "a.ndjson");
+        acc.record("11111111-1111-1111-1111-111111111111", "b.ndjson");
+
+        let r = resolved(
+            vec![exp(
+                "11111111-1111-1111-1111-111111111111",
+                Some("a.ndjson"),
+                Bound::Exactly(1),
+            )],
+            None,
+        );
+        let report = Report::build(acc, &rules(), Some(&r), UnexpectedPolicy::Warn, 0);
+        assert_eq!(report.summary.expectations_passed, 1);
+        assert_eq!(report.expectations[0].actual, 1);
+    }
+
+    #[test]
+    fn unexpected_fire_under_fail_policy_sets_exit_code() {
+        let mut acc = Accumulator::new();
+        // Netstat fires but only Whoami is expected.
+        acc.record("22222222-2222-2222-2222-222222222222", "a.ndjson");
+        let r = resolved(
+            vec![exp(
+                "11111111-1111-1111-1111-111111111111",
+                None,
+                Bound::Exactly(0),
+            )],
+            None,
+        );
+        let report = Report::build(acc, &rules(), Some(&r), UnexpectedPolicy::Fail, 0);
+        assert_eq!(report.summary.unexpected_rules, 1);
+        assert_eq!(report.summary.unexpected_fires, 1);
+        assert_eq!(report.exit_code(), exit_code::FINDINGS);
+    }
+
+    #[test]
+    fn unexpected_fire_under_warn_policy_is_clean_exit() {
+        let mut acc = Accumulator::new();
+        acc.record("22222222-2222-2222-2222-222222222222", "a.ndjson");
+        let r = resolved(
+            vec![exp(
+                "11111111-1111-1111-1111-111111111111",
+                None,
+                Bound::Exactly(0),
+            )],
+            None,
+        );
+        let report = Report::build(acc, &rules(), Some(&r), UnexpectedPolicy::Warn, 0);
+        assert_eq!(report.summary.unexpected_rules, 1);
+        assert_eq!(report.exit_code(), exit_code::SUCCESS);
+    }
+
+    #[test]
+    fn no_expectations_means_no_unexpected_and_clean_exit() {
+        let mut acc = Accumulator::new();
+        acc.record("22222222-2222-2222-2222-222222222222", "a.ndjson");
+        let report = Report::build(acc, &rules(), None, UnexpectedPolicy::Fail, 0);
+        assert_eq!(report.summary.unexpected_rules, 0);
+        assert_eq!(report.exit_code(), exit_code::SUCCESS);
+        // The fired rule still shows up in per-rule stats.
+        assert_eq!(report.rules.len(), 1);
+        assert_eq!(report.rules[0].fires, 1);
+    }
+
+    #[test]
+    fn junit_escapes_and_counts_failures() {
+        let acc = Accumulator::new();
+        let r = resolved(
+            vec![exp(
+                "22222222-2222-2222-2222-222222222222",
+                None,
+                Bound::Range {
+                    at_least: Some(1),
+                    at_most: None,
+                },
+            )],
+            None,
+        );
+        let report = Report::build(acc, &rules(), Some(&r), UnexpectedPolicy::Warn, 0);
+        let xml = report.to_junit_xml();
+        assert!(xml.contains("failures=\"1\""));
+        assert!(xml.contains("<failure"));
+    }
+
+    #[test]
+    fn junit_escapes_special_characters() {
+        assert_eq!(
+            xml_escape(r#"a & b < c > "d" 'e'"#),
+            "a &amp; b &lt; c &gt; &quot;d&quot; &apos;e&apos;"
+        );
+    }
+}

--- a/crates/rsigma-cli/src/commands/backtest/report.rs
+++ b/crates/rsigma-cli/src/commands/backtest/report.rs
@@ -629,7 +629,10 @@ fn rollup_by_logsource(unexpected: &[UnexpectedStat]) -> Vec<LogSourceRollup> {
 }
 
 /// Escape the five XML predefined entities for use in element text and
-/// double-quoted attribute values alike.
+/// double-quoted attribute values alike, and drop characters that are not
+/// legal in XML 1.0 (the C0 control range except tab, LF, and CR). Rule titles
+/// are operator-controlled, so this keeps a stray control byte from producing
+/// a report a strict XML parser would reject.
 fn xml_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -639,6 +642,9 @@ fn xml_escape(s: &str) -> String {
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
+            // Legal XML 1.0 control chars are kept; the rest of C0 is dropped.
+            '\t' | '\n' | '\r' => out.push(c),
+            c if (c as u32) < 0x20 => {}
             _ => out.push(c),
         }
     }
@@ -832,5 +838,12 @@ level: informational
             xml_escape(r#"a & b < c > "d" 'e'"#),
             "a &amp; b &lt; c &gt; &quot;d&quot; &apos;e&apos;"
         );
+    }
+
+    #[test]
+    fn junit_drops_invalid_xml_control_chars_but_keeps_tab_nl_cr() {
+        // A NUL and a vertical tab are illegal in XML 1.0 and are dropped;
+        // tab/newline/carriage-return are legal and preserved.
+        assert_eq!(xml_escape("a\u{0}b\u{0B}c\td\ne"), "abc\td\ne");
     }
 }

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod backtest;
 mod convert;
 #[cfg(feature = "daemon")]
 mod daemon;
@@ -15,6 +16,7 @@ mod parse;
 mod resolve;
 mod validate;
 
+pub(crate) use backtest::{BacktestArgs, apply_backtest_config, cmd_backtest};
 pub(crate) use convert::{
     ConvertArgs, ListFormatsArgs, cmd_convert, cmd_list_formats, cmd_list_targets,
 };

--- a/crates/rsigma-cli/src/config/defaults.rs
+++ b/crates/rsigma-cli/src/config/defaults.rs
@@ -6,8 +6,8 @@
 //! default is written, and a drift-guard test pins clap to these values.
 
 use super::schema::{
-    ApiPartial, CorrelationPartial, DaemonPartial, EnginePartial, EvalPartial, GlobalPartial,
-    InputPartial, OutputPartial, RsigmaConfigPartial, StatePartial,
+    ApiPartial, BacktestPartial, CorrelationPartial, DaemonPartial, EnginePartial, EvalPartial,
+    GlobalPartial, InputPartial, OutputPartial, RsigmaConfigPartial, StatePartial,
 };
 
 pub(crate) const CONFIG_VERSION: u32 = 1;
@@ -117,6 +117,20 @@ pub(crate) fn defaults_partial() -> RsigmaConfigPartial {
             syslog_tz: Some(SYSLOG_TZ.to_string()),
             syslog_strip_bom: Some(SYSLOG_STRIP_BOM),
             fail_on_detection: Some(false),
+        }),
+        backtest: Some(BacktestPartial {
+            // rules, corpus, and expectations are required at runtime and have
+            // no compiled default. `unexpected` is intentionally absent here so
+            // the expectations-file default can take effect when neither the
+            // CLI flag nor the config sets it.
+            rules: None,
+            corpus: None,
+            expectations: None,
+            unexpected: None,
+            pipelines: Some(Vec::new()),
+            input_format: Some(INPUT_FORMAT.to_string()),
+            syslog_tz: Some(SYSLOG_TZ.to_string()),
+            syslog_strip_bom: Some(SYSLOG_STRIP_BOM),
         }),
         // The `mcp` section has no compiled defaults: stdio is the default
         // transport, and the lint-config / rules-dir roots have no default.

--- a/crates/rsigma-cli/src/config/mod.rs
+++ b/crates/rsigma-cli/src/config/mod.rs
@@ -219,7 +219,7 @@ fn load_file(path: &Path) -> Result<(RsigmaConfigPartial, Vec<String>), ConfigEr
             let message = if raw.contains("expected struct RsigmaConfigPartial") {
                 format!(
                     "top-level config must be a YAML mapping of sections \
-                 (global, daemon, eval, mcp); got {raw}"
+                 (global, daemon, eval, backtest, mcp); got {raw}"
                 )
             } else {
                 raw

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -43,6 +43,9 @@ pub(crate) struct RsigmaConfigPartial {
     /// `rsigma engine eval` settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eval: Option<EvalPartial>,
+    /// `rsigma rule backtest` settings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backtest: Option<BacktestPartial>,
     /// `rsigma mcp serve` settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp: Option<McpPartial>,
@@ -55,6 +58,7 @@ impl Merge for RsigmaConfigPartial {
             global: merge_opt(self.global, over.global),
             daemon: merge_opt(self.daemon, over.daemon),
             eval: merge_opt(self.eval, over.eval),
+            backtest: merge_opt(self.backtest, over.backtest),
             mcp: merge_opt(self.mcp, over.mcp),
         }
     }
@@ -410,6 +414,50 @@ impl Merge for EvalPartial {
             syslog_tz: over.syslog_tz.or(self.syslog_tz),
             syslog_strip_bom: over.syslog_strip_bom.or(self.syslog_strip_bom),
             fail_on_detection: over.fail_on_detection.or(self.fail_on_detection),
+        }
+    }
+}
+
+/// `rsigma rule backtest` settings.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct BacktestPartial {
+    /// Default rules path for `rsigma rule backtest`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rules: Option<PathBuf>,
+    /// Event corpus file(s) or directory(ies), walked recursively.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus: Option<Vec<PathBuf>>,
+    /// Expectations YAML file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expectations: Option<PathBuf>,
+    /// Policy for unexpected fires: `fail`, `warn`, or `ignore`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unexpected: Option<String>,
+    /// Builtin pipeline names or YAML file paths.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipelines: Option<Vec<PathBuf>>,
+    /// Input log format for non-NDJSON corpus files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_format: Option<String>,
+    /// Default timezone offset for RFC 3164 syslog.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syslog_tz: Option<String>,
+    /// Strip a leading UTF-8 BOM from RFC 5424 syslog messages (default true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syslog_strip_bom: Option<bool>,
+}
+
+impl Merge for BacktestPartial {
+    fn merge(self, over: Self) -> Self {
+        Self {
+            rules: over.rules.or(self.rules),
+            corpus: over.corpus.or(self.corpus),
+            expectations: over.expectations.or(self.expectations),
+            unexpected: over.unexpected.or(self.unexpected),
+            pipelines: over.pipelines.or(self.pipelines),
+            input_format: over.input_format.or(self.input_format),
+            syslog_tz: over.syslog_tz.or(self.syslog_tz),
+            syslog_strip_bom: over.syslog_strip_bom.or(self.syslog_strip_bom),
         }
     }
 }

--- a/crates/rsigma-cli/src/config/template.yaml
+++ b/crates/rsigma-cli/src/config/template.yaml
@@ -137,6 +137,23 @@ eval:
   syslog_strip_bom: true
   fail_on_detection: false
 
+backtest:
+  # Default rules path for `rsigma rule backtest`.
+  # rules: ./rules
+  # Event corpus file(s) or directory(ies), walked recursively.
+  # corpus: [./corpus]
+  # Expectations YAML (per-rule fire-count assertions).
+  # expectations: ./expectations.yml
+  # Policy for a rule that fires with no covering expectation: fail | warn | ignore.
+  # Unset here so the expectations-file default applies; the CLI flag overrides both.
+  # unexpected: warn
+  # pipelines: [sysmon]
+  # Input log format for non-NDJSON corpus files.
+  input_format: auto
+  syslog_tz: "+00:00"
+  # Strip a leading UTF-8 BOM from RFC 5424 syslog messages. Set false to keep it.
+  syslog_strip_bom: true
+
 # `rsigma mcp serve` settings. The auth token is NOT configurable here by
 # design; supply it via --auth-token or RSIGMA_MCP_AUTH_TOKEN.
 mcp:

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -11,8 +11,8 @@ use std::process;
 
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use commands::{
-    ConditionArgs, ConvertArgs, EvalArgs, FieldsArgs, LintArgs, LintCounts, ListFormatsArgs,
-    MigrateSourcesArgs, ParseArgs, StdinArgs, ValidateArgs,
+    BacktestArgs, ConditionArgs, ConvertArgs, EvalArgs, FieldsArgs, LintArgs, LintCounts,
+    ListFormatsArgs, MigrateSourcesArgs, ParseArgs, StdinArgs, ValidateArgs,
 };
 // `pipeline resolve` resolves dynamic sources, which needs the async runtime
 // (tokio) and the source resolver from rsigma-runtime. Both ship with the
@@ -221,6 +221,9 @@ enum RuleCommands {
     /// List all fields referenced by Sigma rules
     Fields(FieldsArgs),
 
+    /// Replay an event corpus and diff per-rule fires against expectations
+    Backtest(BacktestArgs),
+
     /// Parse a condition expression and print the AST
     Condition(ConditionArgs),
 
@@ -342,7 +345,7 @@ fn dispatch(command: Commands, matches: &ArgMatches, ctx: output::OutputCtx) {
     match command {
         // -- Grouped commands ------------------------------------------------
         Commands::Engine { cmd } => dispatch_engine(cmd, matches, ctx),
-        Commands::Rule { cmd } => dispatch_rule(cmd, ctx),
+        Commands::Rule { cmd } => dispatch_rule(cmd, matches, ctx),
         Commands::Backend { cmd } => dispatch_backend(cmd, ctx),
         #[cfg(feature = "daemon")]
         Commands::Pipeline { cmd } => dispatch_pipeline(cmd),
@@ -430,12 +433,19 @@ fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches, ctx: output::Outpu
     }
 }
 
-fn dispatch_rule(cmd: RuleCommands, ctx: output::OutputCtx) {
+fn dispatch_rule(cmd: RuleCommands, matches: &ArgMatches, ctx: output::OutputCtx) {
     match cmd {
         RuleCommands::Parse(args) => commands::cmd_parse(args, ctx),
         RuleCommands::Validate(args) => commands::cmd_validate(args),
         RuleCommands::Lint(args) => run_lint(args, ctx),
         RuleCommands::Fields(args) => commands::cmd_fields(args, ctx),
+        RuleCommands::Backtest(args) => {
+            let bm = matches
+                .subcommand_matches("rule")
+                .and_then(|m| m.subcommand_matches("backtest"))
+                .expect("rule backtest submatches present");
+            run_backtest(args, bm, ctx);
+        }
         RuleCommands::Condition(args) => commands::cmd_condition(args, ctx),
         RuleCommands::Stdin(args) => commands::cmd_stdin(args, ctx),
         RuleCommands::MigrateSources(args) => commands::cmd_migrate_sources(args),
@@ -467,6 +477,15 @@ fn run_eval(mut args: EvalArgs, matches: &ArgMatches, ctx: output::OutputCtx) {
     if fail_on_detection && had_matches {
         process::exit(exit_code::FINDINGS);
     }
+}
+
+/// Entry point for `rule backtest`. Applies config (CLI flag > env > file >
+/// default) before running, then exits with the report's house exit code
+/// (0 pass, 1 findings, 2 rule error, 3 config error).
+fn run_backtest(mut args: BacktestArgs, matches: &ArgMatches, ctx: output::OutputCtx) {
+    commands::apply_backtest_config(&mut args, matches);
+    let code = commands::cmd_backtest(args, ctx);
+    process::exit(code);
 }
 
 /// Shared lint entry point used by both `rule lint` and the deprecated `lint`
@@ -791,6 +810,36 @@ mod config_default_drift {
             .get_default_values()
             .first()
             .map(|s| s.to_string_lossy().into_owned())
+    }
+
+    fn backtest_default(id: &str) -> Option<String> {
+        let cmd = Cli::command();
+        let rule = cmd.find_subcommand("rule")?;
+        let backtest = rule.find_subcommand("backtest")?;
+        backtest
+            .get_arguments()
+            .find(|a| a.get_id() == id)?
+            .get_default_values()
+            .first()
+            .map(|s| s.to_string_lossy().into_owned())
+    }
+
+    /// The `rule backtest` input-handling flags share the single-source config
+    /// defaults, just like the daemon flags.
+    #[test]
+    fn clap_backtest_defaults_match_config_defaults() {
+        assert_eq!(
+            backtest_default("input_format").as_deref(),
+            Some(defaults::INPUT_FORMAT)
+        );
+        assert_eq!(
+            backtest_default("syslog_tz").as_deref(),
+            Some(defaults::SYSLOG_TZ)
+        );
+        assert_eq!(
+            backtest_default("syslog_strip_bom"),
+            Some(defaults::SYSLOG_STRIP_BOM.to_string())
+        );
     }
 
     #[test]

--- a/crates/rsigma-cli/tests/cli_backtest.rs
+++ b/crates/rsigma-cli/tests/cli_backtest.rs
@@ -22,8 +22,16 @@ fn fixture(name: &str) -> String {
     fixtures().join(name).to_string_lossy().into_owned()
 }
 
+/// Normalize line endings (CRLF -> LF) so the committed goldens compare equal
+/// regardless of checkout: on Windows, git may rewrite the LF golden files to
+/// CRLF, which `include_str!` then embeds, while the binary always writes LF.
+fn normalize_eol(s: &str) -> String {
+    s.replace("\r\n", "\n")
+}
+
 /// Replace the volatile `duration_ms` value with 0 so the timing-free report
-/// can be compared byte-for-byte against the committed golden.
+/// can be compared byte-for-byte against the committed golden. Splitting on
+/// `lines()` also normalizes CRLF to LF.
 fn normalize_duration(s: &str) -> String {
     s.lines()
         .map(|line| match line.find("\"duration_ms\":") {
@@ -65,14 +73,14 @@ fn backtest_report_and_junit_match_golden() {
     let actual_report = std::fs::read_to_string(report.path()).unwrap();
     assert_eq!(
         normalize_duration(&actual_report).trim_end(),
-        REPORT_GOLDEN.trim_end(),
+        normalize_duration(REPORT_GOLDEN).trim_end(),
         "JSON report drifted from golden"
     );
 
     let actual_junit = std::fs::read_to_string(junit.path()).unwrap();
     assert_eq!(
-        actual_junit.trim_end(),
-        JUNIT_GOLDEN.trim_end(),
+        normalize_eol(&actual_junit).trim_end(),
+        normalize_eol(JUNIT_GOLDEN).trim_end(),
         "JUnit XML drifted from golden"
     );
 }

--- a/crates/rsigma-cli/tests/cli_backtest.rs
+++ b/crates/rsigma-cli/tests/cli_backtest.rs
@@ -327,6 +327,52 @@ fn backtest_table_output_is_human_readable() {
         .stdout(predicate::str::contains("FAIL"));
 }
 
+#[cfg(feature = "evtx")]
+#[test]
+fn backtest_evtx_corpus() {
+    // Reuse the runtime crate's committed EVTX fixture. A `.evtx` corpus path
+    // routes through the feature-gated adapter.
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../rsigma-runtime/tests/fixtures/security.evtx");
+    let rule = temp_file(
+        ".yml",
+        r#"
+title: Windows Logon
+id: 00000000-0000-0000-0000-000000004624
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        Event.System.EventID: 4624
+    condition: selection
+level: medium
+"#,
+    );
+    let exp = temp_file(
+        ".yml",
+        "expectations:\n  - rule: 00000000-0000-0000-0000-000000004624\n    at_least: 1\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            rule.path().to_str().unwrap(),
+            "--corpus",
+            fixture.to_str().unwrap(),
+            "--expectations",
+            exp.path().to_str().unwrap(),
+            "--unexpected",
+            "ignore",
+            "--output-format",
+            "ndjson",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Windows Logon"));
+}
+
 #[test]
 fn backtest_dry_run_prints_config() {
     rsigma()

--- a/crates/rsigma-cli/tests/cli_backtest.rs
+++ b/crates/rsigma-cli/tests/cli_backtest.rs
@@ -1,0 +1,345 @@
+//! Integration tests for `rsigma rule backtest`: the golden JSON report and
+//! JUnit XML, plus boundary and error paths (exit codes, per-file scoping,
+//! correlation expectations, config-file layering). Per-rule diff and
+//! expectations-parsing logic is unit-tested in the command module; these
+//! tests cover the end-to-end CLI surface only.
+
+mod common;
+
+use std::path::{Path, PathBuf};
+
+use common::{rsigma, temp_file};
+use predicates::prelude::*;
+
+const REPORT_GOLDEN: &str = include_str!("golden/backtest_report.json");
+const JUNIT_GOLDEN: &str = include_str!("golden/backtest_junit.xml");
+
+fn fixtures() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/backtest")
+}
+
+fn fixture(name: &str) -> String {
+    fixtures().join(name).to_string_lossy().into_owned()
+}
+
+/// Replace the volatile `duration_ms` value with 0 so the timing-free report
+/// can be compared byte-for-byte against the committed golden.
+fn normalize_duration(s: &str) -> String {
+    s.lines()
+        .map(|line| match line.find("\"duration_ms\":") {
+            Some(idx) => format!("{}\"duration_ms\": 0", &line[..idx]),
+            None => line.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn backtest_report_and_junit_match_golden() {
+    let report = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let junit = tempfile::Builder::new().suffix(".xml").tempfile().unwrap();
+
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--expectations",
+            &fixture("expectations.yml"),
+            "--unexpected",
+            "fail",
+            "--report",
+            report.path().to_str().unwrap(),
+            "--junit",
+            junit.path().to_str().unwrap(),
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        // A failed expectation (netstat exactly 0) yields exit code 1.
+        .code(1);
+
+    let actual_report = std::fs::read_to_string(report.path()).unwrap();
+    assert_eq!(
+        normalize_duration(&actual_report).trim_end(),
+        REPORT_GOLDEN.trim_end(),
+        "JSON report drifted from golden"
+    );
+
+    let actual_junit = std::fs::read_to_string(junit.path()).unwrap();
+    assert_eq!(
+        actual_junit.trim_end(),
+        JUNIT_GOLDEN.trim_end(),
+        "JUnit XML drifted from golden"
+    );
+}
+
+#[test]
+fn backtest_all_expectations_pass_is_exit_zero() {
+    // whoami fires twice, netstat once; both satisfied, ping is unexpected but
+    // the default policy is warn, so the run still succeeds.
+    let exp = temp_file(
+        ".yml",
+        "expectations:\n  - rule: 11111111-1111-1111-1111-111111111111\n    at_least: 1\n  - rule: 22222222-2222-2222-2222-222222222222\n    at_least: 1\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--expectations",
+            exp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn backtest_unexpected_fail_policy_fails_the_run() {
+    // Only whoami is expected; ping and netstat fire unexpectedly. Under the
+    // fail policy that is exit code 1 even though the whoami expectation passes.
+    let exp = temp_file(
+        ".yml",
+        "expectations:\n  - rule: 11111111-1111-1111-1111-111111111111\n    at_least: 1\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--expectations",
+            exp.path().to_str().unwrap(),
+            "--unexpected",
+            "fail",
+        ])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn backtest_per_file_scoping() {
+    // whoami fires once in b.ndjson; scoped exactly:1 must pass even though the
+    // corpus-wide count is 2.
+    let exp = temp_file(
+        ".yml",
+        "expectations:\n  - rule: 11111111-1111-1111-1111-111111111111\n    corpus: b.ndjson\n    exactly: 1\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--expectations",
+            exp.path().to_str().unwrap(),
+            "--unexpected",
+            "ignore",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn backtest_unknown_rule_in_expectations_is_config_error() {
+    let exp = temp_file(
+        ".yml",
+        "expectations:\n  - rule: Nonexistent Rule\n    at_least: 1\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--expectations",
+            exp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("not in the loaded ruleset"));
+}
+
+#[test]
+fn backtest_missing_corpus_path_is_config_error() {
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            "/tmp/nonexistent_rsigma_corpus_dir",
+        ])
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("corpus path not found"));
+}
+
+#[test]
+fn backtest_missing_rules_is_config_error() {
+    rsigma()
+        .args(["rule", "backtest", "--corpus", &fixture("corpus")])
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("no rules path"));
+}
+
+#[test]
+fn backtest_without_expectations_reports_stats_and_exits_zero() {
+    // No expectations file: stats-only mode. Every rule fired, but nothing is
+    // diffed and nothing is unexpected, so the run succeeds.
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--output-format",
+            "ndjson",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Whoami Execution"));
+}
+
+#[test]
+fn backtest_correlation_rule_expectation() {
+    let rules = temp_file(
+        ".yml",
+        r#"
+title: Login Failure
+id: 00000000-0000-0000-0000-0000000000a1
+status: test
+logsource:
+    category: test
+    product: test
+detection:
+    selection:
+        EventType: login_failure
+    condition: selection
+level: low
+---
+title: Brute Force
+id: 00000000-0000-0000-0000-0000000000a2
+correlation:
+    type: event_count
+    rules:
+        - 00000000-0000-0000-0000-0000000000a1
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 3
+level: high
+"#,
+    );
+    let corpus = temp_file(
+        ".ndjson",
+        r#"{"EventType": "login_failure", "User": "admin", "@timestamp": "2025-01-01T00:00:01Z"}
+{"EventType": "login_failure", "User": "admin", "@timestamp": "2025-01-01T00:00:02Z"}
+{"EventType": "login_failure", "User": "admin", "@timestamp": "2025-01-01T00:00:03Z"}
+"#,
+    );
+    let exp = temp_file(
+        ".yml",
+        "expectations:\n  - rule: 00000000-0000-0000-0000-0000000000a2\n    at_least: 1\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            rules.path().to_str().unwrap(),
+            "--corpus",
+            corpus.path().to_str().unwrap(),
+            "--expectations",
+            exp.path().to_str().unwrap(),
+            "--unexpected",
+            "ignore",
+            "--output-format",
+            "ndjson",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Brute Force"));
+}
+
+#[test]
+fn backtest_config_file_layering() {
+    // rules and corpus come from the config file; only --config is passed.
+    let cfg = temp_file(
+        ".yaml",
+        &format!(
+            "backtest:\n  rules: {}\n  corpus:\n    - {}\n",
+            fixture("rules.yml"),
+            fixture("corpus"),
+        ),
+    );
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--config",
+            cfg.path().to_str().unwrap(),
+            "--output-format",
+            "ndjson",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Whoami Execution"));
+}
+
+#[test]
+fn backtest_table_output_is_human_readable() {
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--expectations",
+            &fixture("expectations.yml"),
+            "--output-format",
+            "table",
+        ])
+        .assert()
+        // netstat exactly:0 fails, so exit code 1 under the default warn policy.
+        .code(1)
+        .stdout(predicate::str::contains("Backtest summary"))
+        .stdout(predicate::str::contains("PASS"))
+        .stdout(predicate::str::contains("FAIL"));
+}
+
+#[test]
+fn backtest_dry_run_prints_config() {
+    rsigma()
+        .args([
+            "rule",
+            "backtest",
+            "--rules",
+            &fixture("rules.yml"),
+            "--corpus",
+            &fixture("corpus"),
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("input_format"));
+}

--- a/crates/rsigma-cli/tests/fixtures/backtest/corpus/a.ndjson
+++ b/crates/rsigma-cli/tests/fixtures/backtest/corpus/a.ndjson
@@ -1,0 +1,3 @@
+{"Image": "C:\\Windows\\System32\\whoami.exe"}
+{"Image": "C:\\Windows\\System32\\netstat.exe"}
+{"Image": "C:\\Windows\\System32\\ping.exe"}

--- a/crates/rsigma-cli/tests/fixtures/backtest/corpus/b.ndjson
+++ b/crates/rsigma-cli/tests/fixtures/backtest/corpus/b.ndjson
@@ -1,0 +1,1 @@
+{"Image": "C:\\Windows\\System32\\whoami.exe"}

--- a/crates/rsigma-cli/tests/fixtures/backtest/expectations.yml
+++ b/crates/rsigma-cli/tests/fixtures/backtest/expectations.yml
@@ -1,0 +1,7 @@
+defaults:
+  unexpected_detections: warn
+expectations:
+  - rule: 11111111-1111-1111-1111-111111111111
+    at_least: 1
+  - rule: 22222222-2222-2222-2222-222222222222
+    exactly: 0

--- a/crates/rsigma-cli/tests/fixtures/backtest/rules.yml
+++ b/crates/rsigma-cli/tests/fixtures/backtest/rules.yml
@@ -1,0 +1,35 @@
+title: Whoami Execution
+id: 11111111-1111-1111-1111-111111111111
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\whoami.exe'
+    condition: selection
+level: low
+---
+title: Netstat Execution
+id: 22222222-2222-2222-2222-222222222222
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\netstat.exe'
+    condition: selection
+level: informational
+---
+title: Ping Execution
+id: 33333333-3333-3333-3333-333333333333
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\ping.exe'
+    condition: selection
+level: informational

--- a/crates/rsigma-cli/tests/golden/backtest_junit.xml
+++ b/crates/rsigma-cli/tests/golden/backtest_junit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="2">
+  <testsuite name="rsigma backtest" tests="3" failures="2">
+    <testcase name="11111111-1111-1111-1111-111111111111" classname="rsigma.backtest.expectations"/>
+    <testcase name="22222222-2222-2222-2222-222222222222" classname="rsigma.backtest.expectations">
+      <failure message="expected exactly 0, got 1">expected exactly 0, got 1</failure>
+    </testcase>
+    <testcase name="Ping Execution" classname="rsigma.backtest.unexpected">
+      <failure message="unexpected 1 fires with no covering expectation">unexpected 1 fires with no covering expectation</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/crates/rsigma-cli/tests/golden/backtest_report.json
+++ b/crates/rsigma-cli/tests/golden/backtest_report.json
@@ -1,0 +1,93 @@
+{
+  "summary": {
+    "corpus_files": 2,
+    "events_processed": 4,
+    "rules_loaded": 3,
+    "expectations_total": 2,
+    "expectations_passed": 1,
+    "expectations_failed": 1,
+    "unexpected_rules": 1,
+    "unexpected_fires": 1,
+    "unexpected_policy": "fail",
+    "duration_ms": 0
+  },
+  "expectations": [
+    {
+      "rule": "11111111-1111-1111-1111-111111111111",
+      "rule_key": "11111111-1111-1111-1111-111111111111",
+      "bound": ">= 1",
+      "actual": 2,
+      "pass": true
+    },
+    {
+      "rule": "22222222-2222-2222-2222-222222222222",
+      "rule_key": "22222222-2222-2222-2222-222222222222",
+      "bound": "exactly 0",
+      "actual": 1,
+      "pass": false
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "11111111-1111-1111-1111-111111111111",
+      "rule_title": "Whoami Execution",
+      "level": "low",
+      "logsource": {
+        "category": "process_creation",
+        "product": "windows"
+      },
+      "fires": 2,
+      "by_file": {
+        "a.ndjson": 1,
+        "b.ndjson": 1
+      }
+    },
+    {
+      "rule_id": "22222222-2222-2222-2222-222222222222",
+      "rule_title": "Netstat Execution",
+      "level": "informational",
+      "logsource": {
+        "category": "process_creation",
+        "product": "windows"
+      },
+      "fires": 1,
+      "by_file": {
+        "a.ndjson": 1
+      }
+    },
+    {
+      "rule_id": "33333333-3333-3333-3333-333333333333",
+      "rule_title": "Ping Execution",
+      "level": "informational",
+      "logsource": {
+        "category": "process_creation",
+        "product": "windows"
+      },
+      "fires": 1,
+      "by_file": {
+        "a.ndjson": 1
+      }
+    }
+  ],
+  "unexpected": [
+    {
+      "rule_key": "33333333-3333-3333-3333-333333333333",
+      "rule_title": "Ping Execution",
+      "level": "informational",
+      "logsource": {
+        "category": "process_creation",
+        "product": "windows"
+      },
+      "fires": 1
+    }
+  ],
+  "by_logsource": [
+    {
+      "logsource": "windows/process_creation",
+      "unexpected_fires": 1,
+      "rules": [
+        "33333333-3333-3333-3333-333333333333"
+      ]
+    }
+  ]
+}

--- a/docs/cli/engine/eval.md
+++ b/docs/cli/engine/eval.md
@@ -12,7 +12,7 @@ rsigma engine eval [OPTIONS] --rules <RULES>
 
 Loads rules from a file or directory, optionally applies one or more processing pipelines, reads events from `--event` (or stdin), and writes matched `MatchResult` JSON to stdout. Exits when the event source is exhausted.
 
-This is the right tool for CI fixtures, ad-hoc threat hunting, forensic replay over `.evtx` and NDJSON files, and any "run rules against this data, then exit" workflow. For a long-running daemon with hot-reload and metrics, use [`engine daemon`](daemon.md).
+This is the right tool for ad-hoc threat hunting, forensic replay over `.evtx` and NDJSON files, and any "run rules against this data, then exit" workflow. For a long-running daemon with hot-reload and metrics, use [`engine daemon`](daemon.md). For per-rule assertions over a corpus (a CI fixture harness with expected-vs-actual fire counts and a JUnit report), use [`rule backtest`](../rule/backtest.md).
 
 For a narrative tutorial see [Evaluating Rules](../../guide/evaluating-rules.md).
 
@@ -188,4 +188,5 @@ rsigma engine eval -r rules/ --suppress 5m --action reset \
 - [Processing Pipelines](../../guide/processing-pipelines.md) for `-p` semantics and the builtin pipelines.
 - [Performance Tuning](../../guide/performance-tuning.md) for `--bloom-prefilter` and `--cross-rule-ac`.
 - [CI/CD](../../guide/ci-cd.md) for `--fail-on-detection` patterns.
+- [`rule backtest`](../rule/backtest.md) for per-rule corpus assertions and CI reports.
 - [`engine daemon`](daemon.md) for the long-running streaming counterpart.

--- a/docs/cli/rule/.pages
+++ b/docs/cli/rule/.pages
@@ -4,6 +4,7 @@ nav:
   - validate: validate.md
   - lint: lint.md
   - fields: fields.md
+  - backtest: backtest.md
   - condition: condition.md
   - stdin: stdin.md
   - migrate-sources: migrate-sources.md

--- a/docs/cli/rule/backtest.md
+++ b/docs/cli/rule/backtest.md
@@ -1,0 +1,117 @@
+# `rsigma rule backtest`
+
+Replay an event corpus against a ruleset, diff the per-rule fire counts against declared expectations, and emit a CI-native report.
+
+## Synopsis
+
+```text
+rsigma rule backtest [OPTIONS] --rules <RULES> --corpus <PATH>
+```
+
+## Description
+
+`engine eval` answers "what fired on this data." `rule backtest` answers "did the rules I intended to fire actually fire, and did anything else fire that should not." It walks an event corpus (one file or a directory, recursively), evaluates every record, tallies how many times each rule fired per corpus file, and diffs those counts against an optional expectations file.
+
+Unlike `engine eval --fail-on-detection`, which is corpus-global and inverts on any rule firing, backtest asserts per rule. A positive fixture can require a specific rule to fire at least once, a negative fixture can require a specific rule to fire exactly zero times, and any rule that fires without a covering expectation is surfaced as a potential false positive on a known-benign corpus.
+
+Backtest reuses the same input parsing as `engine eval`, so NDJSON, syslog, plain, logfmt, CEF, and EVTX corpora all work the same way. Correlation rules are first-class; correlation state is reset for each corpus file, so each file is an independent time slice (carrying window state across files would produce phantom correlations).
+
+Without an `--expectations` file, backtest still runs and prints per-rule statistics; it just has nothing to diff.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-r, --rules <PATH>` | required | Sigma rule file or directory of rules. May also be supplied via `backtest.rules` in a config file. |
+| `--corpus <PATH>` | required | Event corpus: a file or a directory walked recursively. Repeatable. Extension dispatch: `.ndjson`/`.jsonl` as NDJSON, `.evtx` via the feature-gated adapter, everything else through `--input-format`. May also be supplied via `backtest.corpus`. |
+| `--expectations <PATH>` | unset | Expectations YAML (per-rule fire-count assertions). |
+| `--unexpected <POLICY>` | `warn` | What a rule firing with no covering expectation means: `fail`, `warn`, or `ignore`. Overrides the expectations-file default. |
+| `-p, --pipeline <P>` | unset | Processing pipeline(s) to apply. Builtin names (`ecs_windows`, `sysmon`) or YAML file paths. Repeatable. |
+| `--input-format <FMT>` | `auto` | Input log format for non-NDJSON corpus files: `auto`, `json`, `syslog`, `plain`, `logfmt`, `cef`. |
+| `--syslog-tz <TZ>` | `+00:00` | Default timezone offset for RFC 3164 syslog. |
+| `--syslog-strip-bom <BOOL>` | `true` | Strip a leading UTF-8 BOM from RFC 5424 syslog messages. |
+| `--jq <JQ>` | unset | `jq` filter to extract the event payload from each JSON object. Mutually exclusive with `--jsonpath`. |
+| `--jsonpath <JSONPATH>` | unset | JSONPath (RFC 9535) query to extract the event payload. |
+| `--junit <PATH>` | unset | Write a JUnit XML report (one test case per expectation, plus one per unexpected-firing rule under the `fail` policy). |
+| `--report <PATH>` | unset | Write the full JSON report to a file regardless of the stdout format. |
+| `--config <PATH>` | unset | Load a specific YAML config file instead of running the discovery chain. |
+| `--dry-run` | off | Print the effective `backtest` section and exit `0` without running. |
+
+The global `--output-format` applies: `table` (the TTY default) renders the human report, `json` emits the single report document, and `ndjson`/`csv`/`tsv` emit one row per rule.
+
+## Expectations file
+
+```yaml
+# expectations.yml
+defaults:
+  unexpected_detections: warn   # fail | warn | ignore
+expectations:
+  - rule: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5   # rule id (preferred) or exact title
+    corpus: auth-logs.ndjson                      # optional: scope to one corpus file
+    at_least: 1                                   # must fire
+  - rule: Suspicious Whoami Execution
+    exactly: 0                                    # must not fire anywhere
+  - rule: 9a1b2c3d-...
+    at_least: 3
+    at_most: 10                                   # bounded noise budget
+```
+
+- `rule` matches `rule_id` first, then falls back to `rule_title`. A title shared by more than one rule is a configuration error; reference it by id instead.
+- Each entry sets exactly one of `exactly` or any combination of `at_least`/`at_most`.
+- `corpus` scopes the count to a single corpus file (the path relative to the `--corpus` root, with `/` separators). Omit it to count across the whole corpus.
+- An expectation that references a rule not present in `--rules` is a configuration error, so a renamed or deleted rule fails CI.
+- Correlation rules are referenced the same way and their fires count the same way.
+
+## Report
+
+The JSON document (`--output-format json`, or written via `--report`) has a stable shape:
+
+- `summary`: corpus files, events processed, rules loaded, expectations passed/failed, unexpected-fire counts, the effective policy, and the run duration.
+- `expectations[]`: per expectation, the resolved rule, optional scope, bound, actual count, and pass/fail.
+- `rules[]`: per rule, the id, title, level, logsource, total fires, and a per-corpus-file breakdown.
+- `unexpected[]`: rules that fired with no covering expectation, with counts. This is the false-positive signal on a known-benign corpus.
+- `by_logsource[]`: a rollup of unexpected fires grouped by rule logsource, the per-logsource false-positive-density view.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All expectations met, and no unexpected fires under the `fail` policy. |
+| `1` | At least one expectation failed, or unexpected fires occurred under the `fail` policy. |
+| `2` | The rules path could not be read or compiled. |
+| `3` | Bad expectations file, missing corpus path, or an invalid flag. |
+
+## Examples
+
+### Assert a positive and a negative fixture
+
+```bash
+rsigma rule backtest -r rules/ --corpus ci/corpus/ --expectations ci/expectations.yml
+```
+
+### Fail the build on any unexpected fire over a benign corpus
+
+```bash
+rsigma rule backtest -r rules/ --corpus ci/benign/ \
+    --expectations ci/expectations.yml --unexpected fail
+```
+
+### Emit a JUnit report for CI annotation
+
+```bash
+rsigma rule backtest -r rules/ --corpus ci/corpus/ \
+    --expectations ci/expectations.yml --junit backtest.xml
+```
+
+### Per-rule statistics with no expectations
+
+```bash
+rsigma rule backtest -r rules/ --corpus samples/ --output-format json | jq '.rules'
+```
+
+## See also
+
+- [CI/CD](../../guide/ci-cd.md) for the detection-as-code pipeline that wires backtest into GitHub Actions and GitLab CI.
+- [`engine eval`](../engine/eval.md) for one-shot evaluation; backtest is the corpus-replay test harness built on top of it.
+- [Configuration](../../reference/configuration.md) for the `backtest` config section.
+- [Exit Codes reference](../../reference/exit-codes.md) for the canonical table.

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -1,8 +1,8 @@
 # CI/CD
 
-RSigma is designed to drop into a detection-as-code workflow. The four CLI surfaces that matter for CI are `rule lint`, `rule validate`, `engine eval`, and `backend convert`. Each exits with a structured code that lets CI runners distinguish "no findings, clean exit" from "the tool ran but reported findings" from "the tool could not run because of a configuration or rule error."
+RSigma is designed to drop into a detection-as-code workflow. The CLI surfaces that matter for CI are `rule lint`, `rule validate`, `rule backtest`, `engine eval`, and `backend convert`. Each exits with a structured code that lets CI runners distinguish "no findings, clean exit" from "the tool ran but reported findings" from "the tool could not run because of a configuration or rule error."
 
-This page covers the exit-code model, the failure-controlling flags (`--fail-on-detection`, `--fail-level`), and copy-paste pipelines for GitHub Actions, GitLab CI, pre-commit, and a generic shell runner.
+This page covers the exit-code model, the fixture harness (`rule backtest`), the failure-controlling flags (`--fail-on-detection`, `--fail-level`), and copy-paste pipelines for GitHub Actions, GitLab CI, pre-commit, and a generic shell runner.
 
 ## Exit codes
 
@@ -22,10 +22,43 @@ A few non-obvious behaviours worth pinning down:
 - `engine eval` exits `0` when a rule file contains a Sigma parse error (it logs a warning to stderr and continues with the rules that did load). Use `rule validate` if you want a parse error to fail the build.
 - `engine eval` exits `0` by default even when matches fire. Pass `--fail-on-detection` if you want detections to fail the build.
 - `rule lint` exits `0` for findings below `--fail-level`. The default threshold is `error`, so a clean lint with only info/warning findings still returns `0`.
+- `rule backtest` exits `1` on a failed expectation or, under `--unexpected fail`, on a rule firing with no covering expectation. A bad expectations file or a missing corpus path is exit `3`, and unreadable rules are exit `2`.
+
+## `rule backtest` for fixture suites
+
+`rule backtest` is the recommended fixture harness. It replays a corpus (a file or a directory walked recursively), tallies how many times each rule fired, and diffs those counts against an expectations file. Unlike `engine eval --fail-on-detection`, which is corpus-global and passes when *any* rule fires, backtest asserts per rule, so a broken rule cannot be masked by an unrelated rule matching the same fixture.
+
+Declare what each rule must do in an expectations file:
+
+```yaml
+# ci/expectations.yml
+defaults:
+  unexpected_detections: warn   # fail | warn | ignore
+expectations:
+  - rule: 5f0d7d3c-3aab-43fa-952f-8f7b2d966ee5   # positive fixture: must fire
+    at_least: 1
+  - rule: Suspicious Whoami Execution             # negative fixture: must not fire
+    exactly: 0
+```
+
+Then run the whole suite in one command:
+
+```bash
+rsigma rule backtest -r rules/ --corpus ci/corpus/ --expectations ci/expectations.yml
+```
+
+Exit `1` means an expectation failed (or, under `--unexpected fail`, that a rule fired with no covering expectation, the false-positive signal on a benign corpus). Emit a JUnit report for CI annotation with `--junit`, and the full JSON report with `--report`:
+
+```bash
+rsigma rule backtest -r rules/ --corpus ci/corpus/ \
+    --expectations ci/expectations.yml --junit backtest.xml --unexpected fail
+```
+
+Correlation rules are asserted the same way, by id or title. See [`rule backtest`](../cli/rule/backtest.md) for the full flag table, expectations schema, and report shape.
 
 ## `--fail-on-detection` for `engine eval`
 
-`engine eval` is the right tool for CI tests against fixtures: gold-standard "this event should match" / "this event should not match" pairs that catch detection regressions before they ship.
+`engine eval --fail-on-detection` is the zero-setup fallback when you do not want an expectations file: a single fixture and a single rule, where exit `1` means "something fired."
 
 ```bash
 rsigma engine eval -r rules/ --fail-on-detection -e @ci/should-not-match.ndjson
@@ -40,7 +73,7 @@ if rsigma engine eval -r rules/ --fail-on-detection -e @ci/should-match.ndjson; 
 fi
 ```
 
-The same pattern works for fingerprinting suppression and correlation behaviour. Pair `--fail-on-detection` with `--no-detections` if you only care whether correlations fire:
+Because this check is corpus-global, prefer `rule backtest` once a fixture exercises more than one rule. Pair `--fail-on-detection` with `--no-detections` if you only care whether correlations fire:
 
 ```bash
 rsigma engine eval -r rules/ --fail-on-detection --no-detections \
@@ -95,7 +128,7 @@ See [Linting Rules](linting-rules.md) and [Processing Pipelines](processing-pipe
 
 ## GitHub Actions
 
-A four-job workflow that mirrors a typical detection-engineering loop: lint, validate, fixture eval, then convert and publish.
+A four-job workflow that mirrors a typical detection-engineering loop: lint, validate, backtest, then convert and publish.
 
 ```yaml
 name: detections
@@ -134,7 +167,7 @@ jobs:
       - run: cargo install --locked rsigma --version "${RSIGMA_VERSION}"
       - run: rsigma rule validate rules/ -p pipelines/ecs.yml
 
-  eval-fixtures:
+  backtest:
     runs-on: ubuntu-latest
     needs: [lint, validate]
     permissions:
@@ -144,14 +177,18 @@ jobs:
         with:
           persist-credentials: false
       - run: cargo install --locked rsigma --version "${RSIGMA_VERSION}"
-      - name: Negative fixtures must not match
-        run: rsigma engine eval -r rules/ --fail-on-detection -e @ci/negative.ndjson
-      - name: Positive fixtures must match
+      - name: Backtest fixtures against expectations
         run: |
-          if rsigma engine eval -r rules/ --fail-on-detection -e @ci/positive.ndjson; then
-              echo "::error::positive fixture produced no detection"
-              exit 1
-          fi
+          rsigma rule backtest -r rules/ \
+            --corpus ci/corpus/ \
+            --expectations ci/expectations.yml \
+            --unexpected fail \
+            --junit backtest.xml
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: backtest-junit
+          path: backtest.xml
 
   convert:
     runs-on: ubuntu-latest
@@ -218,11 +255,15 @@ validate:
   script:
     - rsigma rule validate rules/ -p pipelines/ecs.yml
 
-negative-fixtures:
+backtest:
   stage: eval
   <<: *install-rsigma
   script:
-    - rsigma engine eval -r rules/ --fail-on-detection -e @ci/negative.ndjson
+    - rsigma rule backtest -r rules/ --corpus ci/corpus/ --expectations ci/expectations.yml --unexpected fail --junit backtest.xml
+  artifacts:
+    when: always
+    reports:
+      junit: backtest.xml
 
 convert-postgres:
   stage: build
@@ -286,21 +327,13 @@ PIPELINE="${PIPELINE:-pipelines/ecs.yml}"
 $RSIGMA_BIN rule lint    "$RULES_DIR" --fail-level warning
 $RSIGMA_BIN rule validate "$RULES_DIR" -p "$PIPELINE"
 
-for fixture in ci/negative/*.ndjson; do
-    $RSIGMA_BIN engine eval -r "$RULES_DIR" -p "$PIPELINE" \
-        --fail-on-detection -e "@$fixture"
-done
-
-for fixture in ci/positive/*.ndjson; do
-    if $RSIGMA_BIN engine eval -r "$RULES_DIR" -p "$PIPELINE" \
-        --fail-on-detection -e "@$fixture"; then
-        echo "positive fixture $fixture produced no detection" >&2
-        exit 1
-    fi
-done
+$RSIGMA_BIN rule backtest -r "$RULES_DIR" -p "$PIPELINE" \
+    --corpus ci/corpus/ \
+    --expectations ci/expectations.yml \
+    --unexpected fail
 ```
 
-`set -e` plus `set -o pipefail` makes any non-zero exit fail the script, so the structured exit codes work without explicit `if` branches except for the positive-fixture inversion.
+`set -e` plus `set -o pipefail` makes any non-zero exit fail the script, so the structured exit codes work without explicit `if` branches: a failed expectation or an unexpected fire returns exit `1` and stops the run.
 
 ## Tips and gotchas
 
@@ -317,4 +350,4 @@ done
 - [Rule Conversion](rule-conversion.md) for the `backend convert` workflow that feeds `views.sql` into Grafana or alerting.
 - [Processing Pipelines](processing-pipelines.md) for dynamic-source validation via `--resolve-sources`.
 - [Exit Codes reference](../reference/exit-codes.md) for the canonical table and source-code link.
-- [CLI reference: `engine eval`](../cli/engine/eval.md), [`rule lint`](../cli/rule/lint.md), [`rule validate`](../cli/rule/validate.md), [`backend convert`](../cli/backend/convert.md).
+- [CLI reference: `rule backtest`](../cli/rule/backtest.md), [`engine eval`](../cli/engine/eval.md), [`rule lint`](../cli/rule/lint.md), [`rule validate`](../cli/rule/validate.md), [`backend convert`](../cli/backend/convert.md).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-`rsigma engine daemon` and `rsigma engine eval` can be driven by a YAML config file in addition to CLI flags and environment variables. This page describes the schema, the discovery chain, and the precedence model that decides which value wins when more than one layer sets the same key.
+`rsigma engine daemon`, `rsigma engine eval`, and `rsigma rule backtest` can be driven by a YAML config file in addition to CLI flags and environment variables. This page describes the schema, the discovery chain, and the precedence model that decides which value wins when more than one layer sets the same key.
 
 The same machinery is exposed through the [`rsigma config` group](../cli/config/init.md) for scaffolding, validation, introspection, and reload.
 
@@ -72,6 +72,13 @@ eval:
   pipelines: [sysmon]
   input_format: auto
   fail_on_detection: false
+
+backtest:
+  rules: ./rules
+  corpus: [./ci/corpus]
+  expectations: ./ci/expectations.yml
+  # unexpected: warn   # fail | warn | ignore; unset lets the expectations-file default apply
+  input_format: auto
 ```
 
 Run [`rsigma config init`](../cli/config/init.md) to scaffold a full, commented version. The full machine-readable schema is emitted by [`rsigma config schema`](../cli/config/schema.md).
@@ -86,6 +93,7 @@ Run [`rsigma config init`](../cli/config/init.md) to scaffold a full, commented 
 | `daemon.nats` | `engine daemon` | Non-secret NATS knobs (e.g. `consumer_group`). Secrets stay env-only. Inert unless built with `daemon-nats`. |
 | `daemon.engine.cross_rule_ac` | `engine daemon` | Inert unless built with `daachorse-index`. |
 | `eval` | `engine eval` | Mirrors the eval flag surface. |
+| `backtest` | `rule backtest` | `rules`, `corpus`, `expectations`, `unexpected`, `pipelines`, and the syslog input knobs. `unexpected` has no compiled default so the expectations-file default can apply. |
 | `mcp` | `mcp serve` | `mcp.http_addr` (the `--http` bind address; unset means stdio), `mcp.lint_config`, and `mcp.rules_dir`. The auth token is secret and stays flag/env-only. Inert unless built with the `mcp` feature. |
 
 ### Secrets policy
@@ -116,7 +124,7 @@ The uniform scheme is detected by the `__` separator, so it never collides with 
 
 ## `--dry-run` and `config show`
 
-[`config show`](../cli/config/show.md) folds `default + file + env` and reports the winning layer for each leaf. To preview what a real command will use, including its flag layer, the daemon and eval support `--dry-run`:
+[`config show`](../cli/config/show.md) folds `default + file + env` and reports the winning layer for each leaf. To preview what a real command will use, including its flag layer, the daemon, eval, and backtest support `--dry-run`:
 
 ```bash
 rsigma engine daemon --dry-run


### PR DESCRIPTION
## Summary

`engine eval` answers "what fired on this data." `rule backtest` answers "did the rules I intended to fire actually fire, and did anything else fire that should not." It replays an event corpus against a ruleset, tallies per-rule fire counts, and diffs them against an expectations file. Unlike the corpus-global `engine eval --fail-on-detection` (which passes when any rule fires), backtest asserts per rule, so a broken rule cannot be masked by an unrelated rule matching the same fixture.

- Corpus walker: a file or a directory walked recursively, with extension dispatch (`.ndjson`/`.jsonl` as NDJSON, `.evtx` via the feature-gated adapter, everything else through `--input-format`). Correlation state is reset per corpus file.
- Expectations YAML asserts per rule (by id or title): `at_least`, `at_most`, or `exactly`, optionally scoped to one corpus file. A rule that fires with no covering expectation is surfaced as a potential false positive, governed by `--unexpected` (fail/warn/ignore).
- Report renders through the shared output layer (table, json, and per-rule ndjson/csv/tsv rows) and can be written to `--report` (JSON) and `--junit` (hand-rolled XML, no new dependency). It carries per-rule fires with a per-corpus-file breakdown, the unexpected-fire set, and a per-logsource false-positive-density rollup.
- Exit codes follow the house scheme: `0` pass, `1` a failed expectation or a policy-failing unexpected fire, `2` unreadable rules, `3` bad expectations file or corpus path.
- A `backtest` config section (rules, corpus, expectations, unexpected, pipelines, syslog input knobs) flows through `config init/validate/show/schema`, the `RSIGMA_BACKTEST__*` env layer, `--config`, and `--dry-run`, with a clap-defaults drift-guard test.

Zero new dependencies. Builds on the shared `commands::eval_stream` loop from #215, so eval and backtest cannot drift on input parsing.

## Test plan

- [x] in-module unit tests (expectations parsing/validation/resolution, diff logic, policy precedence, corpus walking, JUnit escaping)
- [x] integration tests over a committed fixture corpus, including per-file scoping, unknown-rule/missing-corpus config errors, correlation-rule expectations, config-file layering, table output, and the `.evtx` corpus path (feature-gated, reusing `security.evtx`)
- [x] committed plain-text golden tests for the JSON report and the JUnit XML (timing normalized)
- [x] `cargo clippy -p rsigma --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`
- [x] `mkdocs build --strict` (new `rule backtest` CLI page, CI/CD guide rewrite, configuration reference, READMEs)