### PR TITLE
docs(rstix): SCO per-field rustdoc (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### rstix: SCO per-field rustdoc (#250)
+
+* Per-field documentation on all 18 SCO types, 12 predefined extensions, and nested public structs (`EmailMimePart`, `WindowsRegistryValue`, `X509V3Extensions`, PE header/section types, etc.).
+* Removed `#![allow(missing_docs)]` from `model::sco` and `model::sco::extensions`; strict `cargo doc` now enforced for the SCO surface.
+* Runnable `# Examples` on representative types using spec fixtures.
+
 ### rstix: STIX cyber-observable (SCO) model (#248)
 
 All 18 STIX 2.1 cyber-observable types land in `model::sco` with strict fixture-backed round-trips:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### rstix: SCO per-field rustdoc (#250)
+### rstix: SCO per-field rustdoc (#254)
 
 * Per-field documentation on all 18 SCO types, 12 predefined extensions, and nested public structs (`EmailMimePart`, `WindowsRegistryValue`, `X509V3Extensions`, PE header/section types, etc.).
 * Removed `#![allow(missing_docs)]` from `model::sco` and `model::sco::extensions`; strict `cargo doc` now enforced for the SCO surface.

--- a/crates/rstix/src/model/sco/artifact.rs
+++ b/crates/rstix/src/model/sco/artifact.rs
@@ -6,42 +6,67 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
-/// STIX `artifact` cyber-observable object.
+/// Binary or textual payload captured as a cyber-observable (STIX §6.1).
+///
+/// Exactly one of [`payload_bin`](Self::payload_bin) or [`url`](Self::url) must be
+/// present. When [`url`](Self::url) is used, [`hashes`](Self::hashes) is required.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Artifact;
+///
+/// let json = include_str!("../../../tests/fixtures/spec/sco/artifact-image.json");
+/// let artifact: Artifact = serde_json::from_str(json)?;
+/// assert_eq!(artifact.mime_type.as_deref(), Some("image/jpeg"));
+/// assert!(artifact.payload_bin.is_some());
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Artifact {
+    /// STIX object type (`artifact`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_artifact_type")
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// MIME type of the artifact content (STIX §6.1.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub mime_type: Option<String>,
+    /// Base64-encoded payload bytes (STIX §6.1.2; mutually exclusive with `url`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub payload_bin: Option<String>,
+    /// Remote location of the payload (STIX §6.1.2; mutually exclusive with `payload_bin`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub url: Option<String>,
+    /// Cryptographic hashes of the payload (STIX §6.1.2; required when `url` is set).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub hashes: BTreeMap<String, String>,
+    /// Algorithm used to encrypt the payload (STIX §6.1.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub encryption_algorithm: Option<String>,
+    /// Key used to decrypt the payload (STIX §6.1.2; requires `encryption_algorithm`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -50,8 +75,10 @@ pub struct Artifact {
 }
 
 impl Artifact {
+    /// STIX type name for artifacts.
     pub const TYPE_NAME: &'static str = "artifact";
 
+    /// Check artifact invariants (payload/url exclusivity, hash and encryption rules).
     pub fn validate(&self) -> Result<(), ModelError> {
         let has_payload = self.payload_bin.is_some();
         let has_url = self.url.is_some();

--- a/crates/rstix/src/model/sco/autonomous_system.rs
+++ b/crates/rstix/src/model/sco/autonomous_system.rs
@@ -4,9 +4,35 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX autonomous system (BGP ASN) cyber-observable.
+///
+/// Per STIX §6.2, the required `number` identifies the autonomous system.
+/// Optional `name` and `rir` provide human-readable context and registry attribution.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::AutonomousSystem;
+///
+/// let json = r#"{
+///   "type": "autonomous-system",
+///   "spec_version": "2.1",
+///   "id": "autonomous-system--3aa27478-50b5-5ab8-9da9-cdc12b657fff",
+///   "number": 15139,
+///   "name": "Slime Industries",
+///   "rir": "ARIN"
+/// }"#;
+/// let asn: AutonomousSystem = serde_json::from_str(json)?;
+/// assert_eq!(asn.number, 15139);
+/// assert_eq!(asn.name.as_deref(), Some("Slime Industries"));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct AutonomousSystem {
+    /// STIX object type (`autonomous-system`).
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -15,14 +41,18 @@ pub struct AutonomousSystem {
         )
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Autonomous system number (ASN).
     pub number: u32,
+    /// Organization name associated with the AS.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub name: Option<String>,
+    /// Regional Internet registry (for example `ARIN`, `RIPE`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -31,7 +61,10 @@ pub struct AutonomousSystem {
 }
 
 impl AutonomousSystem {
+    /// STIX type name for autonomous systems.
     pub const TYPE_NAME: &'static str = "autonomous-system";
+
+    /// No type-specific invariants are currently enforced.
     pub fn validate(&self) -> Result<(), ModelError> {
         Ok(())
     }

--- a/crates/rstix/src/model/sco/directory.rs
+++ b/crates/rstix/src/model/sco/directory.rs
@@ -5,37 +5,67 @@ use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 use crate::model::sco::ref_types::DirectoryContainsRef;
 
+/// A STIX directory cyber-observable representing a filesystem directory.
+///
+/// Per STIX §6.3, the required `path` holds the directory location. Optional
+/// timestamps and `contains_refs` describe contents and metadata.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Directory;
+///
+/// let json = r#"{
+///   "type": "directory",
+///   "spec_version": "2.1",
+///   "id": "directory--0a58d0c1-59e6-5afd-8252-dcd3f13e5622",
+///   "path": "C:\\Windows\\System32"
+/// }"#;
+/// let dir: Directory = serde_json::from_str(json)?;
+/// assert_eq!(dir.path, "C:\\Windows\\System32");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Directory {
+    /// STIX object type (`directory`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_directory_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Filesystem path of the directory.
     pub path: String,
+    /// Alternate encoding of `path`.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub path_enc: Option<String>,
+    /// Creation timestamp.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub ctime: Option<StixTimestamp>,
+    /// Modification timestamp.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub mtime: Option<StixTimestamp>,
+    /// Last-access timestamp.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub atime: Option<StixTimestamp>,
+    /// File or directory objects contained in this directory.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
@@ -44,8 +74,10 @@ pub struct Directory {
 }
 
 impl Directory {
+    /// STIX type name for directories.
     pub const TYPE_NAME: &'static str = "directory";
 
+    /// Rejects empty `path`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.path.is_empty() {
             return Err(ModelError::DirectoryPathEmpty);

--- a/crates/rstix/src/model/sco/domain_name.rs
+++ b/crates/rstix/src/model/sco/domain_name.rs
@@ -5,17 +5,46 @@ use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 use crate::model::sco::ref_types::DomainNameResolvesToRef;
 
+/// A STIX domain name cyber-observable.
+///
+/// Per STIX §6.4, the required `value` holds the domain name string. Optional
+/// `resolves_to_refs` links to IPv4, IPv6, or domain-name objects the name
+/// resolved to.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::DomainName;
+///
+/// let json = r#"{
+///   "type": "domain-name",
+///   "spec_version": "2.1",
+///   "id": "domain-name--bedb4899-d24b-5401-bc86-8f6b4cc18ec7",
+///   "value": "example.com",
+///   "resolves_to_refs": ["ipv4-addr--28bb3599-77cd-5a82-a950-b5bc3caf07c4"]
+/// }"#;
+/// let domain: DomainName = serde_json::from_str(json)?;
+/// assert_eq!(domain.value, "example.com");
+/// assert_eq!(domain.resolves_to_refs.len(), 1);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct DomainName {
+    /// STIX object type (`domain-name`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_domain_name_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Domain name (for example `example.com`).
     pub value: String,
+    /// IPv4, IPv6, or domain-name objects this name resolved to.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
@@ -24,8 +53,10 @@ pub struct DomainName {
 }
 
 impl DomainName {
+    /// STIX type name for domain names.
     pub const TYPE_NAME: &'static str = "domain-name";
 
+    /// Rejects empty `value`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.value.is_empty() {
             return Err(ModelError::DomainNameValueEmpty);

--- a/crates/rstix/src/model/sco/email_address.rs
+++ b/crates/rstix/src/model/sco/email_address.rs
@@ -6,22 +6,52 @@ use crate::core::{
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX email address cyber-observable.
+///
+/// Per STIX §6.5, the required `value` holds the mailbox address. Optional
+/// `display_name` and `belongs_to_ref` link the address to a human-readable
+/// label and owning user account.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::EmailAddr;
+///
+/// let json = r#"{
+///   "type": "email-addr",
+///   "spec_version": "2.1",
+///   "id": "email-addr--7165e2a9-671f-585d-b1e1-ca59c671d934",
+///   "value": "john.doe@example.com",
+///   "display_name": "John Doe"
+/// }"#;
+/// let email: EmailAddr = serde_json::from_str(json)?;
+/// assert_eq!(email.value, "john.doe@example.com");
+/// assert_eq!(email.display_name.as_deref(), Some("John Doe"));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct EmailAddr {
+    /// STIX object type (`email-addr`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_email_addr_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Email address value (for example `user@example.com`).
     pub value: String,
+    /// Display name for the mailbox.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub display_name: Option<String>,
+    /// User account that owns this email address.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -30,8 +60,10 @@ pub struct EmailAddr {
 }
 
 impl EmailAddr {
+    /// STIX type name for email addresses.
     pub const TYPE_NAME: &'static str = "email-addr";
 
+    /// Rejects empty `value`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.value.is_empty() {
             return Err(ModelError::EmailAddrValueEmpty);

--- a/crates/rstix/src/model/sco/email_message.rs
+++ b/crates/rstix/src/model/sco/email_message.rs
@@ -10,24 +10,31 @@ use crate::model::common::ScoCommonProps;
 use crate::model::sco::ref_types::EmailMimeBodyRawRef;
 
 /// MIME part of a multipart email body (STIX §6.6.2).
+///
+/// Exactly one of [`body`](Self::body) or [`body_raw_ref`](Self::body_raw_ref) must
+/// be present.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct EmailMimePart {
+    /// Body content of the MIME part (STIX §6.6.2; mutually exclusive with `body_raw_ref`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub body: Option<String>,
+    /// Reference to an artifact holding the raw body bytes (STIX §6.6.2; mutually exclusive with `body`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub body_raw_ref: Option<EmailMimeBodyRawRef>,
+    /// MIME content type of the part (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub content_type: Option<String>,
+    /// Content disposition of the part (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -36,6 +43,7 @@ pub struct EmailMimePart {
 }
 
 impl EmailMimePart {
+    /// Check MIME-part invariants (body/raw-ref exclusivity).
     pub fn validate(&self) -> Result<(), ModelError> {
         let has_body = self.body.is_some();
         let has_raw = self.body_raw_ref.is_some();
@@ -75,83 +83,103 @@ impl<'de> serde::Deserialize<'de> for EmailMimePart {
     }
 }
 
-/// STIX `email-message` cyber-observable object.
+/// An email message (STIX §6.6).
+///
+/// When [`is_multipart`](Self::is_multipart) is true, [`body_multipart`](Self::body_multipart)
+/// must be set and [`body`](Self::body) must be absent; single-part messages use `body` only.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct EmailMessage {
+    /// STIX object type (`email-message`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_email_message_type")
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Whether the message body consists of multiple MIME parts (STIX §6.6.2).
     pub is_multipart: bool,
+    /// Date the email was sent (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub date: Option<StixTimestamp>,
+    /// MIME content type of the message (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub content_type: Option<String>,
+    /// Author of the message content (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub from_ref: Option<EmailAddrId>,
+    /// Entity that sent the message (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub sender_ref: Option<EmailAddrId>,
+    /// Primary recipients (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub to_refs: Vec<EmailAddrId>,
+    /// Carbon-copy recipients (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub cc_refs: Vec<EmailAddrId>,
+    /// Blind carbon-copy recipients (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub bcc_refs: Vec<EmailAddrId>,
+    /// Message identifier from the email header (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub message_id: Option<String>,
+    /// Subject line (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject: Option<String>,
+    /// `Received` header lines in order (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub received_lines: Vec<String>,
+    /// Additional email header fields not otherwise captured (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub additional_header_fields: BTreeMap<String, Vec<String>>,
+    /// Body of a single-part message (STIX §6.6.2; absent when `is_multipart` is true).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub body: Option<String>,
+    /// MIME parts of a multipart message (STIX §6.6.2; required when `is_multipart` is true).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub body_multipart: Option<Vec<EmailMimePart>>,
+    /// Reference to an artifact holding the raw RFC 5322 message (STIX §6.6.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -160,8 +188,10 @@ pub struct EmailMessage {
 }
 
 impl EmailMessage {
+    /// STIX type name for email messages.
     pub const TYPE_NAME: &'static str = "email-message";
 
+    /// Check email-message invariants (multipart/body rules; nested MIME-part validation).
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.is_multipart {
             if self.body.is_some() {

--- a/crates/rstix/src/model/sco/extensions/http_request.rs
+++ b/crates/rstix/src/model/sco/extensions/http_request.rs
@@ -11,23 +11,29 @@ use crate::core::ArtifactId;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HttpRequestExt {
+    /// HTTP method (required, non-empty).
     pub request_method: String,
+    /// Request target (URI path or full request line value; required, non-empty).
     pub request_value: String,
+    /// HTTP protocol version (for example `http/1.1`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub request_version: Option<String>,
+    /// Request headers, keyed by name with one or more values per header.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub request_header: BTreeMap<String, Vec<String>>,
+    /// Message body length in octets.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub message_body_length: Option<u64>,
+    /// Reference to an [`Artifact`](crate::model::sco::Artifact) holding the raw body.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/extensions/icmp.rs
+++ b/crates/rstix/src/model/sco/extensions/icmp.rs
@@ -7,7 +7,9 @@ use crate::model::common::ExtensionMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IcmpExt {
+    /// ICMP type as a lowercase hexadecimal string (required, non-empty).
     pub icmp_type_hex: String,
+    /// ICMP code as a lowercase hexadecimal string (required, non-empty).
     pub icmp_code_hex: String,
 }
 

--- a/crates/rstix/src/model/sco/extensions/mod.rs
+++ b/crates/rstix/src/model/sco/extensions/mod.rs
@@ -1,8 +1,4 @@
 //! Typed STIX SCO predefined extensions.
-//!
-//! Per-field rustdoc is tracked in [issue #250](https://github.com/timescale/rsigma/issues/250).
-
-#![allow(missing_docs)]
 
 mod archive;
 mod http_request;

--- a/crates/rstix/src/model/sco/extensions/ntfs.rs
+++ b/crates/rstix/src/model/sco/extensions/ntfs.rs
@@ -5,16 +5,19 @@ use crate::model::common::ExtensionMap;
 
 use std::collections::BTreeMap;
 
-/// NTFS alternate data stream entry.
+/// NTFS alternate data stream entry (STIX §6.7.3).
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlternateDataStream {
+    /// Stream name (required, non-empty).
     pub name: String,
+    /// Hashes of the stream content, keyed by algorithm name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub hashes: BTreeMap<String, String>,
+    /// Stream size in octets.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -26,11 +29,13 @@ pub struct AlternateDataStream {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NtfsExt {
+    /// NTFS security identifier (SID) string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub sid: Option<String>,
+    /// Alternate data streams attached to the file.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")

--- a/crates/rstix/src/model/sco/extensions/pdf.rs
+++ b/crates/rstix/src/model/sco/extensions/pdf.rs
@@ -9,26 +9,31 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PdfExt {
+    /// PDF version string (for example `1.7`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub version: Option<String>,
+    /// Whether the PDF is linearized (optimized for web viewing).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_optimized: Option<bool>,
+    /// Entries from the PDF Info dictionary.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub document_info_dict: BTreeMap<String, String>,
+    /// First 16-byte PDF document ID.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub pdfid0: Option<String>,
+    /// Second 16-byte PDF document ID.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/extensions/raster_image.rs
+++ b/crates/rstix/src/model/sco/extensions/raster_image.rs
@@ -9,21 +9,25 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RasterImageExt {
+    /// Image height in pixels.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub image_height: Option<u64>,
+    /// Image width in pixels.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub image_width: Option<u64>,
+    /// Color depth in bits per pixel.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub bits_per_pixel: Option<u64>,
+    /// EXIF metadata tags keyed by tag name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")

--- a/crates/rstix/src/model/sco/extensions/socket.rs
+++ b/crates/rstix/src/model/sco/extensions/socket.rs
@@ -9,32 +9,39 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SocketExt {
+    /// Socket address family (required, non-empty; for example `AF_INET`).
     pub address_family: String,
+    /// Whether the socket is in blocking mode.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_blocking: Option<bool>,
+    /// Whether the socket is listening for connections.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_listening: Option<bool>,
+    /// Socket options keyed by option name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub options: BTreeMap<String, u64>,
+    /// Socket type (for example `SOCK_STREAM`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub socket_type: Option<String>,
+    /// Socket file descriptor on Unix-like systems.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub socket_descriptor: Option<u64>,
+    /// Socket handle on Windows.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/extensions/tcp.rs
+++ b/crates/rstix/src/model/sco/extensions/tcp.rs
@@ -7,11 +7,13 @@ use crate::model::common::ExtensionMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TcpExt {
+    /// Source-side TCP flags as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub src_flags_hex: Option<String>,
+    /// Destination-side TCP flags as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/extensions/unix_account.rs
+++ b/crates/rstix/src/model/sco/extensions/unix_account.rs
@@ -7,21 +7,25 @@ use crate::model::common::ExtensionMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnixAccountExt {
+    /// Primary group id (GID).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub gid: Option<u64>,
+    /// Supplementary group names.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub groups: Vec<String>,
+    /// Home directory path.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub home_dir: Option<String>,
+    /// Login shell path.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/extensions/windows_pe.rs
+++ b/crates/rstix/src/model/sco/extensions/windows_pe.rs
@@ -7,120 +7,143 @@ use std::collections::BTreeMap;
 
 use crate::core::StixTimestamp;
 
-/// Windows PE optional header (subset of STIX §6.7.6).
+/// Windows PE optional header (STIX §6.7.6).
 #[derive(Clone, Debug, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowsPeOptionalHeader {
+    /// Optional header magic number as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub magic_hex: Option<String>,
+    /// Major linker version.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub major_linker_version: Option<u32>,
+    /// Minor linker version.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub minor_linker_version: Option<u32>,
+    /// Size of the code section in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_code: Option<u64>,
+    /// Size of initialized data in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_initialized_data: Option<u64>,
+    /// Size of uninitialized data in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_uninitialized_data: Option<u64>,
+    /// Relative virtual address of the entry point.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub address_of_entry_point: Option<u64>,
+    /// Relative virtual address of the start of code.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub base_of_code: Option<u64>,
+    /// Preferred load address of the image.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub image_base: Option<u64>,
+    /// Section alignment in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub section_alignment: Option<u64>,
+    /// File alignment in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub file_alignment: Option<u64>,
+    /// Total size of the image in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_image: Option<u64>,
+    /// Combined size of all headers in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_headers: Option<u64>,
+    /// Image checksum as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub checksum_hex: Option<String>,
+    /// Subsystem type as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subsystem_hex: Option<String>,
+    /// DLL characteristics flags as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dll_characteristics_hex: Option<String>,
+    /// Default stack reserve size in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_stack_reserve: Option<u64>,
+    /// Default stack commit size in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_stack_commit: Option<u64>,
+    /// Default heap reserve size in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_heap_reserve: Option<u64>,
+    /// Default heap commit size in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_heap_commit: Option<u64>,
+    /// Loader flags as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub loader_flags_hex: Option<String>,
+    /// Number of data-directory entries.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub number_of_rva_and_sizes: Option<u64>,
+    /// Hashes of the optional header, keyed by algorithm name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
@@ -156,21 +179,25 @@ impl WindowsPeOptionalHeader {
     }
 }
 
-/// Windows PE section entry.
+/// Windows PE section entry (STIX §6.7.6).
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowsPeSection {
+    /// Section name (required, non-empty).
     pub name: String,
+    /// Section size in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size: Option<u64>,
+    /// Shannon entropy of the section content.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub entropy: Option<f64>,
+    /// Hashes of the section content, keyed by algorithm name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
@@ -182,57 +209,69 @@ pub struct WindowsPeSection {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowsPeBinaryExt {
+    /// PE file type (required, non-empty; for example `exe`, `dll`).
     pub pe_type: String,
+    /// Import hash of the PE file.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub imphash: Option<String>,
+    /// Target machine type as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub machine_hex: Option<String>,
+    /// Number of sections in the PE file.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub number_of_sections: Option<u32>,
+    /// PE file header timestamp.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub time_date_stamp: Option<StixTimestamp>,
+    /// Pointer to the COFF symbol table as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub pointer_to_symbol_table_hex: Option<String>,
+    /// Number of symbols in the COFF symbol table.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub number_of_symbols: Option<u64>,
+    /// Size of the optional header in bytes.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size_of_optional_header: Option<u64>,
+    /// COFF file header characteristics as a lowercase hexadecimal string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub characteristics_hex: Option<String>,
+    /// Hashes of the COFF file header, keyed by algorithm name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub file_header_hashes: BTreeMap<String, String>,
+    /// PE optional header fields.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub optional_header: Option<WindowsPeOptionalHeader>,
+    /// PE section table entries.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")

--- a/crates/rstix/src/model/sco/extensions/windows_process.rs
+++ b/crates/rstix/src/model/sco/extensions/windows_process.rs
@@ -9,36 +9,43 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowsProcessExt {
+    /// Whether address space layout randomization (ASLR) is enabled.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub aslr_enabled: Option<bool>,
+    /// Whether data execution prevention (DEP) is enabled.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dep_enabled: Option<bool>,
+    /// Process priority class.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub priority: Option<String>,
+    /// Security identifier (SID) of the process owner.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub owner_sid: Option<String>,
+    /// Window title of the process's main window.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub windows_title: Option<String>,
+    /// `STARTUPINFO` structure fields keyed by name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub startup_info: BTreeMap<String, serde_json::Value>,
+    /// Process integrity level (for example `low`, `medium`, `high`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/extensions/windows_service.rs
+++ b/crates/rstix/src/model/sco/extensions/windows_service.rs
@@ -9,41 +9,49 @@ use crate::core::FileId;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowsServiceExt {
+    /// Internal service name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub service_name: Option<String>,
+    /// Human-readable service descriptions.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub descriptions: Vec<String>,
+    /// Display name shown in service management tools.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub display_name: Option<String>,
+    /// Service group name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub group_name: Option<String>,
+    /// Service start type (for example `auto`, `manual`, `disabled`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub start_type: Option<String>,
+    /// References to [`File`](crate::model::sco::File) objects for service DLLs.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub service_dll_refs: Vec<FileId>,
+    /// Service type (for example `share_process`, `own_process`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub service_type: Option<String>,
+    /// Current service status (for example `running`, `stopped`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")

--- a/crates/rstix/src/model/sco/file.rs
+++ b/crates/rstix/src/model/sco/file.rs
@@ -11,71 +11,89 @@ use crate::model::sco::extensions::{
     ArchiveExt, NtfsExt, PdfExt, RasterImageExt, WindowsPeBinaryExt,
 };
 
+/// Properties of a file on a file system (STIX §6.7).
+///
+/// At least one of [`hashes`](Self::hashes) or a non-empty [`name`](Self::name) is
+/// required per STIX §6.7.2.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct File {
+    /// STIX object type (`file`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_file_type")
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Dictionary of cryptographic hashes (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub hashes: BTreeMap<String, String>,
+    /// Size of the file in bytes (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub size: Option<u64>,
+    /// Name of the file (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub name: Option<String>,
+    /// Character encoding of the file name (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub name_enc: Option<String>,
+    /// First bytes of the file in hexadecimal (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub magic_number_hex: Option<String>,
+    /// MIME type of the file content (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub mime_type: Option<String>,
+    /// File creation time (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub ctime: Option<StixTimestamp>,
+    /// File modification time (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub mtime: Option<StixTimestamp>,
+    /// File last-access time (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub atime: Option<StixTimestamp>,
+    /// Reference to the directory containing this file (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub parent_directory_ref: Option<DirectoryId>,
+    /// References to files or directories contained in this file (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub contains_refs: Vec<StixId>,
+    /// Reference to an artifact holding the raw file content (STIX §6.7.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -84,8 +102,10 @@ pub struct File {
 }
 
 impl File {
+    /// STIX type name for files.
     pub const TYPE_NAME: &'static str = "file";
 
+    /// Check file invariants (hashes or name required; extension validation).
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.hashes.is_empty() && self.name.as_ref().is_none_or(String::is_empty) {
             return Err(ModelError::FileHashesOrNameRequired);

--- a/crates/rstix/src/model/sco/ipv4_addr.rs
+++ b/crates/rstix/src/model/sco/ipv4_addr.rs
@@ -5,22 +5,50 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX IPv4 address cyber-observable.
+///
+/// Per STIX §6.8, the required `value` holds a dotted-quad address or CIDR
+/// block. Optional `resolves_to_refs` and `belongs_to_refs` link to related
+/// MAC addresses and autonomous systems.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Ipv4Addr;
+///
+/// let json = r#"{
+///   "type": "ipv4-addr",
+///   "spec_version": "2.1",
+///   "id": "ipv4-addr--28bb3599-77cd-5a82-a950-b5bc3caf07c4",
+///   "value": "198.51.100.3"
+/// }"#;
+/// let addr: Ipv4Addr = serde_json::from_str(json)?;
+/// assert_eq!(addr.value, "198.51.100.3");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Ipv4Addr {
+    /// STIX object type (`ipv4-addr`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_ipv4_addr_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// IPv4 address or CIDR block (for example `198.51.100.3` or `10.0.0.0/8`).
     pub value: String,
+    /// MAC addresses this IP address resolved to.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub resolves_to_refs: Vec<MacAddrId>,
+    /// Autonomous systems this address belongs to.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
@@ -29,8 +57,10 @@ pub struct Ipv4Addr {
 }
 
 impl Ipv4Addr {
+    /// STIX type name for IPv4 addresses.
     pub const TYPE_NAME: &'static str = "ipv4-addr";
 
+    /// Rejects empty `value`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.value.is_empty() {
             return Err(ModelError::Ipv4AddrValueEmpty);

--- a/crates/rstix/src/model/sco/ipv6_addr.rs
+++ b/crates/rstix/src/model/sco/ipv6_addr.rs
@@ -5,22 +5,50 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX IPv6 address cyber-observable.
+///
+/// Per STIX §6.9, the required `value` holds an IPv6 address or CIDR block.
+/// Optional `resolves_to_refs` and `belongs_to_refs` link to related MAC
+/// addresses and autonomous systems.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Ipv6Addr;
+///
+/// let json = r#"{
+///   "type": "ipv6-addr",
+///   "spec_version": "2.1",
+///   "id": "ipv6-addr--85a85a8c-ee99-5722-946d-3c3a3270fc6f",
+///   "value": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+/// }"#;
+/// let addr: Ipv6Addr = serde_json::from_str(json)?;
+/// assert_eq!(addr.value, "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Ipv6Addr {
+    /// STIX object type (`ipv6-addr`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_ipv6_addr_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// IPv6 address or CIDR block.
     pub value: String,
+    /// MAC addresses this IP address resolved to.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub resolves_to_refs: Vec<MacAddrId>,
+    /// Autonomous systems this address belongs to.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
@@ -29,8 +57,10 @@ pub struct Ipv6Addr {
 }
 
 impl Ipv6Addr {
+    /// STIX type name for IPv6 addresses.
     pub const TYPE_NAME: &'static str = "ipv6-addr";
 
+    /// Rejects empty `value`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.value.is_empty() {
             return Err(ModelError::Ipv6AddrValueEmpty);

--- a/crates/rstix/src/model/sco/mac_addr.rs
+++ b/crates/rstix/src/model/sco/mac_addr.rs
@@ -4,22 +4,49 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX MAC address cyber-observable.
+///
+/// Per STIX §6.10, the required `value` holds the media access control address,
+/// typically as colon- or hyphen-separated hexadecimal octets.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::MacAddr;
+///
+/// let json = r#"{
+///   "type": "mac-addr",
+///   "spec_version": "2.1",
+///   "id": "mac-addr--757b1725-9903-54f5-a855-1240691d7659",
+///   "value": "d2:fb:49:24:37:18"
+/// }"#;
+/// let mac: MacAddr = serde_json::from_str(json)?;
+/// assert_eq!(mac.value, "d2:fb:49:24:37:18");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct MacAddr {
+    /// STIX object type (`mac-addr`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_mac_addr_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// MAC address string (for example `d2:fb:49:24:37:18`).
     pub value: String,
 }
 
 impl MacAddr {
+    /// STIX type name for MAC addresses.
     pub const TYPE_NAME: &'static str = "mac-addr";
 
+    /// Rejects empty `value`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.value.is_empty() {
             return Err(ModelError::MacAddrValueEmpty);

--- a/crates/rstix/src/model/sco/mod.rs
+++ b/crates/rstix/src/model/sco/mod.rs
@@ -1,10 +1,4 @@
 //! STIX Cyber-observable Objects (18 types).
-//!
-//! Field-level rustdoc for individual SCO properties is tracked in
-//! [issue #250](https://github.com/timescale/rsigma/issues/250); see crate
-//! README invariant table for enforced rules.
-
-#![allow(missing_docs)]
 
 pub mod extensions;
 pub mod ref_types;

--- a/crates/rstix/src/model/sco/mutex.rs
+++ b/crates/rstix/src/model/sco/mutex.rs
@@ -4,22 +4,49 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX mutex cyber-observable representing a named synchronization primitive.
+///
+/// Per STIX §6.11, the required `name` identifies the mutex as observed on the
+/// system (for example a malware mutex string).
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Mutex;
+///
+/// let json = r#"{
+///   "type": "mutex",
+///   "spec_version": "2.1",
+///   "id": "mutex--f93fe911-e545-5239-b9b0-597840d0c871",
+///   "name": "__CLEANSWEEP__"
+/// }"#;
+/// let mutex: Mutex = serde_json::from_str(json)?;
+/// assert_eq!(mutex.name, "__CLEANSWEEP__");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Mutex {
+    /// STIX object type (`mutex`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_mutex_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Mutex name as observed on the system.
     pub name: String,
 }
 
 impl Mutex {
+    /// STIX type name for mutexes.
     pub const TYPE_NAME: &'static str = "mutex";
 
+    /// Rejects empty `name`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.name.is_empty() {
             return Err(ModelError::MutexNameEmpty);

--- a/crates/rstix/src/model/sco/network_traffic.rs
+++ b/crates/rstix/src/model/sco/network_traffic.rs
@@ -11,92 +11,130 @@ use crate::model::common::ScoCommonProps;
 use crate::model::sco::extensions::{HttpRequestExt, IcmpExt, SocketExt, TcpExt};
 use crate::model::sco::ref_types::NetworkTrafficEndpointRef;
 
+/// Network traffic between one or more endpoints (STIX §6.12).
+///
+/// [`protocols`](Self::protocols) is required and at least one of
+/// [`src_ref`](Self::src_ref) or [`dst_ref`](Self::dst_ref) must be set.
+/// An active connection cannot have an `end` time, and `end` must not precede `start`.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::NetworkTraffic;
+///
+/// let json = include_str!("../../../tests/fixtures/spec/sco/network-traffic-tcp.json");
+/// let traffic: NetworkTraffic = serde_json::from_str(json)?;
+/// assert_eq!(traffic.protocols, vec!["tcp"]);
+/// assert!(traffic.src_ref.is_some() && traffic.dst_ref.is_some());
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct NetworkTraffic {
+    /// STIX object type (`network-traffic`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_network_traffic_type")
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Start time of the traffic (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub start: Option<StixTimestamp>,
+    /// End time of the traffic (STIX §6.12.2; incompatible with `is_active = true`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub end: Option<StixTimestamp>,
+    /// Whether the traffic is still ongoing (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_active: Option<bool>,
+    /// Source endpoint (STIX §6.12.2; at least one of `src_ref` or `dst_ref` required).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub src_ref: Option<NetworkTrafficEndpointRef>,
+    /// Destination endpoint (STIX §6.12.2; at least one of `src_ref` or `dst_ref` required).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dst_ref: Option<NetworkTrafficEndpointRef>,
+    /// Source port number (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub src_port: Option<u16>,
+    /// Destination port number (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dst_port: Option<u16>,
+    /// Ordered list of OSI layers and protocols observed (STIX §6.12.2; required).
     pub protocols: Vec<String>,
+    /// Number of bytes sent from source to destination (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub src_byte_count: Option<u64>,
+    /// Number of bytes sent from destination to source (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dst_byte_count: Option<u64>,
+    /// Number of packets sent from source to destination (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub src_packets: Option<u64>,
+    /// Number of packets sent from destination to source (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dst_packets: Option<u64>,
+    /// IPFIX dictionary of additional flow attributes (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub ipfix: BTreeMap<String, serde_json::Value>,
+    /// Artifact containing payload sent from source (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub src_payload_ref: Option<ArtifactId>,
+    /// Artifact containing payload sent from destination (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub dst_payload_ref: Option<ArtifactId>,
+    /// Network traffic objects encapsulated by this flow (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub encapsulates_refs: Vec<NetworkTrafficId>,
+    /// Network traffic object that encapsulates this flow (STIX §6.12.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -105,8 +143,10 @@ pub struct NetworkTraffic {
 }
 
 impl NetworkTraffic {
+    /// STIX type name for network traffic.
     pub const TYPE_NAME: &'static str = "network-traffic";
 
+    /// Check network-traffic invariants (protocols, endpoints, timing, extensions).
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.protocols.is_empty() {
             return Err(ModelError::NetworkTrafficProtocolsRequired);

--- a/crates/rstix/src/model/sco/process.rs
+++ b/crates/rstix/src/model/sco/process.rs
@@ -10,66 +10,97 @@ use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 use crate::model::sco::extensions::{WindowsProcessExt, WindowsServiceExt};
 
+/// A running instance of a program (STIX §6.13).
+///
+/// At least one type-specific property or a recognized process extension
+/// (`windows-process-ext`, `windows-service-ext`) must be present per STIX §6.13.2.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Process;
+///
+/// let json = include_str!("../../../tests/fixtures/spec/sco/process-basic.json");
+/// let process: Process = serde_json::from_str(json)?;
+/// assert_eq!(process.pid, Some(1221));
+/// assert!(process.image_ref.is_some());
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Process {
+    /// STIX object type (`process`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_process_type")
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Whether the process is hidden from task-management utilities (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_hidden: Option<bool>,
+    /// Process identifier (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub pid: Option<u32>,
+    /// Time the process was created (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub created_time: Option<StixTimestamp>,
+    /// Current working directory (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub cwd: Option<String>,
+    /// Full command line used to launch the process (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub command_line: Option<String>,
+    /// Environment variables set when the process was launched (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub environment_variables: BTreeMap<String, String>,
+    /// Network connections opened by the process (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub opened_connection_refs: Vec<NetworkTrafficId>,
+    /// User account that created the process (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub creator_user_ref: Option<UserAccountId>,
+    /// Executable file that backs the process (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub image_ref: Option<FileId>,
+    /// Parent process (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub parent_ref: Option<ProcessId>,
+    /// Child processes spawned by this process (STIX §6.13.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
@@ -78,8 +109,10 @@ pub struct Process {
 }
 
 impl Process {
+    /// STIX type name for processes.
     pub const TYPE_NAME: &'static str = "process";
 
+    /// Check process invariants (at least one property or extension; extension validation).
     pub fn validate(&self) -> Result<(), ModelError> {
         if !self.has_specific_property() {
             return Err(ModelError::ProcessNoProperties);

--- a/crates/rstix/src/model/sco/software.rs
+++ b/crates/rstix/src/model/sco/software.rs
@@ -4,37 +4,71 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX software cyber-observable representing an installed or observed product.
+///
+/// Per STIX §6.14, the required `name` identifies the software. Optional fields
+/// carry CPE, SWID, language, vendor, and version metadata.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Software;
+///
+/// let json = r#"{
+///   "type": "software",
+///   "spec_version": "2.1",
+///   "id": "software--710b0b41-d4d0-5d6c-a400-fc9254554ffc",
+///   "name": "Word",
+///   "cpe": "cpe:2.3:a:microsoft:word:2000:*:*:*:*:*:*:*",
+///   "version": "2002",
+///   "vendor": "Microsoft"
+/// }"#;
+/// let software: Software = serde_json::from_str(json)?;
+/// assert_eq!(software.name, "Word");
+/// assert_eq!(software.vendor.as_deref(), Some("Microsoft"));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Software {
+    /// STIX object type (`software`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_software_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Software product name.
     pub name: String,
+    /// Common Platform Enumeration (CPE) URI.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub cpe: Option<String>,
+    /// Software Identification (SWID) tag identifier.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub swid: Option<String>,
+    /// Language codes supported by the software.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub languages: Vec<String>,
+    /// Vendor or manufacturer name.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub vendor: Option<String>,
+    /// Version string.
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -43,8 +77,10 @@ pub struct Software {
 }
 
 impl Software {
+    /// STIX type name for software objects.
     pub const TYPE_NAME: &'static str = "software";
 
+    /// Rejects empty `name`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.name.is_empty() {
             return Err(ModelError::SoftwareNameEmpty);

--- a/crates/rstix/src/model/sco/url.rs
+++ b/crates/rstix/src/model/sco/url.rs
@@ -4,22 +4,49 @@ use crate::core::{QueryValue, QueryableStixObject, SpecVersion, StixId, StixTime
 use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
+/// A STIX URL cyber-observable representing a uniform resource locator.
+///
+/// Per STIX §6.15, the required `value` holds the URL string. Address format
+/// validation is deferred; only non-empty `value` is enforced at the boundary.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use rstix::model::sco::Url;
+///
+/// let json = r#"{
+///   "type": "url",
+///   "spec_version": "2.1",
+///   "id": "url--47c3cf9a-5027-5bf0-997a-017c7edc7c55",
+///   "value": "https://example.com/research/index.html"
+/// }"#;
+/// let url: Url = serde_json::from_str(json)?;
+/// assert_eq!(url.value, "https://example.com/research/index.html");
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Url {
+    /// STIX object type (`url`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_url_type")
     )]
     object_type: String,
+    /// SCO common properties.
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// URL string (for example `https://example.com/path`).
     pub value: String,
 }
 
 impl Url {
+    /// STIX type name for URLs.
     pub const TYPE_NAME: &'static str = "url";
 
+    /// Rejects empty `value`.
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.value.is_empty() {
             return Err(ModelError::UrlValueEmpty);

--- a/crates/rstix/src/model/sco/user_account.rs
+++ b/crates/rstix/src/model/sco/user_account.rs
@@ -5,81 +5,101 @@ use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 use crate::model::sco::extensions::UnixAccountExt;
 
+/// A user account on a system (STIX §6.16).
+///
+/// At least one type-specific property or a `unix-account-ext` extension must be
+/// present per STIX §6.16.2.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct UserAccount {
+    /// STIX object type (`user-account`).
     #[cfg_attr(
         feature = "serde",
         serde(rename = "type", deserialize_with = "deserialize_user_account_type")
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Platform-specific unique identifier for the account (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub user_id: Option<String>,
+    /// Cleartext or hashed credential (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub credential: Option<String>,
+    /// Login name associated with the account (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub account_login: Option<String>,
+    /// Type of account (STIX §6.16.2; open vocabulary `account-type-ov`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub account_type: Option<String>,
+    /// Human-readable display name (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub display_name: Option<String>,
+    /// Whether the account is a service or system account (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_service_account: Option<bool>,
+    /// Whether the account has elevated privileges (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_privileged: Option<bool>,
+    /// Whether the account can escalate privileges (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub can_escalate_privs: Option<bool>,
+    /// Whether the account is disabled (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_disabled: Option<bool>,
+    /// When the account was created (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub account_created: Option<StixTimestamp>,
+    /// When the account expires (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub account_expires: Option<StixTimestamp>,
+    /// When the credential was last changed (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub credential_last_changed: Option<StixTimestamp>,
+    /// When the account was first used to log in (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub account_first_login: Option<StixTimestamp>,
+    /// When the account was last used to log in (STIX §6.16.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -88,8 +108,10 @@ pub struct UserAccount {
 }
 
 impl UserAccount {
+    /// STIX type name for user accounts.
     pub const TYPE_NAME: &'static str = "user-account";
 
+    /// Check user-account invariants (at least one property or extension; extension validation).
     pub fn validate(&self) -> Result<(), ModelError> {
         if !self.has_specific_property() {
             return Err(ModelError::UserAccountNoProperties);

--- a/crates/rstix/src/model/sco/windows_registry_key.rs
+++ b/crates/rstix/src/model/sco/windows_registry_key.rs
@@ -8,19 +8,25 @@ use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
 /// Windows registry value entry (STIX §6.17.2).
+///
+/// When present in a [`WindowsRegistryKey::values`] list, at least one of
+/// [`name`](Self::name), [`data`](Self::data), or [`data_type`](Self::data_type) must be set.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowsRegistryValue {
+    /// Name of the registry value (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub name: Option<String>,
+    /// Data stored in the registry value (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub data: Option<String>,
+    /// Data type of the registry value (STIX §6.17.2; open vocabulary `windows-registry-datatype-ov`).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -34,9 +40,15 @@ impl WindowsRegistryValue {
     }
 }
 
+/// A Windows registry key (STIX §6.17).
+///
+/// At least one of [`key`](Self::key), [`values`](Self::values),
+/// [`modified_time`](Self::modified_time), [`creator_user_ref`](Self::creator_user_ref), or
+/// [`number_of_subkeys`](Self::number_of_subkeys) must be present per STIX §6.17.2.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct WindowsRegistryKey {
+    /// STIX object type (`windows-registry-key`).
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -45,28 +57,34 @@ pub struct WindowsRegistryKey {
         )
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Full path to the registry key (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub key: Option<String>,
+    /// Values stored under the key (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub values: Vec<WindowsRegistryValue>,
+    /// Last time the key was modified (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub modified_time: Option<StixTimestamp>,
+    /// User account that created the key (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub creator_user_ref: Option<UserAccountId>,
+    /// Number of subkeys under this key (STIX §6.17.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -75,8 +93,10 @@ pub struct WindowsRegistryKey {
 }
 
 impl WindowsRegistryKey {
+    /// STIX type name for Windows registry keys.
     pub const TYPE_NAME: &'static str = "windows-registry-key";
 
+    /// Check registry-key invariants (at least one property; non-empty value entries).
     pub fn validate(&self) -> Result<(), ModelError> {
         if self.key.is_none()
             && self.values.is_empty()

--- a/crates/rstix/src/model/sco/x509_certificate.rs
+++ b/crates/rstix/src/model/sco/x509_certificate.rs
@@ -8,84 +8,102 @@ use crate::model::ModelError;
 use crate::model::common::ScoCommonProps;
 
 /// X.509 v3 extensions block (STIX §6.18.2).
+///
+/// When present on an [`X509Certificate`], at least one extension property must be set.
 #[derive(Clone, Debug, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct X509V3Extensions {
+    /// Basic constraints extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub basic_constraints: Option<String>,
+    /// Name constraints extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub name_constraints: Option<String>,
+    /// Policy constraints extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub policy_constraints: Option<String>,
+    /// Key usage extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub key_usage: Option<String>,
+    /// Extended key usage extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub extended_key_usage: Option<String>,
+    /// Subject key identifier extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject_key_identifier: Option<String>,
+    /// Authority key identifier extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub authority_key_identifier: Option<String>,
+    /// Subject alternative name extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject_alternative_name: Option<String>,
+    /// Issuer alternative name extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub issuer_alternative_name: Option<String>,
+    /// Subject directory attributes extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject_directory_attributes: Option<String>,
+    /// CRL distribution points extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub crl_distribution_points: Option<String>,
+    /// Inhibit anyPolicy extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub inhibit_any_policy: Option<String>,
+    /// Private key usage period start (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub private_key_usage_period_not_before: Option<StixTimestamp>,
+    /// Private key usage period end (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub private_key_usage_period_not_after: Option<StixTimestamp>,
+    /// Certificate policies extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub certificate_policies: Option<String>,
+    /// Policy mappings extension (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -114,9 +132,15 @@ impl X509V3Extensions {
     }
 }
 
+/// An X.509 public-key certificate (STIX §6.18).
+///
+/// At least one type-specific property must be present per STIX §6.18.2. When
+/// [`x509_v3_extensions`](Self::x509_v3_extensions) is set, it must contain at least one
+/// extension field.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct X509Certificate {
+    /// STIX object type (`x509-certificate`).
     #[cfg_attr(
         feature = "serde",
         serde(
@@ -125,68 +149,82 @@ pub struct X509Certificate {
         )
     )]
     object_type: String,
+    /// SCO common properties (STIX §3.2).
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: ScoCommonProps,
+    /// Whether the certificate is self-signed (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub is_self_signed: Option<bool>,
+    /// Cryptographic hashes of the DER-encoded certificate (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "BTreeMap::is_empty")
     )]
     pub hashes: BTreeMap<String, String>,
+    /// Certificate version (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub version: Option<String>,
+    /// Serial number assigned by the issuer (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub serial_number: Option<String>,
+    /// Signature algorithm used to sign the certificate (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub signature_algorithm: Option<String>,
+    /// Distinguished name of the certificate issuer (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub issuer: Option<String>,
+    /// Start of certificate validity period (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub validity_not_before: Option<StixTimestamp>,
+    /// End of certificate validity period (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub validity_not_after: Option<StixTimestamp>,
+    /// Distinguished name of the certificate subject (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject: Option<String>,
+    /// Algorithm used for the subject public key (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject_public_key_algorithm: Option<String>,
+    /// Modulus of the RSA subject public key (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject_public_key_modulus: Option<String>,
+    /// Exponent of the RSA subject public key (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     pub subject_public_key_exponent: Option<u64>,
+    /// X.509 v3 extensions present on the certificate (STIX §6.18.2).
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
@@ -195,8 +233,10 @@ pub struct X509Certificate {
 }
 
 impl X509Certificate {
+    /// STIX type name for X.509 certificates.
     pub const TYPE_NAME: &'static str = "x509-certificate";
 
+    /// Check certificate invariants (at least one property; non-empty extensions block).
     pub fn validate(&self) -> Result<(), ModelError> {
         if !self.has_specific_property() {
             return Err(ModelError::X509CertificateNoProperties);


### PR DESCRIPTION
## Summary

- Adds per-field rustdoc to all 18 STIX SCO types and 12 predefined extensions (plus nested public structs).
- Removes `#![allow(missing_docs)]` from `model::sco` and `model::sco::extensions`.
- Follows `Relationship` / `ScoCommonProps` documentation style with STIX § references and fixture-backed examples.

Closes #250.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`
- [x] `RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --locked --no-deps`
- [x] CI green on PR