### PR TITLE
feat: schema-aware log source recognition (classification and reporting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Schema-aware log source recognition (#TBD)
+### Schema-aware log source recognition (#245)
 
 Content-based schema classification that recognizes the structure of each event from its marker fields and values rather than its wire format, so a mixed JSON stream of ECS, flat Sysmon, rendered Windows Event Log, CEF, and OCSF events can be told apart.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to RSigma are documented in this file. Each entry corresponds to a [GitHub Release](https://github.com/timescale/rsigma/releases).
 
+## [Unreleased]
+
+### Schema-aware log source recognition (#TBD)
+
+Content-based schema classification that recognizes the structure of each event from its marker fields and values rather than its wire format, so a mixed JSON stream of ECS, flat Sysmon, rendered Windows Event Log, CEF, and OCSF events can be told apart.
+
+* `engine classify`: a diagnostic that reads a single event, an NDJSON file, or stdin and reports the recognized schema (or `unknown`) per event plus a per-schema summary, rendered through the global output-format layer. `--schema-config` merges user-defined signatures over the built-ins.
+* Daemon schema observability: `--observe-schemas` classifies every event and exposes the per-schema breakdown and unknown rate over `GET /api/v1/schemas` and the `rsigma_events_by_schema_total{schema}` and `rsigma_events_unknown_schema_total` metrics. An optional `--schema-config` merges user signatures over the built-ins.
+* Declarative signatures (field present/absent, any-of, equals, regex) live in `rsigma-eval`; built-ins cover ECS, OCSF, rendered Windows Event Log, Sysmon, CEF, and a low-specificity `generic_json` fallback. An event matching no signature is reported as `unknown`, the signal for an unsupported schema.
+
+This is recognition and reporting only; it does not route or transform events.
+
 ## [0.17.0] - 2026-06-23
 
 **TL;DR**

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For rule quality and editor integration, a built-in linter validates rules again
 * **Array matching (experimental):** Match members of arrays in nested event data: implicit any-member matching, `[any]`/`[all]` object-scope blocks for same-element correlation, and positional `[N]` indexing, opt-in via `sigma-version: 3`. Evaluated natively and lowered to PostgreSQL JSONB; see the [Array Matching guide](https://timescale.github.io/rsigma/guide/array-matching/)
 * **Streaming daemon:** Run as a streaming detection daemon with hot-reload, Prometheus metrics, and HTTP/NATS/OTLP input
 * **Input formats:** Accept JSON, syslog (RFC 3164/5424), logfmt, CEF, EVTX (Windows Event Log), plain text, and OTLP logs with format auto-detection
+* **Schema recognition:** Recognize which schema each event uses (ECS, Sysmon, rendered Windows Event Log, CEF, OCSF, or user-defined) from its content via `engine classify`, with a live daemon surface (`--observe-schemas`, `GET /api/v1/schemas`) and per-schema metrics for spotting unrecognized sources
 * **Processing pipelines:** Use pySigma-compatible processing pipelines for field mapping, transformations, conditions, and finalizers
 * **Dynamic pipelines:** Populate any pipeline value from external sources (HTTP, files, commands, NATS) with template expansion, auto-refresh, and data extraction via jq, JSONPath, or CEL
 * **Post-evaluation enrichment:** Inject contextual data (asset info, IP reputation, identity, GeoIP, runbook URLs, ...) into detection and correlation results via four primitives (`template`, `lookup`, `http`, `command`) with kind-aware template namespaces, response cache, scope filtering, and hot-reload
@@ -139,6 +140,9 @@ cat events.ndjson | rsigma engine eval -r rules/
 
 # Interactive triage in a terminal: width-aligned table view
 rsigma engine eval -r rules/ -e @events.ndjson --output-format table
+
+# Recognize which schema each event is (ECS, Sysmon, CEF, OCSF, ...)
+cat events.ndjson | rsigma engine classify --output-format table
 
 # Pipe a CSV view into a spreadsheet or data tool
 rsigma engine eval -r rules/ -e @events.ndjson --output-format csv > matches.csv

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -27,6 +27,9 @@ rsigma engine eval -r path/to/rules/ -e @events.ndjson --output-format table
 # CSV for spreadsheets / data tools
 rsigma engine eval -r path/to/rules/ -e @events.ndjson --output-format csv
 
+# Recognize which schema each event is (ECS, Sysmon, CEF, OCSF, ...)
+cat events.ndjson | rsigma engine classify --output-format table
+
 # Long-running daemon with hot-reload, health checks, and Prometheus metrics
 hel run | rsigma engine daemon -r rules/ -p ecs_windows --api-addr 0.0.0.0:9090
 

--- a/crates/rsigma-cli/src/commands/classify.rs
+++ b/crates/rsigma-cli/src/commands/classify.rs
@@ -1,0 +1,332 @@
+//! `engine classify`: report which schema rsigma assigns to each event.
+//!
+//! A diagnostic for tuning schema signatures: it reads JSON (or NDJSON) events
+//! and prints, per event, the recognized schema (or `unknown`), plus a summary
+//! of per-schema counts. It does not load rules or evaluate detections.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::PathBuf;
+use std::process;
+
+use clap::Args;
+use rsigma_eval::{JsonEvent, SchemaClassifier, load_schema_signatures};
+use serde::Serialize;
+
+use crate::output::{DelimitedWriter, OutputCtx, OutputFormat, Tabular, render_json};
+
+/// Arguments for `rsigma engine classify`.
+#[derive(Args, Debug)]
+pub(crate) struct ClassifyArgs {
+    /// A single event as a JSON string, or @path to read NDJSON from a file.
+    /// If omitted, reads NDJSON from stdin.
+    #[arg(short, long)]
+    pub event: Option<String>,
+
+    /// Path to a YAML file of user-defined schema signatures, merged over the
+    /// built-ins.
+    #[arg(long = "schema-config", value_name = "PATH")]
+    pub schema_config: Option<PathBuf>,
+}
+
+pub(crate) fn cmd_classify(args: ClassifyArgs, ctx: OutputCtx) {
+    let classifier = match args.schema_config {
+        Some(path) => match load_schema_signatures(&path) {
+            Ok(sigs) => SchemaClassifier::with_user_signatures(sigs),
+            Err(e) => {
+                eprintln!("Error loading schema signatures: {e}");
+                process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+        },
+        None => SchemaClassifier::builtin(),
+    };
+
+    let report = match build_report(&classifier, args.event) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{e}");
+            process::exit(crate::exit_code::RULE_ERROR);
+        }
+    };
+
+    match ctx.format {
+        OutputFormat::Json => render_json(&report, true),
+        OutputFormat::Ndjson => {
+            for rec in &report.events {
+                render_json(rec, false);
+            }
+            print_summary_stderr(&report, &ctx);
+        }
+        OutputFormat::Csv => render_delimited(&report, ',', &ctx),
+        OutputFormat::Tsv => render_delimited(&report, '\t', &ctx),
+        OutputFormat::Table => print_table(&report, &ctx),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Report types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+struct ClassifyReport {
+    summary: ClassifySummary,
+    events: Vec<ClassifyRecord>,
+}
+
+#[derive(Debug, Serialize)]
+struct ClassifySummary {
+    /// Events successfully parsed and classified (excludes parse errors).
+    total_events: usize,
+    /// Events that matched a schema signature.
+    classified: usize,
+    /// Events that matched no signature.
+    unknown: usize,
+    /// Lines that were not valid JSON.
+    parse_errors: usize,
+    /// Per-schema counts for recognized schemas (excludes `unknown`).
+    by_schema: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct ClassifyRecord {
+    index: usize,
+    /// `None` means the event matched no signature ("unknown").
+    schema: Option<String>,
+    specificity: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Report building
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct Accumulator {
+    events: Vec<ClassifyRecord>,
+    by_schema: BTreeMap<String, usize>,
+    classified: usize,
+    unknown: usize,
+    parse_errors: usize,
+    index: usize,
+}
+
+impl Accumulator {
+    fn classify_value(&mut self, classifier: &SchemaClassifier, value: &serde_json::Value) {
+        let event = JsonEvent::borrow(value);
+        let matched = classifier.classify(&event);
+        match &matched {
+            Some(m) => {
+                self.classified += 1;
+                *self.by_schema.entry(m.name.clone()).or_insert(0) += 1;
+            }
+            None => self.unknown += 1,
+        }
+        self.events.push(ClassifyRecord {
+            index: self.index,
+            schema: matched.as_ref().map(|m| m.name.clone()),
+            specificity: matched.as_ref().map(|m| m.specificity),
+        });
+        self.index += 1;
+    }
+
+    fn classify_line(&mut self, classifier: &SchemaClassifier, line: &str) {
+        if line.trim().is_empty() {
+            return;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(value) => self.classify_value(classifier, &value),
+            Err(_) => self.parse_errors += 1,
+        }
+    }
+
+    fn into_report(self) -> ClassifyReport {
+        ClassifyReport {
+            summary: ClassifySummary {
+                total_events: self.classified + self.unknown,
+                classified: self.classified,
+                unknown: self.unknown,
+                parse_errors: self.parse_errors,
+                by_schema: self.by_schema,
+            },
+            events: self.events,
+        }
+    }
+}
+
+fn build_report(
+    classifier: &SchemaClassifier,
+    event_arg: Option<String>,
+) -> Result<ClassifyReport, String> {
+    let mut acc = Accumulator::default();
+
+    match event_arg {
+        Some(s) if s.starts_with('@') => {
+            let path = PathBuf::from(&s[1..]);
+            if path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("evtx"))
+            {
+                return Err(
+                    "`engine classify` reads JSON/NDJSON; .evtx files are binary. Decode with \
+                     `engine eval -e @file.evtx` or convert to NDJSON first."
+                        .to_string(),
+                );
+            }
+            let file = File::open(&path)
+                .map_err(|e| format!("Error opening event file '{}': {e}", path.display()))?;
+            for line in BufReader::new(file).lines() {
+                let line = line.map_err(|e| format!("Error reading event file: {e}"))?;
+                acc.classify_line(classifier, &line);
+            }
+        }
+        Some(s) => {
+            // Inline `-e` is a single JSON event.
+            let value: serde_json::Value =
+                serde_json::from_str(&s).map_err(|e| format!("Invalid JSON event: {e}"))?;
+            acc.classify_value(classifier, &value);
+        }
+        None => {
+            let stdin = io::stdin();
+            for line in stdin.lock().lines() {
+                let line = line.map_err(|e| format!("Error reading stdin: {e}"))?;
+                acc.classify_line(classifier, &line);
+            }
+        }
+    }
+
+    Ok(acc.into_report())
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+impl Tabular for ClassifyRecord {
+    fn headers() -> &'static [&'static str] {
+        &["#", "SCHEMA", "SPECIFICITY"]
+    }
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.index.to_string(),
+            self.schema.clone().unwrap_or_else(|| "unknown".to_string()),
+            self.specificity
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+        ]
+    }
+}
+
+fn summary_line(report: &ClassifyReport) -> String {
+    let s = &report.summary;
+    let breakdown = if s.by_schema.is_empty() {
+        String::new()
+    } else {
+        let parts: Vec<String> = s
+            .by_schema
+            .iter()
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect();
+        format!(" | {}", parts.join(", "))
+    };
+    format!(
+        "Events: {} classified, {} unknown, {} parse errors{breakdown}",
+        s.classified, s.unknown, s.parse_errors,
+    )
+}
+
+fn print_summary_stderr(report: &ClassifyReport, ctx: &OutputCtx) {
+    if ctx.show_stats() {
+        eprintln!("{}", summary_line(report));
+    }
+}
+
+fn render_delimited(report: &ClassifyReport, sep: char, ctx: &OutputCtx) {
+    print_summary_stderr(report, ctx);
+    let mut writer = DelimitedWriter::new(sep, ClassifyRecord::headers());
+    for rec in &report.events {
+        writer.push(&rec.row());
+    }
+}
+
+fn print_table(report: &ClassifyReport, ctx: &OutputCtx) {
+    if ctx.show_stats() {
+        eprintln!("{}", summary_line(report));
+    }
+    if report.events.is_empty() {
+        if ctx.show_progress() {
+            eprintln!("No events to classify.");
+        }
+        return;
+    }
+    if ctx.show_stats() {
+        eprintln!();
+    }
+    crate::output::render_table(&report.events);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report_for(event: &str) -> ClassifyReport {
+        build_report(&SchemaClassifier::builtin(), Some(event.to_string())).expect("report")
+    }
+
+    #[test]
+    fn classifies_inline_ecs_event() {
+        let report = report_for(r#"{"ecs.version": "8.11.0", "process.command_line": "whoami"}"#);
+        assert_eq!(report.summary.total_events, 1);
+        assert_eq!(report.summary.classified, 1);
+        assert_eq!(report.summary.unknown, 0);
+        assert_eq!(report.events[0].schema.as_deref(), Some("ecs"));
+        assert_eq!(report.events[0].specificity, Some(100));
+        assert_eq!(report.summary.by_schema.get("ecs"), Some(&1));
+    }
+
+    #[test]
+    fn empty_object_is_unknown() {
+        let report = report_for("{}");
+        assert_eq!(report.summary.unknown, 1);
+        assert_eq!(report.summary.classified, 0);
+        assert_eq!(report.events[0].schema, None);
+        assert!(report.summary.by_schema.is_empty());
+    }
+
+    #[test]
+    fn invalid_inline_json_is_an_error() {
+        let err = build_report(&SchemaClassifier::builtin(), Some("not json".to_string()))
+            .expect_err("should error");
+        assert!(err.contains("Invalid JSON event"));
+    }
+
+    #[test]
+    fn counts_accumulate_across_lines() {
+        let mut acc = Accumulator::default();
+        let classifier = SchemaClassifier::builtin();
+        acc.classify_line(&classifier, r#"{"ecs.version": "8.0.0"}"#);
+        acc.classify_line(
+            &classifier,
+            r#"{"EventID": 1, "ProcessGuid": "{x}", "Image": "a"}"#,
+        );
+        acc.classify_line(&classifier, r#"{"random": "blob"}"#);
+        acc.classify_line(&classifier, ""); // blank line skipped
+        acc.classify_line(&classifier, "{bad json");
+        let report = acc.into_report();
+        assert_eq!(report.summary.total_events, 3);
+        assert_eq!(report.summary.classified, 3);
+        assert_eq!(report.summary.parse_errors, 1);
+        assert_eq!(report.summary.by_schema.get("ecs"), Some(&1));
+        assert_eq!(report.summary.by_schema.get("sysmon"), Some(&1));
+        assert_eq!(report.summary.by_schema.get("generic_json"), Some(&1));
+    }
+
+    #[test]
+    fn evtx_path_is_rejected_with_guidance() {
+        let err = build_report(
+            &SchemaClassifier::builtin(),
+            Some("@security.evtx".to_string()),
+        )
+        .expect_err("should error");
+        assert!(err.contains(".evtx"));
+    }
+}

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -337,6 +337,21 @@ pub(crate) struct DaemonArgs {
     #[arg(long = "observe-fields-max-keys", default_value_t = config::defaults::OBSERVE_FIELDS_MAX_KEYS)]
     pub observe_fields_max_keys: usize,
 
+    /// Enable the opt-in schema observer.
+    ///
+    /// Off by default. When set, the engine task classifies every event by
+    /// schema (ECS, Sysmon, Windows Event Log, CEF, OCSF, ...) and surfaces
+    /// the per-schema breakdown and unknown rate via `GET /api/v1/schemas`
+    /// plus the `rsigma_events_by_schema_total` and
+    /// `rsigma_events_unknown_schema_total` metrics.
+    #[arg(long = "observe-schemas")]
+    pub observe_schemas: bool,
+
+    /// Path to a YAML file of user-defined schema signatures, merged over the
+    /// built-ins. Has no effect unless `--observe-schemas` is set.
+    #[arg(long = "schema-config", value_name = "PATH")]
+    pub schema_config: Option<PathBuf>,
+
     /// Enable the cross-rule Aho-Corasick pre-filter (daachorse-index).
     ///
     /// Off by default. When enabled, the engine builds a single
@@ -577,6 +592,8 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         bloom_max_bytes,
         observe_fields,
         observe_fields_max_keys,
+        observe_schemas,
+        schema_config,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
         enrichers,
@@ -702,6 +719,8 @@ pub(crate) fn cmd_daemon(mut args: DaemonArgs, matches: &ArgMatches) {
         bloom_max_bytes,
         observe_fields,
         observe_fields_max_keys,
+        observe_schemas,
+        schema_config,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
         enrichers,
@@ -1118,6 +1137,8 @@ fn run_daemon(
     bloom_max_bytes: Option<usize>,
     observe_fields: bool,
     observe_fields_max_keys: usize,
+    observe_schemas: bool,
+    schema_config: Option<PathBuf>,
     #[cfg(feature = "daachorse-index")] cross_rule_ac: bool,
     enrichers_path: Option<PathBuf>,
     webhook_paths: Vec<PathBuf>,
@@ -1265,6 +1286,8 @@ fn run_daemon(
         bloom_max_bytes,
         observe_fields,
         observe_fields_max_keys,
+        observe_schemas,
+        schema_config,
         #[cfg(feature = "daachorse-index")]
         cross_rule_ac,
         enrichers_path,

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod backtest;
+mod classify;
 mod convert;
 mod coverage;
 #[cfg(feature = "daemon")]
@@ -29,6 +30,7 @@ mod validate;
 mod visibility;
 
 pub(crate) use backtest::{BacktestArgs, apply_backtest_config, cmd_backtest};
+pub(crate) use classify::{ClassifyArgs, cmd_classify};
 pub(crate) use convert::{
     ConvertArgs, ListFormatsArgs, cmd_convert, cmd_list_formats, cmd_list_targets,
 };

--- a/crates/rsigma-cli/src/daemon/metrics.rs
+++ b/crates/rsigma-cli/src/daemon/metrics.rs
@@ -56,6 +56,8 @@ pub struct Metrics {
     pub fields_observed_total: IntCounter,
     pub fields_observer_unique_keys: IntGauge,
     pub fields_observer_overflow_dropped_total: IntCounter,
+    pub events_by_schema: IntCounterVec,
+    pub events_unknown_schema: IntCounter,
     pub tap_sessions_total: IntCounter,
     pub tap_active_sessions: IntGauge,
     pub tap_events_streamed_total: IntCounter,
@@ -500,6 +502,26 @@ impl Metrics {
             .register(Box::new(fields_observer_overflow_dropped_total.clone()))
             .unwrap();
 
+        let events_by_schema = IntCounterVec::new(
+            Opts::new(
+                "rsigma_events_by_schema_total",
+                "Events classified per schema by the opt-in schema observer (--observe-schemas)",
+            ),
+            &["schema"],
+        )
+        .unwrap();
+        let events_unknown_schema = IntCounter::with_opts(Opts::new(
+            "rsigma_events_unknown_schema_total",
+            "Events that matched no schema signature (--observe-schemas)",
+        ))
+        .unwrap();
+        registry
+            .register(Box::new(events_by_schema.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(events_unknown_schema.clone()))
+            .unwrap();
+
         let tap_sessions_total = IntCounter::with_opts(Opts::new(
             "rsigma_tap_sessions_total",
             "Total live event-tap sessions opened (GET /api/v1/tap)",
@@ -601,6 +623,8 @@ impl Metrics {
             fields_observed_total,
             fields_observer_unique_keys,
             fields_observer_overflow_dropped_total,
+            events_by_schema,
+            events_unknown_schema,
             tap_sessions_total,
             tap_active_sessions,
             tap_events_streamed_total,
@@ -637,6 +661,28 @@ impl Metrics {
         if overflow_now > overflow_prev {
             self.fields_observer_overflow_dropped_total
                 .inc_by(overflow_now - overflow_prev);
+        }
+    }
+
+    /// Refresh the schema-observer Prometheus counters from a snapshot.
+    /// Counters must be monotonic; the schema observer is not API-resettable,
+    /// so the per-schema counts and the lifetime unknown total are monotonic
+    /// sources bridged via `inc_by(delta)`.
+    pub fn update_schema_observer_metrics(&self, snapshot: &rsigma_runtime::SchemaObservation) {
+        for entry in &snapshot.by_schema {
+            let counter = self
+                .events_by_schema
+                .with_label_values(&[entry.schema.as_str()]);
+            let prev = counter.get();
+            if entry.count > prev {
+                counter.inc_by(entry.count - prev);
+            }
+        }
+        let unknown_now = snapshot.lifetime_unknown;
+        let unknown_prev = self.events_unknown_schema.get();
+        if unknown_now > unknown_prev {
+            self.events_unknown_schema
+                .inc_by(unknown_now - unknown_prev);
         }
     }
 

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -13,8 +13,9 @@ use axum::{Json, Router};
 use rsigma_eval::{CorrelationConfig, MatchDetailLevel, Pipeline, ProcessResult};
 use rsigma_runtime::{
     AckToken, DeliveryConfig, DeliveryFailure, Dispatcher, EnrichmentPipeline, FieldObserver,
-    FileSink, InputFormat, LogProcessor, MetricsHook, OnFull, RawEvent, RuntimeEngine, Sink,
-    StdinSource, StdoutSink, spawn_source,
+    FileSink, InputFormat, LogProcessor, MetricsHook, OnFull, RawEvent, RuntimeEngine,
+    SchemaClassifier, SchemaObserver, Sink, StdinSource, StdoutSink, load_schema_signatures,
+    spawn_source,
 };
 use serde::Serialize;
 use tokio::sync::mpsc;
@@ -99,6 +100,10 @@ struct AppState {
     /// `--observe-fields`; the engine task records observed field keys
     /// and the `/api/v1/fields/*` handlers (Phase 4) consume snapshots.
     field_observer: Option<Arc<FieldObserver>>,
+    /// Opt-in schema observer. `Some` when the daemon was started with
+    /// `--observe-schemas`; the engine task classifies each event and the
+    /// `GET /api/v1/schemas` handler serves snapshots.
+    schema_observer: Option<Arc<SchemaObserver>>,
     /// Live event-tap state. `Some` when the tap is enabled; the
     /// `GET /api/v1/tap` handler registers capture sessions on it.
     tap: Option<super::tap::TapState>,
@@ -156,6 +161,14 @@ pub struct DaemonConfig {
     /// `rsigma_fields_observer_overflow_dropped_total`); existing keys
     /// keep incrementing.
     pub observe_fields_max_keys: usize,
+    /// Enable the opt-in schema observer that classifies every event so the
+    /// `GET /api/v1/schemas` endpoint and the
+    /// `rsigma_events_by_schema_total` / `rsigma_events_unknown_schema_total`
+    /// counters can surface the schema mix and unknown rate. Off by default.
+    pub observe_schemas: bool,
+    /// Optional path to a YAML file of user-defined schema signatures, merged
+    /// over the built-ins when the schema observer is enabled.
+    pub schema_config: Option<PathBuf>,
     /// Enable the cross-rule Aho-Corasick pre-filter. Off by default;
     /// benefit is workload-dependent (large rule sets with shared
     /// substring patterns). Available behind the `daachorse-index`
@@ -478,6 +491,25 @@ pub async fn run_daemon(config: DaemonConfig) {
         None
     };
 
+    let schema_observer = if config.observe_schemas {
+        let classifier = match &config.schema_config {
+            Some(path) => match load_schema_signatures(path) {
+                Ok(sigs) => SchemaClassifier::with_user_signatures(sigs),
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to load schema signatures; using built-ins only");
+                    SchemaClassifier::builtin()
+                }
+            },
+            None => SchemaClassifier::builtin(),
+        };
+        let observer = Arc::new(SchemaObserver::new(classifier));
+        processor.set_schema_observer(Some(observer.clone()));
+        tracing::info!("Schema observer enabled (GET /api/v1/schemas)");
+        Some(observer)
+    } else {
+        None
+    };
+
     let tap = if config.tap.enabled {
         let registry = rsigma_runtime::TapRegistry::new(
             config.tap.buffer_events,
@@ -528,6 +560,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         otlp_event_tx,
         source_registry: Arc::new(config.source_registry.clone()),
         field_observer: field_observer.clone(),
+        schema_observer: schema_observer.clone(),
         tap: tap.clone(),
         tail: tail.clone(),
     };
@@ -554,6 +587,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         .route("/api/v1/fields/unknown", get(fields_unknown))
         .route("/api/v1/fields/missing", get(fields_missing))
         .route("/api/v1/fields/observer", delete(fields_observer_reset))
+        .route("/api/v1/schemas", get(schemas_full))
         .route("/api/v1/tap", get(tap_stream))
         .route("/api/v1/detections/stream", get(detections_stream));
 
@@ -1665,6 +1699,11 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
         state.metrics.update_field_observer_metrics(&snapshot);
     }
 
+    if let Some(observer) = state.schema_observer.as_ref() {
+        let snapshot = observer.snapshot();
+        state.metrics.update_schema_observer_metrics(&snapshot);
+    }
+
     (
         [(
             axum::http::header::CONTENT_TYPE,
@@ -1901,6 +1940,41 @@ fn observation_disabled_response() -> Response {
         })),
     )
         .into_response()
+}
+
+/// `GET /api/v1/schemas`: the live per-schema breakdown and unknown rate from
+/// the opt-in schema observer. Returns 503 when `--observe-schemas` is off.
+async fn schemas_full(State(state): State<AppState>) -> Response {
+    let Some(observer) = state.schema_observer.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "schema observation disabled",
+                "hint": "restart the daemon with --observe-schemas to enable /api/v1/schemas",
+            })),
+        )
+            .into_response();
+    };
+    let snapshot = observer.snapshot();
+    state.metrics.update_schema_observer_metrics(&snapshot);
+
+    let by_schema: Vec<serde_json::Value> = snapshot
+        .by_schema
+        .iter()
+        .map(|e| serde_json::json!({ "schema": e.schema, "count": e.count }))
+        .collect();
+
+    let body = serde_json::json!({
+        "summary": {
+            "events_observed": snapshot.events_observed,
+            "classified": snapshot.classified,
+            "unknown": snapshot.unknown,
+            "uptime_seconds": snapshot.uptime_seconds,
+        },
+        "by_schema": by_schema,
+    });
+
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 fn missing_field_payload(field: &str, origin: &rsigma_eval::FieldOrigin) -> serde_json::Value {

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -11,9 +11,9 @@ use std::process;
 
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use commands::{
-    BacktestArgs, ConditionArgs, ConvertArgs, CoverageArgs, EvalArgs, FieldsArgs, LintArgs,
-    LintCounts, ListFormatsArgs, MigrateSourcesArgs, ParseArgs, ScorecardArgs, StatusArgs,
-    StdinArgs, TailArgs, TapArgs, ValidateArgs, VisibilityArgs,
+    BacktestArgs, ClassifyArgs, ConditionArgs, ConvertArgs, CoverageArgs, EvalArgs, FieldsArgs,
+    LintArgs, LintCounts, ListFormatsArgs, MigrateSourcesArgs, ParseArgs, ScorecardArgs,
+    StatusArgs, StdinArgs, TailArgs, TapArgs, ValidateArgs, VisibilityArgs,
 };
 // `pipeline resolve` resolves dynamic sources, which needs the async runtime
 // (tokio) and the source resolver from rsigma-runtime. Both ship with the
@@ -202,6 +202,9 @@ enum Commands {
 enum EngineCommands {
     /// Evaluate events against Sigma rules
     Eval(EvalArgs),
+
+    /// Report which schema each event matches (content-based recognition)
+    Classify(ClassifyArgs),
 
     /// Query a running daemon's status (GET /api/v1/status)
     Status(StatusArgs),
@@ -443,6 +446,7 @@ fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches, ctx: output::Outpu
                 .expect("engine eval submatches present");
             run_eval(args, em, ctx);
         }
+        EngineCommands::Classify(args) => commands::cmd_classify(args, ctx),
         EngineCommands::Status(args) => commands::cmd_status(args, ctx),
         EngineCommands::Tap(args) => commands::cmd_tap(args, ctx),
         EngineCommands::Tail(args) => commands::cmd_tail(args, ctx),

--- a/crates/rsigma-cli/tests/cli_classify.rs
+++ b/crates/rsigma-cli/tests/cli_classify.rs
@@ -1,0 +1,104 @@
+//! Integration tests for the `engine classify` subcommand.
+
+mod common;
+
+use common::{rsigma, temp_file};
+use predicates::prelude::*;
+
+#[test]
+fn classifies_inline_ecs_event_as_json() {
+    rsigma()
+        .args([
+            "engine",
+            "classify",
+            "-e",
+            r#"{"ecs.version":"8.11.0","process":{"command_line":"whoami"}}"#,
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"schema\": \"ecs\""))
+        .stdout(predicate::str::contains("\"specificity\": 100"));
+}
+
+#[test]
+fn classifies_ndjson_stream_from_stdin() {
+    let stdin = concat!(
+        r#"{"Channel":"Microsoft-Windows-Sysmon/Operational","EventID":1}"#,
+        "\n",
+        r#"{"class_uid":1001,"metadata":{"version":"1.1.0"}}"#,
+        "\n",
+        r#"{"unrecognized":"blob"}"#,
+        "\n",
+        "{}",
+        "\n",
+    );
+    rsigma()
+        .args(["engine", "classify", "--output-format", "ndjson"])
+        .write_stdin(stdin)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"schema\":\"sysmon\""))
+        .stdout(predicate::str::contains("\"schema\":\"ocsf\""))
+        .stdout(predicate::str::contains("\"schema\":\"generic_json\""))
+        // The empty object matches no signature: reported as null (unknown).
+        .stdout(predicate::str::contains("\"schema\":null"));
+}
+
+#[test]
+fn unknown_count_surfaces_in_summary() {
+    rsigma()
+        .args([
+            "engine",
+            "classify",
+            "-e",
+            "{}",
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"unknown\": 1"))
+        .stdout(predicate::str::contains("\"classified\": 0"));
+}
+
+#[test]
+fn user_signature_overrides_via_schema_config() {
+    let config = temp_file(
+        ".yml",
+        r#"
+schemas:
+  - name: my_vendor
+    specificity: 120
+    match:
+      - field_present: vendor.product
+      - equals:
+          field: event_type
+          value: alert
+"#,
+    );
+    rsigma()
+        .args([
+            "engine",
+            "classify",
+            "-e",
+            r#"{"vendor":{"product":"X"},"event_type":"ALERT"}"#,
+            "--schema-config",
+            config.path().to_str().unwrap(),
+            "--output-format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"schema\": \"my_vendor\""));
+}
+
+#[test]
+fn invalid_inline_json_exits_nonzero() {
+    rsigma()
+        .args(["engine", "classify", "-e", "not json"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid JSON event"));
+}

--- a/crates/rsigma-cli/tests/cli_classify.rs
+++ b/crates/rsigma-cli/tests/cli_classify.rs
@@ -49,14 +49,7 @@ fn classifies_ndjson_stream_from_stdin() {
 #[test]
 fn unknown_count_surfaces_in_summary() {
     rsigma()
-        .args([
-            "engine",
-            "classify",
-            "-e",
-            "{}",
-            "--output-format",
-            "json",
-        ])
+        .args(["engine", "classify", "-e", "{}", "--output-format", "json"])
         .assert()
         .success()
         .stdout(predicate::str::contains("\"unknown\": 1"))

--- a/crates/rsigma-cli/tests/cli_daemon_schemas.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_schemas.rs
@@ -1,0 +1,94 @@
+//! E2E tests for the daemon's schema-observability surface.
+//!
+//! Spawns `rsigma engine daemon --observe-schemas ...`, posts events through
+//! `/api/v1/events`, and asserts what `/api/v1/schemas` and `/metrics` report.
+
+#![cfg(feature = "daemon")]
+
+mod common;
+
+use common::{DaemonProcess, http_get, http_post, poll_until, temp_file};
+use serde_json::Value;
+use std::time::Duration;
+
+const RULE: &str = r#"
+title: Whoami Detector
+id: 00000000-0000-0000-0000-000000000056
+status: test
+logsource:
+    category: test
+    product: test
+detection:
+    selection:
+        CommandLine|contains: "whoami"
+    condition: selection
+level: high
+"#;
+
+fn wait_for_events_observed(daemon: &DaemonProcess, expected: u64) -> Value {
+    poll_until(Duration::from_secs(5), || {
+        let (status, body) = http_get(&daemon.url("/api/v1/schemas"));
+        if status != 200 {
+            return None;
+        }
+        let v: Value = serde_json::from_str(&body).ok()?;
+        let observed = v["summary"]["events_observed"].as_u64()?;
+        if observed >= expected { Some(v) } else { None }
+    })
+    .expect("events not observed within 5s")
+}
+
+#[test]
+fn schemas_endpoint_returns_503_when_observer_disabled() {
+    let rule = temp_file(".yml", RULE);
+    let daemon = DaemonProcess::spawn_http(rule.path().to_str().unwrap());
+
+    let (status, body) = http_get(&daemon.url("/api/v1/schemas"));
+    assert_eq!(status, 503);
+    let v: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["error"], "schema observation disabled");
+}
+
+#[test]
+fn schemas_endpoint_reports_per_schema_and_unknown_counts() {
+    let rule = temp_file(".yml", RULE);
+    let daemon =
+        DaemonProcess::spawn_http_with_args(rule.path().to_str().unwrap(), &["--observe-schemas"]);
+
+    // One ECS event, one flat Sysmon event, one unrecognized-but-structured
+    // (generic_json), and one field-less object (unknown).
+    let payload = concat!(
+        r#"{"ecs.version":"8.11.0","CommandLine":"whoami"}"#,
+        "\n",
+        r#"{"EventID":1,"ProcessGuid":"{x}","CommandLine":"whoami"}"#,
+        "\n",
+        r#"{"vendor_blob":"x"}"#,
+        "\n",
+        "{}",
+    );
+    let (status, _body) = http_post(&daemon.url("/api/v1/events"), payload);
+    assert_eq!(status, 200);
+
+    let report = wait_for_events_observed(&daemon, 4);
+    assert_eq!(report["summary"]["classified"].as_u64().unwrap(), 3);
+    assert_eq!(report["summary"]["unknown"].as_u64().unwrap(), 1);
+
+    let by_schema = report["by_schema"].as_array().unwrap();
+    let count_for = |name: &str| -> u64 {
+        by_schema
+            .iter()
+            .find(|e| e["schema"] == name)
+            .and_then(|e| e["count"].as_u64())
+            .unwrap_or(0)
+    };
+    assert_eq!(count_for("ecs"), 1);
+    assert_eq!(count_for("sysmon"), 1);
+    assert_eq!(count_for("generic_json"), 1);
+
+    // Metrics surface the same signal.
+    let (status, metrics) = http_get(&daemon.url("/metrics"));
+    assert_eq!(status, 200);
+    assert!(metrics.contains("rsigma_events_by_schema_total"));
+    assert!(metrics.contains(r#"schema="ecs""#));
+    assert!(metrics.contains("rsigma_events_unknown_schema_total 1"));
+}

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -135,7 +135,8 @@ pub use result::{
     ProcessResultExt, ResultBody, RuleHeader,
 };
 pub use schema::{
-    FieldValueConfig, SchemaClassifier, SchemaError, SchemaMatch, SchemaPredicate,
-    SchemaPredicateConfig, SchemaSignature, SchemaSignatureConfig, SchemaSignaturesFile,
-    builtin_schema_names, load_schema_signatures, parse_schema_signatures,
+    FieldValueConfig, SchemaClassifier, SchemaCountEntry, SchemaError, SchemaMatch,
+    SchemaObservation, SchemaObserver, SchemaPredicate, SchemaPredicateConfig, SchemaSignature,
+    SchemaSignatureConfig, SchemaSignaturesFile, builtin_schema_names, load_schema_signatures,
+    parse_schema_signatures,
 };

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -102,6 +102,7 @@ pub mod matcher;
 pub mod pipeline;
 pub mod result;
 pub mod rule_index;
+pub mod schema;
 
 // Re-export the most commonly used types and functions at crate root
 pub use compiler::{
@@ -132,4 +133,9 @@ pub use pipeline::{
 pub use result::{
     CorrelationBody, DetectionBody, EvaluationResult, FieldMatch, MatchDetailLevel, MatcherKind,
     ProcessResultExt, ResultBody, RuleHeader,
+};
+pub use schema::{
+    FieldValueConfig, SchemaClassifier, SchemaError, SchemaMatch, SchemaPredicate,
+    SchemaPredicateConfig, SchemaSignature, SchemaSignatureConfig, SchemaSignaturesFile,
+    builtin_schema_names, load_schema_signatures, parse_schema_signatures,
 };

--- a/crates/rsigma-eval/src/schema.rs
+++ b/crates/rsigma-eval/src/schema.rs
@@ -23,8 +23,12 @@
 //! right field-mapping pipeline. It does not collect, transport, or normalize
 //! events.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use regex::Regex;
 use serde::Deserialize;
@@ -428,6 +432,147 @@ pub fn load_schema_signatures(path: &Path) -> Result<Vec<SchemaSignature>, Schem
     parse_schema_signatures(&content)
 }
 
+// =============================================================================
+// SchemaObserver: opt-in per-schema counting for reporting
+// =============================================================================
+
+/// One per-schema counter as exposed via [`SchemaObserver::snapshot`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaCountEntry {
+    /// Recognized schema name.
+    pub schema: String,
+    /// Number of events classified as this schema since the last reset.
+    pub count: u64,
+}
+
+/// Immutable snapshot of a [`SchemaObserver`] at one moment.
+#[derive(Debug, Clone, Default)]
+pub struct SchemaObservation {
+    /// Per-schema counts, sorted by descending count then ascending name.
+    pub by_schema: Vec<SchemaCountEntry>,
+    /// Events classified into a known schema since the last reset.
+    pub classified: u64,
+    /// Events that matched no signature since the last reset.
+    pub unknown: u64,
+    /// Total events observed since the last reset (`classified + unknown`).
+    pub events_observed: u64,
+    /// Lifetime total of classified events, ignoring resets. Monotonic, so it
+    /// can drive Prometheus counters across observer resets.
+    pub lifetime_classified: u64,
+    /// Lifetime total of unknown events, ignoring resets. Monotonic.
+    pub lifetime_unknown: u64,
+    /// Seconds since the observer was created (or last reset).
+    pub uptime_seconds: f64,
+}
+
+/// Opt-in counter that classifies each observed event and tallies per-schema
+/// (and unknown) totals. Mirrors the design of [`FieldObserver`](crate::FieldObserver):
+/// shared behind an `Arc`, cheap repeated snapshots, monotonic lifetime
+/// counters for a Prometheus bridge. The schema set is small and bounded, so
+/// there is no key cap.
+pub struct SchemaObserver {
+    classifier: SchemaClassifier,
+    counts: Mutex<HashMap<String, u64>>,
+    unknown: AtomicU64,
+    events_observed: AtomicU64,
+    lifetime_classified: AtomicU64,
+    lifetime_unknown: AtomicU64,
+    start: Mutex<Instant>,
+}
+
+impl SchemaObserver {
+    /// Create an observer backed by the given classifier.
+    pub fn new(classifier: SchemaClassifier) -> Self {
+        Self {
+            classifier,
+            counts: Mutex::new(HashMap::new()),
+            unknown: AtomicU64::new(0),
+            events_observed: AtomicU64::new(0),
+            lifetime_classified: AtomicU64::new(0),
+            lifetime_unknown: AtomicU64::new(0),
+            start: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Create an observer using the built-in classifier.
+    pub fn builtin() -> Self {
+        Self::new(SchemaClassifier::builtin())
+    }
+
+    /// Classify an event and update the counters. Takes `&self` so the
+    /// observer can be shared behind an `Arc`.
+    pub fn observe<E: Event + ?Sized>(&self, event: &E) {
+        self.events_observed.fetch_add(1, Ordering::Relaxed);
+        match self.classifier.classify(event) {
+            Some(m) => {
+                self.lifetime_classified.fetch_add(1, Ordering::Relaxed);
+                let mut counts = self.counts.lock().expect("schema observer mutex poisoned");
+                *counts.entry(m.name).or_insert(0) += 1;
+            }
+            None => {
+                self.unknown.fetch_add(1, Ordering::Relaxed);
+                self.lifetime_unknown.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Snapshot the current counts, sorted by descending count then name.
+    pub fn snapshot(&self) -> SchemaObservation {
+        let counts = self.counts.lock().expect("schema observer mutex poisoned");
+        let mut by_schema: Vec<SchemaCountEntry> = counts
+            .iter()
+            .map(|(schema, count)| SchemaCountEntry {
+                schema: schema.clone(),
+                count: *count,
+            })
+            .collect();
+        let classified: u64 = counts.values().sum();
+        drop(counts);
+        by_schema.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.schema.cmp(&b.schema)));
+        let unknown = self.unknown.load(Ordering::Relaxed);
+        SchemaObservation {
+            by_schema,
+            classified,
+            unknown,
+            events_observed: self.events_observed.load(Ordering::Relaxed),
+            lifetime_classified: self.lifetime_classified.load(Ordering::Relaxed),
+            lifetime_unknown: self.lifetime_unknown.load(Ordering::Relaxed),
+            uptime_seconds: self
+                .start
+                .lock()
+                .expect("schema observer start mutex poisoned")
+                .elapsed()
+                .as_secs_f64(),
+        }
+    }
+
+    /// Reset the since-last-reset counters (lifetime totals are preserved).
+    /// Returns the previous `(classified, unknown)` pair.
+    pub fn reset(&self) -> (u64, u64) {
+        let mut counts = self.counts.lock().expect("schema observer mutex poisoned");
+        let previous_classified: u64 = counts.values().sum();
+        counts.clear();
+        drop(counts);
+        let previous_unknown = self.unknown.swap(0, Ordering::Relaxed);
+        self.events_observed.store(0, Ordering::Relaxed);
+        *self
+            .start
+            .lock()
+            .expect("schema observer start mutex poisoned") = Instant::now();
+        (previous_classified, previous_unknown)
+    }
+
+    /// Lifetime classified total, ignoring resets. Monotonic.
+    pub fn lifetime_classified(&self) -> u64 {
+        self.lifetime_classified.load(Ordering::Relaxed)
+    }
+
+    /// Lifetime unknown total, ignoring resets. Monotonic.
+    pub fn lifetime_unknown(&self) -> u64 {
+        self.lifetime_unknown.load(Ordering::Relaxed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -589,5 +734,44 @@ schemas:
                 .as_deref(),
             Some("cef_raw")
         );
+    }
+
+    #[test]
+    fn observer_counts_per_schema_and_unknown() {
+        let observer = SchemaObserver::builtin();
+        observer.observe(&JsonEvent::borrow(&json!({"ecs.version": "8.0.0"})));
+        observer.observe(&JsonEvent::borrow(&json!({"ecs.version": "8.1.0"})));
+        observer.observe(&JsonEvent::borrow(
+            &json!({"class_uid": 1001, "metadata": {"version": "1.1.0"}}),
+        ));
+        observer.observe(&JsonEvent::borrow(&json!({})));
+
+        let snap = observer.snapshot();
+        assert_eq!(snap.events_observed, 4);
+        assert_eq!(snap.classified, 3);
+        assert_eq!(snap.unknown, 1);
+        // Sorted by descending count, so ecs (2) comes first.
+        assert_eq!(snap.by_schema[0].schema, "ecs");
+        assert_eq!(snap.by_schema[0].count, 2);
+        let ocsf = snap.by_schema.iter().find(|e| e.schema == "ocsf").unwrap();
+        assert_eq!(ocsf.count, 1);
+    }
+
+    #[test]
+    fn observer_reset_preserves_lifetime_counters() {
+        let observer = SchemaObserver::builtin();
+        observer.observe(&JsonEvent::borrow(&json!({"ecs.version": "8.0.0"})));
+        observer.observe(&JsonEvent::borrow(&json!({})));
+        let (classified, unknown) = observer.reset();
+        assert_eq!(classified, 1);
+        assert_eq!(unknown, 1);
+
+        let snap = observer.snapshot();
+        assert_eq!(snap.classified, 0);
+        assert_eq!(snap.unknown, 0);
+        assert_eq!(snap.events_observed, 0);
+        // Lifetime totals survive the reset for the Prometheus bridge.
+        assert_eq!(snap.lifetime_classified, 1);
+        assert_eq!(snap.lifetime_unknown, 1);
     }
 }

--- a/crates/rsigma-eval/src/schema.rs
+++ b/crates/rsigma-eval/src/schema.rs
@@ -1,0 +1,593 @@
+//! Schema classification: recognize the structure of a parsed event.
+//!
+//! Real-world streams mix log schemas: one feed can carry ECS-normalized
+//! events, raw (rendered) Windows Event Log, flat Sysmon JSON, CEF, OCSF, or
+//! vendor-specific shapes, and the wire format is often still JSON while only
+//! the field names differ. This module recognizes which schema a parsed event
+//! belongs to from its *content* (marker fields and values), not from the
+//! input format, so it works regardless of how the event arrived.
+//!
+//! Classification is declarative: each [`SchemaSignature`] is a set of
+//! [`SchemaPredicate`]s that must all hold (logical AND). The
+//! [`SchemaClassifier`] returns the highest-[`specificity`](SchemaSignature::specificity)
+//! signature that matches, breaking ties by name for determinism. Returning
+//! `None` means the event matched no signature ("unknown"), which is the
+//! actionable signal for surfacing unsupported schemas.
+//!
+//! Built-in signatures cover `ecs`, `ocsf`, `windows_eventlog`, `sysmon`,
+//! `cef`, and a low-specificity `generic_json` fallback for structured events
+//! that match no specific security schema. Users extend the set with their own
+//! signatures loaded from YAML (see [`parse_schema_signatures`]).
+//!
+//! Detection-side only: this recognizes events so callers can route them to the
+//! right field-mapping pipeline. It does not collect, transport, or normalize
+//! events.
+
+use std::fs;
+use std::path::Path;
+
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::event::Event;
+
+/// A single condition over a parsed event used to recognize a schema.
+///
+/// Field names use the same dot-notation as [`Event::get_field`], so nested
+/// shapes like `Event.System.EventID` or `ecs.version` work whether the event
+/// is nested or carries flattened dotted keys.
+#[derive(Debug, Clone)]
+pub enum SchemaPredicate {
+    /// The named field is present (any non-absent value, including null).
+    FieldPresent(String),
+    /// The named field is absent.
+    FieldAbsent(String),
+    /// At least one of the named fields is present.
+    AnyOf(Vec<String>),
+    /// The field is present and its string-coerced value equals `value`
+    /// (ASCII case-insensitive).
+    Equals { field: String, value: String },
+    /// The field is present and its string-coerced value matches `regex`.
+    Matches { field: String, regex: Regex },
+    /// The event has at least one structured field. Used by the
+    /// `generic_json` fallback to distinguish structured events from
+    /// field-less ones (raw text, empty objects), which stay "unknown".
+    HasAnyField,
+}
+
+impl SchemaPredicate {
+    fn eval<E: Event + ?Sized>(&self, event: &E) -> bool {
+        match self {
+            SchemaPredicate::FieldPresent(f) => event.get_field(f).is_some(),
+            SchemaPredicate::FieldAbsent(f) => event.get_field(f).is_none(),
+            SchemaPredicate::AnyOf(fields) => fields.iter().any(|f| event.get_field(f).is_some()),
+            SchemaPredicate::Equals { field, value } => event
+                .get_field(field)
+                .and_then(|v| v.as_str().map(|s| s.as_ref().eq_ignore_ascii_case(value)))
+                .unwrap_or(false),
+            SchemaPredicate::Matches { field, regex } => event
+                .get_field(field)
+                .and_then(|v| v.as_str().map(|s| regex.is_match(s.as_ref())))
+                .unwrap_or(false),
+            SchemaPredicate::HasAnyField => !event.field_keys().is_empty(),
+        }
+    }
+}
+
+/// A named schema recognizer: every predicate must hold for the signature to
+/// match. Higher `specificity` wins when several signatures match the same
+/// event. Multiple signatures may share a `name` (for example several distinct
+/// ways to recognize Sysmon); the classifier reports the name.
+#[derive(Debug, Clone)]
+pub struct SchemaSignature {
+    /// Schema label reported on a match (for example `ecs`, `sysmon`).
+    pub name: String,
+    /// Conditions that must all hold (logical AND). An empty predicate set
+    /// matches every event; prefer [`SchemaPredicate::HasAnyField`] for a
+    /// structured-event fallback.
+    pub predicates: Vec<SchemaPredicate>,
+    /// Tie-breaking weight; the highest-specificity matching signature wins.
+    pub specificity: u32,
+}
+
+impl SchemaSignature {
+    fn matches<E: Event + ?Sized>(&self, event: &E) -> bool {
+        self.predicates.iter().all(|p| p.eval(event))
+    }
+}
+
+/// The result of classifying an event: the matched schema name and the
+/// specificity of the signature that matched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaMatch {
+    pub name: String,
+    pub specificity: u32,
+}
+
+/// Recognizes the schema of parsed events from a set of signatures.
+///
+/// Signatures are sorted once at construction (specificity descending, then
+/// name ascending) so [`classify`](Self::classify) returns the best match with
+/// a single in-order scan.
+#[derive(Debug, Clone)]
+pub struct SchemaClassifier {
+    signatures: Vec<SchemaSignature>,
+}
+
+impl SchemaClassifier {
+    /// Build a classifier from an explicit signature set.
+    pub fn new(mut signatures: Vec<SchemaSignature>) -> Self {
+        signatures.sort_by(|a, b| {
+            b.specificity
+                .cmp(&a.specificity)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        Self { signatures }
+    }
+
+    /// Build a classifier from the built-in signatures only.
+    pub fn builtin() -> Self {
+        Self::new(builtin_signatures())
+    }
+
+    /// Build a classifier from the built-ins plus user-supplied signatures.
+    /// User signatures are added to (not replacing) the built-ins; a user
+    /// signature with a higher specificity than a built-in wins on overlap.
+    pub fn with_user_signatures(user: Vec<SchemaSignature>) -> Self {
+        let mut signatures = builtin_signatures();
+        signatures.extend(user);
+        Self::new(signatures)
+    }
+
+    /// Classify an event. Returns the highest-specificity matching schema, or
+    /// `None` when the event matches no signature ("unknown").
+    pub fn classify<E: Event + ?Sized>(&self, event: &E) -> Option<SchemaMatch> {
+        self.signatures
+            .iter()
+            .find(|s| s.matches(event))
+            .map(|s| SchemaMatch {
+                name: s.name.clone(),
+                specificity: s.specificity,
+            })
+    }
+
+    /// All matching schema names for an event, most specific first. Useful for
+    /// tuning signatures (seeing what else an event could match). Deduplicated
+    /// by name while preserving order.
+    pub fn classify_all<E: Event + ?Sized>(&self, event: &E) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for sig in self.signatures.iter().filter(|s| s.matches(event)) {
+            if !out.iter().any(|n| n == &sig.name) {
+                out.push(sig.name.clone());
+            }
+        }
+        out
+    }
+
+    /// Distinct schema names this classifier can produce, most specific first.
+    pub fn schema_names(&self) -> Vec<&str> {
+        let mut out: Vec<&str> = Vec::new();
+        for sig in &self.signatures {
+            if !out.contains(&sig.name.as_str()) {
+                out.push(sig.name.as_str());
+            }
+        }
+        out
+    }
+}
+
+impl Default for SchemaClassifier {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+/// The built-in schema signatures, derived from the public schema specs:
+/// Elastic Common Schema, OCSF, the Windows event XML model, Microsoft
+/// Sysmon, and the ArcSight CEF spec.
+fn builtin_signatures() -> Vec<SchemaSignature> {
+    vec![
+        // ECS (Elastic Common Schema): `ecs.version` is the canonical marker.
+        SchemaSignature {
+            name: "ecs".to_string(),
+            specificity: 100,
+            predicates: vec![SchemaPredicate::FieldPresent("ecs.version".to_string())],
+        },
+        // OCSF: class_uid plus metadata.version are mandatory discriminators.
+        SchemaSignature {
+            name: "ocsf".to_string(),
+            specificity: 95,
+            predicates: vec![
+                SchemaPredicate::FieldPresent("class_uid".to_string()),
+                SchemaPredicate::FieldPresent("metadata.version".to_string()),
+            ],
+        },
+        // Rendered Windows Event Log (EVTX decoded to JSON): Event.System.*.
+        SchemaSignature {
+            name: "windows_eventlog".to_string(),
+            specificity: 90,
+            predicates: vec![SchemaPredicate::AnyOf(vec![
+                "Event.System.EventID".to_string(),
+                "Event.System.Provider".to_string(),
+            ])],
+        },
+        // Sysmon (flat) via the operational channel marker.
+        SchemaSignature {
+            name: "sysmon".to_string(),
+            specificity: 88,
+            predicates: vec![SchemaPredicate::Equals {
+                field: "Channel".to_string(),
+                value: "Microsoft-Windows-Sysmon/Operational".to_string(),
+            }],
+        },
+        // Sysmon (flat) via the provider marker.
+        SchemaSignature {
+            name: "sysmon".to_string(),
+            specificity: 88,
+            predicates: vec![SchemaPredicate::Equals {
+                field: "Provider_Name".to_string(),
+                value: "Microsoft-Windows-Sysmon".to_string(),
+            }],
+        },
+        // Sysmon (flat) via field shape when no provider/channel tag is present.
+        SchemaSignature {
+            name: "sysmon".to_string(),
+            specificity: 80,
+            predicates: vec![
+                SchemaPredicate::FieldPresent("EventID".to_string()),
+                SchemaPredicate::FieldPresent("ProcessGuid".to_string()),
+                SchemaPredicate::AnyOf(vec!["Image".to_string(), "CommandLine".to_string()]),
+            ],
+        },
+        // CEF: structured header fields produced by the CEF parser or carried
+        // in JSON (deviceVendor / deviceProduct / signatureId).
+        SchemaSignature {
+            name: "cef".to_string(),
+            specificity: 85,
+            predicates: vec![
+                SchemaPredicate::FieldPresent("deviceVendor".to_string()),
+                SchemaPredicate::FieldPresent("deviceProduct".to_string()),
+                SchemaPredicate::FieldPresent("signatureId".to_string()),
+            ],
+        },
+        // Generic JSON: any structured event that matched no specific schema.
+        SchemaSignature {
+            name: "generic_json".to_string(),
+            specificity: 0,
+            predicates: vec![SchemaPredicate::HasAnyField],
+        },
+    ]
+}
+
+/// Distinct built-in schema names, most specific first.
+pub fn builtin_schema_names() -> Vec<&'static str> {
+    vec![
+        "ecs",
+        "ocsf",
+        "windows_eventlog",
+        "sysmon",
+        "cef",
+        "generic_json",
+    ]
+}
+
+// =============================================================================
+// User-supplied signatures (YAML config)
+// =============================================================================
+
+/// Errors raised while loading user schema signatures.
+#[derive(Debug, thiserror::Error)]
+pub enum SchemaError {
+    /// The signatures file could not be read.
+    #[error("cannot read schema signatures file '{path}': {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The signatures YAML failed to parse.
+    #[error("schema signatures YAML parse error: {0}")]
+    Parse(String),
+    /// A predicate carried an invalid regular expression.
+    #[error("invalid regex in schema '{name}': {error}")]
+    InvalidRegex { name: String, error: String },
+}
+
+/// A `{ field: ..., value: ... }` pair used by the `equals` and `matches`
+/// predicate forms.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FieldValueConfig {
+    pub field: String,
+    pub value: String,
+}
+
+/// A predicate as written in YAML: a single-key map, for example
+/// `field_present: ecs.version` or `equals: { field: type, value: alert }`.
+/// Exactly one form must be set per list entry.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SchemaPredicateConfig {
+    /// `field_present: <field>`
+    #[serde(default)]
+    pub field_present: Option<String>,
+    /// `field_absent: <field>`
+    #[serde(default)]
+    pub field_absent: Option<String>,
+    /// `any_of: [<field>, ...]`
+    #[serde(default)]
+    pub any_of: Option<Vec<String>>,
+    /// `equals: { field: <field>, value: <value> }`
+    #[serde(default)]
+    pub equals: Option<FieldValueConfig>,
+    /// `matches: { field: <field>, value: <regex> }`
+    #[serde(default)]
+    pub matches: Option<FieldValueConfig>,
+}
+
+impl SchemaPredicateConfig {
+    fn build(self, schema_name: &str) -> Result<SchemaPredicate, SchemaError> {
+        let mut chosen: Option<SchemaPredicate> = None;
+        let mut set = 0u32;
+        if let Some(f) = self.field_present {
+            set += 1;
+            chosen = Some(SchemaPredicate::FieldPresent(f));
+        }
+        if let Some(f) = self.field_absent {
+            set += 1;
+            chosen = Some(SchemaPredicate::FieldAbsent(f));
+        }
+        if let Some(fields) = self.any_of {
+            set += 1;
+            chosen = Some(SchemaPredicate::AnyOf(fields));
+        }
+        if let Some(fv) = self.equals {
+            set += 1;
+            chosen = Some(SchemaPredicate::Equals {
+                field: fv.field,
+                value: fv.value,
+            });
+        }
+        if let Some(fv) = self.matches {
+            set += 1;
+            chosen = Some(SchemaPredicate::Matches {
+                field: fv.field,
+                regex: Regex::new(&fv.value).map_err(|e| SchemaError::InvalidRegex {
+                    name: schema_name.to_string(),
+                    error: e.to_string(),
+                })?,
+            });
+        }
+        match (set, chosen) {
+            (1, Some(p)) => Ok(p),
+            (0, _) => Err(SchemaError::Parse(format!(
+                "schema '{schema_name}': a predicate has no condition (expected one of \
+                 field_present, field_absent, any_of, equals, matches)"
+            ))),
+            _ => Err(SchemaError::Parse(format!(
+                "schema '{schema_name}': a predicate sets multiple conditions; use one per list item"
+            ))),
+        }
+    }
+}
+
+/// A signature as written in YAML.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SchemaSignatureConfig {
+    /// Schema label reported on a match.
+    pub name: String,
+    /// Tie-breaking weight (default 50, above `generic_json` and below the
+    /// strong built-ins by default).
+    #[serde(default = "default_user_specificity")]
+    pub specificity: u32,
+    /// Conditions that must all hold.
+    #[serde(default, rename = "match")]
+    pub predicates: Vec<SchemaPredicateConfig>,
+}
+
+fn default_user_specificity() -> u32 {
+    50
+}
+
+/// Top-level YAML document holding a `schemas:` list.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SchemaSignaturesFile {
+    #[serde(default)]
+    pub schemas: Vec<SchemaSignatureConfig>,
+}
+
+impl SchemaSignatureConfig {
+    fn build(self) -> Result<SchemaSignature, SchemaError> {
+        let name = self.name;
+        let predicates = self
+            .predicates
+            .into_iter()
+            .map(|p| p.build(&name))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(SchemaSignature {
+            name,
+            predicates,
+            specificity: self.specificity,
+        })
+    }
+}
+
+/// Parse user schema signatures from a YAML string.
+pub fn parse_schema_signatures(yaml: &str) -> Result<Vec<SchemaSignature>, SchemaError> {
+    let file: SchemaSignaturesFile =
+        yaml_serde::from_str(yaml).map_err(|e| SchemaError::Parse(e.to_string()))?;
+    file.schemas.into_iter().map(|s| s.build()).collect()
+}
+
+/// Load user schema signatures from a YAML file path.
+pub fn load_schema_signatures(path: &Path) -> Result<Vec<SchemaSignature>, SchemaError> {
+    let content = fs::read_to_string(path).map_err(|e| SchemaError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    parse_schema_signatures(&content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::JsonEvent;
+    use serde_json::json;
+
+    fn classify(value: &serde_json::Value) -> Option<String> {
+        SchemaClassifier::builtin()
+            .classify(&JsonEvent::borrow(value))
+            .map(|m| m.name)
+    }
+
+    #[test]
+    fn recognizes_ecs_by_version_marker() {
+        let v = json!({"ecs": {"version": "8.11.0"}, "process": {"command_line": "whoami"}});
+        assert_eq!(classify(&v).as_deref(), Some("ecs"));
+    }
+
+    #[test]
+    fn recognizes_ecs_with_flattened_keys() {
+        let v = json!({"ecs.version": "8.11.0", "process.command_line": "whoami"});
+        assert_eq!(classify(&v).as_deref(), Some("ecs"));
+    }
+
+    #[test]
+    fn recognizes_ocsf_by_class_and_metadata() {
+        let v = json!({"class_uid": 1001, "category_uid": 1, "metadata": {"version": "1.1.0"}});
+        assert_eq!(classify(&v).as_deref(), Some("ocsf"));
+    }
+
+    #[test]
+    fn recognizes_rendered_windows_event_log() {
+        let v = json!({"Event": {"System": {"EventID": 4688, "Provider": "Microsoft-Windows-Security-Auditing"}}});
+        assert_eq!(classify(&v).as_deref(), Some("windows_eventlog"));
+    }
+
+    #[test]
+    fn recognizes_sysmon_by_channel() {
+        let v = json!({"Channel": "Microsoft-Windows-Sysmon/Operational", "EventID": 1, "Image": "C:/cmd.exe"});
+        assert_eq!(classify(&v).as_deref(), Some("sysmon"));
+    }
+
+    #[test]
+    fn recognizes_sysmon_by_provider() {
+        let v = json!({"Provider_Name": "Microsoft-Windows-Sysmon", "EventID": 3});
+        assert_eq!(classify(&v).as_deref(), Some("sysmon"));
+    }
+
+    #[test]
+    fn recognizes_flat_sysmon_by_field_shape() {
+        let v = json!({"EventID": 1, "ProcessGuid": "{abc}", "CommandLine": "cmd /c whoami"});
+        assert_eq!(classify(&v).as_deref(), Some("sysmon"));
+    }
+
+    #[test]
+    fn recognizes_cef_structured_fields() {
+        let v = json!({"deviceVendor": "Security", "deviceProduct": "IDS", "signatureId": "100", "src": "10.0.0.1"});
+        assert_eq!(classify(&v).as_deref(), Some("cef"));
+    }
+
+    #[test]
+    fn falls_back_to_generic_json_for_unrecognized_structured_events() {
+        let v = json!({"some_vendor_field": "x", "another": 1});
+        assert_eq!(classify(&v).as_deref(), Some("generic_json"));
+    }
+
+    #[test]
+    fn fieldless_events_are_unknown() {
+        // Empty object: no fields, no signature matches (not even generic_json).
+        assert_eq!(classify(&json!({})), None);
+        // JSON scalar/array carries no named fields either.
+        assert_eq!(classify(&json!("just a string")), None);
+    }
+
+    #[test]
+    fn specificity_prefers_specific_schema_over_generic() {
+        // Carries both an ECS marker and arbitrary extra fields; ECS wins.
+        let v = json!({"ecs.version": "8.0.0", "vendor_blob": {"x": 1}});
+        let cls = SchemaClassifier::builtin();
+        let m = cls.classify(&JsonEvent::borrow(&v)).unwrap();
+        assert_eq!(m.name, "ecs");
+        assert_eq!(m.specificity, 100);
+        // generic_json is still a candidate, just lower priority.
+        let all = cls.classify_all(&JsonEvent::borrow(&v));
+        assert_eq!(all.first().map(String::as_str), Some("ecs"));
+        assert!(all.iter().any(|n| n == "generic_json"));
+    }
+
+    #[test]
+    fn schema_names_lists_builtins_most_specific_first() {
+        let classifier = SchemaClassifier::builtin();
+        let names = classifier.schema_names();
+        assert_eq!(names.first(), Some(&"ecs"));
+        assert!(names.contains(&"generic_json"));
+        // generic_json is the lowest-specificity, so it sorts last.
+        assert_eq!(names.last(), Some(&"generic_json"));
+    }
+
+    #[test]
+    fn parses_user_signatures_from_yaml() {
+        let yaml = r#"
+schemas:
+  - name: my_vendor
+    specificity: 70
+    match:
+      - field_present: vendor.product
+      - equals:
+          field: event_type
+          value: alert
+      - any_of: [a, b]
+"#;
+        let sigs = parse_schema_signatures(yaml).expect("parse");
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].name, "my_vendor");
+        assert_eq!(sigs[0].specificity, 70);
+        assert_eq!(sigs[0].predicates.len(), 3);
+
+        let cls = SchemaClassifier::with_user_signatures(sigs);
+        let v = json!({"vendor": {"product": "X"}, "event_type": "ALERT", "a": 1});
+        assert_eq!(
+            cls.classify(&JsonEvent::borrow(&v))
+                .map(|m| m.name)
+                .as_deref(),
+            Some("my_vendor")
+        );
+    }
+
+    #[test]
+    fn user_signature_with_invalid_regex_is_rejected() {
+        let yaml = r#"
+schemas:
+  - name: bad
+    match:
+      - matches:
+          field: msg
+          value: "([unclosed"
+"#;
+        let err = parse_schema_signatures(yaml).unwrap_err();
+        assert!(matches!(err, SchemaError::InvalidRegex { .. }));
+    }
+
+    #[test]
+    fn user_regex_signature_matches_field_value() {
+        let yaml = r#"
+schemas:
+  - name: cef_raw
+    specificity: 60
+    match:
+      - matches:
+          field: message
+          value: "^CEF:\\d"
+"#;
+        let sigs = parse_schema_signatures(yaml).expect("parse");
+        let cls = SchemaClassifier::with_user_signatures(sigs);
+        let v = json!({"message": "CEF:0|Vendor|Product|1.0|100|Name|9|src=1.2.3.4"});
+        assert_eq!(
+            cls.classify(&JsonEvent::borrow(&v))
+                .map(|m| m.name)
+                .as_deref(),
+            Some("cef_raw")
+        );
+    }
+}

--- a/crates/rsigma-runtime/src/lib.rs
+++ b/crates/rsigma-runtime/src/lib.rs
@@ -88,7 +88,8 @@ pub use tap::{TapPayload, TapRegistry, TapSessionHandle, TapStage};
 
 pub use rsigma_eval::{
     FieldCoverage, FieldObservation, FieldObservationEntry, FieldObserver, ProcessResult,
-    ProcessResultExt,
+    ProcessResultExt, SchemaClassifier, SchemaCountEntry, SchemaError, SchemaObservation,
+    SchemaObserver, load_schema_signatures,
 };
 pub use sources::refresh::{RefreshResult, RefreshScheduler, RefreshTrigger};
 pub use sources::{

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -4,7 +4,9 @@ use parking_lot::Mutex;
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
-use rsigma_eval::{Event, FieldObserver, JsonEvent, ProcessResult, ProcessResultExt, RuleFieldSet};
+use rsigma_eval::{
+    Event, FieldObserver, JsonEvent, ProcessResult, ProcessResultExt, RuleFieldSet, SchemaObserver,
+};
 
 use crate::engine::RuntimeEngine;
 use crate::input::{EventInputDecoded, InputFormat, parse_line};
@@ -32,6 +34,11 @@ pub struct LogProcessor {
     /// recorded. When `None`, the batch path skips iteration entirely
     /// so the hot path stays untouched.
     field_observer: ArcSwap<Option<Arc<FieldObserver>>>,
+    /// Optional opt-in schema observer. When `Some`, every parsed event
+    /// flowing through `process_batch_with_format` is classified and tallied
+    /// per schema. When `None`, the batch path skips classification entirely
+    /// so the hot path stays untouched.
+    schema_observer: ArcSwap<Option<Arc<SchemaObserver>>>,
     /// Optional live event tap. When `Some`, `process_batch_with_format`
     /// offers raw lines and/or decoded events to any active capture
     /// sessions with a non-blocking `try_send`. When `None` (or when no
@@ -47,6 +54,7 @@ impl LogProcessor {
             engine: Arc::new(ArcSwap::from_pointee(Mutex::new(engine))),
             metrics,
             field_observer: ArcSwap::new(Arc::new(None)),
+            schema_observer: ArcSwap::new(Arc::new(None)),
             event_tap: ArcSwap::new(Arc::new(None)),
         }
     }
@@ -65,6 +73,22 @@ impl LogProcessor {
     /// Return the currently-attached field observer, if any.
     pub fn field_observer(&self) -> Option<Arc<FieldObserver>> {
         self.field_observer.load_full().as_ref().clone()
+    }
+
+    /// Attach (or detach) the opt-in schema observer.
+    ///
+    /// When set, [`process_batch_with_format`](Self::process_batch_with_format)
+    /// classifies each parsed event before evaluation. Pass `None` to disable
+    /// classification; the hot path then performs zero extra work. Safe to
+    /// call at runtime: the swap is wait-free, and in-flight batches finish
+    /// against whichever observer they read.
+    pub fn set_schema_observer(&self, observer: Option<Arc<SchemaObserver>>) {
+        self.schema_observer.store(Arc::new(observer));
+    }
+
+    /// Return the currently-attached schema observer, if any.
+    pub fn schema_observer(&self) -> Option<Arc<SchemaObserver>> {
+        self.schema_observer.load_full().as_ref().clone()
     }
 
     /// Attach (or detach) the live event tap.
@@ -286,6 +310,16 @@ impl LogProcessor {
             }
         }
         drop(observer_guard);
+
+        // Optional opt-in schema observation, with the same cheap-when-disabled
+        // discipline as the field observer above.
+        let schema_guard = self.schema_observer.load();
+        if let Some(observer) = schema_guard.as_ref() {
+            for (_, decoded) in &decoded_events {
+                observer.observe(decoded);
+            }
+        }
+        drop(schema_guard);
 
         // Decoded-stage tap: offer each decoded event (post-parse,
         // post-event-filter) to active decoded-stage sessions. The event is

--- a/docs/cli/engine/.pages
+++ b/docs/cli/engine/.pages
@@ -1,6 +1,7 @@
 title: engine
 nav:
   - eval: eval.md
+  - classify: classify.md
   - status: status.md
   - tap: tap.md
   - tail: tail.md

--- a/docs/cli/engine/classify.md
+++ b/docs/cli/engine/classify.md
@@ -1,0 +1,91 @@
+# `rsigma engine classify`
+
+Report which schema each event matches, recognized from the event's content.
+
+## Synopsis
+
+```text
+rsigma engine classify [OPTIONS]
+```
+
+## Description
+
+Reads events and prints, per event, the schema RSigma recognizes it as (or `unknown`), plus a per-schema summary. Recognition is content-based: it keys off marker fields and values, not the wire format, so it tells ECS, flat Sysmon, rendered Windows Event Log, CEF, and OCSF apart even when they all arrive as JSON.
+
+This is a diagnostic for understanding a mixed dataset and for tuning schema signatures before wiring them into a pipeline. It does not load rules or evaluate detections. For the live equivalent on a running daemon, see the `GET /api/v1/schemas` endpoint and the `--observe-schemas` flag on [`engine daemon`](daemon.md).
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-e, --event <EVENT>` | stdin | A single event as a JSON string, or `@path` to read NDJSON from a file. Without this flag, reads NDJSON from stdin. |
+| `--schema-config <PATH>` | unset | YAML file of user-defined schema signatures, merged over the built-ins. |
+
+The global [`--output-format`](../../reference/output.md) flag selects `json`, `ndjson`, `table`, `csv`, or `tsv`.
+
+## Built-in schemas
+
+| Schema | Recognized by |
+|--------|---------------|
+| `ecs` | `ecs.version` present |
+| `ocsf` | `class_uid` and `metadata.version` present |
+| `windows_eventlog` | `Event.System.EventID` or `Event.System.Provider` present (rendered EVTX) |
+| `sysmon` | the Sysmon channel/provider, or flat `EventID` + `ProcessGuid` + `Image`/`CommandLine` |
+| `cef` | `deviceVendor`, `deviceProduct`, and `signatureId` present |
+| `generic_json` | any structured event matching no specific schema |
+
+An event that matches no signature (for example a field-less object or non-JSON line) is reported as `unknown`, which is the signal for an unsupported schema.
+
+## User signatures
+
+`--schema-config` loads additional signatures. Each is a name, an optional `specificity` (higher wins on overlap; default 50), and a `match` list of conditions that must all hold:
+
+```yaml
+schemas:
+  - name: my_vendor
+    specificity: 70
+    match:
+      - field_present: vendor.product
+      - equals:
+          field: event_type
+          value: alert
+      - any_of: [user.name, user.id]
+      - matches:
+          field: message
+          value: "^CEF:\\d"
+      - field_absent: ecs.version
+```
+
+## Examples
+
+Classify a single event:
+
+```bash
+rsigma engine classify -e '{"ecs.version":"8.11.0","process":{"command_line":"whoami"}}'
+```
+
+Classify an NDJSON stream and see the per-schema table:
+
+```bash
+cat events.ndjson | rsigma engine classify --output-format table
+```
+
+Tune custom signatures against a sample:
+
+```bash
+rsigma engine classify -e @sample.ndjson --schema-config schemas.yml --output-format json
+```
+
+## Output
+
+The structured report carries a `summary` (`total_events`, `classified`, `unknown`, `parse_errors`, and `by_schema` counts) and an `events` array with the `index`, `schema`, and `specificity` of each event. In `table`, `csv`, and `tsv` formats the per-event rows go to stdout and the summary line to stderr.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `2` | Bad input (invalid inline JSON, unreadable file) |
+| `3` | Bad schema config |
+
+See [Exit Codes](../../reference/exit-codes.md) for the full scheme.

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -170,6 +170,8 @@ The auth methods are mutually exclusive. See [NATS Streaming](../../guide/nats-s
 |------|---------|-------------|
 | `--observe-fields` | off | Record the field keys of every event evaluated by the engine task so the `/api/v1/fields/*` endpoints can report which event fields no rule references (gap signal) and which rule fields have never appeared in an event (broken-coverage signal). Off by default; when off the engine task does not iterate event fields at all. |
 | `--observe-fields-max-keys <N>` | `10000` | Hard ceiling on distinct field names tracked. Existing keys keep counting after the cap is hit; new keys are dropped and surfaced via `rsigma_fields_observer_overflow_dropped_total`. No effect without `--observe-fields`. |
+| `--observe-schemas` | off | Classify every event by schema (ECS, Sysmon, Windows Event Log, CEF, OCSF, ...) and surface the per-schema breakdown and unknown rate via `GET /api/v1/schemas` and the `rsigma_events_by_schema_total` / `rsigma_events_unknown_schema_total` metrics. Off by default; when off the engine task does not classify events at all. |
+| `--schema-config <PATH>` | unset | YAML file of user-defined schema signatures, merged over the built-ins. No effect without `--observe-schemas`. See [`engine classify`](classify.md#user-signatures) for the signature format. |
 
 See [Observability: detection coverage](../../guide/observability.md#detection-coverage-with-observe-fields) for the operator workflow, and [HTTP API](../../reference/http-api.md#field-observability) for the endpoint payloads.
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -23,6 +23,7 @@ All bodies are JSON unless otherwise noted. All responses include a `Content-Typ
 | `/api/v1/fields/unknown` | GET | none | Fields seen in events that no rule references. Requires `--observe-fields`. |
 | `/api/v1/fields/missing` | GET | none | Fields referenced by rules that have never appeared in an event. Requires `--observe-fields`. |
 | `/api/v1/fields/observer` | DELETE | none | Reset the field observer's counters. Requires `--observe-fields`. |
+| `/api/v1/schemas` | GET | none | Per-schema event breakdown and unknown rate. Requires `--observe-schemas`. |
 | `/api/v1/tap` | GET | none | Stream a bounded, optionally-redacted window of the live event stream as chunked NDJSON. Disabled by default; enable with `daemon.tap.enabled: true`. |
 | `/api/v1/detections/stream` | GET | none | Stream live detections as chunked NDJSON, with optional `level` / `rule` filters. Disabled by default; enable with `daemon.tail.enabled: true`. |
 | `/v1/logs` | POST | none | OTLP/HTTP log ingestion (`application/x-protobuf` or `application/json`, optionally gzip-encoded). Requires `daemon-otlp`. |
@@ -348,6 +349,36 @@ curl -sS -X DELETE http://127.0.0.1:9090/api/v1/fields/observer
 ```
 
 A `DELETE` does not affect rule loading or any other daemon state. Use it after a rule reload to start a clean coverage window against the updated rule set.
+
+## Schema observability
+
+Available when the daemon is started with `--observe-schemas`. Every event is classified by schema (content-based recognition: ECS, Sysmon, rendered Windows Event Log, CEF, OCSF, a `generic_json` fallback, plus any `--schema-config` signatures), so a mixed stream's composition and its unknown rate are visible at a glance. See [`engine classify`](../cli/engine/classify.md) for the one-shot equivalent and the signature format.
+
+### `GET /api/v1/schemas`
+
+Returns the per-schema counts and the classified/unknown totals since daemon start. Returns `503` when `--observe-schemas` is off.
+
+```bash
+curl -sS http://127.0.0.1:9090/api/v1/schemas
+```
+
+```json
+{
+  "summary": {
+    "events_observed": 1248,
+    "classified": 1203,
+    "unknown": 45,
+    "uptime_seconds": 612.4
+  },
+  "by_schema": [
+    {"schema": "ecs", "count": 900},
+    {"schema": "sysmon", "count": 250},
+    {"schema": "generic_json", "count": 53}
+  ]
+}
+```
+
+The same signal is exposed as the `rsigma_events_by_schema_total{schema}` and `rsigma_events_unknown_schema_total` Prometheus counters. A rising unknown rate flags a source whose schema RSigma does not recognize; add a signature with `--schema-config`.
 
 ## Live event tap
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -103,6 +103,15 @@ Exposed unconditionally; values stay at zero unless the daemon was started with 
 | `rsigma_fields_observer_unique_keys` | gauge | — | Distinct field names currently tracked. Saturates at `--observe-fields-max-keys` (default `10000`). |
 | `rsigma_fields_observer_overflow_dropped_total` | counter | — | New-key insert attempts dropped because the observer was at capacity. A persistent positive rate signals that `--observe-fields-max-keys` is too low for the deployment. |
 
+## Schema observability (2 metrics)
+
+Exposed unconditionally; values stay at zero unless the daemon was started with `--observe-schemas`. Both refresh on every `/metrics` scrape and on every `GET /api/v1/schemas` call. See [HTTP API: Schema observability](http-api.md#schema-observability) for the matching endpoint.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `rsigma_events_by_schema_total` | counter | `schema` | Events classified into each recognized schema (`ecs`, `sysmon`, `windows_eventlog`, `cef`, `ocsf`, `generic_json`, or a user-defined name). |
+| `rsigma_events_unknown_schema_total` | counter | — | Events that matched no schema signature. A rising rate signals a source whose schema RSigma does not recognize; add a signature with `--schema-config`. |
+
 ## Live event tap (4 metrics)
 
 Exposed unconditionally; values stay at zero unless the tap is enabled (`daemon.tap.enabled: true`) and an operator opens a session. See [HTTP API: Live event tap](http-api.md#live-event-tap) and [`rsigma engine tap`](../cli/engine/tap.md).


### PR DESCRIPTION
## Summary

- Adds content-based schema classification: recognize which schema each event uses (ECS, OCSF, rendered Windows Event Log, Sysmon, CEF, user-defined, or a `generic_json` fallback) from its marker fields and values rather than its wire format, so a mixed JSON stream can be told apart.
- `engine classify`: a diagnostic that reads a single inline event, an NDJSON file, or stdin and reports the recognized schema (or `unknown`) per event plus a per-schema summary, rendered through the global output-format layer. `--schema-config` merges user-defined signatures over the built-ins. Works without the daemon feature.
- Daemon schema observability: `--observe-schemas` classifies every event and exposes the per-schema breakdown and unknown rate over `GET /api/v1/schemas`, plus the `rsigma_events_by_schema_total{schema}` and `rsigma_events_unknown_schema_total` Prometheus counters.
- Declarative signatures (field present/absent, any-of, equals, regex) live in `rsigma-eval` because they only need the `Event` trait, mirroring `FieldObserver`; the daemon wiring reuses the field-observer pattern with the same cheap-when-disabled discipline.

Implements the recognition and reporting requested in #212. Routing events to a per-schema pipeline is not included here.

## Test plan

- [x] `cargo test -p rsigma-eval schema::` (17 unit tests: signatures, classifier, observer)
- [x] `cargo test -p rsigma --test cli_classify` (5 integration tests)
- [x] `cargo test -p rsigma --test cli_daemon_schemas` (2 E2E tests: endpoint and metrics)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `mkdocs build --strict`
- [x] `rsigma engine classify -e '{"ecs.version":"8.0"}'` reports `ecs`
- [x] a daemon started with `--observe-schemas` serves `GET /api/v1/schemas` and exposes the two metrics