### PR TITLE
fix(deps): crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
Isolated dependency fix — unblocks PRs that touch `Cargo.lock`.
- Bump transitive `crossbeam-epoch` **0.9.18 → 0.9.20** in workspace and `fuzz/Cargo.lock`
- Resolves [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (`rayon` → `crossbeam-deque` → `crossbeam-epoch`)
- No application code changes
## Context
rstix coming changes triggers `audit.yml` because it modifies lockfiles. The advisory affects `main`'s existing dependency tree, not new rstix code. Keeping the security bump in this small PR avoids mixing deps policy with feature work.