### PR TITLE
fix(daemon): make schema observer snapshots internally consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### De-flaked the daemon schema-observer E2E test on Windows
+
+`SchemaObserver::observe` bumped its `events_observed` counter before recording the classification result, so the `/api/v1/schemas` snapshot (served on a different thread than event ingestion) could report `events_observed == N` while the Nth event's `classified`/`unknown` increment had not yet landed. A reader that waited on `events_observed` then read a torn snapshot with `unknown` short by one, which surfaced as a Windows CI failure in `schemas_endpoint_reports_per_schema_and_unknown_counts`. `events_observed` is now derived as `classified + unknown` inside the snapshot, so every snapshot is internally consistent regardless of thread interleaving.
+
 ### Daemon API authentication (bearer tokens + granular RBAC) (#304)
 
 Adds opt-in bearer-token authentication with `resource:action` permissions to the daemon API. Off by default: without configuration the routes stay open as before, and `GET /healthz` / `GET /readyz` are always unauthenticated so liveness probes never need secrets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### De-flaked the daemon schema-observer E2E test on Windows
+### De-flaked the daemon schema-observer E2E test on Windows (#305)
 
 `SchemaObserver::observe` bumped its `events_observed` counter before recording the classification result, so the `/api/v1/schemas` snapshot (served on a different thread than event ingestion) could report `events_observed == N` while the Nth event's `classified`/`unknown` increment had not yet landed. A reader that waited on `events_observed` then read a torn snapshot with `unknown` short by one, which surfaced as a Windows CI failure in `schemas_endpoint_reports_per_schema_and_unknown_counts`. `events_observed` is now derived as `classified + unknown` inside the snapshot, so every snapshot is internally consistent regardless of thread interleaving.
 

--- a/crates/rsigma-eval/src/schema.rs
+++ b/crates/rsigma-eval/src/schema.rs
@@ -1335,7 +1335,6 @@ pub struct SchemaObserver {
     /// Redacted field-key shapes of discovery-unrecognized events (no-match or
     /// `generic_json`), populated only when `discovery_sampling` is set.
     unrecognized_shapes: Mutex<HashMap<Vec<String>, u64>>,
-    events_observed: AtomicU64,
     lifetime_classified: AtomicU64,
     lifetime_unknown: AtomicU64,
     lifetime_ambiguous: AtomicU64,
@@ -1361,7 +1360,6 @@ impl SchemaObserver {
             unknown_shapes: Mutex::new(HashMap::new()),
             discovery_sampling,
             unrecognized_shapes: Mutex::new(HashMap::new()),
-            events_observed: AtomicU64::new(0),
             lifetime_classified: AtomicU64::new(0),
             lifetime_unknown: AtomicU64::new(0),
             lifetime_ambiguous: AtomicU64::new(0),
@@ -1383,7 +1381,6 @@ impl SchemaObserver {
     /// Classify an event and update the counters. Takes `&self` so the
     /// observer can be shared behind an `Arc`.
     pub fn observe<E: Event + ?Sized>(&self, event: &E) {
-        self.events_observed.fetch_add(1, Ordering::Relaxed);
         let (matched, ambiguous) = self.classifier.classify_with_ambiguity(event);
         if ambiguous {
             self.ambiguous.fetch_add(1, Ordering::Relaxed);
@@ -1501,7 +1498,11 @@ impl SchemaObserver {
             ambiguous: self.ambiguous.load(Ordering::Relaxed),
             unknown_shapes,
             unrecognized_shapes,
-            events_observed: self.events_observed.load(Ordering::Relaxed),
+            // Derived (not a separate counter) so every snapshot is internally
+            // consistent: a reader that sees `events_observed == N` also sees
+            // the `classified`/`unknown` reads that sum to N, since each
+            // observed event increments exactly one of the two.
+            events_observed: classified + unknown,
             lifetime_classified: self.lifetime_classified.load(Ordering::Relaxed),
             lifetime_unknown: self.lifetime_unknown.load(Ordering::Relaxed),
             lifetime_ambiguous: self.lifetime_ambiguous.load(Ordering::Relaxed),
@@ -1531,7 +1532,6 @@ impl SchemaObserver {
             .clear();
         let previous_unknown = self.unknown.swap(0, Ordering::Relaxed);
         self.ambiguous.store(0, Ordering::Relaxed);
-        self.events_observed.store(0, Ordering::Relaxed);
         *self
             .start
             .lock()


### PR DESCRIPTION
## Summary

`SchemaObserver::observe` incremented its `events_observed` counter at the very start of the call, before classification recorded the result into the `classified`/`unknown` buckets. The `/api/v1/schemas` endpoint snapshots the observer on a different thread than the one ingesting events (`processor.rs` calls `observe` in a batch loop on the sink thread), so a reader could observe `events_observed == N` for the Nth event while that event's `unknown` (or per-schema) increment had not yet landed.

The daemon E2E test `schemas_endpoint_reports_per_schema_and_unknown_counts` polls `wait_for_events_observed(4)` and then reads `classified`/`unknown` from that same snapshot. The torn read reported `classified=3, unknown=0` instead of `classified=3, unknown=1`, which failed on Windows CI:

```
thread 'schemas_endpoint_reports_per_schema_and_unknown_counts' panicked at crates\rsigma-cli\tests\cli_daemon_schemas.rs:74:5:
assertion `left == right` failed
  left: 0
 right: 1
```

The race is platform-independent; it only surfaced on Windows because of scheduling.

## Fix

`events_observed` is documented as exactly `classified + unknown`, so the separately-incremented atomic is removed and the value is derived inside `snapshot()` from the same `classified` and `unknown` reads. Since every observed event increments exactly one of those two buckets, any snapshot is now internally consistent by construction: when a reader sees `events_observed == N`, the `classified`/`unknown` values it read already sum to N.

- Removed the `events_observed: AtomicU64` field, its initializer, the premature `fetch_add` in `observe`, and the reset store.
- `snapshot()` now sets `events_observed: classified + unknown`.

## Test plan

- [x] `cargo test -p rsigma-eval --lib schema::` (36 passed)
- [x] `cargo test --features daemon --test cli_daemon_schemas` (6 passed)
- [x] `cargo clippy -p rsigma-eval --all-targets -- -D warnings` (clean)