### PR TITLE
Publish rstix to crates.io

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -64,6 +64,8 @@ jobs:
             max_len: 65536
           - target: fuzz_rstix_validate_json
             max_len: 65536
+          - target: fuzz_stix_pattern
+            max_len: 4096
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Pre-flight dry-run (rsigma-parser)
         run: cargo publish --dry-run --locked -p rsigma-parser
 
+      # rstix has no workspace dependencies, so its packaging can also be
+      # dry-run before any upload for an extra pre-flight smoke test.
+      - name: Pre-flight dry-run (rstix)
+        run: cargo publish --dry-run --locked -p rstix
+
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 
@@ -120,5 +125,13 @@ jobs:
       - name: Publish rsigma-lsp
         if: github.event_name != 'workflow_dispatch'
         run: cargo publish --locked -p rsigma-lsp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      # rstix stands alone: no workspace crate depends on it and it depends
+      # on no workspace crate, so no index-wait step is required afterward.
+      - name: Publish rstix
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rstix
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Publish rstix to crates.io
+### Publish rstix to crates.io (#316)
 
 The `rstix` STIX 2.1 library now ships as part of the release. `publish.yml` publishes it to crates.io alongside the other workspace crates (it has no workspace dependencies, so it needs no index-wait), `docs.rs` builds it with all features so the `pattern` and `validate` surfaces are documented, and the weekly fuzz workflow schedules the `fuzz_stix_pattern` target next to the existing rstix parse and validate fuzzers. The crate README and the library docs page are refreshed for the crates.io landing page and link to `docs.rs/rstix`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Publish rstix to crates.io
+
+The `rstix` STIX 2.1 library now ships as part of the release. `publish.yml` publishes it to crates.io alongside the other workspace crates (it has no workspace dependencies, so it needs no index-wait), `docs.rs` builds it with all features so the `pattern` and `validate` surfaces are documented, and the weekly fuzz workflow schedules the `fuzz_stix_pattern` target next to the existing rstix parse and validate fuzzers. The crate README and the library docs page are refreshed for the crates.io landing page and link to `docs.rs/rstix`.
+
 ### rstix Validation Pipeline: conformance corpus and diagnostic coverage (`validate` feature) (#315)
 
 Closes Validation Pipeline conformance work for phases 1–4:

