### PR TITLE
chore(deps): batch dependency updates (Jul 2026)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,7 +41,7 @@ jobs:
           rustup override set stable
       # Pull `cargo-audit` from prebuilt artifacts rather than building
       # it from source every run; saves ~30s per audit invocation.
-      - uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-audit
       - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
           rustup override set stable
-      - uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,15 +51,15 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      - uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
         with:
           context: .
@@ -100,7 +100,7 @@ jobs:
       security-events: write # upload SARIF results
 
     steps:
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      - uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -128,7 +128,7 @@ jobs:
           # so pin grype to the matrix arch instead of the host default.
           GRYPE_PLATFORM: linux/${{ matrix.arch }}
 
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         if: always()
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
@@ -146,7 +146,7 @@ jobs:
       attestations: write # SLSA provenance attestation
 
     steps:
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      - uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -159,7 +159,7 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Derive minor tag for manual run
         id: manual
@@ -168,7 +168,7 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
 
-      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -201,7 +201,7 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.manifest.outputs.digest }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -112,7 +112,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: "distrib/*"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Dependency bumps (#308)
+
+Rolls up five open Dependabot PRs into a single merge. Rust (workspace `Cargo.lock`): `tower-http` 0.6.11 to 0.7.0 (#299), `cel` 0.13.0 to 0.14.0 (#300), `rmcp` 1.8.0 to 2.1.0 (#301), and `phf` 0.13.1 to 0.14.0 (#303); `rsigma-mcp` is migrated to the rmcp 2.x API (`Resource`, `ContentBlock`). CI (all repinned by commit SHA, batched via the `actions-updates` group, #302): `taiki-e/install-action` v2.82.4 to v2.82.7, `docker/setup-buildx-action` v4.1.0 to v4.2.0, `docker/login-action` v4.2.0 to v4.3.0, `docker/build-push-action` v7.2.0 to v7.3.0, `github/codeql-action/upload-sarif` v4.36.2 to v4.36.3, `docker/metadata-action` v6.1.0 to v6.2.0, and `actions/attest-build-provenance` v4.1.0 to v4.1.1. The `rusqlite` 0.39 to 0.40.1 bump (#234) stays held back on MSRV 1.88.
+
 ### Control-plane API audit trail (#307)
 
 Adds an append-only audit log for control-plane mutating daemon API calls (who, what, when, outcome), persisted in the existing SQLite state database when `--state-db` is configured. Auto-enabled with a state database; optional `daemon.api.audit` config tunes retention, optional sink emission, or disables the trail. Each record stores method, matched route pattern, token name, HTTP status, timestamp, and a SHA-256 hex digest of the request body (never the body itself). Data-plane ingest and OTLP are excluded. `GET /api/v1/audit` (`audit:read`) serves paginated entries; bodies over `max_body_bytes` (default 64 KiB) get `413` and the rejected attempt is recorded. New metrics: `rsigma_audit_records_total`, `rsigma_audit_write_errors_total`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3825,7 +3825,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3976,7 +3976,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tonic",
- "tower-http",
+ "tower-http 0.7.0",
  "tower-service",
  "tracing",
  "tracing-subscriber",
@@ -5365,8 +5365,24 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3879,9 +3879,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -3911,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,29 +3126,39 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.14.0",
  "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3159,6 +3169,15 @@ name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -4156,7 +4175,7 @@ version = "0.18.0"
 dependencies = [
  "base64",
  "ipnet",
- "phf",
+ "phf 0.14.0",
  "regex",
  "serde",
  "serde_jcs",
@@ -5222,7 +5241,7 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a40f338a8c3505921000b609279775792c07cc21f97a3011578c0c5e1738ae"
+checksum = "6ed39583e427bf41d93c28c7f27c943a93bcb8697220ff3575fd53a9e13f3814"
 dependencies = [
  "antlr4rust",
  "chrono",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -72,7 +72,7 @@ async-trait = { version = "0.1", optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 notify = { version = "8.2", optional = true }
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
-tower-http = { version = "0.6", features = ["trace"], optional = true }
+tower-http = { version = "0.7", features = ["trace"], optional = true }
 # Live event-tap server-side redaction (deterministic salted hashing).
 sha2 = { version = "0.11", optional = true }
 getrandom = { version = "0.4", optional = true }

--- a/crates/rsigma-mcp/Cargo.toml
+++ b/crates/rsigma-mcp/Cargo.toml
@@ -20,7 +20,7 @@ rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
 rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
 rsigma-convert = { path = "../rsigma-convert", version = "0.18.0", features = ["sigma-cli"] }
 rsigma-runtime = { path = "../rsigma-runtime", version = "0.18.0" }
-rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "2.1", features = ["server", "macros", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -32,7 +32,7 @@ tempfile = "3"
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-rmcp = { version = "1.7", features = ["client", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "2.1", features = ["client", "transport-streamable-http-client-reqwest"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/crates/rsigma-mcp/src/tools.rs
+++ b/crates/rsigma-mcp/src/tools.rs
@@ -21,9 +21,8 @@ use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::router::tool::ToolRouter,
     model::{
-        AnnotateAble, Implementation, ListResourcesResult, PaginatedRequestParams, RawResource,
-        ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
-        ServerInfo,
+        Implementation, ListResourcesResult, PaginatedRequestParams, ReadResourceRequestParams,
+        ReadResourceResult, Resource, ResourceContents, ServerCapabilities, ServerInfo,
     },
     service::RequestContext,
     tool_handler,
@@ -167,10 +166,10 @@ impl ServerHandler for RsigmaMcp {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
         let resources = vec![
-            RawResource::new(RESOURCE_LINT_CATALOGUE, "Lint rule catalogue").no_annotation(),
-            RawResource::new(RESOURCE_ADS_SCHEMA, "ADS section catalogue").no_annotation(),
-            RawResource::new(RESOURCE_MODIFIERS, "Sigma field modifiers").no_annotation(),
-            RawResource::new(RESOURCE_MITRE_TACTICS, "MITRE ATT&CK tactics").no_annotation(),
+            Resource::new(RESOURCE_LINT_CATALOGUE, "Lint rule catalogue"),
+            Resource::new(RESOURCE_ADS_SCHEMA, "ADS section catalogue"),
+            Resource::new(RESOURCE_MODIFIERS, "Sigma field modifiers"),
+            Resource::new(RESOURCE_MITRE_TACTICS, "MITRE ATT&CK tactics"),
         ];
         Ok(ListResourcesResult {
             resources,

--- a/crates/rsigma-mcp/src/tools/shared.rs
+++ b/crates/rsigma-mcp/src/tools/shared.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use rmcp::{
     ErrorData as McpError,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
 };
 use rsigma_convert::Backend;
 use rsigma_eval::{MatchDetailLevel, Pipeline, parse_pipeline_file, resolve_builtin_pipeline};
@@ -41,7 +41,7 @@ pub struct SourceInput {
 /// Wrap a serializable value as a successful tool result carrying pretty JSON text.
 pub(crate) fn json_result(value: &Value) -> CallToolResult {
     let text = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
-    CallToolResult::success(vec![Content::text(text)])
+    CallToolResult::success(vec![ContentBlock::text(text)])
 }
 
 /// Shorthand for an invalid-params MCP error.

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -44,7 +44,7 @@ jaq-core = "3.0"
 jaq-json = "2.0"
 jaq-std = "3.0"
 jsonpath-rust = "1"
-cel = "0.13"
+cel = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 notify = "8.2"

--- a/crates/rstix/Cargo.toml
+++ b/crates/rstix/Cargo.toml
@@ -17,7 +17,7 @@ pattern = ["dep:base64", "dep:ipnet", "dep:regex", "dep:unicode-normalization"]
 validate = ["serde", "pattern"]
 
 [dependencies]
-phf = { version = "0.13", features = ["macros"] }
+phf = { version = "0.14", features = ["macros"] }
 serde_jcs = "0.2"
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing"] }


### PR DESCRIPTION
## Summary

Consolidates open Dependabot PRs into a single batch update:

- tower-http 0.6.11 → 0.7.0 (#299)
- cel 0.13.0 → 0.14.0 (#300)
- rmcp 1.8.0 → 2.1.0 (#301), with rsigma-mcp migrated to the rmcp 2.x API (`Resource`, `ContentBlock`)
- GitHub Actions group update (#302): taiki-e/install-action, docker/setup-buildx-action, docker/login-action, docker/build-push-action, github/codeql-action/upload-sarif, docker/metadata-action, actions/attest-build-provenance
- phf 0.13.1 → 0.14.0 (#303)

Excluded: rusqlite 0.39.0 → 0.40.1 (#234) because 0.40.x requires Rust 1.89 and our MSRV is 1.88.

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo test -p rsigma-mcp --all-features`
- [x] `cargo clippy -p rsigma-mcp --all-features -- -D warnings`
- [ ] CI green on all platforms