### PR TITLE
feat(cli): delegate non-native backend convert targets to sigma-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Reuse pySigma backends through sigma-cli delegation
+
+`rsigma backend convert` now resolves targets native-first: it uses a native rsigma backend when one exists and otherwise delegates the conversion to an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) when one is installed, so the full pySigma backend ecosystem (`splunk`, `elasticsearch`, `kusto`, `qradar`, `loki`, `crowdstrike`, and 30+ more) is reachable from the same command. It is a light subprocess wrapper with no new dependencies; no Python runtime is required unless a delegated target is actually used.
+
+- **Native-first dispatch.** `postgres`/`postgresql`/`pg`, `lynxdb`, and `fibratus` keep converting natively and always win; any other target is delegated. A future native backend transparently supersedes its delegated path.
+- **Discovery.** sigma-cli is found via the `RSIGMA_SIGMA_CLI` path override or a bare `sigma` on `PATH`. When a target has no native backend and sigma-cli is absent, the command exits `3` with install guidance (`pipx install sigma-cli`, `sigma plugin install <target>`).
+- **Flag mapping.** `-t`, `-f`, `-p`, `--without-pipeline`, `-s`, and `-O key=value` pass through to `sigma convert` verbatim; `-O correlation_method=<m>` maps to sigma-cli's `-c/--correlation-method`. The original rule files are handed to sigma-cli, which parses, pipelines, and converts them.
+- **Output.** sigma-cli stdout is relayed through the normal output handling (stdout, `-o <file>`, and the `--output-format json` envelope). A non-zero sigma-cli exit maps to `2` with its stderr relayed; a missing binary or a directory `--output` in delegated mode maps to `3`.
+- **Listing.** `backend targets` appends the installed sigma-cli targets, and `backend formats <target>` shows a delegated target's formats.
+- **Scope.** CLI `backend convert` only; the MCP `convert` tool and the `rsigma_convert` library API convert with native backends. rsigma builtin pipeline names (`ecs_windows`, `sysmon`) are not translated; pass sigma-cli pipeline names or YAML paths in delegated mode.
+
 ### Faster NATS and daemon integration tests (#240)
 
 The `nats_integration`, `cli_daemon_nats`, and `cli_daemon_dynamic` suites spent most of their wall time waiting on fixed sleeps and long-poll timeouts rather than doing real work. Replacing those with deterministic waits cuts each suite's runtime by roughly 7x (30.7s to ~2.7s, 15.1s to ~4.4s, and 4.2s to ~1.9s) with no production code changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Reuse pySigma backends through sigma-cli delegation
+### Reuse pySigma backends through sigma-cli delegation (#241)
 
 `rsigma backend convert` now resolves targets native-first: it uses a native rsigma backend when one exists and otherwise delegates the conversion to an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) when one is installed, so the full pySigma backend ecosystem (`splunk`, `elasticsearch`, `kusto`, `qradar`, `loki`, `crowdstrike`, and 30+ more) is reachable from the same command. It is a light subprocess wrapper with no new dependencies; no Python runtime is required unless a delegated target is actually used.
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows
 # Write one rule file per rule into a directory (drop straight into a Fibratus Rules/ folder)
 rsigma backend convert rules/windows/ -t fibratus -p fibratus_windows -o ./Rules/
 
+# Any non-native target delegates to sigma-cli when it is installed (pipx install sigma-cli)
+rsigma backend convert rules/ -t splunk
+
 # List all fields referenced by a ruleset
 rsigma rule fields -r rules/
 

--- a/crates/rsigma-cli/src/commands/convert.rs
+++ b/crates/rsigma-cli/src/commands/convert.rs
@@ -40,31 +40,55 @@ pub(crate) struct ConvertArgs {
     pub backend_options: Vec<String>,
 }
 
