### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ RSigma v0.18.0 is the "post-engine alerting and detection lifecycle" release: th
 * Schema and logsource routing: content-based schema recognition (#245) and per-schema pipeline routing (#246), plus opt-in conflict-based logsource pruning in the evaluator (#249).
 * Diagnostics: an explain-and-introspect toolkit adds detection explain, pipeline transform diff, and correlation window introspection (#270).
 * Daemon transport: Unix domain socket support for the input source, output sink, and API listener (#273).
-* `rstix` (threat-intel library, not yet independently releasable): completes the STIX 2.1 data model and serialization (#248, #254, #265, #268) and adds a pattern engine that parses and type-checks STIX patterning Levels 1-3 (#272).
+* `rstix` (threat-intel library, not yet independently releasable): completes the STIX 2.1 data model and serialization (#248, #254, #265, #268) and adds a pattern engine that parses and type-checks STIX patterning Levels 1-3 (#272), thanks to @SecurityEnthusiast.
 * Fixes, security, and dependencies: jq `halt`/`halt_error` can no longer terminate the process (#247); a transitive `anyhow` bump clears RUSTSEC-2026-0190 (#271); a rolled-up dependency bump (#257); and the CI/CD guide documents `rsigma-action` (#260).
 
 ### rstix Pattern Engine: parse and type-check (Levels 1–3) (#272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-01
+
+**TL;DR**
+RSigma v0.18.0 is the "post-engine alerting and detection lifecycle" release: the daemon grows an Alertmanager-style processing stage and an entity risk layer, the toolkit gains the triage, hygiene, and ADS pieces that close the detection lifecycle, content-based schema and logsource routing lands, a data-aware diagnostics toolkit ships, and `rstix` completes its STIX 2.1 data model and gains a pattern engine.
+* Post-engine alert processing: an alert pipeline adds deduplication, silencing, inhibition, and incident grouping to the daemon sink path (#255); risk-based alerting scores entities and emits a risk-incident layer (#264); the webhook sink can HMAC-sign every request (#266).
+* Detection lifecycle: a triage feedback loop turns analyst dispositions into a live per-rule false-positive ratio (#263); a rule hygiene report surfaces retirement and clean-up candidates (#262); optional ADS metadata gains linter enforcement and an authoring command (#261).
+* Schema and logsource routing: content-based schema recognition (#245) and per-schema pipeline routing (#246), plus opt-in conflict-based logsource pruning in the evaluator (#249).
+* Diagnostics: an explain-and-introspect toolkit adds detection explain, pipeline transform diff, and correlation window introspection (#270).
+* Daemon transport: Unix domain socket support for the input source, output sink, and API listener (#273).
+* `rstix` (threat-intel library, not yet independently releasable): completes the STIX 2.1 data model and serialization (#248, #254, #265, #268) and adds a pattern engine that parses and type-checks STIX patterning Levels 1-3 (#272).
+* Fixes, security, and dependencies: jq `halt`/`halt_error` can no longer terminate the process (#247); a transitive `anyhow` bump clears RUSTSEC-2026-0190 (#271); a rolled-up dependency bump (#257); and the CI/CD guide documents `rsigma-action` (#260).
+
 ### rstix Pattern Engine: parse and type-check (Levels 1–3) (#272)
 
 Adds the `pattern` feature to `rstix` with a hand-written lexer, recursive-descent parser for STIX patterning Levels 1–3, and an SCO schema type-checker for all 18 cyber-observable types:
@@ -201,6 +213,8 @@ Content-based schema classification that recognizes the structure of each event 
 ### Dependency bumps (#257)
 
 Rolls up the open Dependabot PRs into a single merge, regenerating the lockfiles against current `main` rather than replaying stale lockfile bases. Rust (workspace `Cargo.lock`): `opentelemetry_sdk` 0.32.0 to 0.32.1 (#256), `jaq-core` 3.0.0 to 3.1.0 (#235), `jaq-json` 2.0.0 to 2.0.1 and `jaq-std` 3.0.0 to 3.0.1 (#258), `insta` 1.47.2 to 1.48.0 (#233), `evtx` 0.11 to 0.12.2 (#232), and the `patch-updates` group (#253) `regex` 1.12.3 to 1.12.4, `daachorse` 3.0.1 to 3.0.2, `time` 0.3.47 to 0.3.49, `prost` 0.14.3 to 0.14.4, `getrandom` 0.4.2 to 0.4.3, and `uuid` 1.23.2 to 1.23.3 (the `getrandom` bump drops the `wit-bindgen`/`wasi` build toolchain 0.4.2 pulled in); `regex` 1.12.3 to 1.12.4 in `fuzz/Cargo.lock` (#229). CI (all repinned by commit SHA, batched via the `actions-updates` group, #252): `actions/checkout` v6.0.3 to v7.0.0, `taiki-e/install-action` v2.81.4 to v2.82.0, and `rust-lang/crates-io-auth-action` v1.0.4 to v1.0.5. VS Code extension: `@types/node` 25.9.1 to 25.9.3 and `@types/vscode` 1.120.0 to 1.125.0 (#251), plus the transitive `form-data` 4.0.5 to 4.0.6 (#224), `js-yaml` 4.1.1 to 4.2.0 (#225), `markdown-it` 14.1.1 to 14.2.0 (#226), and `undici` 7.25.0 to 7.28.0 (#236). The `rusqlite` 0.39 to 0.40.1 bump (#234) is held back: it pulls `libsqlite3-sys` 0.38.1, whose build script needs the `cfg_select!` macro that is unavailable on the pinned MSRV (1.88.0).
+
+[v0.17.0...v0.18.0](https://github.com/timescale/rsigma/compare/v0.17.0...v0.18.0)
 
 ## [0.17.0] - 2026-06-23
 
@@ -2187,6 +2201,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.18.0]: https://github.com/timescale/rsigma/releases/tag/v0.18.0
 [0.17.0]: https://github.com/timescale/rsigma/releases/tag/v0.17.0
 [0.16.0]: https://github.com/timescale/rsigma/releases/tag/v0.16.0
 [0.15.0]: https://github.com/timescale/rsigma/releases/tag/v0.15.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "insta",
  "log",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "globset",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -36,11 +36,11 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.17.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.17.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.17.0", optional = true }
-rsigma-mcp = { path = "../rsigma-mcp", version = "0.17.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.18.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.18.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.18.0", optional = true }
+rsigma-mcp = { path = "../rsigma-mcp", version = "0.18.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.17.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.17.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-mcp/Cargo.toml
+++ b/crates/rsigma-mcp/Cargo.toml
@@ -16,10 +16,10 @@ default = []
 http = ["dep:axum", "rmcp/transport-streamable-http-server"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.17.0" }
-rsigma-convert = { path = "../rsigma-convert", version = "0.17.0" }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.17.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
+rsigma-convert = { path = "../rsigma-convert", version = "0.18.0" }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.18.0" }
 rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -22,8 +22,8 @@ uds = ["tokio/net"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.17.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.17.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.18.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -140,6 +140,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +233,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +255,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -282,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +343,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,8 +374,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -373,6 +441,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -485,9 +559,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -528,10 +613,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hifijson"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "http"
@@ -577,6 +677,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1139,6 +1248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1352,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1275,6 +1433,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1363,6 +1527,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1511,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1539,13 +1709,14 @@ dependencies = [
  "rsigma-eval",
  "rsigma-parser",
  "rsigma-runtime",
+ "rstix",
  "serde_json",
  "yaml_serde",
 ]
 
 [[package]]
 name = "rsigma-parser"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "globset",
  "log",
@@ -1561,14 +1732,17 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "base64",
  "cel",
  "chrono",
  "csv",
  "globset",
+ "hex",
+ "hmac",
  "humantime",
  "jaq-core",
  "jaq-json",
@@ -1583,11 +1757,14 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "syslog_loose",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "yaml_serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1598,6 +1775,19 @@ checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rstix"
+version = "0.18.0"
+dependencies = [
+ "phf",
+ "serde",
+ "serde_jcs",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -1669,6 +1859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1916,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,14 +1953,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1777,6 +2001,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1926,6 +2156,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2171,7 +2431,9 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -2651,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"


### PR DESCRIPTION
## Summary

Release v0.18.0. Bumps the workspace from 0.17.0 to 0.18.0 (workspace package version plus all inter-crate path pins across the dependent crates), syncs both `Cargo.lock` and `fuzz/Cargo.lock`, and finalizes `CHANGELOG.md` by promoting the `[Unreleased]` block to `[0.18.0] - 2026-07-01` with a TL;DR, a `v0.17.0...v0.18.0` compare link, and the release reference link.

Headline framing: the "post-engine alerting and detection lifecycle" release. The daemon grows an Alertmanager-style processing stage and an entity risk layer, the toolkit gains the triage, hygiene, and ADS pieces that close the detection lifecycle, content-based schema and logsource routing lands, a data-aware diagnostics toolkit ships, and `rstix` completes its STIX 2.1 data model and gains a pattern engine.

- Post-engine alert processing: an alert pipeline adds deduplication, silencing, inhibition, and incident grouping to the daemon sink path (#255); risk-based alerting scores entities and emits a risk-incident layer (#264); the webhook sink can HMAC-sign every request (#266).
- Detection lifecycle: a triage feedback loop turns analyst dispositions into a live per-rule false-positive ratio (#263); a rule hygiene report surfaces retirement and clean-up candidates (#262); optional ADS metadata gains linter enforcement and an authoring command (#261).
- Schema and logsource routing: content-based schema recognition (#245) and per-schema pipeline routing (#246), plus opt-in conflict-based logsource pruning in the evaluator (#249).
- Diagnostics: an explain-and-introspect toolkit adds detection explain, pipeline transform diff, and correlation window introspection (#270).
- Daemon transport: Unix domain socket support for the input source, output sink, and API listener (#273).
- `rstix` (threat-intel library, not yet independently releasable): completes the STIX 2.1 data model and serialization (#248, #254, #265, #268) and adds a pattern engine that parses and type-checks STIX patterning Levels 1-3 (#272).
- Fixes, security, and dependencies: jq `halt`/`halt_error` can no longer terminate the process (#247); a transitive `anyhow` bump clears RUSTSEC-2026-0190 (#271); a rolled-up dependency bump (#257); and the CI/CD guide documents `rsigma-action` (#260).

The fuzz lockfile change is larger than usual because `fuzz/Cargo.lock` had drifted behind the webhook-signing and `rstix` transitive dependencies that `rsigma-runtime` now pulls in; the bump resyncs it so it resolves under `--locked`.

Full release notes: see the new `[0.18.0]` section in `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata --locked` for the workspace and `fuzz/` (lockfile/manifest consistency)
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked` (3001 passed, 85 suites)
- [x] `mkdocs build --strict`
- [x] `cargo audit` (one pre-allowed `encoding` unmaintained warning via `evtx`)
- [x] `cargo deny check` (advisories, bans, licenses, sources ok)

## Post-merge

After merge, tag `v0.18.0` on `main` and create the GitHub Release using the `[0.18.0]` body verbatim. The `publish.yml`, `release-binaries.yml`, and `docker.yml` workflows fire on `release: published`.