### PR TITLE
docs(dispositions): disposition source recipes for TheHive, Jira, GitHub Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Disposition source recipes (docs)
+### Disposition source recipes (docs) (#311)
 
 A new [Disposition Source Recipes](https://timescale.github.io/rsigma/guide/disposition-recipes/) guide with copy-paste `--disposition-source` configs that pull analyst verdicts from TheHive, Jira, and GitHub Issues into the triage feedback loop. Each recipe is one HTTP dynamic source with a jq `extract` that reshapes the case system's API response into disposition records, plus its verdict mapping, `${ENV_VAR}` auth, and the identity round-trip and idempotency reasoning. The three sources files are committed as test fixtures and their extracts run against canned API responses in CI, so the documented recipes cannot silently drift from what the ingest path accepts. Docs-only beyond the fixture test; no engine or daemon change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Disposition source recipes (docs)
+
+A new [Disposition Source Recipes](https://timescale.github.io/rsigma/guide/disposition-recipes/) guide with copy-paste `--disposition-source` configs that pull analyst verdicts from TheHive, Jira, and GitHub Issues into the triage feedback loop. Each recipe is one HTTP dynamic source with a jq `extract` that reshapes the case system's API response into disposition records, plus its verdict mapping, `${ENV_VAR}` auth, and the identity round-trip and idempotency reasoning. The three sources files are committed as test fixtures and their extracts run against canned API responses in CI, so the documented recipes cannot silently drift from what the ingest path accepts. Docs-only beyond the fixture test; no engine or daemon change.
+
 ### Request body for `http` dynamic sources (#310)
 
 The `http` dynamic-source type gains an optional `body` field, sent verbatim after `${VAR}` environment expansion, so a source can poll a query API that requires a request body (GraphQL, an Elasticsearch/OpenSearch `_search`, TheHive 5's `/api/v1/query`). A source with a `body` and no explicit `method` defaults to `POST`; an explicit `method` still wins. `Content-Type` is not inferred and should be set in `headers`. The reference documentation for `headers` is also corrected: `${VAR}` references have always been expanded from the environment at fetch time, which the field table previously said was unimplemented.

--- a/crates/rsigma-cli/tests/cli_disposition_recipes.rs
+++ b/crates/rsigma-cli/tests/cli_disposition_recipes.rs
@@ -1,0 +1,202 @@
+//! Pins the disposition-source recipe fixtures embedded in the
+//! disposition-recipes guide.
+//!
+//! Each recipe under `tests/fixtures/disposition_recipes/` is the exact
+//! `--disposition-source` sources file the guide shows. This test parses each
+//! with the real loader, runs its jq `extract` over a canned sample of that
+//! case system's API response (swapping the HTTP transport for a `File` source
+//! over the sample, since the `extract` and `format` are what the recipe
+//! actually pins), and asserts the reshaped output validates as disposition
+//! records with the expected verdicts and identities. Docs that embed the exact
+//! tested files therefore cannot drift from what the engine accepts.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rsigma_eval::pipeline::sources::{DynamicSource, ErrorPolicy, RefreshPolicy, SourceType};
+use rsigma_runtime::dispositions::{Disposition, Verdict, parse_dispositions};
+use rsigma_runtime::sources::{DefaultSourceResolver, SourceResolver};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/disposition_recipes")
+}
+
+/// Parse a recipe sources file and return its single source.
+fn parse_recipe(recipe: &str) -> DynamicSource {
+    let sources = rsigma_eval::parse_sources_file(&fixture_dir().join(recipe))
+        .expect("recipe sources file parses");
+    assert_eq!(sources.len(), 1, "{recipe} declares exactly one source");
+    sources.into_iter().next().unwrap()
+}
+
+/// Every recipe polls an HTTP source on a 5-minute interval with an env-scoped
+/// auth header. This pins the source-file schema each recipe documents so a
+/// silently-dropped key (a bad `refresh`, a missing `method`/`body`) is caught.
+#[test]
+fn recipes_declare_the_documented_schema() {
+    for (recipe, auth_header, auth_ref) in [
+        ("github.yml", "Authorization", "${GITHUB_TOKEN}"),
+        ("jira.yml", "Authorization", "${JIRA_BASIC_AUTH}"),
+        ("thehive.yml", "Authorization", "${THEHIVE_API_KEY}"),
+    ] {
+        let source = parse_recipe(recipe);
+        assert_eq!(
+            source.refresh,
+            RefreshPolicy::Interval(Duration::from_secs(300)),
+            "{recipe} polls on a 5m interval"
+        );
+        let SourceType::Http {
+            headers, extract, ..
+        } = &source.source_type
+        else {
+            panic!("{recipe} must declare an http source");
+        };
+        assert!(extract.is_some(), "{recipe} carries an extract");
+        assert!(
+            headers
+                .get(auth_header)
+                .is_some_and(|v| v.contains(auth_ref)),
+            "{recipe} authenticates with the {auth_ref} environment reference"
+        );
+    }
+
+    // TheHive 5 searches cases with a POST body; the others are GET polls.
+    let SourceType::Http { method, body, .. } = parse_recipe("thehive.yml").source_type else {
+        unreachable!()
+    };
+    assert_eq!(method.as_deref(), Some("POST"), "thehive uses POST /query");
+    assert!(
+        body.as_deref().is_some_and(|b| b.contains("listCase")),
+        "thehive carries the listCase query body"
+    );
+}
+
+/// Parse the recipe sources file, then resolve its `extract` over the canned
+/// sample by swapping the HTTP source for a `File` source with the same
+/// `format` and `extract`.
+async fn resolve_recipe(recipe: &str, sample: &str) -> serde_json::Value {
+    let dir = fixture_dir();
+    let sources =
+        rsigma_eval::parse_sources_file(&dir.join(recipe)).expect("recipe sources file parses");
+    assert_eq!(sources.len(), 1, "{recipe} declares exactly one source");
+
+    let (format, extract) = match &sources[0].source_type {
+        SourceType::Http {
+            format, extract, ..
+        } => (*format, extract.clone()),
+        other => panic!("{recipe} must declare an http source, got {other:?}"),
+    };
+    assert!(
+        extract.is_some(),
+        "{recipe} must carry an extract expression"
+    );
+
+    let file_source = DynamicSource {
+        id: "recipe".to_string(),
+        source_type: SourceType::File {
+            path: dir.join(sample),
+            format,
+            extract,
+        },
+        refresh: RefreshPolicy::Once,
+        timeout: None,
+        on_error: ErrorPolicy::Fail,
+        required: true,
+        default: None,
+    };
+
+    DefaultSourceResolver::new()
+        .resolve(&file_source)
+        .await
+        .expect("extract resolves over the sample payload")
+        .data
+}
+
+/// Resolve the recipe, parse the reshaped output as disposition records, and
+/// validate each, returning `(rule_id, verdict, incident_id)` tuples sorted for
+/// stable comparison.
+async fn recipe_dispositions(recipe: &str, sample: &str) -> Vec<(String, Verdict, Option<String>)> {
+    let value = resolve_recipe(recipe, sample).await;
+    let text = serde_json::to_string(&value).expect("reshaped output serializes");
+
+    let raws = parse_dispositions(&text).expect("reshaped output parses as dispositions");
+    let mut out: Vec<(String, Verdict, Option<String>)> = raws
+        .into_iter()
+        .map(|raw| {
+            let d = Disposition::from_raw(raw, 0).expect("reshaped record validates");
+            (
+                d.rule_id.expect("detection scope carries a rule_id"),
+                d.verdict,
+                d.incident_id,
+            )
+        })
+        .collect();
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+#[tokio::test]
+async fn github_recipe_reshapes_closed_issues() {
+    let got = recipe_dispositions("github.yml", "github_sample.json").await;
+    assert_eq!(
+        got,
+        vec![
+            (
+                "proc-injection".to_string(),
+                Verdict::FalsePositive,
+                Some("7f3c9a2b".to_string()),
+            ),
+            (
+                "susp-powershell".to_string(),
+                Verdict::TruePositive,
+                Some("a1b2c3d4".to_string()),
+            ),
+        ],
+        "the pull request and the verdict-less issue are dropped; the two \
+         labeled issues reshape to disposition records"
+    );
+}
+
+#[tokio::test]
+async fn jira_recipe_reshapes_resolved_issues() {
+    let got = recipe_dispositions("jira.yml", "jira_sample.json").await;
+    assert_eq!(
+        got,
+        vec![
+            (
+                "proc-injection".to_string(),
+                Verdict::FalsePositive,
+                Some("7f3c9a2b".to_string()),
+            ),
+            (
+                "susp-powershell".to_string(),
+                Verdict::TruePositive,
+                Some("a1b2c3d4".to_string()),
+            ),
+        ],
+        "the null-resolution issue and the unmapped \"Done\" resolution are \
+         dropped; the two verdict resolutions reshape to disposition records"
+    );
+}
+
+#[tokio::test]
+async fn thehive_recipe_reshapes_resolved_cases() {
+    let got = recipe_dispositions("thehive.yml", "thehive_sample.json").await;
+    assert_eq!(
+        got,
+        vec![
+            (
+                "proc-injection".to_string(),
+                Verdict::FalsePositive,
+                Some("7f3c9a2b".to_string()),
+            ),
+            (
+                "susp-powershell".to_string(),
+                Verdict::TruePositive,
+                Some("a1b2c3d4".to_string()),
+            ),
+        ],
+        "the Indeterminate case is dropped; TruePositive and FalsePositive \
+         reshape to disposition records"
+    );
+}

--- a/crates/rsigma-cli/tests/fixtures/disposition_recipes/github.yml
+++ b/crates/rsigma-cli/tests/fixtures/disposition_recipes/github.yml
@@ -1,0 +1,34 @@
+# Pull analyst verdicts from closed GitHub issues labeled `alert`.
+#
+# Label convention (defined by this recipe; GitHub has no resolution field):
+#   verdict:true-positive | verdict:false-positive | verdict:benign-true-positive
+#   rule:<rule_id>      the rule the alert came from
+#   incident:<id>       the rsigma incident_id stamped into the issue at creation
+#
+# Auth: a read-only token in $GITHUB_TOKEN (fine-grained "Issues: read").
+# API: https://docs.github.com/en/rest/issues/issues#list-repository-issues
+# `since` filters on updated_at (not close time); the issues endpoint also
+# returns pull requests, so the extract drops anything with a `pull_request` key.
+sources:
+  - id: github_dispositions
+    type: http
+    url: "https://api.github.com/repos/acme/detections/issues?state=closed&labels=alert&since=2026-07-01T00:00:00Z&per_page=100"
+    headers:
+      Authorization: "Bearer ${GITHUB_TOKEN}"
+      Accept: "application/vnd.github+json"
+      X-GitHub-Api-Version: "2022-11-28"
+    format: json
+    refresh: 5m
+    extract: |
+      [ .[]
+        | select(has("pull_request") | not)
+        | { l: [.labels[].name], closed: .closed_at, who: (.assignee.login? // null) }
+        | select([.l[] | select(startswith("verdict:"))] | length > 0)
+        | {
+            rule_id: ([.l[] | select(startswith("rule:")) | ltrimstr("rule:")][0]),
+            verdict: ([.l[] | select(startswith("verdict:")) | ltrimstr("verdict:")][0] | gsub("-"; "_")),
+            incident_id: ([.l[] | select(startswith("incident:")) | ltrimstr("incident:")][0]),
+            timestamp: .closed,
+            analyst: .who
+          }
+      ]

--- a/crates/rsigma-cli/tests/fixtures/disposition_recipes/github_sample.json
+++ b/crates/rsigma-cli/tests/fixtures/disposition_recipes/github_sample.json
@@ -1,0 +1,49 @@
+[
+  {
+    "number": 412,
+    "title": "Alert: proc-injection on WKSTN-7",
+    "state": "closed",
+    "labels": [
+      { "name": "alert" },
+      { "name": "rule:proc-injection" },
+      { "name": "incident:7f3c9a2b" },
+      { "name": "verdict:false-positive" }
+    ],
+    "assignee": { "login": "alice" },
+    "closed_at": "2026-07-09T14:20:00Z",
+    "updated_at": "2026-07-09T14:20:05Z"
+  },
+  {
+    "number": 415,
+    "title": "Alert: susp-powershell on SRV-3",
+    "state": "closed",
+    "labels": [
+      { "name": "alert" },
+      { "name": "rule:susp-powershell" },
+      { "name": "incident:a1b2c3d4" },
+      { "name": "verdict:true-positive" }
+    ],
+    "assignee": { "login": "bob" },
+    "closed_at": "2026-07-09T16:05:00Z",
+    "updated_at": "2026-07-09T16:05:10Z"
+  },
+  {
+    "number": 418,
+    "title": "Refactor detection loader",
+    "state": "closed",
+    "labels": [{ "name": "alert" }],
+    "pull_request": { "url": "https://api.github.com/repos/acme/detections/pulls/418" },
+    "assignee": null,
+    "closed_at": "2026-07-09T17:00:00Z",
+    "updated_at": "2026-07-09T17:00:00Z"
+  },
+  {
+    "number": 420,
+    "title": "Alert: triage still pending",
+    "state": "closed",
+    "labels": [{ "name": "alert" }, { "name": "rule:dns-tunnel" }],
+    "assignee": null,
+    "closed_at": "2026-07-09T18:00:00Z",
+    "updated_at": "2026-07-09T18:00:00Z"
+  }
+]

--- a/crates/rsigma-cli/tests/fixtures/disposition_recipes/jira.yml
+++ b/crates/rsigma-cli/tests/fixtures/disposition_recipes/jira.yml
@@ -1,0 +1,39 @@
+# Pull analyst verdicts from resolved Jira Cloud issues.
+#
+# Convention:
+#   resolution name "False Positive" / "True Positive" (add a "False Positive"
+#     resolution to your workflow scheme if the default one lacks it)
+#   label rsigma-rule-<rule_id>     the rule the alert came from
+#   label rsigma-incident-<id>      the rsigma incident_id stamped in at creation
+#
+# Auth: HTTP Basic; $JIRA_BASIC_AUTH is base64("email:api_token") for a
+# read-only token. API token docs:
+# https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+# Endpoint: the legacy /rest/api/3/search returns 410 Gone; use search/jql, which
+# needs an explicit `fields` list and paginates with nextPageToken (not startAt):
+# https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get
+# `resolutiondate` is not RFC 3339 (offset is +0000, no colon), so the extract
+# omits `timestamp` and lets ingest default it; the incident_id keys the record.
+sources:
+  - id: jira_dispositions
+    type: http
+    url: "https://your-domain.atlassian.net/rest/api/3/search/jql?jql=resolution%20in%20(%22False%20Positive%22%2C%22True%20Positive%22)%20AND%20updated%20%3E%3D%20-1d&fields=resolution,resolutiondate,labels,assignee&maxResults=100"
+    headers:
+      Authorization: "Basic ${JIRA_BASIC_AUTH}"
+      Accept: "application/json"
+    format: json
+    refresh: 5m
+    extract: |
+      [ .issues[]
+        | .fields as $f
+        | select($f.resolution != null
+                 and ($f.resolution.name == "False Positive"
+                      or $f.resolution.name == "True Positive"))
+        | {
+            rule_id: ([$f.labels[] | select(startswith("rsigma-rule-")) | ltrimstr("rsigma-rule-")][0]),
+            verdict: (if $f.resolution.name == "False Positive"
+                      then "false_positive" else "true_positive" end),
+            incident_id: ([$f.labels[] | select(startswith("rsigma-incident-")) | ltrimstr("rsigma-incident-")][0]),
+            analyst: ($f.assignee.displayName? // null)
+          }
+      ]

--- a/crates/rsigma-cli/tests/fixtures/disposition_recipes/jira_sample.json
+++ b/crates/rsigma-cli/tests/fixtures/disposition_recipes/jira_sample.json
@@ -1,0 +1,40 @@
+{
+  "issues": [
+    {
+      "key": "SOC-101",
+      "fields": {
+        "resolution": { "name": "False Positive" },
+        "resolutiondate": "2026-07-09T14:20:00.000+0000",
+        "labels": ["rsigma-rule-proc-injection", "rsigma-incident-7f3c9a2b"],
+        "assignee": { "displayName": "Alice Ng" }
+      }
+    },
+    {
+      "key": "SOC-102",
+      "fields": {
+        "resolution": { "name": "True Positive" },
+        "resolutiondate": "2026-07-09T16:05:00.000+0000",
+        "labels": ["rsigma-rule-susp-powershell", "rsigma-incident-a1b2c3d4"],
+        "assignee": null
+      }
+    },
+    {
+      "key": "SOC-103",
+      "fields": {
+        "resolution": null,
+        "resolutiondate": null,
+        "labels": ["rsigma-rule-dns-tunnel"],
+        "assignee": null
+      }
+    },
+    {
+      "key": "SOC-104",
+      "fields": {
+        "resolution": { "name": "Done" },
+        "resolutiondate": "2026-07-09T17:00:00.000+0000",
+        "labels": ["rsigma-rule-other"],
+        "assignee": { "displayName": "Bob Lee" }
+      }
+    }
+  ]
+}

--- a/crates/rsigma-cli/tests/fixtures/disposition_recipes/thehive.yml
+++ b/crates/rsigma-cli/tests/fixtures/disposition_recipes/thehive.yml
@@ -1,0 +1,45 @@
+# Pull analyst verdicts from resolved TheHive 5 (StrangeBee) cases.
+#
+# Convention:
+#   resolutionStatus  TruePositive | FalsePositive
+#     (Indeterminate / Duplicated / Other are skipped in the extract; TheHive
+#      has no native benign-true-positive status, so teams that track BTP add a
+#      case tag and map it here.)
+#   tag rsigma-rule:<rule_id>       the rule the alert came from
+#   tag rsigma-incident:<id>        the rsigma incident_id stamped in at creation
+#
+# Auth: a read-only API key in $THEHIVE_API_KEY.
+# API: TheHive 5 case search is POST /api/v1/query with a JSON body (there is no
+# GET-with-filters equivalent), so this recipe uses the http-source `body` field.
+# https://docs.strangebee.com/thehive/api-docs/
+# `_updatedAt` is epoch milliseconds, not RFC 3339, so the extract omits
+# `timestamp` and lets ingest default it; the incident_id keys the record.
+sources:
+  - id: thehive_dispositions
+    type: http
+    url: "https://thehive.example.com/api/v1/query?name=rsigma-dispositions"
+    method: POST
+    headers:
+      Authorization: "Bearer ${THEHIVE_API_KEY}"
+      Content-Type: "application/json"
+    body: |
+      {"query":[
+        {"_name":"listCase"},
+        {"_name":"filter","_eq":{"_field":"status","_value":"Resolved"}},
+        {"_name":"sort","_fields":[{"_updatedAt":"desc"}]},
+        {"_name":"page","from":0,"to":100}
+      ]}
+    format: json
+    refresh: 5m
+    extract: |
+      [ .[]
+        | select(.resolutionStatus == "TruePositive"
+                 or .resolutionStatus == "FalsePositive")
+        | { tags: (.tags // []), rs: .resolutionStatus, who: (.assignee? // null) }
+        | {
+            rule_id: ([.tags[] | select(startswith("rsigma-rule:")) | ltrimstr("rsigma-rule:")][0]),
+            verdict: (if .rs == "TruePositive" then "true_positive" else "false_positive" end),
+            incident_id: ([.tags[] | select(startswith("rsigma-incident:")) | ltrimstr("rsigma-incident:")][0]),
+            analyst: .who
+          }
+      ]

--- a/crates/rsigma-cli/tests/fixtures/disposition_recipes/thehive_sample.json
+++ b/crates/rsigma-cli/tests/fixtures/disposition_recipes/thehive_sample.json
@@ -1,0 +1,29 @@
+[
+  {
+    "_id": "~40968",
+    "title": "proc-injection on WKSTN-7",
+    "status": "Resolved",
+    "resolutionStatus": "FalsePositive",
+    "tags": ["rsigma-rule:proc-injection", "rsigma-incident:7f3c9a2b"],
+    "assignee": "alice",
+    "_updatedAt": 1783000800000
+  },
+  {
+    "_id": "~40972",
+    "title": "susp-powershell on SRV-3",
+    "status": "Resolved",
+    "resolutionStatus": "TruePositive",
+    "tags": ["rsigma-rule:susp-powershell", "rsigma-incident:a1b2c3d4"],
+    "assignee": "bob",
+    "_updatedAt": 1783006000000
+  },
+  {
+    "_id": "~40990",
+    "title": "dns anomaly on GW-1",
+    "status": "Resolved",
+    "resolutionStatus": "Indeterminate",
+    "tags": ["rsigma-rule:dns-tunnel", "rsigma-incident:ffff0000"],
+    "assignee": "carol",
+    "_updatedAt": 1783010000000
+  }
+]

--- a/docs/cli/engine/daemon.md
+++ b/docs/cli/engine/daemon.md
@@ -256,7 +256,7 @@ The daemon serves [`POST`/`GET /api/v1/dispositions`](../../reference/http-api.m
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--enable-dispositions` | off | Enable the loop for this run; the disposition endpoints then accept requests. Equivalent to `daemon.dispositions.enabled: true`. |
-| `--disposition-source <PATH>` | none | Pull dispositions from a dynamic-source file (file, HTTP, or NATS), the same format as `--source`, whose payload is the disposition records (NDJSON or a JSON array). Refreshed per the source's policy; redelivery is idempotent. Implies the loop is enabled. Overrides `daemon.dispositions.source`. |
+| `--disposition-source <PATH>` | none | Pull dispositions from a dynamic-source file (file, HTTP, or NATS), the same format as `--source`, whose payload is the disposition records (NDJSON or a JSON array). Refreshed per the source's policy; redelivery is idempotent. Implies the loop is enabled. Overrides `daemon.dispositions.source`. See [Disposition Source Recipes](../../guide/disposition-recipes.md) for tested TheHive/Jira/GitHub Issues configs. |
 
 The tuning keys are config-file-only under `daemon.dispositions`:
 

--- a/docs/guide/.pages
+++ b/docs/guide/.pages
@@ -9,6 +9,7 @@ nav:
   - ATT&CK Coverage: attack-coverage.md
   - Detection Scorecard: detection-scorecard.md
   - Triage Feedback Loop: triage-feedback.md
+  - Disposition Source Recipes: disposition-recipes.md
   - Rule Hygiene: rule-hygiene.md
   - Visibility and Data Sources: visibility-and-data-sources.md
   - MCP Server: mcp-server.md

--- a/docs/guide/disposition-recipes.md
+++ b/docs/guide/disposition-recipes.md
@@ -1,0 +1,266 @@
+# Disposition Source Recipes
+
+The [triage feedback loop](triage-feedback.md) turns analyst verdicts into a live per-rule false-positive ratio. Its pull path, `--disposition-source`, reads verdicts from wherever they already live: your case system. This page gives copy-paste, tested `--disposition-source` configs for the three most common ones, TheHive, Jira, and GitHub Issues, so you do not have to re-derive the extract expression, the auth wiring, and the idempotency reasoning yourself.
+
+Each recipe is one [dynamic-source](../reference/dynamic-sources.md) file: an HTTP source that polls the case system for recently-closed cases on an interval, and a jq `extract` that reshapes that system's API response into [disposition records](triage-feedback.md#disposition-format). No extra service, no glue script. The exact files below are committed as test fixtures and run against canned API responses in CI, so they cannot silently drift from what the engine accepts.
+
+## How the pull loop works
+
+`--disposition-source <PATH>` loads a standalone dynamic-source file at daemon startup and refreshes it on the source's `refresh:` interval. For each refresh the runtime fetches the response, decodes it per `format:`, and applies the `extract:` expression **before** anything else sees the payload. The extracted value is fed straight to the disposition ingest path, which accepts a single object, a JSON array, or NDJSON. So an `extract` that builds `[{rule_id, verdict, incident_id, ...}]` from a case-system response is the whole integration.
+
+A configured source implies the loop is enabled, so `--disposition-source thehive.yml` alone is enough; you do not also need `--enable-dispositions`.
+
+```bash
+rsigma engine daemon --disposition-source /etc/rsigma/thehive.yml
+```
+
+## Read this first: the identity round-trip
+
+A verdict only keys back to the right rule if the case carries the alert's identity. Dispositions deduplicate on `(fingerprint or incident_id, verdict, rule_id)`, so the case must know the `incident_id` (or `fingerprint`) the alert was created with, plus the `rule_id`.
+
+That means the integration is a **round-trip**: the alert delivery that opened the case must stamp the identity into it, and the recipe reads it back out. Configure your [webhook sink](webhooks.md) (the carrier that opened the ticket) to template `rule_id` and `incident_id` into the case at creation, as shown in [Closing the loop with delivery](triage-feedback.md#closing-the-loop-with-delivery). Without that, the recipes below have no stable identity to read and the pull path silently mis-keys.
+
+The recipes carry the identity in a label or tag (`incident:<id>`, `rsigma-incident-<id>`, `rsigma-incident:<id>`) because that is the most portable field across case systems. A dedicated custom field works too where you have one.
+
+## GitHub Issues
+
+GitHub has no resolution field, so the recipe defines a label convention: a `verdict:*` label carries the disposition, a `rule:<id>` label carries the rule, and an `incident:<id>` label carries the alert identity. The analyst closes the issue with the right `verdict:` label; the recipe polls closed, `alert`-labeled issues.
+
+**Polling source** (`github.yml`):
+
+```yaml
+# Pull analyst verdicts from closed GitHub issues labeled `alert`.
+#
+# Label convention (defined by this recipe; GitHub has no resolution field):
+#   verdict:true-positive | verdict:false-positive | verdict:benign-true-positive
+#   rule:<rule_id>      the rule the alert came from
+#   incident:<id>       the rsigma incident_id stamped into the issue at creation
+#
+# Auth: a read-only token in $GITHUB_TOKEN (fine-grained "Issues: read").
+# API: https://docs.github.com/en/rest/issues/issues#list-repository-issues
+# `since` filters on updated_at (not close time); the issues endpoint also
+# returns pull requests, so the extract drops anything with a `pull_request` key.
+sources:
+  - id: github_dispositions
+    type: http
+    url: "https://api.github.com/repos/acme/detections/issues?state=closed&labels=alert&since=2026-07-01T00:00:00Z&per_page=100"
+    headers:
+      Authorization: "Bearer ${GITHUB_TOKEN}"
+      Accept: "application/vnd.github+json"
+      X-GitHub-Api-Version: "2022-11-28"
+    format: json
+    refresh: 5m
+    extract: |
+      [ .[]
+        | select(has("pull_request") | not)
+        | { l: [.labels[].name], closed: .closed_at, who: (.assignee.login? // null) }
+        | select([.l[] | select(startswith("verdict:"))] | length > 0)
+        | {
+            rule_id: ([.l[] | select(startswith("rule:")) | ltrimstr("rule:")][0]),
+            verdict: ([.l[] | select(startswith("verdict:")) | ltrimstr("verdict:")][0] | gsub("-"; "_")),
+            incident_id: ([.l[] | select(startswith("incident:")) | ltrimstr("incident:")][0]),
+            timestamp: .closed,
+            analyst: .who
+          }
+      ]
+```
+
+**Verdict mapping.** GitHub has no resolution vocabulary, so the labels *are* the mapping; `gsub("-"; "_")` turns the label suffix into the wire verdict:
+
+| Label | Verdict |
+|-------|---------|
+| `verdict:true-positive` | `true_positive` |
+| `verdict:false-positive` | `false_positive` |
+| `verdict:benign-true-positive` | `benign_true_positive` |
+
+Issues with no `verdict:*` label are skipped (still under triage). The issues endpoint returns pull requests too, so the extract drops anything carrying a `pull_request` key. `closed_at` is RFC 3339, so it is carried as the disposition `timestamp`.
+
+**Outbound-automation variant.** If you prefer push over polling, close the loop with a workflow that POSTs the record when an issue is closed, and skip the source file entirely:
+
+{% raw %}
+```yaml
+# .github/workflows/rsigma-disposition.yml
+name: rsigma disposition
+on:
+  issues:
+    types: [closed]
+jobs:
+  post:
+    if: contains(join(github.event.issue.labels.*.name, ','), 'verdict:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post disposition
+        env:
+          RSIGMA_TOKEN: ${{ secrets.RSIGMA_DISPOSITIONS_TOKEN }}
+          LABELS: ${{ join(github.event.issue.labels.*.name, ' ') }}
+        run: |
+          rule_id=$(printf '%s\n' $LABELS | sed -n 's/^rule://p')
+          verdict=$(printf '%s\n' $LABELS | sed -n 's/^verdict://p' | tr '-' '_')
+          incident=$(printf '%s\n' $LABELS | sed -n 's/^incident://p')
+          curl -sS -X POST https://rsigma.internal/api/v1/dispositions \
+            -H "Authorization: Bearer $RSIGMA_TOKEN" \
+            -d "{\"rule_id\":\"$rule_id\",\"verdict\":\"$verdict\",\"incident_id\":\"$incident\"}"
+```
+{% endraw %}
+
+## Jira
+
+Jira carries the disposition in the issue's **resolution**. Add a `False Positive` resolution to your workflow scheme if the default one lacks it, and map your true-positive resolution name. The recipe carries the rule and incident identities in labels.
+
+!!! warning "Use the `search/jql` endpoint"
+    The legacy `/rest/api/3/search` endpoint returns `410 Gone` on Jira Cloud. Use `/rest/api/3/search/jql`, which requires an explicit `fields` list and paginates with `nextPageToken` rather than `startAt`.
+
+**Polling source** (`jira.yml`):
+
+```yaml
+# Pull analyst verdicts from resolved Jira Cloud issues.
+#
+# Convention:
+#   resolution name "False Positive" / "True Positive" (add a "False Positive"
+#     resolution to your workflow scheme if the default one lacks it)
+#   label rsigma-rule-<rule_id>     the rule the alert came from
+#   label rsigma-incident-<id>      the rsigma incident_id stamped in at creation
+#
+# Auth: HTTP Basic; $JIRA_BASIC_AUTH is base64("email:api_token") for a
+# read-only token. API token docs:
+# https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+# Endpoint: the legacy /rest/api/3/search returns 410 Gone; use search/jql, which
+# needs an explicit `fields` list and paginates with nextPageToken (not startAt):
+# https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get
+# `resolutiondate` is not RFC 3339 (offset is +0000, no colon), so the extract
+# omits `timestamp` and lets ingest default it; the incident_id keys the record.
+sources:
+  - id: jira_dispositions
+    type: http
+    url: "https://your-domain.atlassian.net/rest/api/3/search/jql?jql=resolution%20in%20(%22False%20Positive%22%2C%22True%20Positive%22)%20AND%20updated%20%3E%3D%20-1d&fields=resolution,resolutiondate,labels,assignee&maxResults=100"
+    headers:
+      Authorization: "Basic ${JIRA_BASIC_AUTH}"
+      Accept: "application/json"
+    format: json
+    refresh: 5m
+    extract: |
+      [ .issues[]
+        | .fields as $f
+        | select($f.resolution != null
+                 and ($f.resolution.name == "False Positive"
+                      or $f.resolution.name == "True Positive"))
+        | {
+            rule_id: ([$f.labels[] | select(startswith("rsigma-rule-")) | ltrimstr("rsigma-rule-")][0]),
+            verdict: (if $f.resolution.name == "False Positive"
+                      then "false_positive" else "true_positive" end),
+            incident_id: ([$f.labels[] | select(startswith("rsigma-incident-")) | ltrimstr("rsigma-incident-")][0]),
+            analyst: ($f.assignee.displayName? // null)
+          }
+      ]
+```
+
+**Verdict mapping.** Resolution names are scheme-dependent, so this is the one you are most likely to adjust:
+
+| Jira resolution | Verdict |
+|-----------------|---------|
+| `False Positive` | `false_positive` |
+| `True Positive` | `true_positive` |
+| anything else (`Done`, `Duplicate`, ...) | skipped |
+
+Auth is HTTP Basic, not Bearer: `$JIRA_BASIC_AUTH` is `base64("email:api_token")`. Jira's `resolutiondate` is not RFC 3339 (its offset is `+0000`, without the colon RFC 3339 requires), so the extract omits `timestamp` and lets ingest default it to receive time; the `incident_id` still keys the record, so dedup stays correct.
+
+**Outbound-automation variant.** A Jira Automation rule on "Issue resolved" with a "Send web request" action POSTs the record directly, templating the fields with Jira smart values:
+
+{% raw %}
+```json
+{
+  "rule_id": "{{issue.labels.match("rsigma-rule-(.*)")}}",
+  "verdict": "{{#if(equals(issue.resolution.name, "False Positive"))}}false_positive{{else}}true_positive{{/}}",
+  "incident_id": "{{issue.labels.match("rsigma-incident-(.*)")}}"
+}
+```
+{% endraw %}
+
+## TheHive
+
+TheHive carries the disposition in each case's `resolutionStatus`. TheHive 5 (StrangeBee) searches cases through `POST /api/v1/query` with a JSON body (there is no GET-with-filters equivalent), so the recipe uses the HTTP source's `body` field.
+
+**Polling source** (`thehive.yml`):
+
+```yaml
+# Pull analyst verdicts from resolved TheHive 5 (StrangeBee) cases.
+#
+# Convention:
+#   resolutionStatus  TruePositive | FalsePositive
+#     (Indeterminate / Duplicated / Other are skipped in the extract; TheHive
+#      has no native benign-true-positive status, so teams that track BTP add a
+#      case tag and map it here.)
+#   tag rsigma-rule:<rule_id>       the rule the alert came from
+#   tag rsigma-incident:<id>        the rsigma incident_id stamped in at creation
+#
+# Auth: a read-only API key in $THEHIVE_API_KEY.
+# API: TheHive 5 case search is POST /api/v1/query with a JSON body (there is no
+# GET-with-filters equivalent), so this recipe uses the http-source `body` field.
+# https://docs.strangebee.com/thehive/api-docs/
+# `_updatedAt` is epoch milliseconds, not RFC 3339, so the extract omits
+# `timestamp` and lets ingest default it; the incident_id keys the record.
+sources:
+  - id: thehive_dispositions
+    type: http
+    url: "https://thehive.example.com/api/v1/query?name=rsigma-dispositions"
+    method: POST
+    headers:
+      Authorization: "Bearer ${THEHIVE_API_KEY}"
+      Content-Type: "application/json"
+    body: |
+      {"query":[
+        {"_name":"listCase"},
+        {"_name":"filter","_eq":{"_field":"status","_value":"Resolved"}},
+        {"_name":"sort","_fields":[{"_updatedAt":"desc"}]},
+        {"_name":"page","from":0,"to":100}
+      ]}
+    format: json
+    refresh: 5m
+    extract: |
+      [ .[]
+        | select(.resolutionStatus == "TruePositive"
+                 or .resolutionStatus == "FalsePositive")
+        | { tags: (.tags // []), rs: .resolutionStatus, who: (.assignee? // null) }
+        | {
+            rule_id: ([.tags[] | select(startswith("rsigma-rule:")) | ltrimstr("rsigma-rule:")][0]),
+            verdict: (if .rs == "TruePositive" then "true_positive" else "false_positive" end),
+            incident_id: ([.tags[] | select(startswith("rsigma-incident:")) | ltrimstr("rsigma-incident:")][0]),
+            analyst: .who
+          }
+      ]
+```
+
+**Verdict mapping.** TheHive's `resolutionStatus` enum maps cleanly for the two verdicts that matter, and the rest are triage-inconclusive, so they are skipped:
+
+| TheHive `resolutionStatus` | Verdict |
+|----------------------------|---------|
+| `TruePositive` | `true_positive` |
+| `FalsePositive` | `false_positive` |
+| `Indeterminate`, `Duplicated`, `Other` | skipped |
+
+TheHive has no native benign-true-positive status. Teams that track BTP add a case tag (say `rsigma-btp`) and extend the `verdict` branch to emit `benign_true_positive` when that tag is present. `_updatedAt` is epoch milliseconds rather than RFC 3339, so the extract omits `timestamp` and lets ingest default it; the `incident_id` keys the record.
+
+**Outbound-automation variant.** A TheHive notification with a webhook endpoint fires on case resolution; point it at an intermediary that reshapes the notification body into a disposition record and POSTs it, or template it at a SOAR step. TheHive notifications do not template arbitrary JSON at the sender the way Jira Automation does, so polling is the recommended path here.
+
+## Idempotency and windowing
+
+**Re-polls are safe.** Every recipe polls on an interval and returns the same closed cases until they age out of the query window. That is fine: ingestion deduplicates on `(fingerprint or incident_id, verdict, rule_id)`, so a case returned on ten consecutive polls counts once. This is what makes interval polling correct rather than a double-counting hazard.
+
+**Window to bound payload size, not for correctness.** Each recipe filters to recently-updated closed cases (`since=` for GitHub, `updated >= -1d` for Jira, a `_updatedAt` sort plus `page` for TheHive). This keeps each response small; it is not required for correctness because of the dedup above. Pick a window comfortably larger than your poll interval.
+
+**No pagination following.** A source does a single fetch (capped at 10 MiB); it does not follow a `Link` header or a `nextPageToken` cursor. Keep each response inside one page by pairing a tight update window with the page-size cap (`per_page=100`, `maxResults=100`, TheHive's `page` clause). If more cases close in one window than a single page holds, the overflow is picked up on the next poll only if it still matches the window, so size the window and interval so a single page comfortably covers the closures between polls.
+
+**Healthy signal.** A working recipe increments `rsigma_disposition_ingest_total{source="http",result="accepted"}` on first sight of each verdict and `result="duplicate"` on every re-poll thereafter. A recipe whose extract emits a malformed record increments `rsigma_disposition_ingest_errors_total{reason="validation"}`; a broken sources file fails the daemon at boot with `CONFIG_ERROR`, so a recipe either loads and works or stops the daemon loudly.
+
+## Limits and follow-ons
+
+- **No direct raw-webhook ingestion.** A raw TheHive/Jira/GitHub webhook cannot point at `POST /api/v1/dispositions`, because that endpoint parses its body directly as disposition records and applies no transform. Webhook-shaped integrations therefore go through the sender's own templating (the outbound-automation variants above) or a relay. A server-side `extract` option on the POST endpoint would close that gap natively; it is a possible future addition, deliberately not part of this docs-only integration.
+- **NATS relay for push without sender templating.** If you want push delivery but your case system cannot template JSON at the sender, publish its webhook to a NATS subject through a thin relay and point a [NATS dynamic source](../reference/dynamic-sources.md) with the same `extract` at that subject. The reshaping is identical; only the transport changes.
+- **Other case systems.** Any system with a queryable closed-case API follows the same three parts: an HTTP (or NATS) source, an auth header from `${ENV_VAR}`, and a jq `extract` that emits disposition records. ServiceNow, PagerDuty, and others drop into the same template.
+
+## See also
+
+- [Triage Feedback Loop](triage-feedback.md) for the loop these recipes feed.
+- [Dynamic Sources](../reference/dynamic-sources.md) for the full source-file schema (HTTP `body`, `extract` languages, refresh policies, error handling).
+- [HTTP API: Dispositions](../reference/http-api.md#dispositions) for the record shape and the `POST` endpoint the outbound variants target.
+- [`engine daemon` disposition flags](../cli/engine/daemon.md#triage-feedback-loop) for `--disposition-source` and the `daemon.dispositions` config keys.

--- a/docs/guide/triage-feedback.md
+++ b/docs/guide/triage-feedback.md
@@ -49,7 +49,7 @@ curl -sS http://127.0.0.1:9090/api/v1/dispositions
 There are two ways in, and both are idempotent:
 
 - **The endpoint.** `POST /api/v1/dispositions` for push-style ingest from whatever delivered the alert.
-- **A pull source.** `--disposition-source <PATH>` (or `daemon.dispositions.source`) points at a dynamic-source file (the same format as `--source`) whose payload is the disposition records. File, HTTP, and NATS transports are supported, refreshed per the source's policy.
+- **A pull source.** `--disposition-source <PATH>` (or `daemon.dispositions.source`) points at a dynamic-source file (the same format as `--source`) whose payload is the disposition records. File, HTTP, and NATS transports are supported, refreshed per the source's policy. See [Disposition Source Recipes](disposition-recipes.md) for copy-paste, tested configs that pull verdicts from TheHive, Jira, and GitHub Issues.
 
 Redelivery is safe: dispositions deduplicate on `(fingerprint or incident_id, verdict)`, falling back to `(rule_id, timestamp, analyst)` when no alert identity is carried, so a file re-read, a NATS redelivery, or an HTTP re-poll never double counts.
 
@@ -94,6 +94,7 @@ See [Triage feedback loop](../reference/metrics.md#triage-feedback-loop-4-metric
 
 ## See also
 
+- [Disposition Source Recipes](disposition-recipes.md)
 - [HTTP API: Dispositions](../reference/http-api.md#dispositions)
 - [Detection Scorecard](detection-scorecard.md)
 - [Alert Pipeline](alert-pipeline.md)

--- a/docs/reference/dynamic-sources.md
+++ b/docs/reference/dynamic-sources.md
@@ -363,6 +363,7 @@ Exceeding any limit produces a `SourceErrorKind::ResourceLimit` failure with a d
 ## See also
 
 - [Processing Pipelines: dynamic pipelines](../guide/processing-pipelines.md#dynamic-pipelines) for the narrative version.
+- [Disposition Source Recipes](../guide/disposition-recipes.md) for worked HTTP sources (env-header auth, POST `body`, jq `extract`) that pull case-system verdicts into the triage loop.
 - [`pipeline resolve`](../cli/pipeline/resolve.md) for offline source testing.
 - [`rule validate --resolve-sources`](../cli/rule/validate.md) for the strict CI gate.
 - [Prometheus metrics: dynamic pipeline sources](metrics.md#dynamic-pipeline-sources-5-metrics) for what every successful and failing resolve exposes.


### PR DESCRIPTION
## Summary

Adds a Disposition Source Recipes guide with copy-paste, tested `--disposition-source` configs that pull analyst verdicts from the three most common case systems (TheHive, Jira, GitHub Issues) into the #70 triage feedback loop, closing the pull path's "pull verdicts from the case system where they already live" gap.

Each recipe is one HTTP dynamic source plus a jq `extract` that reshapes the case system's API response into disposition records, with its verdict mapping, `${ENV_VAR}` auth, an outbound-automation variant, and the identity round-trip and idempotency reasoning. Docs-only beyond a fixture-backed test; no engine or daemon change. Builds on the `http` source `body` field from #310 (merged) for the TheHive 5 `POST /api/v1/query` recipe.

## What's in it

- `docs/guide/disposition-recipes.md`: per-system recipes (TheHive 5, Jira Cloud, GitHub Issues), verdict-mapping tables, outbound-automation variants (GitHub Actions, Jira Automation), identity round-trip, idempotency/windowing, and a limits section.
- Nav entry after Triage Feedback Loop plus cross-links from the triage guide, the daemon CLI page, and the dynamic sources reference.
- Three sources files committed as test fixtures with canned API samples under `crates/rsigma-cli/tests/fixtures/disposition_recipes/`.
- `crates/rsigma-cli/tests/cli_disposition_recipes.rs`: parses each fixture with the real loader, runs its extract over the sample, and asserts the reshaped output validates as disposition records, plus that each file declares the documented schema (5m interval, env auth header, TheHive POST body). So the embedded recipes cannot drift from what the ingest path accepts.
- `CHANGELOG.md` `[Unreleased]` docs entry.

## Schema correctness

Recipes are pinned and dated (verified 2026-07) with upstream API links, since case-system APIs drift:
- GitHub: filters out pull requests (`pull_request` key), `since` filters `updated_at`, `closed_at` carried as RFC 3339 timestamp.
- Jira: uses `/rest/api/3/search/jql` (the legacy `/rest/api/3/search` is 410 Gone), Basic auth, explicit `fields`; `resolutiondate` is not RFC 3339 so timestamp is defaulted at ingest (incident_id keys the record).
- TheHive 5: `POST /api/v1/query` with the `_eq` filter on `status = Resolved`, reading `resolutionStatus` (`TruePositive`/`FalsePositive`; `Indeterminate`/`Duplicated`/`Other` skipped, no native BTP); `_updatedAt` is epoch-ms so timestamp is defaulted.

## Test plan

- [x] `cargo test -p rsigma --test cli_disposition_recipes` (4 passed)
- [x] `cargo clippy -p rsigma --tests --all-features` clean
- [x] `cargo fmt`
- [x] `mkdocs build --strict`