### PR TITLE
fix(rstix): PR #268 review follow-up (docs + validation tests)

### DIFF
--- a/crates/rstix/src/model/sdo/observed_data.rs
+++ b/crates/rstix/src/model/sdo/observed_data.rs
@@ -10,7 +10,7 @@ use crate::model::sdo::validate_number_observed;
 use crate::model::sro::{SroObject, deserialize_sro_object_from_value};
 use crate::model::validate::validate_sco_or_sro_ref;
 
-/// Embedded object in deprecated observed-data [`objects`] (STIX §4.14.1).
+/// Embedded object in the deprecated observed-data `objects` map (STIX §4.14.1).
 ///
 /// The STIX 2.1 Specification §4.14.1 defines deprecated **`objects`** as a dictionary of
 /// cyber-observable (SCO) content and **`object_refs`** as a list of SCO and SRO

--- a/crates/rstix/src/model/sdo/observed_data.rs
+++ b/crates/rstix/src/model/sdo/observed_data.rs
@@ -10,13 +10,19 @@ use crate::model::sdo::validate_number_observed;
 use crate::model::sro::{SroObject, deserialize_sro_object_from_value};
 use crate::model::validate::validate_sco_or_sro_ref;
 
-/// Embedded object in deprecated observed-data `objects` (SCO or SRO).
+/// Embedded object in deprecated observed-data [`objects`] (STIX §4.14.1).
+///
+/// The STIX 2.1 Specification §4.14.1 defines deprecated **`objects`** as a dictionary of
+/// cyber-observable (SCO) content and **`object_refs`** as a list of SCO and SRO
+/// identifiers. This enum accepts both SCO and SRO members in the deprecated map so
+/// embedded entries align with the **`object_refs`** target set from the same section
+/// (§4.14.1, embedded **`object_refs`** in §4.14.2).
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ObservedDataEmbeddedObject {
-    /// Embedded cyber-observable.
+    /// Embedded cyber-observable (SCO), the type required by §4.14.1 **`objects`**.
     Sco(ScoObject),
-    /// Embedded relationship or sighting (STIX §4.14.1 deprecated form).
+    /// Embedded SRO in deprecated **`objects`** (see type-level note; allowed by **`object_refs`** targets in §4.14.1).
     Sro(SroObject),
 }
 

--- a/crates/rstix/src/model/validation.rs
+++ b/crates/rstix/src/model/validation.rs
@@ -396,6 +396,13 @@ fn selector_resolves(value: &serde_json::Value, selector: &str) -> bool {
     resolve_selector_value(value, selector).is_some()
 }
 