-fn get_backend(
+/// Canonical names of the targets rsigma converts natively, for listings and
+/// error messages. Aliases (`postgresql`, `pg`) and the internal test backends
+/// are accepted by [`try_native_backend`] but intentionally not advertised.
+const NATIVE_TARGETS: &[&str] = &["postgres", "lynxdb", "fibratus"];
+
+/// Return the native backend for `target`, or `None` when rsigma has no native
+/// backend for it, in which case `backend convert` delegates to sigma-cli.
+fn try_native_backend(
     target: &str,
     options: &std::collections::HashMap<String, String>,
-) -> Box<dyn rsigma_convert::Backend> {
+) -> Option<Box<dyn rsigma_convert::Backend>> {
     match target {
-        "postgres" | "postgresql" | "pg" => {
-            Box::new(rsigma_convert::backends::postgres::PostgresBackend::from_options(options))
-        }
-        "lynxdb" => Box::new(rsigma_convert::backends::lynxdb::LynxDbBackend::new()),
-        "fibratus" => {
-            Box::new(rsigma_convert::backends::fibratus::FibratusBackend::from_options(options))
-        }
-        "test" => Box::new(rsigma_convert::backends::test::TextQueryTestBackend::new()),
-        "test_mandatory_pipeline" => {
-            Box::new(rsigma_convert::backends::test::MandatoryPipelineTestBackend::new())
-        }
-        _ => {
-            eprintln!("Unknown target: {target}");
-            eprintln!("Available targets: postgres, lynxdb, fibratus, test");
-            process::exit(crate::exit_code::CONFIG_ERROR);
-        }
+        "postgres" | "postgresql" | "pg" => Some(Box::new(
+            rsigma_convert::backends::postgres::PostgresBackend::from_options(options),
+        )),
+        "lynxdb" => Some(Box::new(
+            rsigma_convert::backends::lynxdb::LynxDbBackend::new(),
+        )),
+        "fibratus" => Some(Box::new(
+            rsigma_convert::backends::fibratus::FibratusBackend::from_options(options),
+        )),
+        "test" => Some(Box::new(
+            rsigma_convert::backends::test::TextQueryTestBackend::new(),
+        )),
+        "test_mandatory_pipeline" => Some(Box::new(
+            rsigma_convert::backends::test::MandatoryPipelineTestBackend::new(),
+        )),
+        _ => None,
     }
 }
 
 pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
+    let options: std::collections::HashMap<String, String> = args
+        .backend_options
+        .iter()
+        .filter_map(|opt| {
+            opt.split_once('=')
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+        })
+        .collect();
+
+    // Native-first dispatch: convert with a native rsigma backend when one
+    // exists, otherwise delegate the whole conversion to a discovered
+    // sigma-cli (or fail with install guidance when neither is available).
+    let Some(backend) = try_native_backend(&args.target, &options) else {
+        run_delegated(&args, &ctx);
+        return;
+    };
+
     let ConvertArgs {
         rules,
         target,
@@ -73,7 +97,7 @@ pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
         without_pipeline,
         skip_unsupported,
         output,
-        backend_options,
+        backend_options: _,
     } = args;
 
     let collection = crate::load_collection_multi(&rules);
@@ -86,15 +110,6 @@ pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
              events with dynamic pipelines."
         );
     }
-
-    let options: std::collections::HashMap<String, String> = backend_options
-        .iter()
-        .filter_map(|opt| {
-            opt.split_once('=')
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-        })
-        .collect();
-    let backend = get_backend(&target, &options);
 
     if backend.requires_pipeline() && pipelines.is_empty() && !without_pipeline {
         eprintln!("Backend '{target}' requires a pipeline. Use -p or --without-pipeline.");
@@ -230,28 +245,181 @@ pub(crate) fn cmd_convert(args: ConvertArgs, ctx: OutputCtx) {
     }
 }
 
