### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ RSigma v0.17.0 is the "detection-engineering toolkit" release: the rule-side rep
 * `rstix`: Phase 2 adds STIX meta objects (#213) and relationship/sighting objects (#220), thanks to @SecurityEnthusiast; the crate is not releasable on its own yet.
 * Fibratus conversion fixes: emit the required `version` field so converted rules load (#219), and map `file_access`/`file_event`/`create_remote_thread` to their idiomatic macros (#217), thanks to @rabbitstack.
 * Faster NATS and daemon integration tests: deterministic waits replace fixed sleeps and long-poll timeouts, cutting each suite's runtime by roughly 7x with no production code changes (#240).
+* Security: bump the transitive `quinn-proto` (via `reqwest`) to 0.11.15 to clear RUSTSEC-2026-0185, a high-severity remote memory exhaustion advisory.
 
 ### `rule scorecard`: fuse the rule-side reports into per-rule keep/tune/retire verdicts (#243)
 
@@ -170,6 +171,10 @@ Phase 2 adds STIX meta objects (not releasable on its own until `StixObject` dis
 - **Deserialize:** each meta type validates JSON `"type"` against `TYPE_NAME` in a single serde pass (`ModelError::UnexpectedObjectType`); no intermediate `serde_json::Value` parse.
 - **Tests:** `roundtrip_strict` for complete types (meta objects, `ExternalReference`, `GranularMarking`, `ExtensionMap`); subset `roundtrip` for `SdoSroCommonProps` / `ScoCommonProps` fixtures that carry unmodeled SDO keys. Fixtures under `tests/fixtures/spec/meta/` include minimal TLP markings, a rich marking-def with common properties, and cross-type reject coverage. Unit pins for all nine TLP ids.
 - **Docs:** STIX object model version vs TLP marking encoding in `crates/rstix/README.md` and `docs/library/rstix.md`.
+
+### Security: transitive `quinn-proto` bump for RUSTSEC-2026-0185
+
+`cargo audit` flagged [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185), a high-severity (7.5) remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly, published 2026-06-22. It reaches the tree transitively through `reqwest -> quinn -> quinn-proto`. A targeted `cargo update -p quinn-proto --precise 0.11.15` moves the workspace and fuzz lockfiles from 0.11.14 to the fixed 0.11.15 with no other dependency changes.
 
 [v0.16.0...v0.17.0](https://github.com/timescale/rsigma/compare/v0.16.0...v0.17.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to RSigma are documented in this file. Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
-## [Unreleased]
+## [0.17.0] - 2026-06-23
+
+**TL;DR**
+RSigma v0.17.0 is the "detection-engineering toolkit" release: the rule-side reporting suite that closes the program loop, plus the daemon output-delivery layer and live daemon introspection.
+* Detection-engineering reports: `rule backtest` replays an event corpus against a ruleset and diffs per-rule fire counts against declared expectations (#216); `rule coverage` maps a ruleset onto MITRE ATT&CK, exports a Navigator layer, and reports coverage gaps (#221); `rule visibility` turns the field-observability signal into a DeTT&CT administration pair and a visibility Navigator layer (#242); `rule scorecard` fuses backtest precision/recall, coverage, and fire volume into per-rule keep/tune/retire verdicts (#243).
+* Output delivery: detection results now flow through a per-sink async delivery layer with bounded queues, retry/backoff, batching, and an at-least-once ack-join across fan-out (#222); an OTLP output sink exports detections over OTLP/HTTP and OTLP/gRPC (#223); a generic, template-driven webhook sink delivers to Slack, Teams, Discord, PagerDuty, or any HTTP endpoint (#227).
+* Daemon introspection: `engine status` queries a running daemon from the command line (#237), `engine tap` records a redactable, replayable live event fixture (#238), and `engine tail` streams live detections to the terminal (#239).
+* Conversion reach: `backend convert` resolves targets native-first and delegates anything without a native backend to an installed sigma-cli, reaching the full pySigma backend ecosystem with no new dependency (#241).
+* `rstix`: Phase 2 adds STIX meta objects (#213) and relationship/sighting objects (#220), thanks to @SecurityEnthusiast; the crate is not releasable on its own yet.
+* Fibratus conversion fixes: emit the required `version` field so converted rules load (#219), and map `file_access`/`file_event`/`create_remote_thread` to their idiomatic macros (#217), thanks to @rabbitstack.
+* Faster NATS and daemon integration tests: deterministic waits replace fixed sleeps and long-poll timeouts, cutting each suite's runtime by roughly 7x with no production code changes (#240).
 
 ### `rule scorecard`: fuse the rule-side reports into per-rule keep/tune/retire verdicts (#243)
 
@@ -160,6 +170,8 @@ Phase 2 adds STIX meta objects (not releasable on its own until `StixObject` dis
 - **Deserialize:** each meta type validates JSON `"type"` against `TYPE_NAME` in a single serde pass (`ModelError::UnexpectedObjectType`); no intermediate `serde_json::Value` parse.
 - **Tests:** `roundtrip_strict` for complete types (meta objects, `ExternalReference`, `GranularMarking`, `ExtensionMap`); subset `roundtrip` for `SdoSroCommonProps` / `ScoCommonProps` fixtures that carry unmodeled SDO keys. Fixtures under `tests/fixtures/spec/meta/` include minimal TLP markings, a rich marking-def with common properties, and cross-type reject coverage. Unit pins for all nine TLP ids.
 - **Docs:** STIX object model version vs TLP marking encoding in `crates/rstix/README.md` and `docs/library/rstix.md`.
+
+[v0.16.0...v0.17.0](https://github.com/timescale/rsigma/compare/v0.16.0...v0.17.0)
 
 ## [0.16.0] - 2026-06-15
 
@@ -1970,6 +1982,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.17.0]: https://github.com/timescale/rsigma/releases/tag/v0.17.0
 [0.16.0]: https://github.com/timescale/rsigma/releases/tag/v0.16.0
 [0.15.0]: https://github.com/timescale/rsigma/releases/tag/v0.15.0
 [0.14.0]: https://github.com/timescale/rsigma/releases/tag/v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "insta",
  "log",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-mcp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "globset",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "phf",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -36,11 +36,11 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.16.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.16.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.16.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.16.0", optional = true }
-rsigma-mcp = { path = "../rsigma-mcp", version = "0.16.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.17.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.17.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.17.0", optional = true }
+rsigma-mcp = { path = "../rsigma-mcp", version = "0.17.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.16.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.16.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.17.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.16.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.16.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.16.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.17.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-mcp/Cargo.toml
+++ b/crates/rsigma-mcp/Cargo.toml
@@ -16,10 +16,10 @@ default = []
 http = ["dep:axum", "rmcp/transport-streamable-http-server"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.16.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.16.0" }
-rsigma-convert = { path = "../rsigma-convert", version = "0.16.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.16.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.17.0" }
+rsigma-convert = { path = "../rsigma-convert", version = "0.17.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.17.0" }
 rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -19,8 +19,8 @@ evtx = ["dep:evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.16.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.16.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.17.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "globset",
  "log",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arc-swap",
  "async-trait",


### PR DESCRIPTION
## Summary

Release v0.17.0. Bumps the workspace from 0.16.0 to 0.17.0 (workspace package version plus all inter-crate path pins across the dependent crates), syncs both `Cargo.lock` and `fuzz/Cargo.lock`, and finalizes `CHANGELOG.md` by promoting the `[Unreleased]` block to `[0.17.0] - 2026-06-23` with a TL;DR, a `v0.16.0...v0.17.0` compare link, and the release reference link.

Headline framing: the "detection-engineering toolkit" release. The rule-side reporting suite that closes the program loop lands, alongside the daemon output-delivery layer and live daemon introspection.

- Detection-engineering reports: `rule backtest` replays an event corpus against a ruleset and diffs per-rule fire counts against declared expectations (#216); `rule coverage` maps a ruleset onto MITRE ATT&CK and exports a Navigator layer with gap analysis (#221); `rule visibility` turns the field-observability signal into a DeTT&CT administration pair and a visibility Navigator layer (#242); `rule scorecard` fuses backtest precision/recall, coverage, and fire volume into per-rule keep/tune/retire verdicts (#243).
- Output delivery: a per-sink async delivery layer with bounded queues, retry/backoff, batching, and an at-least-once ack-join across fan-out (#222); an OTLP output sink over OTLP/HTTP and OTLP/gRPC (#223); a generic, template-driven webhook sink for Slack, Teams, Discord, PagerDuty, or any HTTP endpoint (#227).
- Daemon introspection: `engine status` (#237), `engine tap` for a redactable replayable fixture (#238), and `engine tail` for live detections (#239).
- Conversion reach: `backend convert` resolves native-first and delegates non-native targets to an installed sigma-cli, reaching the full pySigma backend ecosystem with no new dependency (#241).
- `rstix`: Phase 2 STIX meta objects (#213) and relationship/sighting objects (#220), thanks to @SecurityEnthusiast; the crate is not releasable on its own yet.
- Fibratus conversion fixes: emit the required `version` field (#219) and map `file_access`/`file_event`/`create_remote_thread` to their idiomatic macros (#217), thanks to @rabbitstack.
- Faster NATS and daemon integration tests: deterministic waits cut each suite by roughly 7x with no production code changes (#240).

Full release notes: see the new `[0.17.0]` section in `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata --locked` for the workspace and `fuzz/` (lockfile/manifest consistency)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (CI)
- [x] `cargo test --workspace --all-features` (CI)
- [x] `mkdocs build --strict` (CI)
- [x] `cargo deny check` (CI)

This commit is a version and changelog bump only; no source changed since the last merge to `main`, so the heavier gates are left to CI.

## Post-merge

After merge, tag `v0.17.0` on `main` and create the GitHub Release using the `[0.17.0]` body verbatim. The `publish.yml`, `release-binaries.yml`, and `docker.yml` workflows fire on `release: published`.