### PR TITLE
feat: unix domain socket support for the daemon (input, output, API listener)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Unix domain socket support for the daemon (input source, output sink, API listener)
+### Unix domain socket support for the daemon (input source, output sink, API listener) (#273)
 
 The daemon now speaks `unix://` on three surfaces (Unix targets only; gated behind the new runtime `uds` feature, which the `daemon` feature enables):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Unix domain socket support for the daemon (input source, output sink, API listener)
+
+The daemon now speaks `unix://` on three surfaces (Unix targets only; gated behind the new runtime `uds` feature, which the `daemon` feature enables):
+
+* **`--input unix:///path/to.sock`** ingests newline-delimited events over a Unix domain socket, so co-located log shippers (rsyslog `omuxsock`, syslog-ng `unix-stream`, Vector, Fluent Bit) can feed the daemon without a TCP port or the HTTP-ingest overhead. One reader task per connection feeds the bounded event channel (the same back-pressure model as stdin), with a 1 MiB per-line cap so an unterminated line cannot exhaust memory.
+* **`--output unix:///path/to.sock`** (also accepted by `--dlq`) writes NDJSON detections and incidents to a collector listening on a local socket, reconnecting once on a transient write failure before routing to the DLQ.
+* **`--api-addr unix:///path/to.sock`** serves the health, metrics, and `/api/v1/*` API (plus OTLP ingestion when built with `daemon-otlp`) over a permission-gated local socket. The socket is created `0600` and unlinked on clean shutdown, and a stale socket left by a crashed run is reclaimed on the next start. TLS terminates on TCP only, so `--tls-cert`/`--tls-key` combined with a `unix://` address is rejected at startup, and a `unix://` address is exempt from the non-loopback plaintext-bind refusal (the socket file is the trust boundary).
+
+On non-Unix targets `unix://` is rejected with the existing unsupported-scheme config error.
+
 ### Security: transitive `anyhow` bump for RUSTSEC-2026-0190 (#271)
 
 `cargo deny` flagged [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190), an unsoundness in `anyhow`'s `Error::downcast_mut()` where adding context via `Error::context` and then calling `downcast_mut` on the returned error violates borrow rules and triggers undefined behavior. It reaches the tree transitively. A targeted `cargo update -p anyhow` moves the workspace lockfile from 1.0.102 to the fixed 1.0.103 with no other dependency changes.

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 
 [features]
 default = ["daemon"]
