### PR TITLE
fix(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Security: transitive `anyhow` bump for RUSTSEC-2026-0190
+### Security: transitive `anyhow` bump for RUSTSEC-2026-0190 (#271)
 
 `cargo deny` flagged [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190), an unsoundness in `anyhow`'s `Error::downcast_mut()` where adding context via `Error::context` and then calling `downcast_mut` on the returned error violates borrow rules and triggers undefined behavior. It reaches the tree transitively. A targeted `cargo update -p anyhow` moves the workspace lockfile from 1.0.102 to the fixed 1.0.103 with no other dependency changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Security: transitive `anyhow` bump for RUSTSEC-2026-0190
+
+`cargo deny` flagged [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190), an unsoundness in `anyhow`'s `Error::downcast_mut()` where adding context via `Error::context` and then calling `downcast_mut` on the returned error violates borrow rules and triggers undefined behavior. It reaches the tree transitively. A targeted `cargo update -p anyhow` moves the workspace lockfile from 1.0.102 to the fixed 1.0.103 with no other dependency changes.
+
 ### Explain and introspect toolkit: detection explain, pipeline diff, correlation introspection (#270)
 
 A data-aware diagnostics suite that answers questions static tooling structurally cannot. Validation, linting, and the LSP operate on rule files with no event data, so they answer "is this rule well-formed?" A rule can be valid and still silently fail to match the event it was written for. This toolkit answers the orthogonal question: given this rule, this event, this pipeline, and this correlation state, why did I get this result? It ships in three independent tiers, all additive with no hot-path change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
## Summary

- The `audit` workflow on `main` is failing because `cargo deny` now flags [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190), an unsoundness in `anyhow`'s `Error::downcast_mut()`. Adding context via `Error::context` and then calling `downcast_mut` on the returned error violates borrow rules and triggers undefined behavior.
- `anyhow` is a transitive dependency, so this is a targeted lockfile-only bump from 1.0.102 to the fixed 1.0.103 via `cargo update -p anyhow`, with no other dependency changes.
- Adds a `### Security` entry to the `[Unreleased]` changelog section.

## Test plan

- [x] `cargo deny check` passes locally (advisories ok, bans ok, licenses ok, sources ok)
- [x] `audit` workflow green in CI