### PR TITLE
feat(cli): add `engine status` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### `engine status`: query a running daemon from the command line
+
+A new `rsigma engine status` subcommand fetches a running daemon's `/api/v1/status` snapshot and renders it through the shared output layer, so checking a daemon no longer requires `curl`.
+
+- **Address resolution.** `--addr` takes a `host:port` or full URL and defaults to `daemon.api.addr` from the resolved config; wildcard binds (`0.0.0.0`, `[::]`) map to loopback, and `https://` URLs work for TLS deployments. It shares this convention with `config reload`.
+- **Output.** Rendered through the global `--output-format` layer: a TTY-aware default (pretty `json` on a terminal, `ndjson` when piped) plus a `METRIC | VALUE` `table` view and `csv`/`tsv`. The snapshot covers rules loaded, events processed, detections and correlations fired, correlation state entries, uptime, and the dynamic-source summary when configured.
+- **No daemon feature required.** The command uses the synchronous `ureq` client, so a build without the `daemon` feature can still inspect a remote daemon. It exits `3` when the daemon is unreachable or returns an error.
+
 ### Webhook output sink: deliver detections to Slack, Teams, Discord, PagerDuty, or any HTTP endpoint (#227)
 
 A generic, template-driven webhook sink turns a detection or correlation into a templated HTTP request. It is one configurable sink rather than a set of bespoke integrations: Slack, Microsoft Teams, Discord, and PagerDuty ship as field-parametric YAML recipes in the [webhooks guide](https://timescale.github.io/rsigma/guide/webhooks/), while the engine stays service-agnostic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### `engine status`: query a running daemon from the command line
+### `engine status`: query a running daemon from the command line (#237)
 
 A new `rsigma engine status` subcommand fetches a running daemon's `/api/v1/status` snapshot and renders it through the shared output layer, so checking a daemon no longer requires `curl`.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ rsigma engine daemon -r rules/ -p ecs.yml --api-addr 0.0.0.0:9090
 # Accept events via HTTP POST
 rsigma engine daemon -r rules/ --input http
 
+# Check a running daemon's status (rules loaded, events processed, uptime)
+rsigma engine status
+
 # Convert rules to PostgreSQL SQL
 rsigma backend convert rules/ -t postgres
 ```

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -486,6 +486,26 @@ The `tracing` spans installed on hot paths (batch processing, source resolution,
 
 **Feature flags:** the daemon subcommand requires the `daemon` feature (enabled by default). NATS flags require the `daemon-nats` feature. OTLP log ingestion (HTTP and gRPC) requires the `daemon-otlp` feature. To build without daemon dependencies: `cargo build --no-default-features`.
 
+### `engine status`: Query a running daemon
+
+Fetch a running daemon's `/api/v1/status` snapshot (rules loaded, events processed, detections and correlations fired, correlation state entries, uptime, and the dynamic-source summary when configured) and render it through the shared output layer instead of reaching for `curl`.
+
+```bash
+# Default address (daemon.api.addr from the resolved config)
+rsigma engine status
+
+# A specific daemon, width-aligned table view
+rsigma engine status --addr 10.0.0.5:9090 --output-format table
+
+# A TLS deployment
+rsigma engine status --addr https://daemon.internal:9443
+
+# Machine-readable, for a script
+rsigma engine status --output-format json | jq '.events_processed'
+```
+
+`--addr` takes a `host:port` or full URL and defaults to `daemon.api.addr`; wildcard binds map to loopback. The command uses the synchronous `ureq` client, so it builds and runs without the `daemon` feature, and exits `3` when the daemon is unreachable or returns an error. It shares the `--addr` convention with `config reload`.
+
 ### `engine eval`: Evaluate events against rules
 
 Evaluate JSON events against Sigma detection and correlation rules.

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod parse;
 // ship with the `daemon` feature.
 #[cfg(feature = "daemon")]
 mod resolve;
+mod status;
 mod validate;
 
 pub(crate) use backtest::{BacktestArgs, apply_backtest_config, cmd_backtest};
@@ -33,4 +34,5 @@ pub(crate) use migrate_sources::{MigrateSourcesArgs, cmd_migrate_sources};
 pub(crate) use parse::{ConditionArgs, ParseArgs, StdinArgs, cmd_condition, cmd_parse, cmd_stdin};
 #[cfg(feature = "daemon")]
 pub(crate) use resolve::{ResolveArgs, cmd_resolve};
+pub(crate) use status::{StatusArgs, cmd_status};
 pub(crate) use validate::{ValidateArgs, cmd_validate};

--- a/crates/rsigma-cli/src/commands/status.rs
+++ b/crates/rsigma-cli/src/commands/status.rs
@@ -1,0 +1,270 @@
+//! `rsigma engine status`: query a running daemon's `/api/v1/status` endpoint
+//! and render the snapshot through the shared TTY-aware output layer.
+//!
+//! This is the read-only client counterpart to `engine daemon`. It copies the
+//! `config reload` client conventions (`--addr` resolves from
+//! `daemon.api.addr`, wildcard binds map to loopback) and uses the same
+//! synchronous `ureq` transport, so it builds without the `daemon` feature and
+//! a lightweight build can still inspect a remote daemon.
+
+use std::path::PathBuf;
+use std::process;
+use std::time::Duration;
+
+use clap::Args;
+use serde::Deserialize;
+
+use crate::config;
+use crate::exit_code;
+use crate::output::{self, DelimitedWriter, OutputCtx, OutputFormat, Tabular};
+
+#[derive(Args, Debug)]
+pub(crate) struct StatusArgs {
+    /// Daemon API address as `host:port` or a full URL.
+    /// Defaults to `daemon.api.addr` from the resolved config.
+    #[arg(long)]
+    pub addr: Option<String>,
+
+    /// Explicit config file used to resolve the daemon address.
+    #[arg(short, long)]
+    pub config: Option<PathBuf>,
+}
+
+/// Typed mirror of the daemon's `/api/v1/status` response, used to build the
+/// table / CSV / TSV views. Unknown fields are ignored so a newer daemon does
+/// not break an older client; the `json` / `ndjson` views echo the raw body
+/// and preserve every field.
+#[derive(Debug, Deserialize)]
+struct DaemonStatus {
+    status: String,
+    detection_rules: u64,
+    correlation_rules: u64,
+    correlation_state_entries: u64,
+    events_processed: u64,
+    detection_matches: u64,
+    correlation_matches: u64,
+    uptime_seconds: f64,
+    #[serde(default)]
+    dynamic_sources: Option<DynamicSources>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DynamicSources {
+    total: u64,
+    resolves_total: u64,
+    errors_total: u64,
+    cache_hits: u64,
+}
+
+/// One `METRIC | VALUE` row for the human-facing renderers.
+struct StatusRow {
+    metric: String,
+    value: String,
+}
+
+impl StatusRow {
+    fn new(metric: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            metric: metric.into(),
+            value: value.into(),
+        }
+    }
+}
+
+impl Tabular for StatusRow {
+    fn headers() -> &'static [&'static str] {
+        &["METRIC", "VALUE"]
+    }
+
+    fn row(&self) -> Vec<String> {
+        vec![self.metric.clone(), self.value.clone()]
+    }
+}
+
+pub(crate) fn cmd_status(args: StatusArgs, ctx: OutputCtx) {
+    let addr = config::resolve_daemon_addr(args.addr, args.config.as_deref());
+    let url = config::api_url(&addr, "/api/v1/status");
+
+    let resp = match ureq::get(&url).call() {
+        Ok(resp) => resp,
+        Err(ureq::Error::StatusCode(code)) => {
+            eprintln!("status failed: {url} returned HTTP {code}");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+        Err(e) => {
+            eprintln!("status failed: could not reach {url}: {e}");
+            eprintln!("(is the daemon running?)");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+    };
+
+    let body = match resp.into_body().read_to_string() {
+        Ok(body) => body,
+        Err(e) => {
+            eprintln!("status failed: could not read response from {url}: {e}");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&body) {
+        Ok(value) => value,
+        Err(e) => {
+            eprintln!("status failed: invalid JSON from {url}: {e}");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+    };
+
+    match ctx.format {
+        OutputFormat::Json => output::render_json(&value, ctx.pretty_json()),
+        OutputFormat::Ndjson => output::render_ndjson(&value),
+        OutputFormat::Table | OutputFormat::Csv | OutputFormat::Tsv => {
+            let status: DaemonStatus = match serde_json::from_value(value) {
+                Ok(status) => status,
+                Err(e) => {
+                    eprintln!("status failed: unexpected response shape from {url}: {e}");
+                    process::exit(exit_code::CONFIG_ERROR);
+                }
+            };
+            let rows = status_rows(&status);
+            match ctx.format {
+                OutputFormat::Csv => {
+                    push_rows(DelimitedWriter::new(',', StatusRow::headers()), &rows)
+                }
+                OutputFormat::Tsv => {
+                    push_rows(DelimitedWriter::new('\t', StatusRow::headers()), &rows)
+                }
+                _ => output::render_table(&rows),
+            }
+        }
+    }
+}
+
+/// Stream every row through a `csv`/`tsv` writer.
+fn push_rows(mut writer: DelimitedWriter, rows: &[StatusRow]) {
+    for row in rows {
+        writer.push(&row.row());
+    }
+}
+
+/// Flatten a [`DaemonStatus`] into ordered `METRIC | VALUE` rows. The optional
+/// dynamic-source block is appended with dotted metric names when present.
+fn status_rows(status: &DaemonStatus) -> Vec<StatusRow> {
+    let mut rows = vec![
+        StatusRow::new("status", status.status.clone()),
+        StatusRow::new("detection_rules", status.detection_rules.to_string()),
+        StatusRow::new("correlation_rules", status.correlation_rules.to_string()),
+        StatusRow::new(
+            "correlation_state_entries",
+            status.correlation_state_entries.to_string(),
+        ),
+        StatusRow::new("events_processed", status.events_processed.to_string()),
+        StatusRow::new("detection_matches", status.detection_matches.to_string()),
+        StatusRow::new(
+            "correlation_matches",
+            status.correlation_matches.to_string(),
+        ),
+        StatusRow::new("uptime", format_uptime(status.uptime_seconds)),
+    ];
+    if let Some(ds) = &status.dynamic_sources {
+        rows.push(StatusRow::new(
+            "dynamic_sources.total",
+            ds.total.to_string(),
+        ));
+        rows.push(StatusRow::new(
+            "dynamic_sources.resolves_total",
+            ds.resolves_total.to_string(),
+        ));
+        rows.push(StatusRow::new(
+            "dynamic_sources.errors_total",
+            ds.errors_total.to_string(),
+        ));
+        rows.push(StatusRow::new(
+            "dynamic_sources.cache_hits",
+            ds.cache_hits.to_string(),
+        ));
+    }
+    rows
+}
+
+/// Render `uptime_seconds` as a human-friendly duration for the table view
+/// (e.g. `1h 2m 3s`). Sub-second uptimes collapse to `0s`.
+fn format_uptime(seconds: f64) -> String {
+    let secs = seconds.max(0.0) as u64;
+    humantime::format_duration(Duration::from_secs(secs)).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+        "status": "running",
+        "detection_rules": 3,
+        "correlation_rules": 1,
+        "correlation_state_entries": 2,
+        "events_processed": 10,
+        "detection_matches": 4,
+        "correlation_matches": 1,
+        "uptime_seconds": 63.5
+    }"#;
+
+    #[test]
+    fn parses_status_without_dynamic_sources() {
+        let status: DaemonStatus = serde_json::from_str(SAMPLE).unwrap();
+        assert_eq!(status.status, "running");
+        assert!(status.dynamic_sources.is_none());
+        let rows = status_rows(&status);
+        assert_eq!(rows.len(), 8);
+        assert!(
+            rows.iter()
+                .all(|r| !r.metric.starts_with("dynamic_sources"))
+        );
+    }
+
+    #[test]
+    fn includes_dynamic_source_rows_when_present() {
+        let json = r#"{
+            "status": "running",
+            "detection_rules": 1,
+            "correlation_rules": 0,
+            "correlation_state_entries": 0,
+            "events_processed": 0,
+            "detection_matches": 0,
+            "correlation_matches": 0,
+            "uptime_seconds": 1.0,
+            "dynamic_sources": {"total": 2, "resolves_total": 4, "errors_total": 0, "cache_hits": 1}
+        }"#;
+        let status: DaemonStatus = serde_json::from_str(json).unwrap();
+        let rows = status_rows(&status);
+        assert_eq!(rows.len(), 12);
+        assert!(
+            rows.iter()
+                .any(|r| r.metric == "dynamic_sources.total" && r.value == "2")
+        );
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored() {
+        // A newer daemon may add fields the client does not know about; the
+        // typed view must not reject the response.
+        let json = r#"{
+            "status": "running",
+            "detection_rules": 1,
+            "correlation_rules": 0,
+            "correlation_state_entries": 0,
+            "events_processed": 0,
+            "detection_matches": 0,
+            "correlation_matches": 0,
+            "uptime_seconds": 1.0,
+            "some_future_field": true
+        }"#;
+        let status: DaemonStatus = serde_json::from_str(json).unwrap();
+        assert_eq!(status.detection_rules, 1);
+    }
+
+    #[test]
+    fn uptime_is_humanized() {
+        assert_eq!(format_uptime(0.4), "0s");
+        assert_eq!(format_uptime(63.0), "1m 3s");
+    }
+}

--- a/crates/rsigma-cli/src/config/commands.rs
+++ b/crates/rsigma-cli/src/config/commands.rs
@@ -14,9 +14,9 @@ use serde_json::{Value, json};
 
 use crate::exit_code;
 
-use super::defaults::{self, defaults_partial};
+use super::defaults::defaults_partial;
 use super::resolve::{Source, env_partial, resolve_layers, to_value, value_at};
-use super::{discover, inactive_sections, load_and_merge, load_layered};
+use super::{discover, inactive_sections, load_layered};
 
 /// The committed, commented template emitted by `rsigma config init`.
 const TEMPLATE: &str = include_str!("template.yaml");
@@ -295,14 +295,8 @@ fn cmd_path(args: PathArgs) {
 }
 
 fn cmd_reload(args: ReloadArgs) {
-    let addr = args.addr.unwrap_or_else(|| {
-        let base = load_and_merge(args.config.as_deref());
-        base.daemon
-            .and_then(|d| d.api)
-            .and_then(|a| a.addr)
-            .unwrap_or_else(|| defaults::API_ADDR.to_string())
-    });
-    let url = reload_url(&addr);
+    let addr = super::resolve_daemon_addr(args.addr, args.config.as_deref());
+    let url = super::api_url(&addr, "/api/v1/reload");
 
     match ureq::post(&url).send_empty() {
         Ok(resp) if resp.status().is_success() => {
@@ -317,43 +311,5 @@ fn cmd_reload(args: ReloadArgs) {
             eprintln!("(is the daemon running? on unix you can also `kill -HUP <pid>`)");
             process::exit(exit_code::CONFIG_ERROR);
         }
-    }
-}
-
-/// Build the reload endpoint URL from a `host:port` or full URL. Wildcard bind
-/// addresses are mapped to loopback so the client can actually connect.
-fn reload_url(addr: &str) -> String {
-    if addr.starts_with("http://") || addr.starts_with("https://") {
-        format!("{}/api/v1/reload", addr.trim_end_matches('/'))
-    } else {
-        let host_port = addr
-            .replace("0.0.0.0", "127.0.0.1")
-            .replace("[::]", "[::1]");
-        format!("http://{host_port}/api/v1/reload")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::reload_url;
-
-    #[test]
-    fn reload_url_maps_wildcard_to_loopback() {
-        assert_eq!(
-            reload_url("0.0.0.0:9090"),
-            "http://127.0.0.1:9090/api/v1/reload"
-        );
-        assert_eq!(
-            reload_url("10.0.0.1:9090"),
-            "http://10.0.0.1:9090/api/v1/reload"
-        );
-    }
-
-    #[test]
-    fn reload_url_accepts_full_url() {
-        assert_eq!(
-            reload_url("https://daemon.internal:9443/"),
-            "https://daemon.internal:9443/api/v1/reload"
-        );
     }
 }

--- a/crates/rsigma-cli/src/config/mod.rs
+++ b/crates/rsigma-cli/src/config/mod.rs
@@ -50,6 +50,34 @@ pub(crate) fn load_and_merge(explicit: Option<&Path>) -> RsigmaConfigPartial {
     }
 }
 
+/// Resolve the daemon admin address for client commands (`config reload`,
+/// `engine status`, ...). Precedence: an explicit `--addr` wins, otherwise
+/// `daemon.api.addr` from the layered config, otherwise the compiled default.
+pub(crate) fn resolve_daemon_addr(addr: Option<String>, explicit: Option<&Path>) -> String {
+    addr.unwrap_or_else(|| {
+        load_and_merge(explicit)
+            .daemon
+            .and_then(|d| d.api)
+            .and_then(|a| a.addr)
+            .unwrap_or_else(|| defaults::API_ADDR.to_string())
+    })
+}
+
+/// Build an admin endpoint URL from a `host:port` or full URL, appending
+/// `path` (which must start with `/`). Wildcard bind addresses are mapped to
+/// loopback so the client can connect to a daemon that advertised `0.0.0.0`
+/// or `[::]`.
+pub(crate) fn api_url(addr: &str, path: &str) -> String {
+    if addr.starts_with("http://") || addr.starts_with("https://") {
+        format!("{}{path}", addr.trim_end_matches('/'))
+    } else {
+        let host_port = addr
+            .replace("0.0.0.0", "127.0.0.1")
+            .replace("[::]", "[::1]");
+        format!("http://{host_port}{path}")
+    }
+}
+
 /// Best-effort lookup of `global.log_format` from the config files (honoring an
 /// explicit `--config` path when present) and the `RSIGMA_*` env (no compiled
 /// default, so this is `None` unless an operator set it). Used by `main` to
@@ -322,5 +350,33 @@ mod tests {
         let (partial, unknown) = load_file(&path).unwrap();
         assert!(partial.version.is_none());
         assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn api_url_maps_wildcard_to_loopback() {
+        assert_eq!(
+            api_url("0.0.0.0:9090", "/api/v1/status"),
+            "http://127.0.0.1:9090/api/v1/status"
+        );
+        assert_eq!(
+            api_url("[::]:9090", "/api/v1/status"),
+            "http://[::1]:9090/api/v1/status"
+        );
+        assert_eq!(
+            api_url("10.0.0.1:9090", "/api/v1/reload"),
+            "http://10.0.0.1:9090/api/v1/reload"
+        );
+    }
+
+    #[test]
+    fn api_url_accepts_full_url() {
+        assert_eq!(
+            api_url("https://daemon.internal:9443/", "/api/v1/status"),
+            "https://daemon.internal:9443/api/v1/status"
+        );
+        assert_eq!(
+            api_url("http://127.0.0.1:9090", "/api/v1/reload"),
+            "http://127.0.0.1:9090/api/v1/reload"
+        );
     }
 }

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -12,7 +12,8 @@ use std::process;
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use commands::{
     BacktestArgs, ConditionArgs, ConvertArgs, CoverageArgs, EvalArgs, FieldsArgs, LintArgs,
-    LintCounts, ListFormatsArgs, MigrateSourcesArgs, ParseArgs, StdinArgs, ValidateArgs,
+    LintCounts, ListFormatsArgs, MigrateSourcesArgs, ParseArgs, StatusArgs, StdinArgs,
+    ValidateArgs,
 };
 // `pipeline resolve` resolves dynamic sources, which needs the async runtime
 // (tokio) and the source resolver from rsigma-runtime. Both ship with the
@@ -201,6 +202,9 @@ enum Commands {
 enum EngineCommands {
     /// Evaluate events against Sigma rules
     Eval(EvalArgs),
+
+    /// Query a running daemon's status (GET /api/v1/status)
+    Status(StatusArgs),
 
     /// Run as a long-running daemon with hot-reload, health checks, and metrics
     #[cfg(feature = "daemon")]
@@ -425,6 +429,7 @@ fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches, ctx: output::Outpu
                 .expect("engine eval submatches present");
             run_eval(args, em, ctx);
         }
+        EngineCommands::Status(args) => commands::cmd_status(args, ctx),
         #[cfg(feature = "daemon")]
         EngineCommands::Daemon(args) => {
             let dm = matches

--- a/crates/rsigma-cli/tests/cli_daemon_status.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_status.rs
@@ -1,0 +1,77 @@
+//! E2E tests for `rsigma engine status`, the client that queries a running
+//! daemon's `/api/v1/status` endpoint and renders it through the shared
+//! output layer.
+
+#![cfg(feature = "daemon")]
+
+mod common;
+
+use common::{DaemonProcess, SIMPLE_RULE, rsigma, temp_file};
+use predicates::prelude::*;
+
+#[test]
+fn status_default_ndjson_against_running_daemon() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
+
+    // Piped stdout (not a TTY) defaults to a single NDJSON line.
+    rsigma()
+        .args(["engine", "status", "--addr", daemon.api_addr()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\":\"running\""))
+        .stdout(predicate::str::contains("\"detection_rules\":1"));
+}
+
+#[test]
+fn status_table_format() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
+
+    rsigma()
+        .args([
+            "engine",
+            "status",
+            "--addr",
+            daemon.api_addr(),
+            "--output-format",
+            "table",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("METRIC"))
+        .stdout(predicate::str::contains("detection_rules"))
+        .stdout(predicate::str::contains("uptime"));
+}
+
+#[test]
+fn status_json_format() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
+
+    rsigma()
+        .args([
+            "engine",
+            "status",
+            "--addr",
+            daemon.api_addr(),
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\""))
+        .stdout(predicate::str::contains("running"));
+}
+
+#[test]
+fn status_unreachable_daemon_exits_config_error() {
+    // Port 1 is reserved and never has the daemon listening, so the connection
+    // is refused and the command exits with the config-error code.
+    rsigma()
+        .args(["engine", "status", "--addr", "127.0.0.1:1"])
+        .assert()
+        .failure()
+        .code(3)
+        .stderr(predicate::str::contains("could not reach"));
+}

--- a/docs/cli/engine/.pages
+++ b/docs/cli/engine/.pages
@@ -1,4 +1,5 @@
 title: engine
 nav:
   - eval: eval.md
+  - status: status.md
   - daemon: daemon.md

--- a/docs/cli/engine/status.md
+++ b/docs/cli/engine/status.md
@@ -1,0 +1,79 @@
+# `rsigma engine status`
+
+Query a running daemon's `/api/v1/status` endpoint and render the snapshot through the shared output layer.
+
+## Synopsis
+
+```text
+rsigma engine status [OPTIONS]
+```
+
+## Description
+
+Fetches a one-shot snapshot of engine counters (rules loaded, events processed, detections fired, correlation state entries, uptime, and the dynamic-source summary when configured) from a running [`engine daemon`](daemon.md) and prints it. It is the read-only client counterpart to the daemon: the same information served at `GET /api/v1/status`, formatted for a human instead of `curl`.
+
+The command uses a synchronous HTTP client and does not need the `daemon` build feature, so a lightweight build can still inspect a remote daemon. It follows the same address convention as [`config reload`](../config/reload.md): `--addr` defaults to `daemon.api.addr` from the resolved config, and wildcard bind addresses (`0.0.0.0`, `[::]`) are mapped to loopback so the client can connect to a daemon that advertised every interface.
+
+For continuous monitoring, scrape [`/metrics`](../../reference/metrics.md) instead; `engine status` is for a quick interactive check.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--addr <HOST:PORT or URL>` | from `daemon.api.addr` | Daemon API address as `host:port` or a full URL. `https://` URLs work for TLS deployments. |
+| `-c, --config <PATH>` | discovery chain | Explicit config file used to resolve the daemon address. |
+
+The global `--output-format` / `--color` / `--quiet` / `--no-stats` flags apply; see [Output Formats](../../reference/output.md). The default is TTY-aware: pretty `json` on a terminal, `ndjson` when piped. `table`, `csv`, and `tsv` render a `METRIC | VALUE` view.
+
+## Examples
+
+### Quick check against the default address
+
+```bash
+rsigma engine status
+```
+
+### A specific daemon, table view
+
+```bash
+rsigma engine status --addr 10.0.0.5:9090 --output-format table
+```
+
+```text
+METRIC                     VALUE
+-------------------------  -------
+status                     running
+detection_rules            22
+correlation_rules          2
+correlation_state_entries  0
+events_processed           1248
+detection_matches          37
+correlation_matches        4
+uptime                     5m 12s
+```
+
+### A TLS deployment
+
+```bash
+rsigma engine status --addr https://daemon.internal:9443
+```
+
+### Machine-readable snapshot for a script
+
+```bash
+rsigma engine status --output-format json | jq '.events_processed'
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | The daemon responded and the snapshot was printed. |
+| `3` | The daemon could not be reached, returned a non-2xx status, or sent an unparseable response. |
+
+## See also
+
+- [`engine daemon`](daemon.md) for the long-running service this command queries.
+- [HTTP API: `GET /api/v1/status`](../../reference/http-api.md#status-and-counters) for the raw endpoint and response shape.
+- [`config reload`](../config/reload.md) for the sibling daemon-client command that shares the `--addr` convention.
+- [Prometheus Metrics](../../reference/metrics.md) for continuous monitoring of the same counters.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -89,7 +89,7 @@ curl -sS http://127.0.0.1:9090/api/v1/status
 }
 ```
 
-The same counters are exposed in Prometheus form on `/metrics`. Use `/api/v1/status` for a quick one-shot snapshot; use `/metrics` for monitoring.
+The same counters are exposed in Prometheus form on `/metrics`. Use `/api/v1/status` for a quick one-shot snapshot; use `/metrics` for monitoring. For a formatted view from the command line, [`rsigma engine status`](../cli/engine/status.md) fetches this endpoint and renders it as a table (or `json`/`ndjson`/`csv`/`tsv`).
 
 ### `GET /api/v1/rules`
 


### PR DESCRIPTION
## Summary

- Add `rsigma engine status`, a client command that fetches a running daemon's `/api/v1/status` snapshot and renders it through the shared output layer, so checking a daemon no longer requires `curl`. Output follows the global `--output-format`: a TTY-aware `json`/`ndjson` default plus a `METRIC | VALUE` `table`, `csv`, and `tsv`. The snapshot covers rules loaded, events processed, detections and correlations fired, correlation state entries, uptime, and the dynamic-source summary when configured.
- Extract the daemon address resolution and endpoint-URL building out of `config reload` into shared `config::resolve_daemon_addr` and `config::api_url` helpers, so daemon-client commands share one implementation of the `--addr` precedence (flag > `daemon.api.addr` > compiled default) and the wildcard to loopback mapping. `config reload` now calls the helpers; behavior is unchanged.
- The command uses the existing synchronous `ureq` client and builds without the `daemon` feature, so a lightweight build can still inspect a remote daemon. It exits `3` when the daemon is unreachable or returns an error.

It lands under the `engine` group (`rsigma engine status`) for consistency with `engine daemon` and `engine eval` rather than as a flat top-level command.

## Test plan

- [x] `cargo test -p rsigma --test cli_daemon_status` (default ndjson, table, and json formats; unreachable-daemon exits 3)
- [x] `cargo test -p rsigma --bins` (status and config unit tests)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `mkdocs build --strict`
- [x] Manual: `rsigma engine status --addr <daemon> --output-format table`