-daemon = ["rsigma-runtime", "tokio", "axum", "async-trait", "prometheus", "notify", "rusqlite", "tower-http", "tokio-stream", "dep:sha2", "dep:getrandom"]
+daemon = ["rsigma-runtime", "rsigma-runtime/uds", "tokio", "axum", "async-trait", "prometheus", "notify", "rusqlite", "tower-http", "tokio-stream", "dep:sha2", "dep:getrandom"]
 # MCP server (`rsigma mcp serve`). Pulls in rmcp via rsigma-mcp and needs a
 # tokio runtime; opt-in, build with --features mcp (the prebuilt binaries and
 # Docker image, built with --all-features, include it).

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -52,7 +52,10 @@ pub(crate) struct DaemonArgs {
     #[arg(long)]
     pub pretty: bool,
 
-    /// Address for health, metrics, and API server (default: 0.0.0.0:9090)
+    /// Address for the health, metrics, and API server. A TCP `host:port`
+    /// (default 0.0.0.0:9090), or on Unix `unix:///path/to.sock` for a
+    /// permission-gated local socket (TLS is rejected on a unix:// address;
+    /// the socket file is the trust boundary).
     #[arg(long = "api-addr", default_value = config::defaults::API_ADDR)]
     pub api_addr: String,
 
@@ -1414,13 +1417,13 @@ fn run_daemon(
         &timestamp_fallback,
     );
 
-    let addr: std::net::SocketAddr = api_addr.parse().unwrap_or_else(|e| {
+    let addr = daemon::listen::ListenAddr::parse(&api_addr).unwrap_or_else(|e| {
         eprintln!("Invalid API address '{api_addr}': {e}");
         process::exit(exit_code::CONFIG_ERROR);
     });
 
     #[cfg(feature = "daemon-tls")]
-    let tls_state = build_tls_state(&tls_args, addr);
+    let tls_state = build_tls_state(&tls_args, &addr);
 
     #[cfg(feature = "daemon-nats")]
     let nats_config = rsigma_runtime::NatsConnectConfig {
@@ -1585,8 +1588,29 @@ pub(crate) fn parse_input_format(
 /// requested. Exits with `CONFIG_ERROR` on validation failure so the
 /// operator sees the problem before the daemon spins up.
 #[cfg(feature = "daemon-tls")]
-fn build_tls_state(args: &TlsCliArgs, addr: std::net::SocketAddr) -> Option<daemon::tls::TlsState> {
+fn build_tls_state(
+    args: &TlsCliArgs,
+    addr: &daemon::listen::ListenAddr,
+) -> Option<daemon::tls::TlsState> {
     use daemon::tls::{TlsCliConfig, TlsMinVersion, TlsState, enforce_plaintext_policy};
+
+    // TLS terminates on a TCP socket. A unix:// listener is gated by filesystem
+    // permissions instead, so cert/key on a UDS address is a configuration
+    // error and plaintext over a UDS needs no `--allow-plaintext` opt-in.
+    let tcp_addr = match addr {
+        daemon::listen::ListenAddr::Tcp(sa) => *sa,
+        #[cfg(unix)]
+        daemon::listen::ListenAddr::Unix(_) => {
+            if args.cert.is_some() || args.key.is_some() {
+                eprintln!(
+                    "--tls-cert/--tls-key cannot be combined with a unix:// API address; \
+                     a unix socket is secured by filesystem permissions, not TLS"
+                );
+                process::exit(exit_code::CONFIG_ERROR);
+            }
+            return None;
+        }
+    };
 
     match (args.cert.as_ref(), args.key.as_ref()) {
         (Some(cert), Some(key)) => {
@@ -1610,7 +1634,7 @@ fn build_tls_state(args: &TlsCliArgs, addr: std::net::SocketAddr) -> Option<daem
             }
         }
         (None, None) => {
-            if let Err(msg) = enforce_plaintext_policy(addr, args.allow_plaintext) {
+            if let Err(msg) = enforce_plaintext_policy(tcp_addr, args.allow_plaintext) {
                 eprintln!("{msg}");
                 process::exit(exit_code::CONFIG_ERROR);
             }

--- a/crates/rsigma-cli/src/commands/daemon.rs
+++ b/crates/rsigma-cli/src/commands/daemon.rs
@@ -103,7 +103,8 @@ pub(crate) struct DaemonArgs {
     pub state_save_interval: u64,
 
     /// Event input source. Supported schemes: `stdin`, `http`,
-    /// `nats://<host>:<port>/<subject>`.
+    /// `nats://<host>:<port>/<subject>`, and on Unix `unix:///path/to.sock`
+    /// (newline-delimited events over a Unix domain socket).
     #[arg(long = "input", default_value = config::defaults::INPUT_SOURCE)]
     pub input: String,
 
@@ -111,6 +112,7 @@ pub(crate) struct DaemonArgs {
     /// Supported schemes: `stdout`, `file://<path>`,
     /// `nats://<host>:<port>/<subject>`, `otlp(s)://<host>:<port>` (OTLP/gRPC),
     /// `otlphttp(s)://<host>:<port>` (OTLP/HTTP); the `s` variants use TLS.
+    /// On Unix, `unix:///path/to.sock` writes NDJSON to a local socket.
     /// Query params: `?on_full=drop` (best-effort), `?compression=gzip` (OTLP),
     /// and for TLS `?ca=`, `?client_cert=`, `?client_key=` (PEM paths, the last
     /// two for mutual TLS) and `?tls_domain=` (SNI override).
@@ -152,9 +154,9 @@ pub(crate) struct DaemonArgs {
     pub batch_flush_ms: u64,
 
     /// Dead-letter queue target for events that fail processing.
-    /// Accepts the same schemes as `--output`: `stdout`,
-    /// `file://<path>`, `nats://<host>:<port>/<subject>`. When not
-    /// set, failed events are logged and discarded.
+    /// Accepts the same schemes as `--output` (`stdout`, `file://<path>`,
+    /// `nats://<host>:<port>/<subject>`, and on Unix `unix:///path/to.sock`).
+    /// When not set, failed events are logged and discarded.
     #[arg(long = "dlq")]
     pub dlq: Option<String>,
 

--- a/crates/rsigma-cli/src/config/schema.rs
+++ b/crates/rsigma-cli/src/config/schema.rs
@@ -190,7 +190,9 @@ impl Merge for DaemonPartial {
 /// API listener settings.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct ApiPartial {
-    /// Bind address for health, metrics, and the HTTP/OTLP API.
+    /// Bind address for health, metrics, and the HTTP/OTLP API: a TCP
+    /// `host:port`, or on Unix `unix:///path/to.sock` (TLS is rejected on a
+    /// unix:// address).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
     /// TLS settings. Ignored unless built with `daemon-tls`.
@@ -237,7 +239,8 @@ impl Merge for TlsPartial {
 /// Event input settings.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct InputPartial {
-    /// Event source: `stdin`, `http`, `nats://host:port/subject`.
+    /// Event source: `stdin`, `http`, `nats://host:port/subject`, or on Unix
+    /// `unix:///path/to.sock` (newline-delimited events over a Unix socket).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
     /// Log format: `auto`, `json`, `syslog`, `plain`, `logfmt`, `cef`.
@@ -281,7 +284,8 @@ impl Merge for InputPartial {
 pub(crate) struct OutputPartial {
     /// Detection sinks: `stdout`, `file://path`, `nats://host:port/subject`,
     /// `otlp(s)://host:port` (gRPC), `otlphttp(s)://host:port` (HTTP); the `s`
-    /// variants use TLS. Optional query suffixes: `?on_full=drop`,
+    /// variants use TLS. On Unix, `unix:///path/to.sock` writes NDJSON to a
+    /// local socket. Optional query suffixes: `?on_full=drop`,
     /// `?compression=gzip`, and for TLS `?ca=`, `?client_cert=`, `?client_key=`,
     /// `?tls_domain=`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/rsigma-cli/src/daemon/listen.rs
+++ b/crates/rsigma-cli/src/daemon/listen.rs
@@ -1,0 +1,88 @@
+//! Listen address for the daemon API server: a TCP `host:port` or, on Unix, a
+//! `unix:///path/to.sock` domain socket.
+//!
+//! A Unix socket is gated by filesystem permissions rather than TLS, so it is
+//! treated as a local trust boundary: TLS is rejected on a `unix://` address
+//! and the plaintext-bind refusal does not apply.
+
+use std::fmt;
+use std::net::SocketAddr;
+#[cfg(unix)]
+use std::path::PathBuf;
+
+/// Where the daemon API server listens.
+#[derive(Clone, Debug)]
+pub(crate) enum ListenAddr {
+    /// A TCP socket address.
+    Tcp(SocketAddr),
+    /// A Unix domain socket path (Unix only).
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+impl ListenAddr {
+    /// Parse `--api-addr`: a `unix://` URI becomes [`ListenAddr::Unix`],
+    /// anything else is parsed as a TCP `SocketAddr`.
+    pub(crate) fn parse(spec: &str) -> Result<Self, String> {
+        if let Some(path) = spec.strip_prefix("unix://") {
+            #[cfg(unix)]
+            {
+                if path.is_empty() {
+                    return Err("unix:// socket path is empty".to_string());
+                }
+                return Ok(ListenAddr::Unix(PathBuf::from(path)));
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = path;
+                return Err(
+                    "unix:// API addresses are only supported on Unix platforms".to_string()
+                );
+            }
+        }
+        spec.parse::<SocketAddr>()
+            .map(ListenAddr::Tcp)
+            .map_err(|e| format!("expected host:port or unix://path: {e}"))
+    }
+}
+
+impl fmt::Display for ListenAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ListenAddr::Tcp(addr) => write!(f, "{addr}"),
+            #[cfg(unix)]
+            ListenAddr::Unix(path) => write!(f, "unix://{}", path.display()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tcp_addr() {
+        let addr = ListenAddr::parse("127.0.0.1:9090").unwrap();
+        assert!(matches!(addr, ListenAddr::Tcp(_)));
+        assert_eq!(addr.to_string(), "127.0.0.1:9090");
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(ListenAddr::parse("not-an-addr").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_unix_path() {
+        let addr = ListenAddr::parse("unix:///run/rsigma/api.sock").unwrap();
+        assert!(matches!(addr, ListenAddr::Unix(_)));
+        assert_eq!(addr.to_string(), "unix:///run/rsigma/api.sock");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_empty_unix_path() {
+        assert!(ListenAddr::parse("unix://").is_err());
+    }
+}

--- a/crates/rsigma-cli/src/daemon/mod.rs
+++ b/crates/rsigma-cli/src/daemon/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod dispositions;
 pub(crate) mod enrichment;
 mod health;
 mod instrumented_resolver;
+pub(crate) mod listen;
 mod metrics;
 mod reload;
 pub(crate) mod server;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -1259,10 +1259,29 @@ pub async fn run_daemon(config: DaemonConfig) {
                 }
             }
         }
+        #[cfg(unix)]
+        input if input.starts_with("unix://") => {
+            let path = input.strip_prefix("unix://").unwrap_or(input);
+            match rsigma_runtime::UnixSocketSource::bind(std::path::Path::new(path)).await {
+                Ok(source) => {
+                    let h = spawn_source(
+                        source,
+                        event_tx,
+                        Some(metrics.clone() as Arc<dyn rsigma_runtime::MetricsHook>),
+                    );
+                    tracing::info!(path = path, "Unix socket source started");
+                    Some(h)
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, path = path, "Failed to bind unix socket source");
+                    std::process::exit(crate::exit_code::CONFIG_ERROR);
+                }
+            }
+        }
         other => {
             tracing::error!(
                 input = other,
-                "Unsupported input source (supported: stdin, http, nats://)"
+                "Unsupported input source (supported: stdin, http, nats://, unix://)"
             );
             std::process::exit(crate::exit_code::CONFIG_ERROR);
         }
@@ -2077,9 +2096,23 @@ async fn build_sink(
         }
     }
 
+    #[cfg(unix)]
+    if let Some(path) = base.strip_prefix("unix://") {
+        return match rsigma_runtime::UnixSocketSink::connect(std::path::Path::new(path)).await {
+            Ok(unix_sink) => {
+                tracing::info!(path, "Unix socket sink started");
+                (Sink::Unix(Box::new(unix_sink)), on_full)
+            }
+            Err(e) => {
+                tracing::error!(path, error = %e, "Failed to connect unix socket sink");
+                std::process::exit(crate::exit_code::CONFIG_ERROR);
+            }
+        };
+    }
+
     tracing::error!(
         output = base,
-        "Unsupported output sink (supported: stdout, file://<path>, nats://, otlp://, otlphttp://)"
+        "Unsupported output sink (supported: stdout, file://<path>, nats://, otlp://, otlphttp://, unix://)"
     );
     std::process::exit(crate::exit_code::CONFIG_ERROR);
 }

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -37,10 +36,18 @@ struct DlqEntry {
 }
 
 use super::health::HealthState;
+use super::listen::ListenAddr;
 use super::metrics::Metrics;
 use super::reload;
 use super::store::{SourcePosition, SqliteStateStore};
 use crate::EventFilter;
+
+/// The bound API listener: a TCP socket, or a Unix domain socket on Unix.
+enum BoundListener {
+    Tcp(tokio::net::TcpListener),
+    #[cfg(unix)]
+    Unix(tokio::net::UnixListener),
+}
 
 /// Effective live event-tap limits, resolved from `daemon.tap.*` plus the
 /// `--enable-tap` flag.
@@ -155,7 +162,7 @@ pub struct DaemonConfig {
     pub corr_config: CorrelationConfig,
     pub include_event: bool,
     pub pretty: bool,
-    pub api_addr: SocketAddr,
+    pub api_addr: super::listen::ListenAddr,
     pub event_filter: Arc<EventFilter>,
     pub state_db: Option<PathBuf>,
     pub state_save_interval: u64,
@@ -878,13 +885,39 @@ pub async fn run_daemon(config: DaemonConfig) {
 
     let app = app.layer(TraceLayer::new_for_http()).with_state(app_state);
 
-    let listener = tokio::net::TcpListener::bind(config.api_addr)
-        .await
-        .unwrap_or_else(|e| {
-            tracing::error!(addr = %config.api_addr, error = %e, "Failed to bind API server");
-            std::process::exit(crate::exit_code::CONFIG_ERROR);
-        });
-    let actual_addr = listener.local_addr().unwrap_or(config.api_addr);
+    // The UDS guard unlinks the socket file when `run_daemon` returns (after
+    // the drain), so a clean shutdown leaves no stale socket behind.
+    #[cfg(unix)]
+    let mut _uds_guard: Option<rsigma_runtime::UnixSocketGuard> = None;
+    let (bound, actual_addr) = match &config.api_addr {
+        ListenAddr::Tcp(addr) => {
+            let listener = tokio::net::TcpListener::bind(addr)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!(addr = %addr, error = %e, "Failed to bind API server");
+                    std::process::exit(crate::exit_code::CONFIG_ERROR);
+                });
+            let actual = listener
+                .local_addr()
+                .map(|a| a.to_string())
+                .unwrap_or_else(|_| addr.to_string());
+            (BoundListener::Tcp(listener), actual)
+        }
+        #[cfg(unix)]
+        ListenAddr::Unix(path) => {
+            let (listener, guard) = rsigma_runtime::bind_unix_listener(path)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!(path = %path.display(), error = %e, "Failed to bind API server unix socket");
+                    std::process::exit(crate::exit_code::CONFIG_ERROR);
+                });
+            _uds_guard = Some(guard);
+            (
+                BoundListener::Unix(listener),
+                format!("unix://{}", path.display()),
+            )
+        }
+    };
 
     // Install the OS signal handlers eagerly, before the listener is
     // announced and reachable. The kernel completes the TCP handshake for
@@ -1767,25 +1800,39 @@ pub async fn run_daemon(config: DaemonConfig) {
     #[cfg(not(feature = "daemon-otlp"))]
     let unified_app: axum::Router = app;
 
-    let mut serve_handle = {
-        #[cfg(feature = "daemon-tls")]
-        {
-            if let Some(state) = tls_state {
-                let tls_listener = super::tls::RustlsListener::new(
-                    listener,
-                    state.config.clone(),
-                    metrics.tls_active_connections.clone(),
-                );
-                let shutdown_fut = shutdown_fut.take().expect("shutdown future consumed once");
-                tokio::spawn(async move {
-                    if let Err(e) = axum::serve(tls_listener, unified_app)
-                        .with_graceful_shutdown(shutdown_fut)
-                        .await
-                    {
-                        tracing::error!(error = %e, "server error");
-                    }
-                })
-            } else {
+    let mut serve_handle = match bound {
+        BoundListener::Tcp(listener) => {
+            #[cfg(feature = "daemon-tls")]
+            {
+                if let Some(state) = tls_state {
+                    let tls_listener = super::tls::RustlsListener::new(
+                        listener,
+                        state.config.clone(),
+                        metrics.tls_active_connections.clone(),
+                    );
+                    let shutdown_fut = shutdown_fut.take().expect("shutdown future consumed once");
+                    tokio::spawn(async move {
+                        if let Err(e) = axum::serve(tls_listener, unified_app)
+                            .with_graceful_shutdown(shutdown_fut)
+                            .await
+                        {
+                            tracing::error!(error = %e, "server error");
+                        }
+                    })
+                } else {
+                    let shutdown_fut = shutdown_fut.take().expect("shutdown future consumed once");
+                    tokio::spawn(async move {
+                        if let Err(e) = axum::serve(listener, unified_app)
+                            .with_graceful_shutdown(shutdown_fut)
+                            .await
+                        {
+                            tracing::error!(error = %e, "server error");
+                        }
+                    })
+                }
+            }
+            #[cfg(not(feature = "daemon-tls"))]
+            {
                 let shutdown_fut = shutdown_fut.take().expect("shutdown future consumed once");
                 tokio::spawn(async move {
                     if let Err(e) = axum::serve(listener, unified_app)
@@ -1797,8 +1844,10 @@ pub async fn run_daemon(config: DaemonConfig) {
                 })
             }
         }
-        #[cfg(not(feature = "daemon-tls"))]
-        {
+        // A unix:// listener never terminates TLS (rejected at config time), so
+        // it always serves plaintext over the socket.
+        #[cfg(unix)]
+        BoundListener::Unix(listener) => {
             let shutdown_fut = shutdown_fut.take().expect("shutdown future consumed once");
             tokio::spawn(async move {
                 if let Err(e) = axum::serve(listener, unified_app)

--- a/crates/rsigma-cli/tests/cli_daemon_uds.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_uds.rs
@@ -1,0 +1,136 @@
+//! E2E tests for the daemon's `--api-addr unix://` listener.
+//!
+//! The shared `DaemonProcess` harness is TCP-only (it probes with
+//! `TcpStream::connect`), so these tests spawn the daemon directly and speak
+//! raw HTTP/1.1 over a `UnixStream`.
+
+#![cfg(all(feature = "daemon", unix))]
+
+mod common;
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use common::{SIMPLE_RULE, rsigma_bin, temp_file};
+
+/// Kills + reaps the daemon on drop so a failed assertion never leaks it.
+struct Daemon(std::process::Child);
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Send `GET <route>` over the Unix socket and return `(status, body)`.
+fn uds_get(path: &std::path::Path, route: &str) -> std::io::Result<(u16, String)> {
+    let mut stream = UnixStream::connect(path)?;
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    write!(
+        stream,
+        "GET {route} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    )?;
+    stream.flush()?;
+
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw)?;
+    let text = String::from_utf8_lossy(&raw);
+    let status = text
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(0);
+    let body = text.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+    Ok((status, body))
+}
+
+#[test]
+fn api_listener_serves_healthz_over_unix_socket() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("api.sock");
+
+    let child = Command::new(rsigma_bin())
+        .args([
+            "engine",
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--input",
+            "http",
+            "--api-addr",
+            &format!("unix://{}", sock.display()),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn daemon");
+    let _daemon = Daemon(child);
+
+    // Poll until the listener answers (the socket file appears at bind, but the
+    // serve task starts a moment later).
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok((200, body)) = uds_get(&sock, "/healthz") {
+            let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(v["status"], "ok");
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("daemon /healthz never answered over the unix socket within 10s");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(feature = "daemon-tls")]
+#[test]
+fn tls_cert_with_unix_api_addr_is_rejected() {
+    let rule = temp_file(".yml", SIMPLE_RULE);
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("api.sock");
+
+    // The rejection fires before any TLS material is loaded, so the cert/key
+    // paths need not exist.
+    let mut child = Command::new(rsigma_bin())
+        .args([
+            "engine",
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--input",
+            "http",
+            "--api-addr",
+            &format!("unix://{}", sock.display()),
+            "--tls-cert",
+            "/nonexistent/cert.pem",
+            "--tls-key",
+            "/nonexistent/key.pem",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn daemon");
+
+    let stderr = child.stderr.take().unwrap();
+    let mut message = String::new();
+    for line in BufReader::new(stderr).lines() {
+        let Ok(line) = line else { break };
+        if line.contains("unix://") {
+            message = line;
+            break;
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        message.contains("cannot be combined with a unix://"),
+        "expected a TLS-over-UDS rejection, got: {message:?}"
+    );
+}

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -16,6 +16,9 @@ otlp = ["opentelemetry-proto", "prost", "tonic", "flate2", "rustls"]
 logfmt = []
 cef = []
 evtx = ["dep:evtx"]
+# Unix domain socket event source and sink (unix:// input/output). Pulls in
+# tokio's net feature; the code is additionally #[cfg(unix)]-gated.
+uds = ["tokio/net"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]

--- a/crates/rsigma-runtime/src/io/mod.rs
+++ b/crates/rsigma-runtime/src/io/mod.rs
@@ -10,6 +10,12 @@ mod nats_source;
 pub mod otlp;
 mod stdin;
 mod stdout;
+#[cfg(all(unix, feature = "uds"))]
+mod unix;
+#[cfg(all(unix, feature = "uds"))]
+mod unix_sink;
+#[cfg(all(unix, feature = "uds"))]
+mod unix_source;
 pub mod webhook;
 
 pub use delivery::{
@@ -24,6 +30,12 @@ pub use nats_sink::NatsSink;
 pub use nats_source::{NatsSource, ReplayPolicy};
 pub use stdin::StdinSource;
 pub use stdout::StdoutSink;
+#[cfg(all(unix, feature = "uds"))]
+pub use unix::{UnixSocketGuard, bind_unix_listener, parse_unix_scheme};
+#[cfg(all(unix, feature = "uds"))]
+pub use unix_sink::UnixSocketSink;
+#[cfg(all(unix, feature = "uds"))]
+pub use unix_source::UnixSocketSource;
 
 use std::sync::Arc;
 
@@ -128,6 +140,9 @@ pub enum Sink {
     Otlp(Box<otlp::OtlpSink>),
     /// Render and POST a templated HTTP request per result.
     Webhook(Box<webhook::WebhookSink>),
+    /// Write NDJSON to a Unix domain socket (client connection).
+    #[cfg(all(unix, feature = "uds"))]
+    Unix(Box<UnixSocketSink>),
     /// Fan out to multiple sinks.
     FanOut(Vec<Sink>),
 }
@@ -163,6 +178,8 @@ impl Sink {
                 // with a per-item context; this direct path is a completeness
                 // fallback, so it mints a one-shot context.
                 Sink::Webhook(s) => s.send(result, &DeliveryContext::new()).await,
+                #[cfg(all(unix, feature = "uds"))]
+                Sink::Unix(s) => s.send(result).await,
                 Sink::FanOut(sinks) => {
                     for (idx, sink) in sinks.iter_mut().enumerate() {
                         if let Err(e) = sink.send(result).await {
@@ -200,6 +217,8 @@ impl Sink {
                 // delivery path always uses `send`, so this is never hit on
                 // the webhook hot path.
                 Sink::Webhook(_) => Ok(()),
+                #[cfg(all(unix, feature = "uds"))]
+                Sink::Unix(s) => s.send_raw(json).await,
                 Sink::FanOut(sinks) => {
                     for (idx, sink) in sinks.iter_mut().enumerate() {
                         if let Err(e) = sink.send_raw(json).await {
@@ -241,6 +260,8 @@ impl Sink {
                 #[cfg(feature = "otlp")]
                 Sink::Otlp(_) => Ok(()),
                 Sink::Webhook(_) => Ok(()),
+                #[cfg(all(unix, feature = "uds"))]
+                Sink::Unix(s) => s.send_raw(&env.json).await,
                 Sink::FanOut(sinks) => {
                     for (idx, sink) in sinks.iter_mut().enumerate() {
                         if let Err(e) = sink.send_incident(env).await {
@@ -272,6 +293,8 @@ impl Sink {
             // The webhook id (leaked to `&'static`) so its shared per-sink
             // series maps one-to-one to the `rsigma_webhook_*` series.
             Sink::Webhook(s) => s.label(),
+            #[cfg(all(unix, feature = "uds"))]
+            Sink::Unix(_) => "unix",
             Sink::FanOut(_) => "fanout",
         }
     }

--- a/crates/rsigma-runtime/src/io/unix.rs
+++ b/crates/rsigma-runtime/src/io/unix.rs
@@ -1,0 +1,146 @@
+//! Shared Unix domain socket helpers: scheme parsing, listener binding with
+//! stale-socket recovery, and socket-file cleanup.
+//!
+//! Used by the `unix://` event source ([`super::UnixSocketSource`]) and the
+//! daemon's `--api-addr unix://` listener. Gated behind
+//! `#[cfg(all(unix, feature = "uds"))]`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use tokio::net::{UnixListener, UnixStream};
+
+/// Permission mode applied to a freshly bound socket file: owner read/write
+/// only. The socket is the local trust boundary, so it must not be group- or
+/// world-accessible by default.
+const SOCKET_MODE: u32 = 0o600;
+
+/// Strip a `unix://` scheme prefix, returning the socket path, or `None` when
+/// `spec` is not a `unix://` URI.
+pub fn parse_unix_scheme(spec: &str) -> Option<PathBuf> {
+    spec.strip_prefix("unix://").map(PathBuf::from)
+}
+
+/// Unlinks a bound socket file when dropped.
+///
+/// The daemon listener and the event source hold one for the socket's lifetime
+/// so a clean shutdown leaves no stale file behind. A crash leaves the file,
+/// which [`bind_unix_listener`] removes on the next start.
+#[derive(Debug)]
+pub struct UnixSocketGuard {
+    path: PathBuf,
+}
+
+impl Drop for UnixSocketGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Bind a [`UnixListener`] at `path`, recovering from a stale socket file left
+/// by a previously crashed run.
+///
+/// On `AddrInUse` the existing socket is probed by connecting to it: a
+/// successful connect means another live process owns it (returned as an error
+/// so two daemons never fight over one path), while a failed connect means the
+/// file is stale and is removed and rebound. The socket file is then restricted
+/// to `0600`.
+///
+/// Returns the listener plus a [`UnixSocketGuard`] that unlinks the socket on
+/// drop; hold it for the listener's lifetime.
+pub async fn bind_unix_listener(path: &Path) -> io::Result<(UnixListener, UnixSocketGuard)> {
+    let listener = match UnixListener::bind(path) {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == io::ErrorKind::AddrInUse => {
+            if UnixStream::connect(path).await.is_ok() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AddrInUse,
+                    format!(
+                        "unix socket {} is already in use by a running process",
+                        path.display()
+                    ),
+                ));
+            }
+            tracing::warn!(path = %path.display(), "removing stale unix socket");
+            std::fs::remove_file(path)?;
+            UnixListener::bind(path)?
+        }
+        Err(e) => return Err(e),
+    };
+
+    set_socket_permissions(path)?;
+    Ok((
+        listener,
+        UnixSocketGuard {
+            path: path.to_path_buf(),
+        },
+    ))
+}
+
+/// Restrict the socket file to owner-only access.
+///
+/// There is a small window between `bind` and this `chmod` during which the
+/// socket inherits the process umask; deployments that need to close it should
+/// place the socket in a directory only the daemon's user can traverse.
+fn set_socket_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(SOCKET_MODE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_unix_scheme_strips_prefix() {
+        assert_eq!(
+            parse_unix_scheme("unix:///run/rsigma.sock"),
+            Some(PathBuf::from("/run/rsigma.sock"))
+        );
+        assert_eq!(parse_unix_scheme("stdin"), None);
+        assert_eq!(parse_unix_scheme("nats://host/subject"), None);
+    }
+
+    #[tokio::test]
+    async fn bind_creates_owner_only_socket_and_guard_unlinks() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("api.sock");
+
+        let (listener, guard) = bind_unix_listener(&path).await.unwrap();
+        assert!(path.exists());
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, SOCKET_MODE);
+
+        drop(listener);
+        drop(guard);
+        assert!(!path.exists(), "guard should unlink the socket on drop");
+    }
+
+    #[tokio::test]
+    async fn bind_recovers_stale_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("api.sock");
+
+        // First bind, then drop only the listener (leaving a stale file as if
+        // the process had crashed without the guard running).
+        let (listener, guard) = bind_unix_listener(&path).await.unwrap();
+        std::mem::forget(guard); // skip the unlink-on-drop
+        drop(listener);
+        assert!(path.exists());
+
+        // A fresh bind must reclaim the stale path rather than failing.
+        let (_listener, _guard) = bind_unix_listener(&path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bind_rejects_live_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("api.sock");
+
+        let (_listener, _guard) = bind_unix_listener(&path).await.unwrap();
+        // A second bind while the first listener is alive must fail.
+        let err = bind_unix_listener(&path).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+    }
+}

--- a/crates/rsigma-runtime/src/io/unix_sink.rs
+++ b/crates/rsigma-runtime/src/io/unix_sink.rs
@@ -1,0 +1,111 @@
+//! `unix://` output sink: forward NDJSON detections and incidents to a
+//! collector listening on a Unix domain socket.
+//!
+//! Dials the socket as a client and reconnects once on a write failure before
+//! surfacing the error (which the daemon routes to the DLQ, like any other
+//! sink failure).
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+
+use rsigma_eval::ProcessResult;
+
+use crate::error::RuntimeError;
+
+/// Writes NDJSON to a Unix domain socket, reconnecting on transient failures.
+pub struct UnixSocketSink {
+    path: PathBuf,
+    stream: Option<UnixStream>,
+}
+
+impl UnixSocketSink {
+    /// Connect to the collector socket at `path`.
+    pub async fn connect(path: &Path) -> std::io::Result<Self> {
+        let stream = UnixStream::connect(path).await?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            stream: Some(stream),
+        })
+    }
+
+    /// Serialize and deliver each entry of a `ProcessResult` as one NDJSON line.
+    pub async fn send(&mut self, result: &ProcessResult) -> Result<(), RuntimeError> {
+        if result.is_empty() {
+            return Ok(());
+        }
+        for m in result {
+            let json = serde_json::to_string(m)?;
+            self.write_line(&json).await?;
+        }
+        Ok(())
+    }
+
+    /// Write a pre-serialized JSON line directly to the socket.
+    pub async fn send_raw(&mut self, json: &str) -> Result<(), RuntimeError> {
+        self.write_line(json).await
+    }
+
+    /// Write one line, reconnecting once if the socket has gone away.
+    async fn write_line(&mut self, json: &str) -> Result<(), RuntimeError> {
+        if self.try_write(json).await.is_err() {
+            // Drop the dead stream and try a single reconnect; a second
+            // failure surfaces to the caller (and the DLQ).
+            self.stream = None;
+            self.try_write(json).await?;
+        }
+        Ok(())
+    }
+
+    async fn try_write(&mut self, json: &str) -> Result<(), RuntimeError> {
+        let stream = match self.stream.as_mut() {
+            Some(stream) => stream,
+            None => {
+                let stream = UnixStream::connect(&self.path).await?;
+                self.stream.insert(stream)
+            }
+        };
+        stream.write_all(json.as_bytes()).await?;
+        stream.write_all(b"\n").await?;
+        stream.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::UnixListener;
+
+    #[tokio::test]
+    async fn writes_ndjson_lines_to_collector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("collector.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let accept = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut lines = BufReader::new(stream).lines();
+            let mut out = Vec::new();
+            while let Some(line) = lines.next_line().await.unwrap() {
+                out.push(line);
+                if out.len() == 2 {
+                    break;
+                }
+            }
+            out
+        });
+
+        let mut sink = UnixSocketSink::connect(&path).await.unwrap();
+        sink.send_raw("{\"a\":1}").await.unwrap();
+        sink.send_raw("{\"b\":2}").await.unwrap();
+
+        let received = accept.await.unwrap();
+        assert_eq!(
+            received,
+            vec!["{\"a\":1}".to_string(), "{\"b\":2}".to_string()]
+        );
+    }
+}

--- a/crates/rsigma-runtime/src/io/unix_source.rs
+++ b/crates/rsigma-runtime/src/io/unix_source.rs
@@ -1,0 +1,186 @@
+//! `unix://` event source: accept newline-delimited events over a Unix domain
+//! socket.
+//!
+//! Modeled on [`StdinSource`](super::StdinSource) but fed by an accept loop, so
+//! co-located log shippers (rsyslog `omuxsock`, syslog-ng `unix-stream`,
+//! Vector, Fluent Bit) can connect concurrently. Each line becomes one
+//! [`RawEvent`]; acks are a no-op (a raw stream has no per-message ack).
+
+use std::path::Path;
+
+use tokio::io::AsyncReadExt;
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::mpsc;
+
+use super::unix::{UnixSocketGuard, bind_unix_listener};
+use super::{AckToken, EventSource, RawEvent};
+
+/// Maximum length of a single newline-delimited line. Mirrors the daemon's
+/// HTTP ingest cap so a client that never sends a newline cannot exhaust
+/// memory; longer lines are dropped with a warning.
+const MAX_LINE_BYTES: usize = 1024 * 1024;
+
+/// Channel capacity between the socket readers and the engine. Bounded so a
+/// slow pipeline back-pressures the readers (which stop draining their
+/// sockets) instead of buffering unboundedly.
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// Reads events from a Unix domain socket, one record per line.
+pub struct UnixSocketSource {
+    rx: mpsc::Receiver<String>,
+    /// Unlinks the socket file when the source is dropped (daemon shutdown).
+    _guard: UnixSocketGuard,
+}
+
+impl UnixSocketSource {
+    /// Bind the socket at `path` and start accepting connections.
+    pub async fn bind(path: &Path) -> std::io::Result<Self> {
+        let (listener, guard) = bind_unix_listener(path).await?;
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        tokio::spawn(accept_loop(listener, tx));
+        Ok(Self { rx, _guard: guard })
+    }
+}
+
+/// Accept connections, spawning one reader task per connection. Ends when every
+/// reader has dropped the shared sender (the channel receiver closed on
+/// shutdown) or is aborted with the daemon.
+async fn accept_loop(listener: UnixListener, tx: mpsc::Sender<String>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _addr)) => {
+                tokio::spawn(read_connection(stream, tx.clone()));
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "unix socket accept failed");
+                // Brief backoff so a persistent accept error does not spin.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    }
+}
+
+/// Read newline-delimited records from one connection, forwarding each to the
+/// engine. Bounds each line to `MAX_LINE_BYTES`, discarding longer ones.
+async fn read_connection(mut stream: UnixStream, tx: mpsc::Sender<String>) {
+    let mut line: Vec<u8> = Vec::with_capacity(256);
+    let mut chunk = [0u8; 8192];
+    // True while discarding the tail of an over-long line.
+    let mut discarding = false;
+
+    loop {
+        let n = match stream.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(error = %e, "unix socket read failed");
+                break;
+            }
+        };
+        for &byte in &chunk[..n] {
+            if byte == b'\n' {
+                if discarding {
+                    discarding = false;
+                } else if !line.is_empty() {
+                    let decoded = take_line(&mut line);
+                    if tx.send(decoded).await.is_err() {
+                        return; // receiver gone: shutting down
+                    }
+                }
+                line.clear();
+            } else if discarding {
+                continue;
+            } else if line.len() >= MAX_LINE_BYTES {
+                tracing::warn!(
+                    max_bytes = MAX_LINE_BYTES,
+                    "dropping over-long unix socket line"
+                );
+                discarding = true;
+                line.clear();
+            } else {
+                line.push(byte);
+            }
+        }
+    }
+
+    // Flush a trailing line that ended at EOF without a newline.
+    if !discarding && !line.is_empty() {
+        let _ = tx.send(take_line(&mut line)).await;
+    }
+}
+
+/// Decode the accumulated bytes (minus a trailing CR) as UTF-8, returning an
+/// empty string for invalid UTF-8 (skipped downstream).
+fn take_line(line: &mut Vec<u8>) -> String {
+    if line.last() == Some(&b'\r') {
+        line.pop();
+    }
+    match std::str::from_utf8(line) {
+        Ok(s) => s.to_string(),
+        Err(_) => {
+            tracing::warn!("dropping non-UTF-8 line on unix socket");
+            String::new()
+        }
+    }
+}
+
+impl EventSource for UnixSocketSource {
+    async fn recv(&mut self) -> Option<RawEvent> {
+        loop {
+            match self.rx.recv().await {
+                Some(line) if !line.trim().is_empty() => {
+                    return Some(RawEvent {
+                        payload: line,
+                        ack_token: AckToken::Noop,
+                    });
+                }
+                Some(_) => continue,
+                None => return None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn round_trips_newline_delimited_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ingest.sock");
+
+        let mut source = UnixSocketSource::bind(&path).await.unwrap();
+
+        let mut client = UnixStream::connect(&path).await.unwrap();
+        client
+            .write_all(b"{\"a\":1}\n   \n{\"b\":2}\n")
+            .await
+            .unwrap();
+        client.flush().await.unwrap();
+
+        let first = source.recv().await.unwrap();
+        assert_eq!(first.payload, "{\"a\":1}");
+        // The blank line is skipped.
+        let second = source.recv().await.unwrap();
+        assert_eq!(second.payload, "{\"b\":2}");
+    }
+
+    #[tokio::test]
+    async fn drops_over_long_lines_but_keeps_the_next() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ingest.sock");
+
+        let mut source = UnixSocketSource::bind(&path).await.unwrap();
+
+        let mut client = UnixStream::connect(&path).await.unwrap();
+        let huge = vec![b'x'; MAX_LINE_BYTES + 10];
+        client.write_all(&huge).await.unwrap();
+        client.write_all(b"\n{\"ok\":true}\n").await.unwrap();
+        client.flush().await.unwrap();
+
+        let event = source.recv().await.unwrap();
+        assert_eq!(event.payload, "{\"ok\":true}");
+    }
+}

--- a/crates/rsigma-runtime/src/lib.rs
+++ b/crates/rsigma-runtime/src/lib.rs
@@ -100,6 +100,10 @@ pub use io::{
     EventSource, FileSink, IncidentEnvelope, OnFull, RawEvent, Sink, StdinSource, StdoutSink,
     spawn_source,
 };
+#[cfg(all(unix, feature = "uds"))]
+pub use io::{
+    UnixSocketGuard, UnixSocketSink, UnixSocketSource, bind_unix_listener, parse_unix_scheme,
+};
 pub use metrics::{MetricsHook, NoopMetrics};
 pub use pipeline_deprecation::warn_pipeline_inline_sources;
 pub use processor::{EventFilter, LogProcessor};

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -35,7 +35,7 @@ For narrative coverage see [Streaming Detection](../../guide/streaming-detection
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--input <URL>` | `stdin` | Event source. Schemes: `stdin`, `http` (accepts `POST /api/v1/events`), `nats://<host>:<port>/<subject>`. |
+| `--input <URL>` | `stdin` | Event source. Schemes: `stdin`, `http` (accepts `POST /api/v1/events`), `nats://<host>:<port>/<subject>`, and on Unix `unix:///path/to.sock` (newline-delimited events over a Unix domain socket). |
 | `--input-format <FORMAT>` | `auto` | Input log format: `auto`, `json`, `syslog`, `plain`. With features: `logfmt`, `cef`. |
 | `--syslog-tz <OFFSET>` | `+00:00` | Timezone offset for RFC 3164 syslog (`+HH:MM` or `-HH:MM`). |
 | `--syslog-strip-bom <BOOL>` | `true` | Strip a leading UTF-8 BOM (`U+FEFF`) from RFC 5424 syslog messages. RFC 5424 treats the BOM as an encoding marker, not content. Pass `--syslog-strip-bom false` to keep it byte-for-byte. |
@@ -46,7 +46,7 @@ For narrative coverage see [Streaming Detection](../../guide/streaming-detection
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--output <URL>` | `stdout` | Detection sink. Schemes: `stdout`, `file://<path>`, `nats://<host>:<port>/<subject>`, `otlp(s)://<host>:<port>` (OTLP/gRPC), `otlphttp(s)://<host>:<port>` (OTLP/HTTP, posts to `/v1/logs`); the `s` variants use TLS. Repeatable for fan-out. Query params: `?on_full=drop` (best-effort), `?compression=gzip` (OTLP), and for TLS `?ca=`, `?client_cert=`, `?client_key=` (PEM paths, the last two for mutual TLS) and `?tls_domain=` (SNI override). OTLP schemes require the `daemon-otlp` build. |
+| `--output <URL>` | `stdout` | Detection sink. Schemes: `stdout`, `file://<path>`, `nats://<host>:<port>/<subject>`, `otlp(s)://<host>:<port>` (OTLP/gRPC), `otlphttp(s)://<host>:<port>` (OTLP/HTTP, posts to `/v1/logs`); the `s` variants use TLS. On Unix, `unix:///path/to.sock` writes NDJSON to a local collector socket. Repeatable for fan-out. Query params: `?on_full=drop` (best-effort), `?compression=gzip` (OTLP), and for TLS `?ca=`, `?client_cert=`, `?client_key=` (PEM paths, the last two for mutual TLS) and `?tls_domain=` (SNI override). OTLP schemes require the `daemon-otlp` build. |
 | `--dlq <URL>` | unset | Dead-letter queue for events that fail parsing or sink delivery. Same schemes as `--output`. When unset, failed events are logged and discarded. |
 | `--include-event` | off | Embed the full event JSON in every detection match. |
 | `--match-detail <LEVEL>` | `off` | Match-detail verbosity: `off` (field + value only), `summary` (adds matcher kind, selection, case sensitivity, and reports keyword/absence matches), or `full` (also records the matched pattern). Also settable via `daemon.engine.match_detail`. See [Evaluating Rules](../../guide/evaluating-rules.md#match-detail). |
@@ -87,7 +87,7 @@ The webhooks file (also settable as the `daemon.output.webhooks` path list) decl
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--api-addr <ADDR>` | `0.0.0.0:9090` | Bind address for `/healthz`, `/readyz`, `/metrics`, `/api/v1/*`, and (with the `daemon-otlp` feature) `/v1/logs`. |
+| `--api-addr <ADDR>` | `0.0.0.0:9090` | Bind address for `/healthz`, `/readyz`, `/metrics`, `/api/v1/*`, and (with the `daemon-otlp` feature) `/v1/logs`. A TCP `host:port`, or on Unix `unix:///path/to.sock` for a permission-gated local socket. A `unix://` address cannot be combined with TLS (the socket file is the trust boundary) and is exempt from the plaintext-bind refusal. |
 
 ### TLS (requires the `daemon-tls` build feature)
 

--- a/docs/guide/streaming-detection.md
+++ b/docs/guide/streaming-detection.md
@@ -58,6 +58,7 @@ The `--input` flag selects the primary event source:
 | stdin | `--input stdin` (default) | Read NDJSON from standard input. |
 | HTTP | `--input http` | Accept NDJSON `POST` requests on `/api/v1/events`. |
 | NATS JetStream | `--input nats://host:port/subject` | Subscribe to a JetStream subject with at-least-once delivery. Requires the `daemon-nats` feature. |
+| Unix socket | `--input unix:///path/to.sock` | Accept newline-delimited events over a Unix domain socket (Unix only). Co-located log shippers (rsyslog `omuxsock`, syslog-ng `unix-stream`, Vector, Fluent Bit) write to it directly without a TCP port. |
 
 OTLP ingestion is always available alongside the primary source when the daemon is built with the `daemon-otlp` feature. Agents can post to `/v1/logs` (HTTP, protobuf or JSON) or use the gRPC `LogsService/Export` on the same `--api-addr` port.
 
@@ -120,6 +121,7 @@ The `--output` flag is repeatable, which gives you fan-out for free. Each match 
 | `stdout` | NDJSON to stdout. Default. |
 | `file:///path/to/file.ndjson` | Append NDJSON to a file, rotating only if you wrap it externally (logrotate, etc.). |
 | `nats://host:port/subject` | Publish via JetStream with server-confirmed persistence. Requires `daemon-nats`. |
+| `unix:///path/to.sock` | Write NDJSON to a collector listening on a Unix domain socket (Unix only). Reconnects once on a transient write failure. |
 
 Failed deliveries are routed to the dead-letter queue when `--dlq` is configured:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -47,13 +47,13 @@ daemon:
   # alert_pipeline: /etc/rsigma/alert-pipeline.yml   # dedup (see the Alert Pipeline guide)
   # risk: /etc/rsigma/risk.yml                       # risk-based alerting (see the Risk-Based Alerting guide)
   api:
-    addr: "0.0.0.0:9090"
+    addr: "0.0.0.0:9090"   # TCP host:port, or unix:///run/rsigma/api.sock (Unix; no TLS)
   input:
-    source: stdin
+    source: stdin          # stdin | http | nats://... | unix:///run/rsigma/ingest.sock (Unix)
     format: auto
     buffer_size: 10000
   output:
-    sinks: [stdout]
+    sinks: [stdout]        # stdout | file://... | nats://... | otlp://... | unix:///run/rsigma/out.sock (Unix)
     drain_timeout: 5
     # webhooks: [/etc/rsigma/webhooks/]   # template-driven HTTP sinks
   correlation:

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -105,8 +105,9 @@ The `engine daemon` HTTP and gRPC listeners share one socket. With the optional 
 - Build with `daemon-tls` and pass `--tls-cert`/`--tls-key` to terminate TLS in-process for HTTP REST, OTLP/HTTP, and OTLP/gRPC on the same `--api-addr`. Add `--tls-client-ca` to require mTLS for agent-to-daemon pinning. See [TLS termination](#tls-termination-for-the-api-listener).
 - Bind to loopback (`--api-addr 127.0.0.1:9090`) and access via a reverse proxy that adds TLS and authentication. Nginx, Caddy, and Traefik all work; an example is documented in [Docker deployment](../deployment/docker.md).
 - Bind to a private network segment that the SOC controls.
+- On Unix, bind a domain socket with `--api-addr unix:///run/rsigma/api.sock`. Access is gated by the socket file's permissions (created `0600`), so it never leaves the host and needs no TLS. This is the simplest hardened shape for a co-located admin/metrics client or a sidecar that proxies the socket.
 
-To prevent accidental cleartext exposure when `daemon-tls` is built in, the daemon refuses to start on a non-loopback `--api-addr` unless either `--tls-cert`/`--tls-key` or `--allow-plaintext` is supplied. Loopback (`127.0.0.0/8`, `::1`) always allows plaintext.
+To prevent accidental cleartext exposure when `daemon-tls` is built in, the daemon refuses to start on a non-loopback `--api-addr` unless either `--tls-cert`/`--tls-key` or `--allow-plaintext` is supplied. Loopback (`127.0.0.0/8`, `::1`) always allows plaintext. A `unix://` address is treated as local: it is exempt from this refusal and, because TLS terminates on TCP only, combining it with `--tls-cert`/`--tls-key` is rejected at startup.
 
 NATS connections from the daemon (source, sink, DLQ) support five auth methods (creds file, token, user+password, NKey, mTLS) and TLS-required mode. See [NATS Streaming: authentication](../guide/nats-streaming.md#authentication).
 


### PR DESCRIPTION
## Summary

Adds `unix://` support to the `engine daemon` on three surfaces (Unix targets only). All socket code is `#[cfg(unix)]`-gated and the runtime source/sink sit behind a new `rsigma-runtime` `uds` feature (which enables tokio's `net`); the `daemon` feature turns it on. On non-Unix targets `unix://` falls through to the existing unsupported-scheme config error.

- `--input unix:///path/to.sock` ingests newline-delimited events over a Unix domain socket, so co-located log shippers (rsyslog `omuxsock`, syslog-ng `unix-stream`, Vector, Fluent Bit) can feed the daemon without a TCP port or the HTTP-ingest overhead. One reader task per connection feeds the bounded event channel (same back-pressure model as stdin), with a 1 MiB per-line cap so an unterminated line cannot exhaust memory.
- `--output unix:///path/to.sock` (also accepted by `--dlq`) writes NDJSON detections and incidents to a collector listening on a local socket, reconnecting once on a transient write failure before routing to the DLQ. New `Sink::Unix` variant.
- `--api-addr unix:///path/to.sock` serves the health, metrics, and `/api/v1/*` API (plus OTLP ingestion when built with `daemon-otlp`) over a permission-gated local socket. A new `ListenAddr` enum parses the flag; the listener is bound through a shared helper and served via `axum::serve`.

Security and lifecycle:

- The socket file is created `0600` and unlinked on clean shutdown; a stale socket left by a crashed run is reclaimed on the next start (probe-then-unlink on `AddrInUse`).
- TLS terminates on TCP only: `--tls-cert`/`--tls-key` combined with a `unix://` API address is rejected at startup, and a `unix://` address is exempt from the non-loopback plaintext-bind refusal (the socket file is the trust boundary).

## Commits

- `feat(runtime)`: the `UnixSocketSource`, `UnixSocketSink`, and shared bind helper behind the `uds` feature.
- `feat(cli)`: wire `unix://` into the daemon input source and output sink.
- `feat(cli)`: `ListenAddr` enum and the `unix://` API listener with the TLS/plaintext-policy handling.
- `docs`: daemon CLI reference, streaming-detection guide, configuration/security references, config-schema comments, and a CHANGELOG entry.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rsigma-runtime --features uds` (round-trip over the socket, over-long-line drop, stale-socket rebind, live-socket rejection, scheme parsing)
- [x] `cargo test -p rsigma --features daemon,daemon-tls,daemon-otlp` (new `cli_daemon_uds`: `/healthz` over a UDS, and TLS-over-UDS rejected)
- [x] `mkdocs build --strict`
- [ ] NATS integration tests require Docker; not run locally (unaffected by this change), covered by CI.