### PR TITLE
fix(fuzz): build cargo-fuzz on nightly and repair two fuzz targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -73,7 +73,11 @@ jobs:
           workspaces: fuzz -> target
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        # Build cargo-fuzz with the nightly toolchain explicitly. The repo's
+        # rust-toolchain.toml pins ambient `cargo` to the MSRV, which is too
+        # old to compile recent cargo-fuzz dependencies, so select nightly with
+        # `+nightly` to match the toolchain used for the fuzz run below.
+        run: cargo +nightly install cargo-fuzz --locked
 
       - name: Restore corpus cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Content-based schema classification that recognizes the structure of each event 
 * Daemon schema observability: `--observe-schemas` classifies every event and exposes the per-schema breakdown and unknown rate over `GET /api/v1/schemas` and the `rsigma_events_by_schema_total{schema}` and `rsigma_events_unknown_schema_total` metrics. An optional `--schema-config` merges user signatures over the built-ins.
 * Declarative signatures (field present/absent, any-of, equals, regex) live in `rsigma-eval`; built-ins cover ECS, OCSF, rendered Windows Event Log, Sysmon, CEF, and a low-specificity `generic_json` fallback. An event matching no signature is reported as `unknown`, the signal for an unsupported schema.
 
+### Fixed
+
+* jq extract expressions can no longer terminate the process. The `halt` and `halt_error` filters are implemented in `jaq-std` with `std::process::exit`, so a single source or enrichment expression could take the whole engine down; both are now removed from the supported filter surface and surface as an ordinary expression error instead.
+
 ## [0.17.0] - 2026-06-23
 
 **TL;DR**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Content-based schema classification that recognizes the structure of each event 
 
 ### Fixed
 
