### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-13
+
+**TL;DR**
+RSigma v0.19.0 is the "secured daemon control plane and shipped threat-intel library" release: the daemon API gains authentication, granular RBAC, and an audit trail, detection authoring grows rule drafting and schema discovery, `rstix` completes its validation pipeline and pattern engine and ships to crates.io, and the documentation moves to a new docmd site on rsigma.io.
+* Daemon API security and governance: opt-in bearer-token authentication with `resource:action` RBAC and anonymous permission grants (#304), plus an append-only control-plane audit trail persisted in the state database (#307).
+* Detection authoring: draft a complete Sigma rule from exemplar events (#286), mine ranked candidate schema signatures from unknown events (#285), and schema and logsource routing v2 with richer signatures and schema-derived logsource pruning (#277).
+* `rstix` threat-intel library: STIX pattern evaluation, canonical printer, and Indicator wiring (#276, #296); a validation pipeline taken from scaffold to all twelve checks to a conformance corpus (#297, #298, #315); and the crate now publishes to crates.io (#316), thanks to @SecurityEnthusiast.
+* WASM: an ABI version 1 contract and a JavaScript-free `wasm32-unknown-unknown` build for `rsigma-parser` and `rsigma-eval` (#306).
+* Dynamic sources: `http` sources can send a request body (#310), copy-paste disposition source recipes for TheHive, Jira, and GitHub Issues (#311), and pipeline-embedded `sources:` blocks are removed in favor of standalone source files (#293).
+* Integrations: the MCP `convert_rules` tool can delegate to sigma-cli for the pySigma backend set (#290).
+* Documentation: migrated to docmd with search on rsigma.io and refreshed branding (#312, #313, #314).
+* Cleanup and performance: the deprecated flat CLI aliases are removed (#292), and the benchmark suite is refreshed with four new suites (#291).
+* Fixes and dependencies: de-flaked the Windows schema-observer and macOS TLS end-to-end tests (#305, #295), and two rolled-up dependency bumps (#289, #308).
+
 ### Publish rstix to crates.io (#316)
 
 The `rstix` STIX 2.1 library now ships as part of the release. `publish.yml` publishes it to crates.io alongside the other workspace crates (it has no workspace dependencies, so it needs no index-wait), `docs.rs` builds it with all features so the `pattern` and `validate` surfaces are documented, and the weekly fuzz workflow schedules the `fuzz_stix_pattern` target next to the existing rstix parse and validate fuzzers. The crate README and the library docs page are refreshed for the crates.io landing page and link to `docs.rs/rstix`.
@@ -203,6 +217,8 @@ Adds STIX pattern evaluation to the `pattern` feature:
 * **Tests** — manifest-driven SCO field coverage (`tests/pattern_eval_sco_fields.rs`, 276 cases), per-operator eval (`tests/pattern_eval_operators.rs`), every `PatternMatchError` path (`tests/pattern_eval_errors.rs`), §9.8 spec eval (`tests/pattern_spec_eval.rs`); 447 tests pass with `pattern,serde`.
 
 Canonical printer, `IndicatorPattern::Stix { ast }` serde wiring, and `fuzz_stix_pattern` remain in the next Pattern Engine slice.
+
+[v0.18.0...v0.19.0](https://github.com/timescale/rsigma/compare/v0.18.0...v0.19.0)
 
 ## [0.18.0] - 2026-07-01
 
@@ -2401,6 +2417,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.19.0]: https://github.com/timescale/rsigma/releases/tag/v0.19.0
 [0.18.0]: https://github.com/timescale/rsigma/releases/tag/v0.18.0
 [0.17.0]: https://github.com/timescale/rsigma/releases/tag/v0.17.0
 [0.16.0]: https://github.com/timescale/rsigma/releases/tag/v0.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "insta",
  "log",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-mcp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "globset",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64",
  "email_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz", "ci/wasm-smoke"]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/ci/wasm-smoke/Cargo.lock
+++ b/ci/wasm-smoke/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsigma-eval"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "globset",
  "log",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -36,11 +36,11 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.18.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.18.0", features = ["sigma-cli"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.18.0", optional = true }
-rsigma-mcp = { path = "../rsigma-mcp", version = "0.18.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.19.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.19.0", features = ["sigma-cli"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.19.0", optional = true }
+rsigma-mcp = { path = "../rsigma-mcp", version = "0.19.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -22,8 +22,8 @@ default = []
 sigma-cli = []
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,7 +14,7 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.18.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.19.0", default-features = false }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-mcp/Cargo.toml
+++ b/crates/rsigma-mcp/Cargo.toml
@@ -16,10 +16,10 @@ default = []
 http = ["dep:axum", "rmcp/transport-streamable-http-server"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.18.0" }
-rsigma-convert = { path = "../rsigma-convert", version = "0.18.0", features = ["sigma-cli"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.18.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
+rsigma-convert = { path = "../rsigma-convert", version = "0.19.0", features = ["sigma-cli"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.19.0" }
 rmcp = { version = "2.1", features = ["server", "macros", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -22,8 +22,8 @@ uds = ["tokio/net"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.18.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.18.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.19.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -189,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a40f338a8c3505921000b609279775792c07cc21f97a3011578c0c5e1738ae"
+checksum = "6ed39583e427bf41d93c28c7f27c943a93bcb8697220ff3575fd53a9e13f3814"
 dependencies = [
  "antlr4rust",
  "chrono",
@@ -253,6 +254,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +321,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -423,6 +450,15 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -1357,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -1368,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -1378,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1391,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -1670,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1705,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "globset",
  "log",
@@ -1721,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1768,9 +1804,11 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64",
+ "email_address",
+ "idna",
  "ipnet",
  "phf",
  "regex",
@@ -1780,6 +1818,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "unicode-normalization",
+ "url",
  "uuid",
 ]
 
@@ -2168,6 +2207,15 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]


### PR DESCRIPTION
Bump the workspace and all inter-crate version pins from 0.18.0 to 0.19.0, sync the workspace and fuzz lockfiles, and finalize the CHANGELOG by promoting the `[Unreleased]` section to `[0.19.0]` with a TL;DR summary and a release reference link.

Once merged, publishing the `v0.19.0` GitHub Release triggers the crates.io, binary, and Docker workflows.

## TL;DR

RSigma v0.19.0 is the "secured daemon control plane and shipped threat-intel library" release: the daemon API gains authentication, granular RBAC, and an audit trail, detection authoring grows rule drafting and schema discovery, `rstix` completes its validation pipeline and pattern engine and ships to crates.io, and the documentation moves to a new docmd site on rsigma.io.

- Daemon API security and governance: opt-in bearer-token authentication with `resource:action` RBAC and anonymous permission grants (#304), plus an append-only control-plane audit trail persisted in the state database (#307).
- Detection authoring: draft a complete Sigma rule from exemplar events (#286), mine ranked candidate schema signatures from unknown events (#285), and schema and logsource routing v2 (#277).
- `rstix` threat-intel library: STIX pattern evaluation, canonical printer, and Indicator wiring (#276, #296); a validation pipeline from scaffold to all twelve checks to a conformance corpus (#297, #298, #315); and the crate now publishes to crates.io (#316), thanks to @SecurityEnthusiast.
- WASM: an ABI version 1 contract and a JavaScript-free `wasm32-unknown-unknown` build for `rsigma-parser` and `rsigma-eval` (#306).
- Dynamic sources: `http` sources can send a request body (#310), disposition source recipes for TheHive, Jira, and GitHub Issues (#311), and pipeline-embedded `sources:` blocks are removed (#293).
- Integrations: the MCP `convert_rules` tool can delegate to sigma-cli for the pySigma backend set (#290).
- Documentation: migrated to docmd with search on rsigma.io and refreshed branding (#312, #313, #314).
- Cleanup and performance: the deprecated flat CLI aliases are removed (#292), and the benchmark suite is refreshed with four new suites (#291).
- Fixes and dependencies: de-flaked the Windows schema-observer and macOS TLS end-to-end tests (#305, #295), and two rolled-up dependency bumps (#289, #308).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo metadata --locked` for the workspace and `fuzz/`
- [x] `npm run docs:build` and `npm run docs:validate`