### PR TITLE
feat(sources): optional request body for http dynamic sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Request body for `http` dynamic sources
+### Request body for `http` dynamic sources (#310)
 
 The `http` dynamic-source type gains an optional `body` field, sent verbatim after `${VAR}` environment expansion, so a source can poll a query API that requires a request body (GraphQL, an Elasticsearch/OpenSearch `_search`, TheHive 5's `/api/v1/query`). A source with a `body` and no explicit `method` defaults to `POST`; an explicit `method` still wins. `Content-Type` is not inferred and should be set in `headers`. The reference documentation for `headers` is also corrected: `${VAR}` references have always been expanded from the environment at fetch time, which the field table previously said was unimplemented.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Request body for `http` dynamic sources
+
+The `http` dynamic-source type gains an optional `body` field, sent verbatim after `${VAR}` environment expansion, so a source can poll a query API that requires a request body (GraphQL, an Elasticsearch/OpenSearch `_search`, TheHive 5's `/api/v1/query`). A source with a `body` and no explicit `method` defaults to `POST`; an explicit `method` still wins. `Content-Type` is not inferred and should be set in `headers`. The reference documentation for `headers` is also corrected: `${VAR}` references have always been expanded from the environment at fetch time, which the field table previously said was unimplemented.
+
 ### Dependency bumps (#308)
 
 Rolls up five open Dependabot PRs into a single merge. Rust (workspace `Cargo.lock`): `tower-http` 0.6.11 to 0.7.0 (#299), `cel` 0.13.0 to 0.14.0 (#300), `rmcp` 1.8.0 to 2.1.0 (#301), and `phf` 0.13.1 to 0.14.0 (#303); `rsigma-mcp` is migrated to the rmcp 2.x API (`Resource`, `ContentBlock`). CI (all repinned by commit SHA, batched via the `actions-updates` group, #302): `taiki-e/install-action` v2.82.4 to v2.82.7, `docker/setup-buildx-action` v4.1.0 to v4.2.0, `docker/login-action` v4.2.0 to v4.3.0, `docker/build-push-action` v7.2.0 to v7.3.0, `github/codeql-action/upload-sarif` v4.36.2 to v4.36.3, `docker/metadata-action` v6.1.0 to v6.2.0, and `actions/attest-build-provenance` v4.1.0 to v4.1.1. The `rusqlite` 0.39 to 0.40.1 bump (#234) stays held back on MSRV 1.88.

--- a/crates/rsigma-eval/src/pipeline/parsing.rs
+++ b/crates/rsigma-eval/src/pipeline/parsing.rs
@@ -908,10 +908,15 @@ pub fn parse_dynamic_source(value: &yaml_serde::Value) -> Result<DynamicSource> 
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let headers = parse_string_headers(obj.get(ykey("headers")));
+            let body = obj
+                .get(ykey("body"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
             SourceType::Http {
                 url,
                 method,
                 headers,
+                body,
                 format,
                 extract,
             }

--- a/crates/rsigma-eval/src/pipeline/sources.rs
+++ b/crates/rsigma-eval/src/pipeline/sources.rs
@@ -42,6 +42,11 @@ pub enum SourceType {
         url: String,
         method: Option<String>,
         headers: HashMap<String, String>,
+        /// Optional request body sent verbatim after `${VAR}` expansion. When
+        /// set and `method` is unset, the request defaults to `POST`. Pairs
+        /// with query APIs that require a body (GraphQL, `_search`, TheHive 5's
+        /// `/api/v1/query`).
+        body: Option<String>,
         format: DataFormat,
         extract: Option<ExtractExpr>,
     },

--- a/crates/rsigma-eval/src/pipeline/tests.rs
+++ b/crates/rsigma-eval/src/pipeline/tests.rs
@@ -1739,6 +1739,37 @@ transformations:
 }
 
 #[test]
+fn test_source_with_http_body() {
+    let yaml = r#"
+name: Query Source
+sources:
+  - id: query_source
+    type: http
+    url: https://api.internal/api/v1/query
+    headers:
+      Content-Type: application/json
+    body: |
+      {"query": [{"_name": "listCase"}]}
+    format: json
+transformations:
+  - type: value_placeholders
+"#;
+    let src_list = parse_source_list(yaml).unwrap();
+    match &src_list[0].source_type {
+        sources::SourceType::Http { method, body, .. } => {
+            // The method stays unset in the parse; the POST default is applied
+            // by the resolver when a body is present.
+            assert_eq!(method.as_deref(), None);
+            assert_eq!(
+                body.as_deref(),
+                Some("{\"query\": [{\"_name\": \"listCase\"}]}\n")
+            );
+        }
+        _ => panic!("expected Http"),
+    }
+}
+
+#[test]
 fn test_source_with_default_value() {
     let yaml = r#"
 name: Default Value

--- a/crates/rsigma-runtime/src/sources/http.rs
+++ b/crates/rsigma-runtime/src/sources/http.rs
@@ -55,6 +55,7 @@ pub async fn resolve_http(
     url: &str,
     method: Option<&str>,
     headers: &HashMap<String, String>,
+    body: Option<&str>,
     format: DataFormat,
     extract_expr: Option<&ExtractExpr>,
     timeout: Option<Duration>,
@@ -63,6 +64,7 @@ pub async fn resolve_http(
         url,
         method,
         headers,
+        body,
         format,
         extract_expr,
         timeout,
@@ -72,10 +74,12 @@ pub async fn resolve_http(
 }
 
 /// Inner implementation with a configurable size limit (for testing).
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn resolve_http_with_limit(
     url: &str,
     method: Option<&str>,
     headers: &HashMap<String, String>,
+    body: Option<&str>,
     format: DataFormat,
     extract_expr: Option<&ExtractExpr>,
     timeout: Option<Duration>,
@@ -83,7 +87,9 @@ pub(crate) async fn resolve_http_with_limit(
 ) -> Result<ResolvedValue, SourceError> {
     let client = shared_http_source_client()?;
 
-    let method_str = method.unwrap_or("GET");
+    // A request carrying a body defaults to POST when no method is given; a
+    // bodyless request defaults to GET. An explicit method always wins.
+    let method_str = method.unwrap_or(if body.is_some() { "POST" } else { "GET" });
     let reqwest_method = method_str
         .parse::<reqwest::Method>()
         .map_err(|e| SourceError {
@@ -98,6 +104,10 @@ pub(crate) async fn resolve_http_with_limit(
     for (key, value) in headers {
         let expanded_value = expand_env_vars(value);
         request = request.header(key.as_str(), expanded_value);
+    }
+
+    if let Some(body) = body {
+        request = request.body(expand_env_vars(body));
     }
 
     let response = request.send().await.map_err(|e| {
@@ -192,6 +202,8 @@ fn expand_env_vars(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{body_string, method as method_matcher, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn shared_http_source_client_is_arc_stable() {
@@ -203,5 +215,88 @@ mod tests {
             Arc::ptr_eq(&a, &b),
             "shared HTTP source client must be process-wide stable"
         );
+    }
+
+    #[tokio::test]
+    async fn body_is_sent_and_method_defaults_to_post() {
+        let server = MockServer::start().await;
+        // The mock only answers a POST carrying the exact body, so a passing
+        // request proves both the body was sent and the unset method defaulted
+        // to POST.
+        Mock::given(method_matcher("POST"))
+            .and(path("/query"))
+            .and(body_string(r#"{"query":"listCase"}"#))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"cases":3}"#))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = resolve_http(
+            &format!("{}/query", server.uri()),
+            None,
+            &HashMap::new(),
+            Some(r#"{"query":"listCase"}"#),
+            DataFormat::Json,
+            None,
+            None,
+        )
+        .await
+        .expect("request should succeed");
+
+        assert_eq!(result.data, serde_json::json!({"cases": 3}));
+    }
+
+    #[tokio::test]
+    async fn body_expands_env_vars() {
+        // SAFETY: a uniquely named variable avoids racing other tests' env use.
+        unsafe { std::env::set_var("RSIGMA_TEST_HTTP_BODY_TOKEN", "s3cret") };
+
+        let server = MockServer::start().await;
+        Mock::given(method_matcher("POST"))
+            .and(path("/query"))
+            .and(body_string(r#"{"token":"s3cret"}"#))
+            .respond_with(ResponseTemplate::new(200).set_body_string("[]"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = resolve_http(
+            &format!("{}/query", server.uri()),
+            None,
+            &HashMap::new(),
+            Some(r#"{"token":"${RSIGMA_TEST_HTTP_BODY_TOKEN}"}"#),
+            DataFormat::Json,
+            None,
+            None,
+        )
+        .await
+        .expect("request should succeed");
+
+        assert_eq!(result.data, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn bodyless_request_defaults_to_get() {
+        let server = MockServer::start().await;
+        Mock::given(method_matcher("GET"))
+            .and(path("/feed"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = resolve_http(
+            &format!("{}/feed", server.uri()),
+            None,
+            &HashMap::new(),
+            None,
+            DataFormat::Json,
+            None,
+            None,
+        )
+        .await
+        .expect("request should succeed");
+
+        assert_eq!(result.data, serde_json::json!({"ok": true}));
     }
 }

--- a/crates/rsigma-runtime/src/sources/mod.rs
+++ b/crates/rsigma-runtime/src/sources/mod.rs
@@ -157,6 +157,7 @@ impl SourceResolver for DefaultSourceResolver {
                 url,
                 method,
                 headers,
+                body,
                 format,
                 extract,
             } => {
@@ -164,6 +165,7 @@ impl SourceResolver for DefaultSourceResolver {
                     url,
                     method.as_deref(),
                     headers,
+                    body.as_deref(),
                     *format,
                     extract.as_ref(),
                     source.timeout,

--- a/docs/reference/dynamic-sources.md
+++ b/docs/reference/dynamic-sources.md
@@ -107,7 +107,7 @@ Reads a local file, parses it according to `format`, applies `extract` if set, a
 
 ### `http`
 
-GET (or other method) request, response body parsed and optionally extracted. Uses `reqwest`.
+GET (or other method) request, response body parsed and optionally extracted. Uses `reqwest`. A request may carry a `body` for query APIs that require one (GraphQL, `_search`, TheHive 5's `/api/v1/query`).
 
 ```yaml
 - id: ip_blocklist
@@ -115,19 +115,36 @@ GET (or other method) request, response body parsed and optionally extracted. Us
   url: https://feeds.example.com/blocklist.json
   format: json
   extract: ".ips"
-  method: GET                  # default
+  method: GET                  # default (POST when a body is set)
   headers:                     # optional
-    Authorization: "Bearer ${env:FEED_TOKEN}"
+    Authorization: "Bearer ${FEED_TOKEN}"
   timeout: 10s                 # default 30s
   refresh: 300s
   on_error: use_cached
 ```
 
+A POST query with a request body:
+
+```yaml
+- id: thehive_cases
+  type: http
+  url: https://thehive.example.com/api/v1/query
+  headers:
+    Authorization: "Bearer ${THEHIVE_API_KEY}"
+    Content-Type: application/json
+  body: |
+    {"query": [{"_name": "listCase"}, {"_name": "filter", "_field": "status", "_value": "Resolved"}]}
+  format: json
+  extract: ".[]"
+  refresh: 300s
+```
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `url` | string | yes | Full HTTP(S) URL. |
-| `method` | string | no | `GET` (default), `POST`, `PUT`, etc. |
-| `headers` | mapping | no | Request headers. Static values only; env-variable interpolation is not implemented. |
+| `method` | string | no | `GET` (default), `POST`, `PUT`, etc. Defaults to `POST` when `body` is set. |
+| `headers` | mapping | no | Request headers. `${VAR}` references are expanded from the environment at fetch time, so tokens stay out of the committed YAML. |
+| `body` | string | no | Request body sent verbatim after `${VAR}` expansion. Set `Content-Type` in `headers`; the engine does not infer it. |
 | `format` | enum | yes | `json`, `yaml`, `lines`, or `csv`. |
 | `extract` | string or object | no | Filter applied after parsing. |
 | `timeout` | duration | no | Request timeout. Default `30s`. |


### PR DESCRIPTION
## Summary

Adds an optional `body` field to the `http` dynamic-source type so a source can poll a query API that requires a request body. The body is sent verbatim after `${VAR}` environment expansion (the same expansion already applied to headers), so tokens stay in the environment rather than the committed YAML.

- A source with a `body` and no explicit `method` defaults to `POST`; an explicit `method` still wins.
- `Content-Type` is not inferred; it is set through `headers`.
- Unblocks polling query APIs whose search is body-based: GraphQL, an Elasticsearch or OpenSearch `_search`, and TheHive 5's `POST /api/v1/query` (which has no GET-with-filters equivalent).

The reference docs for `headers` are also corrected: `${VAR}` references have always been expanded at fetch time, which the field table previously said was unimplemented (the example also used a stale `${env:...}` form).

## Changes

- `SourceType::Http` gains `body: Option<String>`, parsed from the `body` key in the sources-file parser and threaded through `resolve_http` to the reqwest builder.
- Reference documentation: a `body` row plus a POST-query example, and the `headers` env-expansion correction.
- `CHANGELOG.md` `[Unreleased]` entry.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rsigma-eval -p rsigma-runtime --all-features` (1205 passed)
- [x] `cargo doc --workspace --all-features --locked --no-deps`
- [x] `mkdocs build --strict`
- [x] New parsing round-trip test and three wiremock integration tests (body sent with POST default, `${VAR}` expansion in body, bodyless request stays GET)