-* jq extract expressions can no longer terminate the process. The `halt` and `halt_error` filters are implemented in `jaq-std` with `std::process::exit`, so a single source or enrichment expression could take the whole engine down; both are now removed from the supported filter surface and surface as an ordinary expression error instead.
+* jq extract expressions can no longer terminate the process. The `halt` and `halt_error` filters are implemented in `jaq-std` with `std::process::exit`, so a single source or enrichment expression could take the whole engine down; both are now removed from the supported filter surface and surface as an ordinary expression error instead (#247).
 
 ## [0.17.0] - 2026-06-23
 

--- a/crates/rsigma-runtime/src/sources/extract.rs
+++ b/crates/rsigma-runtime/src/sources/extract.rs
@@ -30,6 +30,13 @@ pub fn apply_extract(
 /// `length`, …) so the supported filter surface matches real jq for
 /// the operator-facing expressions documented in the dynamic-pipelines
 /// and enrichment references.
+///
+/// The `halt` native filter and the `halt`/`halt_error` definitions are
+/// excluded. In `jaq-std`, `halt` is implemented with `std::process::exit`, so
+/// an expression containing `halt` or `halt_error` would terminate the whole
+/// process (for example a long-running daemon) instead of failing the single
+/// extraction. With them removed, those filters are undefined and surface as an
+/// ordinary compile error.
 fn apply_jq(data: &serde_json::Value, expr: &str) -> Result<serde_json::Value, SourceError> {
     use jaq_core::load::{Arena, File, Loader};
     use jaq_core::{Compiler, Ctx, Vars, data, unwrap_valr};
@@ -42,10 +49,12 @@ fn apply_jq(data: &serde_json::Value, expr: &str) -> Result<serde_json::Value, S
 
     let defs = jaq_core::defs()
         .chain(jaq_std::defs())
-        .chain(jaq_json::defs());
+        .chain(jaq_json::defs())
+        .filter(|def| def.name != "halt" && def.name != "halt_error");
     let funs = jaq_core::funs()
         .chain(jaq_std::funs())
-        .chain(jaq_json::funs());
+        .chain(jaq_json::funs())
+        .filter(|(name, _, _)| *name != "halt");
 
     let arena = Arena::default();
     let modules = Loader::new(defs)

--- a/crates/rsigma-runtime/tests/sources_integration.rs
+++ b/crates/rsigma-runtime/tests/sources_integration.rs
@@ -126,6 +126,25 @@ async fn extract_invalid_cel_returns_error() {
     assert!(result.is_err());
 }
 
+#[test]
+fn extract_jq_halt_does_not_exit_process() {
+    use rsigma_runtime::sources::extract::apply_extract;
+
+    let data = serde_json::json!([1, 2, 3]);
+
+    // `halt` and `halt_error` are implemented in jaq-std with
+    // `std::process::exit`. They must surface as ordinary errors so a single
+    // bad expression cannot terminate a long-running process. If this filter
+    // were still wired up, the test binary would exit here instead of failing.
+    for expr in ["halt", "halt_error", ".[] | halt(0)", "halt_error(2)"] {
+        let result = apply_extract(&data, &ExtractExpr::Jq(expr.to_string()));
+        assert!(
+            result.is_err(),
+            "expected jq `{expr}` to error instead of exiting the process",
+        );
+    }
+}
+
 #[tokio::test]
 async fn file_source_lines() {
     let dir = tempfile::tempdir().unwrap();

--- a/fuzz/fuzz_targets/fuzz_eval_matching.rs
+++ b/fuzz/fuzz_targets/fuzz_eval_matching.rs
@@ -4,7 +4,7 @@ use rsigma_eval::{CompiledRule, JsonEvent, compile_rule, evaluate_rule};
 use std::sync::LazyLock;
 
 static RULES: LazyLock<Vec<CompiledRule>> = LazyLock::new(|| {
-    let yaml = include_str!("../corpus/fuzz_eval_matching/rules.yml");
+    let yaml = include_str!("../seeds/fuzz_eval_matching/rules.yml");
     let collection = rsigma_parser::parse_sigma_yaml(yaml).unwrap();
     collection
         .rules


### PR DESCRIPTION
## Summary

The Fuzz workflow had never gone green. There were three independent problems, traced through the run history:

- All 14 jobs failed at the `Install cargo-fuzz` step. The step ran `cargo install cargo-fuzz --locked` with ambient `cargo`, but `rust-toolchain.toml` pins ambient invocations to the workspace MSRV. Recent cargo-fuzz dependencies need a newer compiler (latest run: `cargo-platform@0.3.3 requires rustc 1.91`; earlier runs: `rustix` needing nightly-only attributes), so the install failed before any fuzzing happened. The run step already used `cargo +nightly`; the install step now does too.
- Once install worked, `fuzz_eval_matching` failed to build: it embedded its rule fixture with `include_str!("../corpus/fuzz_eval_matching/rules.yml")`, but `fuzz/.gitignore` ignores `corpus/`, so the file is never committed and is absent on a fresh checkout. An identical committed copy already lives under the tracked `seeds/` directory, so the include now points there.
- `fuzz_extract_jq` reported a real finding. The jq extractor loaded jaq-std's `halt`/`halt_error` filters, which are implemented with `std::process::exit`. A jq source or enrichment expression containing `halt` could terminate the whole engine (a daemon availability footgun). Both are now removed from the supported filter surface, so they fail as ordinary expression errors instead.

## Test plan

- [x] `cargo test -p rsigma-runtime --test sources_integration` (34 passed, including the new `halt` regression test and existing valid-jq tests like `.emails[]`)
- [x] `cargo clippy -p rsigma-runtime --all-targets` is clean
- [x] `cargo +nightly fuzz build fuzz_eval_matching` and `cargo +nightly fuzz build fuzz_extract_jq` both succeed
- [x] Replayed the original crash input (`.[99.99999]*=halt\0[1,2,3]`) through `fuzz_extract_jq`: it now runs to completion instead of exiting the process
- [ ] Scheduled Fuzz workflow (or a `workflow_dispatch` run) goes green