### PR TITLE
fix(docs): build site at root for rsigma.io search

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,8 +61,6 @@ jobs:
 
       - name: Build site
         run: npm run docs:build
-        env:
-          DOCMD_BASE: /rsigma/ # GitHub Pages project site is served under /rsigma/
 
       - name: Validate links
         run: npm run docs:validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Docs site search on rsigma.io
+
+Build the docmd site with base `/` and canonical URL `https://rsigma.io/` so the search client loads `search-index.json` from the site root. The previous `/rsigma/` base matched the old GitHub Pages project path but broke search after the custom domain went live.
+
 ### Documentation site migrated to docmd (#312)
 
 Replaces MkDocs Material with [docmd](https://docs.docmd.io/) for the published docs at `https://timescale.github.io/rsigma/`. The whole docmd project is self-contained under `docs/` (config, `package.json`, local plugin, assets, and Markdown under `docs/content/`). `docs/docmd.config.js` carries the reorganized navigation (User Guide grouped into Author/Test, Deploy/Detect, Alert/Respond, Measure/Hunt, Operate, and Integrate sub-categories; Benchmarks under Reference; Editors/Ecosystem under Integrations; Release Notes/Contributing/Security under Project) and defaults to dark mode. A local `docmd-plugin-rsigma` plugin preserves Cargo.toml-synced version, MSRV, and lint-count macros and the inlining of root CHANGELOG/CONTRIBUTING/BENCHMARKS/SECURITY, and strips docmd's site-root `<base>` tag so the project subpath resolves correctly. MkDocs-specific syntax (`!!!` admonitions, Material grid cards) is converted to docmd callouts and card grids. CI builds from `docs/` with `npm run docs:build` and `npm run docs:validate` via SHA-pinned first-party GitHub Actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Docs site search on rsigma.io
+### Docs site search on rsigma.io (#313)
 
 Build the docmd site with base `/` and canonical URL `https://rsigma.io/` so the search client loads `search-index.json` from the site root. The previous `/rsigma/` base matched the old GitHub Pages project path but broke search after the custom domain went live.
 

--- a/docs/docmd-plugin-rsigma/index.js
+++ b/docs/docmd-plugin-rsigma/index.js
@@ -235,12 +235,10 @@ export default {
   },
 
   // docmd emits page-relative asset/link URLs (e.g. `../../assets/...`) together
-  // with a `<base href="{siteRoot}">` tag. On a GitHub Pages project subpath
-  // (`/rsigma/`) the base tag re-roots those relative URLs above the subpath, so
-  // every deep page loads its CSS/JS from `/assets/...` (404) instead of
-  // `/rsigma/assets/...`. The client JS reads `window.DOCMD_BASE`, not the tag,
-  // so removing the tag lets relative URLs resolve against the real document URL
-  // (correct on both the root dev server and the `/rsigma/` production site).
+  // with a `<base href="{siteRoot}">` tag. The base tag re-roots those relative
+  // URLs at the site root, which breaks deep pages when combined with how the
+  // client resolves paths. The client JS reads `window.DOCMD_BASE`, not the tag,
+  // so removing the tag lets relative URLs resolve against the real document URL.
   onPostBuild(ctx) {
     const outputDir = ctx?.outputDir ?? path.join(process.cwd(), "site");
     const log = typeof ctx?.log === "function" ? ctx.log : () => {};

--- a/docs/docmd.config.js
+++ b/docs/docmd.config.js
@@ -1,12 +1,11 @@
 // docmd emits page-relative asset and link URLs anchored by the <base href> tag.
-// The base must be "/" for the local dev server (served at the root) and
-// "/rsigma/" for the GitHub Pages project site. CI sets DOCMD_BASE=/rsigma/
-// for the production build; local `docmd dev` and `docmd build` default to "/".
+// The site is published at https://rsigma.io/ (GitHub Pages custom domain); base
+// stays "/". Override with DOCMD_BASE only for local experiments.
 const base = process.env.DOCMD_BASE || "/";
 
 export default {
   title: "RSigma",
-  url: "https://timescale.github.io/rsigma/",
+  url: "https://rsigma.io/",
   src: "content",
   out: "site",
   base,


### PR DESCRIPTION
## Summary
- Stop setting `DOCMD_BASE=/rsigma/` in the docs CI build; the site is served at `https://rsigma.io/` via the GitHub Pages custom domain.
- Point `docmd.config.js` `url` at `https://rsigma.io/` so generated metadata matches production.
- Fixes search showing "Failed to load search index." because the client fetched `/rsigma/search-index.json` (404) instead of `/search-index.json`.

## Test plan
- [ ] Merge and wait for the docs workflow to deploy
- [ ] Open search on https://rsigma.io/ and confirm results load
- [ ] Open search on a deep page (e.g. `/guide/streaming-detection/`) and confirm results load
- [ ] Confirm `https://rsigma.io/search-index.json` returns 200