+/// Convert via an external sigma-cli for a target rsigma has no native backend
+/// for. The original rule files and a near 1:1 flag mapping are passed straight
+/// through, and sigma-cli's stdout is relayed through rsigma's output handling,
+/// so the result is identical to running sigma-cli directly.
+fn run_delegated(args: &ConvertArgs, ctx: &OutputCtx) {
+    use super::sigma_cli::{self, SigmaCli};
+
+    let target = args.target.as_str();
+    let format = args.format.as_str();
+    let output = args.output.as_deref();
+
+    // Per-rule directory splitting reuses a native backend's finalizer, which a
+    // delegated stream has no equivalent of; fail clearly rather than write a
+    // single concatenated file into the directory.
+    if let Some(dir) = output.filter(|p| is_directory_target(p)) {
+        eprintln!(
+            "Per-rule directory output ('-o {}') is only supported by native backends; \
+             the delegated target '{target}' produces a single stream. Use a file path or stdout.",
+            dir.display()
+        );
+        process::exit(crate::exit_code::CONFIG_ERROR);
+    }
+
+    let cli = SigmaCli::configured();
+    let argv = sigma_cli::build_convert_args(
+        target,
+        format,
+        &args.pipeline,
+        args.without_pipeline,
+        args.skip_unsupported,
+        &args.backend_options,
+        &args.rules,
+    );
+
+    let result = match cli.run(&argv) {
+        Ok(out) => out,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "{}",
+                sigma_cli::install_hint(target, cli.program(), cli.is_override(), NATIVE_TARGETS)
+            );
+            process::exit(crate::exit_code::CONFIG_ERROR);
+        }
+        Err(e) => {
+            eprintln!(
+                "Failed to launch sigma-cli ('{}'): {e}",
+                cli.program().display()
+            );
+            process::exit(crate::exit_code::CONFIG_ERROR);
+        }
+    };
+
+    // Relay sigma-cli diagnostics verbatim (warnings, skipped-rule notes, errors).
+    if !result.stderr.is_empty() {
+        eprint!("{}", String::from_utf8_lossy(&result.stderr));
+    }
+    if !result.status.success() {
+        process::exit(crate::exit_code::RULE_ERROR);
+    }
+
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let queries = stdout.trim_end_matches('\n');
+
+    // `--output-format json` wraps the delegated queries in the same envelope
+    // shape the native path emits. sigma-cli text backends emit one query per
+    // line, so each non-empty line becomes a query object.
+    if ctx.format == OutputFormat::Json && output.is_none() {
+        let query_objs: Vec<serde_json::Value> = queries
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|q| serde_json::json!({ "query": q }))
+            .collect();
+        render_json(
+            &serde_json::json!({
+                "target": target,
+                "format": format,
+                "engine": "sigma-cli",
+                "queries": query_objs,
+            }),
+            ctx.pretty_json(),
+        );
+        return;
+    }
+
+    if ctx.explicit_format
+        && !matches!(ctx.format, OutputFormat::Json | OutputFormat::Ndjson)
+        && ctx.show_progress()
+    {
+        eprintln!(
+            "warning: `--output-format {}` is not supported by `backend convert`; falling back to raw query text.",
+            ctx.format.as_str(),
+        );
+    }
+
+    write_output(queries, output);
+}
+
 pub(crate) fn cmd_list_targets() {
     println!("Available conversion targets:");
     println!("  postgres  - PostgreSQL/TimescaleDB (aliases: postgresql, pg)");
     println!("  lynxdb    - LynxDB log analytics engine");
     println!("  fibratus  - Fibratus kernel-event detection engine");
     println!("  test      - Backend-neutral test backend");
+
+    // Any other target is delegated to sigma-cli when it is installed; list its
+    // targets too so the user sees the full set available from this machine.
+    let cli = super::sigma_cli::SigmaCli::configured();
+    match cli.run(["list", "targets"]) {
+        Ok(out) if out.status.success() && !out.stdout.is_empty() => {
+            println!(
+                "\nAdditional targets via sigma-cli ('{}'):",
+                cli.program().display()
+            );
+            print!("{}", String::from_utf8_lossy(&out.stdout));
+        }
+        _ => {
+            println!(
+                "\nInstall sigma-cli for more targets (splunk, elasticsearch, kusto, qradar, loki, ...):"
+            );
+            println!("  pipx install sigma-cli && sigma plugin install <target>");
+        }
+    }
 }
 
 pub(crate) fn cmd_list_formats(target: String) {
-    let backend = get_backend(&target, &std::collections::HashMap::new());
-    println!("Available formats for '{target}':");
-    for (name, desc) in backend.formats() {
-        println!("  {name}  - {desc}");
-    }
-    let methods = backend.correlation_methods();
-    if !methods.is_empty() {
-        println!(
-            "\nCorrelation methods for '{target}' (select with -O correlation_method=NAME, default: {}):",
-            backend.default_correlation_method()
-        );
-        for (name, desc) in methods {
+    if let Some(backend) = try_native_backend(&target, &std::collections::HashMap::new()) {
+        println!("Available formats for '{target}':");
+        for (name, desc) in backend.formats() {
             println!("  {name}  - {desc}");
+        }
+        let methods = backend.correlation_methods();
+        if !methods.is_empty() {
+            println!(
+                "\nCorrelation methods for '{target}' (select with -O correlation_method=NAME, default: {}):",
+                backend.default_correlation_method()
+            );
+            for (name, desc) in methods {
+                println!("  {name}  - {desc}");
+            }
+        }
+        return;
+    }
+
+    // Delegated target: ask sigma-cli for the formats it supports.
+    let cli = super::sigma_cli::SigmaCli::configured();
+    match cli.run(["list", "formats", target.as_str()]) {
+        Ok(out) => {
+            if !out.stdout.is_empty() {
+                print!("{}", String::from_utf8_lossy(&out.stdout));
+            }
+            if !out.stderr.is_empty() {
+                eprint!("{}", String::from_utf8_lossy(&out.stderr));
+            }
+            if !out.status.success() {
+                process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "{}",
+                super::sigma_cli::install_hint(
+                    &target,
+                    cli.program(),
+                    cli.is_override(),
+                    NATIVE_TARGETS
+                )
+            );
+            process::exit(crate::exit_code::CONFIG_ERROR);
+        }
+        Err(e) => {
+            eprintln!(
+                "Failed to launch sigma-cli ('{}'): {e}",
+                cli.program().display()
+            );
+            process::exit(crate::exit_code::CONFIG_ERROR);
         }
     }
 }

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -15,6 +15,8 @@ mod parse;
 // ship with the `daemon` feature.
 #[cfg(feature = "daemon")]
 mod resolve;
+// Delegation to an external sigma-cli for non-native conversion targets.
+mod sigma_cli;
 mod status;
 mod tail;
 mod tap;

--- a/crates/rsigma-cli/src/commands/sigma_cli.rs
+++ b/crates/rsigma-cli/src/commands/sigma_cli.rs
@@ -1,0 +1,278 @@
+//! Optional delegation to an external `sigma-cli` for conversion targets that
+//! rsigma has no native backend for.
+//!
+//! This is a light subprocess wrapper, not a port or an embedded interpreter:
+//! `rsigma backend convert` hands the original rule files plus a near 1:1
+//! flag mapping to `sigma convert` and relays its output. No Python runtime is
+//! required unless a delegated target is actually used, so the rsigma binary
+//! stays self-contained for everyone converting to a native backend.
+//!
+//! Discovery uses the `RSIGMA_SIGMA_CLI` environment override when set, falling
+//! back to a bare `sigma` resolved on `PATH`. A spawn that fails with
+//! [`std::io::ErrorKind::NotFound`] means sigma-cli is not installed, which the
+//! caller turns into install guidance rather than a conversion failure.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Environment variable that overrides discovery with an explicit path to the
+/// `sigma` executable.
+pub(crate) const SIGMA_CLI_ENV: &str = "RSIGMA_SIGMA_CLI";
+
+/// Program name used when the override is unset.
+const DEFAULT_PROGRAM: &str = "sigma";
+
+/// A resolved sigma-cli invocation target.
+pub(crate) struct SigmaCli {
+    program: PathBuf,
+    is_override: bool,
+}
+
+impl SigmaCli {
+    /// Resolve the configured sigma-cli from the current environment.
+    pub(crate) fn configured() -> Self {
+        let (program, is_override) = resolve_program(std::env::var_os(SIGMA_CLI_ENV));
+        Self {
+            program,
+            is_override,
+        }
+    }
+
+    /// The executable that will be spawned (override path or bare `sigma`).
+    pub(crate) fn program(&self) -> &Path {
+        &self.program
+    }
+
+    /// Whether the executable came from the `RSIGMA_SIGMA_CLI` override.
+    pub(crate) fn is_override(&self) -> bool {
+        self.is_override
+    }
+
+    /// Run sigma-cli with `args`, capturing stdout, stderr, and the exit status.
+    pub(crate) fn run<I, S>(&self, args: I) -> std::io::Result<Output>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        Command::new(&self.program).args(args).output()
+    }
+}
+
+/// Decide the program name and whether it came from the override.
+///
+/// An override that is set but empty is treated as unset so an accidental
+/// `RSIGMA_SIGMA_CLI=` does not break discovery.
+fn resolve_program(env_value: Option<OsString>) -> (PathBuf, bool) {
+    match env_value {
+        Some(value) if !value.is_empty() => (PathBuf::from(value), true),
+        _ => (PathBuf::from(DEFAULT_PROGRAM), false),
+    }
+}
+
+/// Build the `sigma convert` argument vector from rsigma's convert arguments.
+///
+/// The mapping is near 1:1; the only transform is rsigma's
+/// `-O correlation_method=<m>` option, which becomes sigma-cli's
+/// `-c/--correlation-method <m>`. Every other `-O key=value` is forwarded as a
+/// sigma-cli `-O/--backend-option`, and pipelines, the no-pipeline and
+/// skip-unsupported toggles, the output format, and the rule paths pass through
+/// unchanged. `--output` is intentionally not forwarded: rsigma captures
+/// sigma-cli's stdout and routes it through its own output handling.
+pub(crate) fn build_convert_args(
+    target: &str,
+    format: &str,
+    pipelines: &[PathBuf],
+    without_pipeline: bool,
+    skip_unsupported: bool,
+    backend_options: &[String],
+    rules: &[PathBuf],
+) -> Vec<OsString> {
+    fn os(value: impl AsRef<OsStr>) -> OsString {
+        value.as_ref().to_os_string()
+    }
+
+    let mut argv: Vec<OsString> = vec![os("convert"), os("-t"), os(target), os("-f"), os(format)];
+
+    for pipeline in pipelines {
+        argv.push(os("-p"));
+        argv.push(os(pipeline));
+    }
+    if without_pipeline {
+        argv.push(os("--without-pipeline"));
+    }
+    if skip_unsupported {
+        argv.push(os("-s"));
+    }
+
+    for option in backend_options {
+        match option.split_once('=') {
+            Some(("correlation_method", value)) => {
+                argv.push(os("-c"));
+                argv.push(os(value));
+            }
+            _ => {
+                argv.push(os("-O"));
+                argv.push(os(option));
+            }
+        }
+    }
+
+    for rule in rules {
+        argv.push(os(rule));
+    }
+
+    argv
+}
+
+/// Message shown when a target has no native backend and sigma-cli cannot be
+/// run, guiding the user to install it (or fix a broken override).
+pub(crate) fn install_hint(
+    target: &str,
+    program: &Path,
+    is_override: bool,
+    native_targets: &[&str],
+) -> String {
+    let program = program.display();
+    let native = native_targets.join(", ");
+    if is_override {
+        format!(
+            "No native rsigma backend for target '{target}' (native targets: {native}), \
+             and the sigma-cli override {SIGMA_CLI_ENV}='{program}' could not be executed.\n\
+             Point {SIGMA_CLI_ENV} at a working sigma executable, or unset it to use one on PATH."
+        )
+    } else {
+        format!(
+            "No native rsigma backend for target '{target}' (native targets: {native}), \
+             and sigma-cli was not found on PATH.\n\
+             Install it to convert to '{target}':\n\
+             \x20\x20pipx install sigma-cli\n\
+             \x20\x20sigma plugin install {target}\n\
+             Or set {SIGMA_CLI_ENV} to the path of an existing sigma executable."
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_strings(argv: &[OsString]) -> Vec<String> {
+        argv.iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn resolve_program_prefers_override() {
+        let (program, is_override) = resolve_program(Some(OsString::from("/opt/sigma/bin/sigma")));
+        assert_eq!(program, PathBuf::from("/opt/sigma/bin/sigma"));
+        assert!(is_override);
+    }
+
+    #[test]
+    fn resolve_program_falls_back_to_path() {
+        let (program, is_override) = resolve_program(None);
+        assert_eq!(program, PathBuf::from("sigma"));
+        assert!(!is_override);
+    }
+
+    #[test]
+    fn resolve_program_treats_empty_override_as_unset() {
+        let (program, is_override) = resolve_program(Some(OsString::new()));
+        assert_eq!(program, PathBuf::from("sigma"));
+        assert!(!is_override);
+    }
+
+    #[test]
+    fn build_args_maps_flags_one_to_one() {
+        let argv = build_convert_args(
+            "splunk",
+            "default",
+            &[PathBuf::from("ecs.yml"), PathBuf::from("custom.yml")],
+            false,
+            true,
+            &["index=main".to_string()],
+            &[PathBuf::from("rule.yml")],
+        );
+        assert_eq!(
+            to_strings(&argv),
+            vec![
+                "convert",
+                "-t",
+                "splunk",
+                "-f",
+                "default",
+                "-p",
+                "ecs.yml",
+                "-p",
+                "custom.yml",
+                "-s",
+                "-O",
+                "index=main",
+                "rule.yml",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_args_special_cases_correlation_method() {
+        let argv = build_convert_args(
+            "loki",
+            "default",
+            &[],
+            false,
+            false,
+            &["correlation_method=stats".to_string()],
+            &[PathBuf::from("rule.yml")],
+        );
+        assert_eq!(
+            to_strings(&argv),
+            vec![
+                "convert", "-t", "loki", "-f", "default", "-c", "stats", "rule.yml",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_args_adds_without_pipeline_flag() {
+        let argv = build_convert_args(
+            "loki",
+            "ruler",
+            &[],
+            true,
+            false,
+            &[],
+            &[PathBuf::from("a.yml"), PathBuf::from("b.yml")],
+        );
+        assert_eq!(
+            to_strings(&argv),
+            vec![
+                "convert",
+                "-t",
+                "loki",
+                "-f",
+                "ruler",
+                "--without-pipeline",
+                "a.yml",
+                "b.yml",
+            ]
+        );
+    }
+
+    #[test]
+    fn install_hint_mentions_plugin_install_when_not_override() {
+        let hint = install_hint("splunk", Path::new("sigma"), false, &["postgres", "lynxdb"]);
+        assert!(hint.contains("sigma-cli was not found"));
+        assert!(hint.contains("sigma plugin install splunk"));
+        assert!(hint.contains("RSIGMA_SIGMA_CLI"));
+        assert!(hint.contains("native targets: postgres, lynxdb"));
+    }
+
+    #[test]
+    fn install_hint_mentions_override_path_when_override() {
+        let hint = install_hint("splunk", Path::new("/bad/sigma"), true, &["postgres"]);
+        assert!(hint.contains("/bad/sigma"));
+        assert!(hint.contains("could not be executed"));
+    }
+}

--- a/crates/rsigma-cli/tests/cli_convert.rs
+++ b/crates/rsigma-cli/tests/cli_convert.rs
@@ -304,10 +304,13 @@ fn convert_requires_pipeline_error() {
         .stderr(predicate::str::contains("requires a pipeline"));
 }
 
+// A non-native target with no usable sigma-cli (forced via a bogus override)
+// fails with install guidance rather than a conversion error.
 #[test]
 fn convert_invalid_target() {
     let rule = temp_file(".yml", SIMPLE_DETECTION);
-    let output = rsigma()
+    rsigma()
+        .env("RSIGMA_SIGMA_CLI", "/nonexistent/rsigma-test-sigma-cli")
         .args([
             "backend",
             "convert",
@@ -315,13 +318,12 @@ fn convert_invalid_target() {
             "--target",
             "nonexistent_backend",
         ])
-        .output()
-        .unwrap();
-    assert!(!output.status.success());
-    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
-    Unknown target: nonexistent_backend
-    Available targets: postgres, lynxdb, fibratus, test
-    ");
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "No native rsigma backend for target 'nonexistent_backend'",
+        ))
+        .stderr(predicate::str::contains("RSIGMA_SIGMA_CLI"));
 }
 
 #[test]
@@ -467,17 +469,25 @@ fn convert_split_creates_directory_from_trailing_separator() {
 // list-targets / list-formats
 // ---------------------------------------------------------------------------
 
+// With sigma-cli forced absent, `backend targets` lists the native targets and
+// points the user at sigma-cli for the rest. (The sigma-cli-present path is
+// environment-dependent and covered by the gated delegation test.)
 #[test]
 fn list_targets() {
-    let output = rsigma().args(["backend", "targets"]).output().unwrap();
-    assert!(output.status.success());
-    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @"
-    Available conversion targets:
-      postgres  - PostgreSQL/TimescaleDB (aliases: postgresql, pg)
-      lynxdb    - LynxDB log analytics engine
-      fibratus  - Fibratus kernel-event detection engine
-      test      - Backend-neutral test backend
-    ");
+    rsigma()
+        .env("RSIGMA_SIGMA_CLI", "/nonexistent/rsigma-test-sigma-cli")
+        .args(["backend", "targets"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Available conversion targets:"))
+        .stdout(predicate::str::contains(
+            "postgres  - PostgreSQL/TimescaleDB",
+        ))
+        .stdout(predicate::str::contains("lynxdb"))
+        .stdout(predicate::str::contains("fibratus"))
+        .stdout(predicate::str::contains(
+            "Install sigma-cli for more targets",
+        ));
 }
 
 #[test]
@@ -502,15 +512,70 @@ fn list_formats_postgres() {
     ");
 }
 
+// A non-native format target with no usable sigma-cli fails with install
+// guidance instead of a native unknown-target error.
 #[test]
 fn list_formats_invalid_target() {
-    let output = rsigma()
+    rsigma()
+        .env("RSIGMA_SIGMA_CLI", "/nonexistent/rsigma-test-sigma-cli")
         .args(["backend", "formats", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "No native rsigma backend for target 'nonexistent'",
+        ))
+        .stderr(predicate::str::contains("RSIGMA_SIGMA_CLI"));
+}
+
+// ---------------------------------------------------------------------------
+// sigma-cli delegation (runtime-gated)
+// ---------------------------------------------------------------------------
+
+/// Probe for a usable sigma-cli that has the `loki` backend installed, honoring
+/// the `RSIGMA_SIGMA_CLI` override. Returns `None` so the delegation test skips
+/// on machines without sigma-cli; CI never depends on it being present.
+fn sigma_cli_with_loki() -> Option<String> {
+    let program = std::env::var("RSIGMA_SIGMA_CLI").unwrap_or_else(|_| "sigma".to_string());
+    let out = std::process::Command::new(&program)
+        .args(["list", "targets"])
+        .output()
+        .ok()?;
+    if out.status.success() && String::from_utf8_lossy(&out.stdout).contains("loki") {
+        Some(program)
+    } else {
+        None
+    }
+}
+
+// When rsigma has no native backend for a target but sigma-cli does, the
+// conversion is delegated and its output relayed.
+#[test]
+fn delegates_to_sigma_cli_when_no_native_backend() {
+    if sigma_cli_with_loki().is_none() {
+        eprintln!("skipping: sigma-cli with the loki backend is not installed");
+        return;
+    }
+
+    let rule = temp_file(".yml", SIMPLE_DETECTION);
+    let output = rsigma()
+        .args([
+            "backend",
+            "convert",
+            rule.path().to_str().unwrap(),
+            "--target",
+            "loki",
+        ])
         .output()
         .unwrap();
-    assert!(!output.status.success());
-    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
-    Unknown target: nonexistent
-    Available targets: postgres, lynxdb, fibratus, test
-    ");
+
+    assert!(
+        output.status.success(),
+        "delegated loki conversion failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("whoami"),
+        "expected a LogQL query matching the rule value, got: {stdout}"
+    );
 }

--- a/crates/rsigma-convert/README.md
+++ b/crates/rsigma-convert/README.md
@@ -287,7 +287,7 @@ For text-based query backends (the vast majority), create a `TextQueryConfig` wi
 1. Define a `TextQueryConfig` constant with your backend's tokens and expressions.
 2. Create a struct that implements `Backend`, delegating most methods to the `text_convert_*` helpers.
 3. Override specific methods for backend-specific behavior (e.g. deferred regex for Splunk, SQL-specific CIDR handling for PostgreSQL).
-4. Register your backend in the CLI's `get_backend()` registry.
+4. Register your backend in the CLI's `try_native_backend()` registry (a native backend takes precedence over sigma-cli delegation for that target).
 
 See `backends/test.rs` for a complete reference implementation, `backends/postgres.rs` for a production backend with SQL-specific overrides, and `backends/lynxdb/` for a `TextQueryConfig`-based backend with deferred expressions and custom precedence handling.
 

--- a/docs/cli/backend/convert.md
+++ b/docs/cli/backend/convert.md
@@ -12,6 +12,8 @@ rsigma backend convert [OPTIONS] --target <TARGET> [RULES]...
 
 Reads one or more rule files (or a directory) and emits backend-native query strings, one per rule. Output goes to stdout by default; use `-o` to write to a file. Use [`backend targets`](targets.md) to list available backends and [`backend formats`](formats.md) to list the output formats supported by a specific backend.
 
+Targets with no native backend are delegated to an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) when one is installed, unlocking the full pySigma backend ecosystem (`splunk`, `elasticsearch`, `kusto`, `qradar`, `loki`, …). See [sigma-cli delegation](../../reference/backends/sigma-cli.md) for discovery, the `RSIGMA_SIGMA_CLI` override, the flag mapping, and limitations.
+
 For narrative coverage, including the PostgreSQL and LynxDB workflows, see [Rule Conversion](../../guide/rule-conversion.md).
 
 ## Flags
@@ -20,7 +22,7 @@ For narrative coverage, including the PostgreSQL and LynxDB workflows, see [Rule
 
 | Flag | Description |
 |------|-------------|
-| `-t, --target <TARGET>` | Backend to convert to. Run [`backend targets`](targets.md) for the live list. Today: `postgres` (aliases `postgresql`, `pg`), `lynxdb`, `test`. |
+| `-t, --target <TARGET>` | Backend to convert to. Run [`backend targets`](targets.md) for the live list. Native: `postgres` (aliases `postgresql`, `pg`), `lynxdb`, `fibratus`, `test`. Any other target is delegated to sigma-cli when installed. |
 | `[RULES]...` | Path(s) to Sigma rule file(s) or a directory. |
 
 ### Output
@@ -112,8 +114,8 @@ psql -f /var/lib/rsigma/sql/views.sql
 | Code | Meaning |
 |------|---------|
 | `0` | Conversion succeeded. |
-| `2` | One or more rules failed to convert (unless `--skip-unsupported`), or rules path empty. |
-| `3` | Unknown `--target`, unknown `--format`, unwritable `--output`, or other CLI configuration error. |
+| `2` | One or more rules failed to convert (unless `--skip-unsupported`), rules path empty, or a delegated sigma-cli run exited non-zero (its stderr is relayed). |
+| `3` | Unknown `--format`, unwritable `--output`, a target with no native backend and no sigma-cli installed, a directory `--output` for a delegated target, or other CLI configuration error. |
 
 ## See also
 

--- a/docs/cli/backend/targets.md
+++ b/docs/cli/backend/targets.md
@@ -10,7 +10,9 @@ rsigma backend targets [OPTIONS]
 
 ## Description
 
-Prints every backend that [`backend convert`](convert.md) can target, plus a one-line description. Backend names are case-insensitive and accept short aliases (`pg` for PostgreSQL).
+Prints every native backend that [`backend convert`](convert.md) can target, plus a one-line description. Backend names are case-insensitive and accept short aliases (`pg` for PostgreSQL).
+
+When an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) is discoverable, its targets are appended too (marked "via sigma-cli"), since `backend convert` delegates any non-native target to it. When sigma-cli is not installed, the command prints a short hint on how to add it. See [sigma-cli delegation](../../reference/backends/sigma-cli.md).
 
 ## Flags
 

--- a/docs/developers/adding-backends.md
+++ b/docs/developers/adding-backends.md
@@ -1,6 +1,8 @@
 # Adding a new backend
 
-The `Backend` trait in [`rsigma-convert`](../library/convert.md) is the plug-in surface for SIEM query generation. The shipped implementations are `PostgresBackend`, `LynxDbBackend`, and the two test backends; this page walks through adding your own (Splunk, Elastic, KQL, ClickHouse, …) and wiring it into the CLI.
+The `Backend` trait in [`rsigma-convert`](../library/convert.md) is the plug-in surface for SIEM query generation. The shipped implementations are `PostgresBackend`, `LynxDbBackend`, `FibratusBackend`, and the two test backends; this page walks through adding your own (Splunk, Elastic, KQL, ClickHouse, …) and wiring it into the CLI.
+
+A native backend always takes precedence over [sigma-cli delegation](../reference/backends/sigma-cli.md): adding one for a target (for example `splunk`) transparently replaces the delegated path for that target, with no change to how users invoke `rsigma backend convert -t splunk`.
 
 ## Decide on the shape
 

--- a/docs/guide/rule-conversion.md
+++ b/docs/guide/rule-conversion.md
@@ -50,6 +50,20 @@ Available formats for 'postgres':
   sliding_window  - Correlation queries using window functions for per-row sliding detection
 ```
 
+## Delegated targets (sigma-cli)
+
+The targets above are converted natively. For any other target, `rsigma backend convert` delegates to an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) when one is installed, so the full pySigma backend ecosystem (`splunk`, `elasticsearch`, `kusto`, `qradar`, `loki`, `crowdstrike`, and more) is reachable from the same command. No Python is required unless you actually convert to a delegated target, and native backends always take precedence.
+
+Install sigma-cli and the backend you want, then convert as usual:
+
+```bash
+pipx install sigma-cli
+sigma plugin install splunk
+rsigma backend convert -t splunk rules/
+```
+
+If a target has no native backend and sigma-cli is not installed, the command exits with code `3` and tells you how to install it. Set `RSIGMA_SIGMA_CLI` to point at a specific `sigma` executable when it is not on `PATH`. See the [sigma-cli delegation reference](../reference/backends/sigma-cli.md) for the full flag mapping, discovery rules, and limitations.
+
 ## PostgreSQL and TimescaleDB
 
 The PostgreSQL backend is the most fully featured. It leverages native operators that map cleanly to Sigma modifiers:

--- a/docs/reference/backends/.pages
+++ b/docs/reference/backends/.pages
@@ -3,3 +3,4 @@ nav:
   - PostgreSQL/TimescaleDB: postgres.md
   - LynxDB: lynxdb.md
   - Fibratus: fibratus.md
+  - sigma-cli delegation: sigma-cli.md

--- a/docs/reference/backends/sigma-cli.md
+++ b/docs/reference/backends/sigma-cli.md
@@ -1,0 +1,77 @@
+# sigma-cli delegation
+
+rsigma converts a handful of targets natively (`postgres`, `lynxdb`, `fibratus`). For any other target, `rsigma backend convert` delegates to an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) when one is installed, so the full pySigma backend ecosystem (`splunk`, `elasticsearch`, `kusto`, `qradar`, `loki`, `crowdstrike`, and 30+ more) is reachable through the same `rsigma backend convert` command. This is a light subprocess wrapper, not an embedded Python interpreter: no Python runtime is required unless you actually convert to a delegated target.
+
+## Resolution order
+
+`rsigma backend convert -t <target>` resolves the target in this order:
+
+1. **Native backend.** If rsigma has a native backend for the target (`postgres`/`postgresql`/`pg`, `lynxdb`, `fibratus`), it is used, exactly as before. Native always wins.
+2. **Delegated to sigma-cli.** Otherwise, if a `sigma` executable is discoverable, rsigma runs `sigma convert` with the original rule files and a mapped flag set, and relays its output. The result is identical to running sigma-cli directly.
+3. **Error.** If neither is available, the command exits with code `3` and prints guidance to install sigma-cli (or fix the discovery override).
+
+Because native always wins, a target that is delegated today is transparently taken over by a native backend if one ships later, with no change to how you invoke it.
+
+## Discovery
+
+rsigma finds sigma-cli in this order:
+
+1. The `RSIGMA_SIGMA_CLI` environment variable, when set to a path to the `sigma` executable. An empty value is treated as unset.
+2. A bare `sigma` resolved on `PATH`.
+
+A spawn that fails because the executable is missing is reported as "not found" with install guidance, rather than as a conversion failure.
+
+## Installing sigma-cli
+
+```bash
+pipx install sigma-cli
+sigma plugin install <target>   # e.g. splunk, elasticsearch, loki, kusto
+```
+
+Confirm what is installed:
+
+```bash
+sigma plugin list --plugin-type backend
+rsigma backend targets           # lists native targets plus sigma-cli's
+```
+
+## Flag mapping
+
+`rsigma backend convert` flags map almost 1:1 to `sigma convert`:
+
+| rsigma flag | sigma-cli flag |
+|-------------|----------------|
+| `-t, --target <TARGET>` | `-t, --target` |
+| `-f, --format <FORMAT>` | `-f, --format` |
+| `-p, --pipeline <P>` (repeatable) | `-p, --pipeline` |
+| `--without-pipeline` | `--without-pipeline` |
+| `-s, --skip-unsupported` | `-s, --skip-unsupported` |
+| `-O, --option key=value` | `-O, --backend-option key=value` |
+| `-O correlation_method=<m>` | `-c, --correlation-method <m>` |
+| `[RULES]...` | `INPUT...` |
+
+`-O correlation_method=<m>` is the only transform: rsigma's option style becomes sigma-cli's dedicated `-c/--correlation-method` flag.
+
+## Output
+
+sigma-cli's stdout is captured and routed through rsigma's normal output handling, so `-o <file>` and `--output-format json` behave as they do for native backends. With `--output-format json`, the delegated queries are wrapped as `{ "target", "format", "engine": "sigma-cli", "queries": [ { "query": ... } ] }`, one object per output line.
+
+## Limitations
+
+- **Per-rule directory output is native-only.** `-o <dir>/` (one file per rule) reuses a native backend's finalizer, which a delegated stream has no equivalent of, so delegated mode rejects a directory `--output`. Use a file path or stdout.
+- **Pipeline shortcut names are not translated.** rsigma's builtin pipeline names (`ecs_windows`, `sysmon`) are not mapped to sigma-cli pipeline identifiers. In delegated mode, pass a sigma-cli pipeline name (see `sigma list pipelines`) or a YAML file path to `-p`.
+- **CLI only.** Delegation applies to `rsigma backend convert` (and `backend targets`/`backend formats`). The MCP `convert` tool and the `rsigma_convert` library API convert with native backends only.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Conversion succeeded. |
+| `2` | sigma-cli ran but exited non-zero (an unknown target, an unconvertible rule, and so on). Its stderr is relayed verbatim. |
+| `3` | No native backend and sigma-cli was not found, a directory `--output` in delegated mode, or another CLI configuration error. |
+
+## See also
+
+- [Rule Conversion](../../guide/rule-conversion.md#delegated-targets-sigma-cli) for the narrative workflow.
+- [`backend convert`](../../cli/backend/convert.md), [`backend targets`](../../cli/backend/targets.md), [`backend formats`](../../cli/backend/formats.md).
+- [PostgreSQL](postgres.md), [LynxDB](lynxdb.md), and [Fibratus](fibratus.md) for the native backends.


### PR DESCRIPTION
## Summary

- `rsigma backend convert` now resolves targets native-first: it uses a native rsigma backend when one exists (`postgres`/`lynxdb`/`fibratus`) and otherwise delegates the conversion to an external [sigma-cli](https://github.com/SigmaHQ/sigma-cli) when one is installed, so the full pySigma backend ecosystem (`splunk`, `elasticsearch`, `kusto`, `qradar`, `loki`, `crowdstrike`, and more) is reachable from the same command. It is a light subprocess wrapper with no new dependencies; no Python runtime is required unless a delegated target is actually used.
- Discovery uses the `RSIGMA_SIGMA_CLI` path override or a bare `sigma` on `PATH`. When a target has no native backend and sigma-cli is absent, the command exits `3` with install guidance.
- Flags map near 1:1 to `sigma convert` (`-t`, `-f`, `-p`, `--without-pipeline`, `-s`, `-O key=value`), with `-O correlation_method=<m>` mapped to sigma-cli's `-c`. The original rule files are handed to sigma-cli, which parses, pipelines, and converts them, so output matches sigma-cli exactly.
- sigma-cli stdout is relayed through the existing output handling (stdout, `-o <file>`, and the `--output-format json` envelope). A non-zero sigma-cli exit maps to `2` with its stderr relayed; a missing binary or a directory `--output` in delegated mode maps to `3`. `backend targets` appends installed sigma-cli targets and `backend formats <target>` lists a delegated target's formats.

A native backend always takes precedence, so a future native backend for a delegated target transparently supersedes it. Scope is the CLI `backend convert` path only; the MCP `convert` tool and the `rsigma_convert` library API stay native-only. rsigma builtin pipeline names (`ecs_windows`, `sysmon`) are not translated; pass sigma-cli pipeline names or YAML paths in delegated mode.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rsigma --bins` (unit, incl. discovery, argv mapping, install-hint)
- [x] `cargo test -p rsigma --test cli_convert` (incl. a runtime-gated delegation test that converts via the installed loki backend, and skips when sigma-cli is absent)
- [x] `cargo test -p rsigma --test cli_deprecation` and `--test cli_output_format`
- [x] `mkdocs build --strict`
- [x] Manual: delegated loki convert (default + json), native lynxdb unaffected, `backend targets`/`formats`, uninstalled-target relay (exit 2), directory-output rejection (exit 3), bogus-override install hint (exit 3)