--- a/crates/rstix/Cargo.toml
+++ b/crates/rstix/Cargo.toml
@@ -9,6 +9,12 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+# docs.rs builds with default features unless told otherwise; the pattern
+# engine and validation pipeline are feature-gated public API and must
+# appear in the rendered docs.
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["serde"]
 

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -2,11 +2,21 @@
 
 [![CI](https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/rsigma/actions/workflows/ci.yml)
 
-`rstix` is a Rust library crate for STIX 2.1 and TAXII 2.1 in the rsigma workspace.
-**Core Foundation** is complete: core primitive types, deterministic SCO ID helpers,
-and vocabulary tables are available for downstream model/validation phases.
+`rstix` is a Rust library crate for STIX 2.1 in the rsigma workspace. It provides a typed object model for all built-in STIX types (meta objects, all 19 SDOs, SROs, 18 SCOs, and extensions), `StixObject` dispatch, `Bundle` parsing with streaming support (`parse_reader`) for ATT&CK-scale corpora, deterministic SCO ID derivation, and advisory semantic checks (`Bundle::validate()`), all with fixture-backed tests.
 
-**Data Model + Serialization** is **complete**. The typed object model (meta, all 19 SDOs, SROs, 18 SCOs + extensions), `StixObject` dispatch, `Bundle` parsing (including streaming via `parse_reader`), and advisory semantic checks (`Bundle::validate()`) are in place with fixture-backed tests. **Pattern Engine** is **complete** behind the optional `pattern` feature. **Validation Pipeline** is **shipped** behind `validate` (profiles, all twelve checks, `STIX-E/W/I/H` diagnostics, raw JSON entry, pattern parse/semantic split). **Graph + Marking + Store** and **TAXII Client** follow later.
+Two optional features extend the core model:
+
+- `pattern` — the STIX patterning engine: parse, type-check, and Level 1-3 evaluation against observations, a canonical printer, and `Indicator` wiring via `IndicatorBuilder`.
+- `validate` — a profile-based validation pipeline with all twelve checks, `STIX-E/W/I/H` diagnostics, raw-JSON entry points, and a pattern parse/semantic split.
+
+## Install
+
+```toml
+[dependencies]
+rstix = "0.18"
+# For the pattern engine and validation pipeline:
+# rstix = { version = "0.18", features = ["pattern", "validate"] }
+```
 
 This library is part of [rsigma].
 

--- a/docs/content/library/rstix.md
+++ b/docs/content/library/rstix.md
@@ -1,8 +1,16 @@
 # rstix
 
-`rstix` is the rsigma workspace crate for **STIX 2.1** (and future **TAXII 2.1** client work). It provides typed Rust objects for all 42 built-in STIX types, bundle ingestion, extension round-trip, and a semantic validation pipeline.
+`rstix` is the rsigma workspace crate for **STIX 2.1**. It provides typed Rust objects for all 42 built-in STIX types, bundle ingestion, extension round-trip, and a semantic validation pipeline.
 
-API reference: the [crate README](https://github.com/timescale/rsigma/blob/main/crates/rstix/README.md) and [crate source](https://github.com/timescale/rsigma/tree/main/crates/rstix).
+API reference: [docs.rs/rstix](https://docs.rs/rstix), the [crate README](https://github.com/timescale/rsigma/blob/main/crates/rstix/README.md), and the [crate source](https://github.com/timescale/rsigma/tree/main/crates/rstix).
+
+```toml
+# Cargo.toml
+[dependencies]
+rstix = "{{ rsigma.version }}"
+# For the pattern engine and validation pipeline:
+# rstix = { version = "{{ rsigma.version }}", features = ["pattern", "validate"] }
+```
 
 ## Feature status
 
@@ -12,8 +20,6 @@ API reference: the [crate README](https://github.com/timescale/rsigma/blob/main/
 | **Data Model + Serialization** (`model`, `Bundle`, `parse_reader`, `Bundle::validate`) | Complete |
 | **Pattern Engine** (`pattern` — parse, type-check, full Level 3 evaluation, canonical printer, Indicator wiring, `IndicatorBuilder`) | **Complete** |
 | **Validation Pipeline** (`validate` — `Validator`, profiles, `STIX-E/W/I/H` diagnostics, all twelve checks, raw JSON entry) | **Complete** |
-| **Graph + Marking + Store** | Planned |
-| **TAXII Client** | Planned |
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

`rstix`, the STIX 2.1 library crate, is production-ready but was the only workspace member not wired into the release pipeline. This wires it up so it publishes with the next release.

- `publish.yml` gains a pre-flight dry-run and a publish step for `rstix`. It has no workspace dependencies and no workspace dependents, so it needs no index-wait step.
- `fuzz.yml` schedules the `fuzz_stix_pattern` target alongside the existing `fuzz_rstix_parse_bundle` and `fuzz_rstix_validate_json` fuzzers.
- `crates/rstix/Cargo.toml` sets `[package.metadata.docs.rs] all-features = true` so the feature-gated `pattern` and `validate` surfaces render on docs.rs.
- The crate README and the `docs/content/library/rstix.md` page are refreshed for the crates.io landing page, add an install snippet, and link to docs.rs/rstix.

Trusted Publishing for `rstix` is already configured on crates.io (GitHub publisher, `timescale/rsigma`, workflow `publish.yml`, environment `crates.io`).

## Test plan

- [x] `cargo publish --dry-run --locked -p rstix` succeeds on a clean tree
- [x] `zizmor --pedantic` reports no findings on `publish.yml` and `fuzz.yml`
- [x] `npm run docs:build` and `npm run docs:validate` pass; the version macro renders to the workspace version

CC @SecurityEnthusiast 