### PR TITLE
ci: speed up the Windows test job (cache scoping, lighter debuginfo, lld-link)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     permissions:
       contents: read
+    env:
+      # Drop full debuginfo down to line tables: cuts codegen and, on
+      # Windows, the expensive PDB generation/link step, while keeping panic
+      # file:line in CI logs. Disable incremental compilation: it adds
+      # overhead and bloats the cache for no benefit in from-scratch CI runs.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,12 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
       CARGO_INCREMENTAL: "0"
+      # Link with LLVM's lld-link instead of MSVC link.exe on the Windows
+      # target (the windows-latest runner ships LLVM on PATH). LLD roughly
+      # halves MSVC link time, which dominates this job. The var only affects
+      # the windows-msvc target, so it is a no-op on the Linux/macOS legs and
+      # never touches the release-binary builds.
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: lld-link.exe
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Write the cache only from main; PRs restore it but never save. This
+          # drops the slow per-PR cache upload (notably ~3 min on the Windows
+          # runner) and keeps the shared cache from thrashing across branches.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --workspace --all-targets --all-features --locked
 
   msrv:
@@ -64,6 +69,8 @@ jobs:
       - name: Install Rust 1.88.0
         run: rustup toolchain install 1.88.0 --profile minimal --no-self-update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # `--all-targets` so tests, examples, and benches compile against
       # the MSRV too. Without it a contributor can add a test-only
       # dependency that requires a newer Rust without anyone noticing.
@@ -98,6 +105,8 @@ jobs:
           rustup toolchain install stable --profile minimal --component clippy --no-self-update
           rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   test:
@@ -119,6 +128,8 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --workspace --all-features --locked
 
   coverage:
@@ -138,6 +149,8 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Generate coverage
         run: |
           cargo llvm-cov --workspace --all-features --locked --lcov --output-path lcov.info
@@ -170,6 +183,8 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Fail the build on broken intra-doc links and any other rustdoc
       # warning. `--no-deps` keeps the work bounded to first-party
       # crates so this job does not chase a transitive dep's doc
@@ -199,6 +214,8 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build rsigma
         run: cargo build --release --all-features --locked -p rsigma
       - name: Fetch SigmaHQ rules at pinned SHA
@@ -259,6 +276,8 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Build the CLI with the opt-in `mcp` feature, then drive the
       # built binary end to end over both transports. `python3` ships
       # on the runner and the harness uses only the standard library.


### PR DESCRIPTION
## Summary

Three changes to cut the `Test` job time, where Windows dominates CI (the Windows `cargo test` compile/link alone runs ~8 min, vs ~3 min on Linux/macOS). All are scoped so local dev and the release-binary builds are unaffected.

### 1. Save the rust cache only from `main`

Adds `save-if: ${{ github.ref == 'refs/heads/main' }}` to every `Swatinem/rust-cache` step. PR runs restore the shared cache but no longer save it. The save (the `Post Run` step) measured ~174s on the Windows runner (vs ~17-32s on Linux/macOS) because it compresses and uploads a multi-GB `target/` of MSVC artifacts. `main` pushes still populate the cache.

### 2. Lighter debuginfo + no incremental on the Test job

The job compiled with full debuginfo (`debug=2`) and incremental on. On Windows that means generating and linking large PDBs for every test binary. Scoped to the `Test` job via env:

- `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG = line-tables-only` keeps panic `file:line` in CI logs while dropping the bulk of debuginfo codegen and PDB cost.
- `CARGO_INCREMENTAL=0` removes incremental overhead that has no payoff in from-scratch CI builds.

### 3. Link the Windows build with `lld-link`

`CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: lld-link.exe` points the windows-msvc target at LLVM's LLD (already on PATH on the `windows-latest` runner) instead of MSVC `link.exe`, which is the dominant cost of the job. LLD is reported to roughly halve MSVC link time. The var only affects the windows-msvc target, so it is a no-op on the Linux/macOS legs and never touches the release-binary builds.

## Test plan

- [x] `zizmor --pedantic` passes with no findings.
- [x] Profile/incremental env overrides validated locally (parse and build cleanly).
- [ ] This PR's Windows `Test` job is green with `lld-link` (validates change 3, which could not be tested locally), shows a shorter total, and no long `Post Run` cache step.
- [ ] A panic backtrace (if any) still shows file:line under line-tables-only.