### PR TITLE
fix(convert): emit the required `version` field in Fibratus rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Fibratus conversion: emit the required `version` field (#NNN)
+### Fibratus conversion: emit the required `version` field (#219)
 
 Fibratus rules require a top-level `version` attribute (the rule content version, distinct from `min-engine-version`); the loader rejects a rule that omits it. The converted YAML envelope never emitted it, so every converted rule failed to load. Reported by @rabbitstack.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Fibratus conversion: emit the required `version` field (#NNN)
+
+Fibratus rules require a top-level `version` attribute (the rule content version, distinct from `min-engine-version`); the loader rejects a rule that omits it. The converted YAML envelope never emitted it, so every converted rule failed to load. Reported by @rabbitstack.
+
+- The envelope now emits `version:` right after `id` for both detection and correlation rules, regardless of `emit_metadata`. It defaults to `1.0.0` and is overridable with `-O version=<value>`.
+
 ### Fibratus conversion: file and remote-thread macro fixes (#217)
 
 Three Fibratus conversion bugs reported by @rabbitstack are fixed, so the converted rules now use the idiomatic macros the upstream loader expects instead of raw or unmapped predicates.

--- a/crates/rsigma-convert/src/backends/fibratus/config.rs
+++ b/crates/rsigma-convert/src/backends/fibratus/config.rs
@@ -18,6 +18,14 @@ pub struct FibratusConfig {
     /// Value emitted in the `min-engine-version:` field of every rule.
     pub min_engine_version: String,
 
+    /// Value emitted in the required `version:` field of every rule. This
+    /// is the rule *content* version (a free-form string the upstream
+    /// rules library writes as semver, e.g. `1.0.1`), distinct from
+    /// `min-engine-version`. Sigma has no equivalent attribute, so it
+    /// defaults to `1.0.0` and is overridable with `-O version=<value>`.
+    /// The Fibratus loader rejects a rule that omits it.
+    pub rule_version: String,
+
     /// Whether to walk the condition AST and rewrite recognized
     /// sub-trees into idiomatic Fibratus macros
     /// (`spawn_process`/`open_file`/...). Phase 3 wires the recognition;
@@ -73,6 +81,7 @@ impl Default for FibratusConfig {
         Self {
             action: None,
             min_engine_version: "3.0.0".to_string(),
+            rule_version: "1.0.0".to_string(),
             use_macros: true,
             default_logsource: "windows".to_string(),
             emit_metadata: true,
@@ -108,6 +117,11 @@ impl FibratusConfig {
         }
         if let Some(v) = options.get("min_engine") {
             cfg.min_engine_version = v.clone();
+        }
+        if let Some(v) = options.get("version")
+            && !v.trim().is_empty()
+        {
+            cfg.rule_version = v.clone();
         }
         if let Some(v) = options.get("use_macros") {
             cfg.use_macros = parse_bool(v).unwrap_or(true);
@@ -168,12 +182,23 @@ mod tests {
         let cfg = FibratusConfig::default();
         assert_eq!(cfg.action, None);
         assert_eq!(cfg.min_engine_version, "3.0.0");
+        assert_eq!(cfg.rule_version, "1.0.0");
         assert!(cfg.use_macros);
         assert_eq!(cfg.default_logsource, "windows");
         assert!(cfg.emit_metadata);
         assert_eq!(cfg.max_repeated_slots, 5);
         assert!(!cfg.temporal_permute);
         assert!(!cfg.case_sensitive);
+    }
+
+    #[test]
+    fn from_options_overrides_rule_version() {
+        let cfg = FibratusConfig::from_options(&opts(&[("version", "2.3.1")]));
+        assert_eq!(cfg.rule_version, "2.3.1");
+        // An empty value keeps the required default rather than emitting a
+        // blank `version:` the loader would reject.
+        let cfg_empty = FibratusConfig::from_options(&opts(&[("version", "  ")]));
+        assert_eq!(cfg_empty.rule_version, "1.0.0");
     }
 
     #[test]

--- a/crates/rsigma-convert/src/backends/fibratus/envelope.rs
+++ b/crates/rsigma-convert/src/backends/fibratus/envelope.rs
@@ -2,8 +2,8 @@
 //!
 //! Each Sigma rule produces one YAML document. The envelope wraps a
 //! pre-rendered Fibratus filter expression in the metadata Fibratus
-//! expects on disk (`name`, `id`, `description`, `labels`, `condition`,
-//! `min-engine-version`, optional `action`).
+//! expects on disk (`name`, `id`, `version`, `description`, `labels`,
+//! `condition`, `min-engine-version`, optional `action`).
 //!
 //! YAML is hand-rolled rather than routed through [`yaml_serde`] so the
 //! emitter has full control over field ordering, block-scalar style for
@@ -42,9 +42,9 @@ pub fn render_rule_yaml(rule: &SigmaRule, condition_expr: &str, cfg: &FibratusCo
 ///
 /// The body of `condition_expr` is the already-built `sequence`/`maxspan`
 /// DSL produced by [`super::correlation`]. The envelope shape is
-/// identical to a detection rule (`name`/`id`/`description`/`labels`/
-/// `condition`/`min-engine-version`/`action`); only the condition body
-/// differs.
+/// identical to a detection rule (`name`/`id`/`version`/`description`/
+/// `labels`/`condition`/`min-engine-version`/`action`); only the
+/// condition body differs.
 pub fn render_correlation_yaml(
     rule: &CorrelationRule,
     condition_expr: &str,
@@ -82,6 +82,12 @@ fn render_envelope(
     {
         let _ = writeln!(out, "id: {}", yaml_inline_str(id));
     }
+
+    // `version` is a required top-level attribute; the Fibratus loader
+    // rejects a rule that omits it. It is emitted regardless of
+    // `emit_metadata` (a minimal envelope still has to load) and carries
+    // the rule *content* version, distinct from `min-engine-version`.
+    let _ = writeln!(out, "version: {}", yaml_inline_str(&cfg.rule_version));
 
     if cfg.emit_metadata {
         if let Some(desc) = description
@@ -345,6 +351,7 @@ detection:
         let expected = "\
 name: Test Rule
 id: 12345678-1234-1234-1234-1234567890ab
+version: 1.0.0
 condition: >
   ps.name = 'cmd.exe'
 min-engine-version: 3.0.0
@@ -463,5 +470,29 @@ detection:
         assert!(!out.contains("description:"));
         assert!(!out.contains("labels:"));
         assert!(!out.contains("tactic.id"));
+        // The required `version` is emitted even in the minimal envelope.
+        assert!(out.contains("version: 1.0.0\n"));
+    }
+
+    #[test]
+    fn render_rule_emits_configured_version() {
+        let r = rule(
+            r#"
+title: Versioned
+id: 11111111-2222-3333-4444-555555555555
+detection:
+  selection:
+    ps.name: x
+  condition: selection
+"#,
+        );
+        let mut c = cfg();
+        c.rule_version = "2.3.1".to_string();
+        let out = render_rule_yaml(&r, "ps.name = 'x'", &c);
+        // `version` follows `id` and precedes the condition body.
+        assert!(
+            out.contains("id: 11111111-2222-3333-4444-555555555555\nversion: 2.3.1\n"),
+            "got: {out}",
+        );
     }
 }

--- a/docs/guide/rule-conversion.md
+++ b/docs/guide/rule-conversion.md
@@ -345,7 +345,7 @@ Always pair the backend with the bundled `fibratus_windows` pipeline so Sigma's 
 rsigma backend convert rules/windows/process_creation/ -t fibratus -p fibratus_windows
 ```
 
-Two output formats: `default` (also aliased as `yaml`/`rule`) emits a complete YAML rule document per Sigma rule with the `name`/`id`/`description`/`labels`/`condition`/`min-engine-version`/`action` envelope, with `---` separators when multiple rules are converted at once. `expr` strips the envelope and emits only the bare filter expression for piping into ad-hoc Fibratus commands.
+Two output formats: `default` (also aliased as `yaml`/`rule`) emits a complete YAML rule document per Sigma rule with the `name`/`id`/`version`/`description`/`labels`/`condition`/`min-engine-version`/`action` envelope, with `---` separators when multiple rules are converted at once. `expr` strips the envelope and emits only the bare filter expression for piping into ad-hoc Fibratus commands.
 
 Because Fibratus loads one rule per file from its `Rules/` directory, point `--output` at a directory to get a separate `<title-slug>.yml` file per rule instead of one combined stream, ready to drop straight into the sensor:
 

--- a/docs/reference/backends/fibratus.md
+++ b/docs/reference/backends/fibratus.md
@@ -10,7 +10,7 @@ Fibratus is a runtime detection engine, not a log store. Three differences drive
 
 - **Case-insensitive matching needs an operator switch, not a wrapper.** Fibratus's plain operators (`=`, `contains`, `startswith`, `endswith`, `matches`, `in`, `intersects`) are case-sensitive; the `i`-prefixed cousins (`icontains`, `istartswith`, ...) and the `~=` string-equality operator are not. Sigma defaults to case-insensitive matching, so the backend emits the case-insensitive forms by default and flips to the bare forms only when Sigma's `|cased` modifier is present (or when `-O case_sensitive=true` is set globally). Plain literal equality (no `*`/`?` wildcards) uses the dedicated string-equality operators (`~=` default, `=` cased) instead of a wildcard match because they evaluate more efficiently and read the way the upstream rules library writes literal equality; `imatches`/`matches` are reserved for values that actually carry wildcards. The `evt.name` event discriminator always uses the exact `=` operator, matching the macro and rules libraries.
 - **Regex is a function call, not an operator.** Fibratus has no `=~`-style regex operator; instead it exposes the [`regex(field, 'pat1', 'pat2', ...) = true`](https://www.fibratus.io/) filter function. Sigma `|re` lowers to that call; the negated form uses a leading `not`. The underlying RE2 engine rejects PCRE-only constructs (lookarounds, backreferences); patterns that use those return a structured `UnsupportedModifier` rather than emitting something Fibratus would reject at load time.
-- **YAML envelope, not query string.** Every rule emits as a complete YAML document with `name`, `id`, `description`, `labels`, `condition`, `min-engine-version`, and optional `action`. Multi-rule output is `---`-separated so the entire stream loads as a valid YAML stream.
+- **YAML envelope, not query string.** Every rule emits as a complete YAML document with `name`, `id`, `version`, `description`, `labels`, `condition`, `min-engine-version`, and optional `action`. The `version` field is the rule content version, required by the loader. Multi-rule output is `---`-separated so the entire stream loads as a valid YAML stream.
 
 Fibratus has a native `not` operator and no parser envelope, so the backend ships no De Morgan negation push-down (unlike Loki) and no stream-selector machinery.
 
@@ -22,6 +22,7 @@ Pass with `-O key=value` (repeatable). Unknown keys are silently ignored so forw
 |--------|---------|---------|
 | `action` | unset | Comma-separated list of Fibratus actions to append to each rule envelope (`-O action=kill,isolate` emits `action: [- name: kill, - name: isolate]`). |
 | `min_engine` | `3.0.0` | Value written to the `min-engine-version:` field of every emitted rule. |
+| `version` | `1.0.0` | Value written to the required `version:` field (the rule content version) of every emitted rule. Sigma has no equivalent attribute; the Fibratus loader rejects a rule that omits it. |
 | `use_macros` | `true` | When `true`, rewrites recognized condition clause runs into idiomatic Fibratus macro calls (`spawn_process`, `create_thread`, `write_file`, `read_file`, `open_file`, `create_file`, `set_value`, `open_process`, `open_thread`, ...). The recognizer walks top-level `and` clauses and greedy-longest-match-replaces contiguous runs that match a macro's clause sequence (single-clause forms like `evt.name = 'CreateProcess'` and multi-clause runs like `evt.name = 'CreateFile' and file.operation ~= 'OPEN' and file.status ~= 'Success'`). Each clause is matched against both the exact (`=`) and case-insensitive (`~=`) operator forms, so it recognizes the same macros regardless of `-O case_sensitive`. Set to `false` to keep the raw `evt.name = '...'` forms. |
 | `default_logsource` | `windows` | Default `product:` to assume when a Sigma rule lacks an explicit logsource. Used by the matching pipeline transformations. |
 | `emit_metadata` | `true` | When `false`, omit the `description:` and `labels:` blocks. Useful when the target Fibratus install already enriches rule metadata from another source. |
@@ -129,6 +130,7 @@ One YAML rule document per Sigma rule, separated by `---`:
 ```yaml
 name: Suspicious cmd via Explorer
 id: 11111111-2222-3333-4444-555555555555
+version: 1.0.0
 description: |
   Detect cmd.exe spawned by explorer.exe with whoami in args.
 labels:
@@ -184,6 +186,7 @@ Example: 3 failed authentications from the same source IP within 5 minutes lower
 ```yaml
 name: Brute force from single source
 id: 22222222-aaaa-bbbb-cccc-000000000002
+version: 1.0.0
 description: |
   3 failed logins from the same source within 5 minutes.
 labels:


### PR DESCRIPTION
## Summary

Follow-up to #217. The Fibratus author found that converted rules fail to load because the rule envelope is missing the required top-level `version` attribute:

```
Error: invalid rule definition:
 ...
 (root): version is required
```

`version` is the rule content version (a free-form string the upstream rules library writes as semver, e.g. `1.0.1`), distinct from `min-engine-version`. Sigma has no equivalent attribute.

## Changes

- The YAML envelope now emits `version:` right after `id` for both detection and correlation rules. It is emitted regardless of `emit_metadata` since even a minimal envelope must load.
- Defaults to `1.0.0`, overridable with `-O version=<value>`.
- Docs updated: backend options table, envelope field list, and the `default`/correlation output examples.

## Test plan

- [x] `cargo test -p rsigma-convert` (envelope unit tests updated for the new field; added coverage for the configured version and the minimal-envelope case)
- [x] `cargo test -p rsigma --test cli_convert`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `mkdocs build --strict`