+/// Language-content nested rules (STIX 2.1 Specification §7.1.1).
+///
+/// When **`object_modified`** is present it MUST exactly match the referenced object's
+/// **`modified`** timestamp (§7.1.1). Mismatch is reported at validate time rather than
+/// during parse. [`Bundle::validate()`] emits
+/// [`ValidationCode::LanguageContentObjectModifiedMismatch`] when the target is in the
+/// bundle and the timestamps differ.
 fn check_language_content(
     bundle: &Bundle,
     content: &LanguageContent,

--- a/crates/rstix/tests/fixtures/validation/bundle-language-content-object-modified-mismatch.json
+++ b/crates/rstix/tests/fixtures/validation/bundle-language-content-object-modified-mismatch.json
@@ -1,0 +1,28 @@
+{
+  "type": "bundle",
+  "id": "bundle--00000000-0000-0000-0000-00000000001b",
+  "objects": [
+    {
+      "type": "attack-pattern",
+      "spec_version": "2.1",
+      "id": "attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+      "created": "2016-05-12T08:17:27.000Z",
+      "modified": "2016-05-12T08:17:27.000Z",
+      "name": "Spearphishing"
+    },
+    {
+      "type": "language-content",
+      "spec_version": "2.1",
+      "id": "language-content--c2c2c2c2-c2c2-4c2c-8c2c-c2c2c2c2c2c2",
+      "created": "2016-05-12T08:17:27.000Z",
+      "modified": "2016-05-12T08:17:27.000Z",
+      "object_ref": "attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+      "object_modified": "2017-01-01T00:00:00.000Z",
+      "contents": {
+        "de": {
+          "name": "Spearphishing"
+        }
+      }
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/validation/bundle-language-content-unknown-field.json
+++ b/crates/rstix/tests/fixtures/validation/bundle-language-content-unknown-field.json
@@ -1,0 +1,27 @@
+{
+  "type": "bundle",
+  "id": "bundle--00000000-0000-0000-0000-000000000019",
+  "objects": [
+    {
+      "type": "attack-pattern",
+      "spec_version": "2.1",
+      "id": "attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+      "created": "2016-05-12T08:17:27.000Z",
+      "modified": "2016-05-12T08:17:27.000Z",
+      "name": "Spearphishing"
+    },
+    {
+      "type": "language-content",
+      "spec_version": "2.1",
+      "id": "language-content--b1b1b1b1-b1b1-4b1b-8b1b-b1b1b1b1b1b1",
+      "created": "2016-05-12T08:17:27.000Z",
+      "modified": "2016-05-12T08:17:27.000Z",
+      "object_ref": "attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+      "contents": {
+        "de": {
+          "not_a_real_field": "translation"
+        }
+      }
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/validation/bundle-sco-deterministic-id-mismatch.json
+++ b/crates/rstix/tests/fixtures/validation/bundle-sco-deterministic-id-mismatch.json
@@ -1,0 +1,12 @@
+{
+  "type": "bundle",
+  "id": "bundle--00000000-0000-0000-0000-000000000018",
+  "objects": [
+    {
+      "type": "domain-name",
+      "spec_version": "2.1",
+      "id": "domain-name--00000000-0000-0000-0000-000000000001",
+      "value": "example.com"
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/validation/bundle-tlp1-marking-ref.json
+++ b/crates/rstix/tests/fixtures/validation/bundle-tlp1-marking-ref.json
@@ -7,11 +7,7 @@
       "spec_version": "2.1",
       "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
       "created": "2017-01-20T00:00:00.000Z",
-      "definition_type": "tlp",
-      "name": "TLP:WHITE",
-      "definition": {
-        "tlp": "white"
-      }
+      "name": "TLP:WHITE"
     },
     {
       "type": "attack-pattern",

--- a/crates/rstix/tests/fixtures/validation/bundle-tlp1-marking-ref.json
+++ b/crates/rstix/tests/fixtures/validation/bundle-tlp1-marking-ref.json
@@ -1,0 +1,28 @@
+{
+  "type": "bundle",
+  "id": "bundle--00000000-0000-0000-0000-00000000001a",
+  "objects": [
+    {
+      "type": "marking-definition",
+      "spec_version": "2.1",
+      "id": "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9",
+      "created": "2017-01-20T00:00:00.000Z",
+      "definition_type": "tlp",
+      "name": "TLP:WHITE",
+      "definition": {
+        "tlp": "white"
+      }
+    },
+    {
+      "type": "attack-pattern",
+      "spec_version": "2.1",
+      "id": "attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061",
+      "created": "2016-05-12T08:17:27.000Z",
+      "modified": "2016-05-12T08:17:27.000Z",
+      "name": "TLP1 marking ref",
+      "object_marking_refs": [
+        "marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"
+      ]
+    }
+  ]
+}

--- a/crates/rstix/tests/validation.rs
+++ b/crates/rstix/tests/validation.rs
@@ -203,11 +203,13 @@ fn tlp1_object_marking_ref_warns() {
     let bundle =
         parse_bundle(&load_fixture("validation/bundle-tlp1-marking-ref.json")).expect("parse");
     let report = bundle.validate();
-    assert!(
-        report
-            .warnings_with_code(ValidationCode::StixW0031TlpV1Encoding)
-            .next()
-            .is_some()
+    let warnings: Vec<_> = report
+        .warnings_with_code(ValidationCode::StixW0031TlpV1Encoding)
+        .collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].object_id.as_deref(),
+        Some("attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061")
     );
 }
 

--- a/crates/rstix/tests/validation.rs
+++ b/crates/rstix/tests/validation.rs
@@ -154,6 +154,64 @@ fn language_content_type_mismatch_warns() {
 }
 
 #[test]
+fn sco_deterministic_id_mismatch_warns() {
+    let bundle = parse_bundle(&load_fixture(
+        "validation/bundle-sco-deterministic-id-mismatch.json",
+    ))
+    .expect("parse");
+    let report = bundle.validate();
+    assert!(
+        report
+            .warnings_with_code(ValidationCode::ScoDeterministicIdMismatch)
+            .next()
+            .is_some()
+    );
+}
+
+#[test]
+fn language_content_unknown_field_warns() {
+    let bundle = parse_bundle(&load_fixture(
+        "validation/bundle-language-content-unknown-field.json",
+    ))
+    .expect("parse");
+    let report = bundle.validate();
+    assert!(
+        report
+            .warnings_with_code(ValidationCode::LanguageContentFieldUnknown)
+            .next()
+            .is_some()
+    );
+}
+
+#[test]
+fn language_content_object_modified_mismatch_warns() {
+    let bundle = parse_bundle(&load_fixture(
+        "validation/bundle-language-content-object-modified-mismatch.json",
+    ))
+    .expect("parse");
+    let report = bundle.validate();
+    assert!(
+        report
+            .warnings_with_code(ValidationCode::LanguageContentObjectModifiedMismatch)
+            .next()
+            .is_some()
+    );
+}
+
+#[test]
+fn tlp1_object_marking_ref_warns() {
+    let bundle =
+        parse_bundle(&load_fixture("validation/bundle-tlp1-marking-ref.json")).expect("parse");
+    let report = bundle.validate();
+    assert!(
+        report
+            .warnings_with_code(ValidationCode::StixW0031TlpV1Encoding)
+            .next()
+            .is_some()
+    );
+}
+
+#[test]
 fn validate_is_clean_for_minimal_bundle() {
     let raw = fixtures::load_spec_fixture("bundle/bundle-minimal.json");
     let bundle = Bundle::parse(&raw).expect("parse");


### PR DESCRIPTION
## Summary

Follow-up to merged PR #268 (@mostafa review). Closes non-blocking items #1–#3; defers #4 (validate performance / wire cache).

### Docs
- observed-data embedded SRO intent (STIX 2.1 §4.14.1)
- language-content `object_modified` checked at validate time (§7.1.1), not parse

### Tests
**Reviewer-requested (#3):** integration fixtures for validation codes called out in review:
- `ScoDeterministicIdMismatch`
- `LanguageContentFieldUnknown`
- `StixW0031TlpV1Encoding` (via `object_marking_refs`)

**Additional:** `LanguageContentObjectModifiedMismatch` — pairs with the #2 doc change so the validate-time `object_modified` check has explicit test coverage, not only rustdoc.

### Deferred (#4)
`validate()` re-serializes each object to JSON for selector / SCO-id / language-content checks (see `validation.rs` — `to_value` in the main loop and again for targets). Reviewer suggested caching wire JSON on `Bundle` to avoid redundant work at ATT&CK scale.

**Out of scope for this PR** (docs + test fixtures only). 
**Follow-up:** dedicated perf PR with lazy wire cache; behavior and advisory validate API unchanged.

## Test plan

- [x] `cargo test -p rstix --features serde --test validation` — 15 passed
- [ ] CI green on all OS