### PR TITLE
test(ci): drain stderr after child exit in spawn_expect_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### De-flaked the TLS misconfiguration E2E tests on macOS
+### De-flaked the TLS misconfiguration E2E tests on macOS (#295)
 
 `spawn_expect_failure` in the CLI test harness raced the daemon's exit against its stderr: the collection loop broke as soon as `try_wait()` saw the process gone, so when a misconfigured daemon failed fast (as `encrypted_key_password_is_rejected_with_guidance` does, the encrypted-key check being the first thing TLS init runs), the reader thread could still be holding the error line and the test asserted against empty stderr. The helper now drains the channel after reaping the child; closing the pipe ends the reader thread, so the drain terminates deterministically.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### De-flaked the TLS misconfiguration E2E tests on macOS
+
+`spawn_expect_failure` in the CLI test harness raced the daemon's exit against its stderr: the collection loop broke as soon as `try_wait()` saw the process gone, so when a misconfigured daemon failed fast (as `encrypted_key_password_is_rejected_with_guidance` does, the encrypted-key check being the first thing TLS init runs), the reader thread could still be holding the error line and the test asserted against empty stderr. The helper now drains the channel after reaping the child; closing the pipe ends the reader thread, so the drain terminates deterministically.
+
 ### Removed pipeline-embedded `sources:` blocks (#293)
 
 Dynamic source declarations no longer live inside pipeline files. A pipeline that still declares an inline `sources:` block is now rejected with a hard parse error that points at `rsigma rule migrate-sources`; source declarations come exclusively from standalone `--source` files, and a pipeline only references them with `${source.<id>}`. This completes the deprecation cycle started in v0.12.0 (#135, visible-deprecated) and continued in v0.13.0 (#136, hidden from docs).

--- a/crates/rsigma-cli/tests/common/mod.rs
+++ b/crates/rsigma-cli/tests/common/mod.rs
@@ -288,6 +288,14 @@ pub fn spawn_expect_failure(args: &[&str], deadline: Duration) -> String {
     }
     let _ = child.kill();
     let _ = child.wait();
+    // The child may exit before the reader thread forwards its final
+    // lines, so drain what is still in flight. `wait()` closed the
+    // pipe, so the reader thread hits EOF and drops the sender, which
+    // makes `recv_timeout` return `Disconnected` once the channel is
+    // empty. The timeout is only a safety net.
+    while let Ok(line) = rx.recv_timeout(Duration::from_secs(1)) {
+        collected.push(line);
+    }
     collected.join("\n")
 }
 


### PR DESCRIPTION
## Summary

`encrypted_key_password_is_rejected_with_guidance` failed on macOS in the CI run for the #294 merge commit with empty stderr, even though that PR only bumped `crossbeam-epoch` in the lockfiles. The failure is a race in the `spawn_expect_failure` test helper: the collection loop breaks as soon as `try_wait()` sees the child gone, without draining lines the stderr reader thread has already queued or is about to queue. A misconfigured daemon exits within milliseconds (the encrypted-key rejection is the first thing TLS init runs), so on a slow runner the loop could observe the exit before the reader thread forwarded the `openssl` guidance line, and the test asserted against empty stderr.

The helper now drains the channel after killing and reaping the child. Reaping closes the pipe, so the reader thread hits EOF and drops the sender, making the drain terminate deterministically; the 1-second `recv_timeout` is only a safety net. This also hardens the other tests built on the same helper (`missing_cert_file_refuses_to_start` and the plaintext-policy suite).

## Testing

- Full `cli_daemon_tls` suite passes locally (12/12) with `--features daemon-tls`
- `cargo fmt --check` and `cargo clippy --tests -D warnings` clean