### PR TITLE
Faithful HIR matcher model (Stage 1: ir + eval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Intermediate representation crate and IR-backed compile (#360)
+### Intermediate representation crate and IR-backed compile (#360, #362)
 
-- **`rsigma-ir`** — new sync-only crate with HIR types (`IrRule`, `IrDetection`, `IrMatcher`, `IrCondition`, `IrCorrelation`, `IrFilter`) and `lower_rule` / `lower_*` that resolve modifiers before eval. Quantified selectors are preserved so evaluation stays count-based.
-- **`rsigma-eval`** — `compile_rule` routes through `lower_rule` → `compile_to_compiled`. `compile_rule_legacy` remains for dual-path differential tests. Public physical API (`CompiledRule`, `evaluate_rule`, `Engine`) is unchanged.
+- **`rsigma-ir`** — new sync-only crate with HIR types (`IrRule`, `IrDetection`, `IrMatcher`, `IrCondition`, `IrCorrelation`, `IrFilter`) and `lower_rule` / `lower_*` that resolve modifiers before eval. Quantified selectors are preserved so evaluation stays count-based. The matcher model is faithful and lossless: string matches keep a wildcard-aware, original-case `IrPattern` and encoding modifiers stay explicit as `IrEncoding` steps, so lowering never lowercases, compiles regexes, or expands encodings.
+- **`rsigma-eval`** — `compile_rule` routes through `lower_rule` → `compile_to_compiled`, which performs the physical work (lowercasing, regex/aho-corasick, encoding expansion). `compile_rule_legacy` remains for dual-path differential tests. Public physical API (`CompiledRule`, `evaluate_rule`, `Engine`) is unchanged.
 - **`rsigma-convert`** — detection-rule conversion resolves conditions through IR (`convert_rule_via_ir`); detection-item dispatch still uses the parser AST. PostgreSQL, LynxDB, and Fibratus golden tests unchanged.
 
 ### Dependency bumps (#354, #357)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,9 +4067,6 @@ dependencies = [
 name = "rsigma-ir"
 version = "0.19.0"
 dependencies = [
- "base64",
- "ipnet",
- "regex",
  "rsigma-eval",
  "rsigma-parser",
  "serde",

--- a/ci/wasm-smoke/Cargo.lock
+++ b/ci/wasm-smoke/Cargo.lock
@@ -458,9 +458,6 @@ dependencies = [
 name = "rsigma-ir"
 version = "0.19.0"
 dependencies = [
- "base64",
- "ipnet",
- "regex",
  "rsigma-parser",
  "serde",
  "serde_json",

--- a/crates/rsigma-convert/src/condition_ir.rs
+++ b/crates/rsigma-convert/src/condition_ir.rs
@@ -1,8 +1,8 @@
 //! Convert selector-free [`IrCondition`] trees against parser AST detections.
 //!
-//! Detection bodies still use the existing `Backend::convert_detection` path
-//! (modifier dispatch via AST / `SurfaceSpec` comes later). Conditions are
-//! taken from `lower_rule` so convert no longer re-resolves selectors.
+//! Detection bodies still use the existing `Backend::convert_detection` path;
+//! conditions are taken from `lower_conditions` so convert no longer resolves
+//! selectors itself.
 
 use std::collections::HashMap;
 

--- a/crates/rsigma-eval/src/compiler/from_ir.rs
+++ b/crates/rsigma-eval/src/compiler/from_ir.rs
@@ -6,18 +6,22 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use regex::Regex;
 use rsigma_ir::{
-    IrCondition, IrDetection, IrDetectionItem, IrExpandPart, IrMatcher, IrNumber, IrRule,
-    IrTimePart, IrValue,
+    IrCondition, IrDetection, IrDetectionItem, IrEncoding, IrExpandPart, IrMatcher, IrNumber,
+    IrPattern, IrPatternPart, IrRule, IrStrOp, IrTimePart,
 };
-use rsigma_parser::ConditionExpr;
+use rsigma_parser::value::{SigmaString, SpecialChar, StringPart};
+use rsigma_parser::{ConditionExpr, Modifier, SigmaValue};
 
 use crate::error::{EvalError, Result};
 use crate::matcher::{CompiledMatcher, ExpandPart, TimePart};
 
+use super::helpers::build_regex;
 use super::optimizer;
-use super::{CompiledDetection, CompiledDetectionItem, CompiledRule};
+use super::{
+    CompiledDetection, CompiledDetectionItem, CompiledRule, ModCtx, compile_sigma_string,
+    compile_string_value, compile_value,
+};
 
 /// Compile an [`IrRule`] into a physical [`CompiledRule`] ready for evaluation.
 pub fn compile_to_compiled(ir: &IrRule) -> Result<CompiledRule> {
@@ -128,42 +132,42 @@ fn compile_ir_detection_item(item: &IrDetectionItem) -> Result<CompiledDetection
 
 fn compile_ir_matcher(matcher: &IrMatcher) -> Result<CompiledMatcher> {
     match matcher {
-        IrMatcher::Exact {
-            value,
+        IrMatcher::Str {
+            op,
+            pattern,
             case_insensitive,
-        } => Ok(CompiledMatcher::Exact {
-            value: ir_value_literal(value)?,
-            case_insensitive: *case_insensitive,
-        }),
-        IrMatcher::Contains {
-            value,
-            case_insensitive,
-        } => Ok(CompiledMatcher::Contains {
-            value: ir_value_literal(value)?,
-            case_insensitive: *case_insensitive,
-        }),
-        IrMatcher::StartsWith {
-            value,
-            case_insensitive,
-        } => Ok(CompiledMatcher::StartsWith {
-            value: ir_value_literal(value)?,
-            case_insensitive: *case_insensitive,
-        }),
-        IrMatcher::EndsWith {
-            value,
-            case_insensitive,
-        } => Ok(CompiledMatcher::EndsWith {
-            value: ir_value_literal(value)?,
-            case_insensitive: *case_insensitive,
-        }),
-        IrMatcher::Regex { pattern } => {
-            let pattern = ir_value_literal(pattern)?;
-            let regex = Regex::new(&pattern).map_err(EvalError::InvalidRegex)?;
-            Ok(CompiledMatcher::Regex(regex))
+        } => {
+            let ctx = str_modctx(*op, *case_insensitive, &[]);
+            if pattern.is_plain() {
+                compile_string_value(&pattern.as_plain().unwrap_or_default(), &ctx)
+            } else {
+                compile_sigma_string(&sigma_from_pattern(pattern), &ctx)
+            }
         }
+        IrMatcher::Encoded {
+            encodings,
+            op,
+            value,
+            case_insensitive,
+        } => {
+            // Replay the encoding chain through the proven value compiler by
+            // reconstructing the equivalent modifier context and plain value.
+            let ctx = str_modctx(*op, *case_insensitive, encodings);
+            compile_value(&SigmaValue::String(sigma_plain(value)), &ctx)
+        }
+        IrMatcher::Regex {
+            pattern,
+            case_insensitive,
+            multiline,
+            dotall,
+        } => Ok(CompiledMatcher::Regex(build_regex(
+            pattern,
+            *case_insensitive,
+            *multiline,
+            *dotall,
+        )?)),
         IrMatcher::Cidr { network } => {
-            let cidr_str = ir_value_literal(network)?;
-            let net: ipnet::IpNet = cidr_str.parse().map_err(EvalError::InvalidCidr)?;
+            let net: ipnet::IpNet = network.parse().map_err(EvalError::InvalidCidr)?;
             Ok(CompiledMatcher::Cidr(net))
         }
         IrMatcher::NumericEq(n) => Ok(CompiledMatcher::NumericEq(ir_number_literal(n)?)),
@@ -204,6 +208,62 @@ fn compile_ir_matcher(matcher: &IrMatcher) -> Result<CompiledMatcher> {
     }
 }
 
+/// Reconstruct the modifier context for a string/encoded matcher so the proven
+/// value compilers produce byte-identical `CompiledMatcher`s.
+fn str_modctx(op: IrStrOp, case_insensitive: bool, encodings: &[IrEncoding]) -> ModCtx {
+    let mut mods: Vec<Modifier> = Vec::new();
+    match op {
+        IrStrOp::Exact => {}
+        IrStrOp::Contains => mods.push(Modifier::Contains),
+        IrStrOp::StartsWith => mods.push(Modifier::StartsWith),
+        IrStrOp::EndsWith => mods.push(Modifier::EndsWith),
+    }
+    if !case_insensitive {
+        mods.push(Modifier::Cased);
+    }
+    for e in encodings {
+        mods.push(match e {
+            IrEncoding::Wide => Modifier::Wide,
+            IrEncoding::Utf16 => Modifier::Utf16,
+            IrEncoding::Utf16Be => Modifier::Utf16be,
+            IrEncoding::Base64 => Modifier::Base64,
+            IrEncoding::Base64Offset => Modifier::Base64Offset,
+            IrEncoding::Windash => Modifier::WindAsh,
+        });
+    }
+    ModCtx::from_modifiers(&mods)
+}
+
+fn sigma_plain(s: &str) -> SigmaString {
+    SigmaString {
+        parts: vec![StringPart::Plain(s.to_string())],
+        original: s.to_string(),
+    }
+}
+
+fn sigma_from_pattern(pattern: &IrPattern) -> SigmaString {
+    let mut original = String::new();
+    let parts = pattern
+        .parts
+        .iter()
+        .map(|p| match p {
+            IrPatternPart::Literal(t) => {
+                original.push_str(t);
+                StringPart::Plain(t.clone())
+            }
+            IrPatternPart::WildcardMulti => {
+                original.push('*');
+                StringPart::Special(SpecialChar::WildcardMulti)
+            }
+            IrPatternPart::WildcardSingle => {
+                original.push('?');
+                StringPart::Special(SpecialChar::WildcardSingle)
+            }
+        })
+        .collect();
+    SigmaString { parts, original }
+}
+
 fn ir_condition_to_expr(cond: &IrCondition) -> ConditionExpr {
     match cond {
         IrCondition::Detection(name) => ConditionExpr::Identifier(name.clone()),
@@ -221,16 +281,6 @@ fn ir_condition_to_expr(cond: &IrCondition) -> ConditionExpr {
             quantifier: quantifier.clone(),
             pattern: pattern.clone(),
         },
-    }
-}
-
-fn ir_value_literal(value: &IrValue) -> Result<String> {
-    match value {
-        IrValue::Literal(s) => Ok(s.clone()),
-        IrValue::DynamicSourceRef { source_id, .. } => Err(EvalError::IncompatibleValue(format!(
-            "unresolved dynamic source reference '{source_id}' cannot be compiled; \
-             specialize the IR first"
-        ))),
     }
 }
 

--- a/crates/rsigma-eval/src/error.rs
+++ b/crates/rsigma-eval/src/error.rs
@@ -58,8 +58,6 @@ impl From<rsigma_ir::IrError> for EvalError {
     fn from(err: rsigma_ir::IrError) -> Self {
         use rsigma_ir::IrError;
         match err {
-            IrError::InvalidRegex(e) => EvalError::InvalidRegex(e),
-            IrError::InvalidCidr(e) => EvalError::InvalidCidr(e),
             IrError::UnknownDetection(name) => EvalError::UnknownDetection(name),
             IrError::InvalidModifiers(msg) => EvalError::InvalidModifiers(msg),
             IrError::IncompatibleValue(msg) => EvalError::IncompatibleValue(msg),

--- a/crates/rsigma-ir/Cargo.toml
+++ b/crates/rsigma-ir/Cargo.toml
@@ -14,10 +14,7 @@ rsigma-parser = { path = "../rsigma-parser", version = "0.19.0", default-feature
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-base64 = "0.22"
 yaml_serde = "0.10"
-ipnet = "2"
-regex = "1"
 
 [dev-dependencies]
 rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }

--- a/crates/rsigma-ir/src/error.rs
+++ b/crates/rsigma-ir/src/error.rs
@@ -5,12 +5,6 @@ pub enum IrError {
     #[error("lowering error: {0}")]
     Lowering(String),
 
-    #[error("invalid regex pattern: {0}")]
-    InvalidRegex(#[from] regex::Error),
-
-    #[error("invalid CIDR: {0}")]
-    InvalidCidr(#[from] ipnet::AddrParseError),
-
     #[error("unknown detection identifier: {0}")]
     UnknownDetection(String),
 

--- a/crates/rsigma-ir/src/hir.rs
+++ b/crates/rsigma-ir/src/hir.rs
@@ -107,47 +107,118 @@ pub struct IrDetectionItem {
     pub field: Option<String>,
     pub matcher: IrMatcher,
     pub exists: Option<bool>,
-    /// Original surface for convert / reverse-convert. Eval ignores this.
-    pub surface: Option<SurfaceSpec>,
-}
-
-/// Original field declaration before modifier resolution.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SurfaceSpec {
-    pub field: Option<String>,
-    pub modifiers: Vec<rsigma_parser::Modifier>,
-    pub values: Vec<rsigma_parser::SigmaValue>,
 }
 
 // =============================================================================
 // IrMatcher
 // =============================================================================
 
+/// String match operator.
+///
+/// The comparison is decided here rather than re-derived from modifiers by
+/// each consumer. `Exact` is full-value equality.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IrStrOp {
+    Exact,
+    Contains,
+    StartsWith,
+    EndsWith,
+}
+
+/// A backend-neutral string pattern: decoded literal segments interleaved with
+/// wildcards, **original case preserved**.
+///
+/// This is the lossless heart of the faithful HIR. Eval lowercases (for
+/// case-insensitive matching) and compiles wildcards into a regex at compile
+/// time; convert renders the wildcards into backend-native tokens. Neither
+/// transform happens during lowering, so the pattern round-trips exactly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IrPatternPart {
+    Literal(String),
+    /// `*` — matches any run of characters.
+    WildcardMulti,
+    /// `?` — matches any single character.
+    WildcardSingle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IrPattern {
+    pub parts: Vec<IrPatternPart>,
+}
+
+impl IrPattern {
+    /// A pattern with no wildcards.
+    pub fn is_plain(&self) -> bool {
+        self.parts
+            .iter()
+            .all(|p| matches!(p, IrPatternPart::Literal(_)))
+    }
+
+    /// Whether the pattern contains any wildcard.
+    pub fn has_wildcards(&self) -> bool {
+        !self.is_plain()
+    }
+
+    /// The concatenated literal text if the pattern is plain.
+    pub fn as_plain(&self) -> Option<String> {
+        if !self.is_plain() {
+            return None;
+        }
+        let mut s = String::new();
+        for p in &self.parts {
+            if let IrPatternPart::Literal(t) = p {
+                s.push_str(t);
+            }
+        }
+        Some(s)
+    }
+}
+
+/// A value transformation applied before matching (an encoding modifier).
+///
+/// Kept explicit rather than pre-expanded so consumers can either replay the
+/// transform (eval) or reject it as inexpressible (convert backends).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IrEncoding {
+    Wide,
+    Utf16,
+    Utf16Be,
+    Base64,
+    Base64Offset,
+    Windash,
+}
+
 /// Resolved match operation. Grow by appending variants and bumping the pack
 /// IR schema major. No `Unknown` catch-all.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IrMatcher {
-    Exact {
-        value: IrValue,
+    /// Structured string match (equality/substring/prefix/suffix) over a
+    /// wildcard-aware, original-case [`IrPattern`].
+    Str {
+        op: IrStrOp,
+        pattern: IrPattern,
         case_insensitive: bool,
     },
-    Contains {
-        value: IrValue,
+    /// Encoding-transformed string match (`base64`, `base64offset`, `wide`,
+    /// `utf16`, `utf16be`, `windash`). `value` is the untransformed plain
+    /// string. Eval replays `encodings` (in order) to build the concrete
+    /// matcher; convert backends that cannot express the transform reject it.
+    Encoded {
+        encodings: Vec<IrEncoding>,
+        op: IrStrOp,
+        value: String,
         case_insensitive: bool,
     },
-    StartsWith {
-        value: IrValue,
-        case_insensitive: bool,
-    },
-    EndsWith {
-        value: IrValue,
-        case_insensitive: bool,
-    },
+    /// Explicit regex (`|re`) with raw pattern and flags kept separate so eval
+    /// compiles them and convert renders them (case-sensitive vs insensitive).
     Regex {
-        pattern: IrValue,
+        pattern: String,
+        case_insensitive: bool,
+        multiline: bool,
+        dotall: bool,
     },
     Cidr {
-        network: IrValue,
+        network: String,
     },
     NumericEq(IrNumber),
     NumericGt(IrNumber),
@@ -193,17 +264,8 @@ pub enum IrTimePart {
 }
 
 // =============================================================================
-// IrValue / IrNumber
+// IrNumber
 // =============================================================================
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum IrValue {
-    Literal(String),
-    DynamicSourceRef {
-        source_id: String,
-        extract: Option<IrExtractExpr>,
-    },
-}
 
 /// Numeric literal or deferred source reference.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/rsigma-ir/src/hir.rs
+++ b/crates/rsigma-ir/src/hir.rs
@@ -10,13 +10,13 @@
 //!   identical to native evaluation (no boolean expansion).
 //! - **Array-scope complete**: [`IrDetection`] mirrors
 //!   `CompiledDetection::{ArrayMatch, And, Conditional}`.
-//! - **Serializable**: no compiled `Regex`, no `IpNet`.
-//! - **Placeholder-aware** when lowering preserves `${source.*}` as
-//!   [`IrValue::DynamicSourceRef`].
+//! - **Faithful and lossless**: string matches keep a wildcard-aware,
+//!   original-case [`IrPattern`]; encoding modifiers stay explicit as
+//!   [`IrEncoding`]. Lowering never lowercases, compiles regexes, or expands
+//!   encodings, so both eval (at compile time) and convert (at emit time)
+//!   render it exactly.
 //! - **`RuleHeader`-projecting**: [`IrRuleMetadata`] is a superset; compile
 //!   projects the subset used by `rsigma_eval::result::RuleHeader`.
-//! - **Convert-friendly**: each [`IrDetectionItem`] may carry an optional
-//!   [`SurfaceSpec`] that eval ignores but convert / reverse-convert uses.
 
 use std::collections::HashMap;
 

--- a/crates/rsigma-ir/src/lib.rs
+++ b/crates/rsigma-ir/src/lib.rs
@@ -33,10 +33,11 @@
 //!   `Conditional`.  Array-scope quantifiers (`any`/`all`/`all-or-empty`/`none`)
 //!   are preserved.
 //!
-//! - **`SurfaceSpec`** — optional sidecar on `IrDetectionItem` that records the
-//!   original field name, modifiers, and values.  Eval ignores it; convert
-//!   backends use it when they need the modifier spelling for idiomatic query
-//!   emission.
+//! - **`IrMatcher`** — a faithful, lossless match model. String matches keep a
+//!   wildcard-aware, original-case [`hir::IrPattern`]; encoding modifiers stay
+//!   explicit as [`hir::IrEncoding`] steps. Nothing is lowercased,
+//!   regex-compiled, or encoding-expanded during lowering, so both eval (at
+//!   compile time) and convert (at emit time) can render it exactly.
 //!
 //! ## Constraints
 //!

--- a/crates/rsigma-ir/src/lower/helpers.rs
+++ b/crates/rsigma-ir/src/lower/helpers.rs
@@ -1,7 +1,9 @@
-//! Encoding and value helpers ported from `rsigma-eval` compiler helpers.
+//! Value-extraction helpers for lowering.
+//!
+//! Encoding, regex, and wildcard rendering deliberately live in the consumers
+//! (eval's compile step and convert), not here: lowering stays purely
+//! structural so the HIR round-trips faithfully.
 
-use base64::Engine as Base64Engine;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use rsigma_parser::SigmaValue;
 
 use crate::error::IrError;
@@ -76,134 +78,6 @@ pub(super) fn value_to_f64(value: &SigmaValue) -> Result<f64> {
     }
 }
 
-pub(super) fn sigma_string_to_bytes(s: &rsigma_parser::SigmaString) -> Vec<u8> {
-    let plain = s.as_plain().unwrap_or_else(|| s.original.clone());
-    plain.into_bytes()
-}
-
-pub(super) fn to_utf16le_bytes(bytes: &[u8]) -> Vec<u8> {
-    let s = String::from_utf8_lossy(bytes);
-    let mut wide = Vec::with_capacity(s.len() * 2);
-    for c in s.chars() {
-        let mut buf = [0u16; 2];
-        let encoded = c.encode_utf16(&mut buf);
-        for u in encoded {
-            wide.extend_from_slice(&u.to_le_bytes());
-        }
-    }
-    wide
-}
-
-pub(super) fn to_utf16be_bytes(bytes: &[u8]) -> Vec<u8> {
-    let s = String::from_utf8_lossy(bytes);
-    let mut wide = Vec::with_capacity(s.len() * 2);
-    for c in s.chars() {
-        let mut buf = [0u16; 2];
-        let encoded = c.encode_utf16(&mut buf);
-        for u in encoded {
-            wide.extend_from_slice(&u.to_be_bytes());
-        }
-    }
-    wide
-}
-
-pub(super) fn to_utf16_bom_bytes(bytes: &[u8]) -> Vec<u8> {
-    let mut result = vec![0xFF, 0xFE];
-    result.extend_from_slice(&to_utf16le_bytes(bytes));
-    result
-}
-
-pub(super) fn base64_offset_patterns(value: &[u8]) -> Vec<String> {
-    let mut patterns = Vec::with_capacity(3);
-
-    for offset in 0..3usize {
-        let mut padded = vec![0u8; offset];
-        padded.extend_from_slice(value);
-
-        let encoded = BASE64_STANDARD.encode(&padded);
-        let start = (offset * 4).div_ceil(3);
-        let trimmed = encoded.trim_end_matches('=');
-        let end = trimmed.len();
-
-        if start < end {
-            patterns.push(trimmed[start..end].to_string());
-        }
-    }
-
-    patterns
-}
-
-/// Assemble a regex pattern string with inline flags.
-///
-/// The pattern is not compiled here: the eval compile step compiles it into a
-/// physical matcher (and surfaces any syntax error), while convert emits it to
-/// a backend with its own regex engine. Compiling here would both double the
-/// work on the eval path and reject patterns valid for a target backend but
-/// not for the Rust `regex` crate.
-pub(super) fn build_regex_pattern(
-    pattern: &str,
-    case_insensitive: bool,
-    multiline: bool,
-    dotall: bool,
-) -> String {
-    let mut flags = String::new();
-    if case_insensitive {
-        flags.push('i');
-    }
-    if multiline {
-        flags.push('m');
-    }
-    if dotall {
-        flags.push('s');
-    }
-
-    if flags.is_empty() {
-        pattern.to_string()
-    } else {
-        format!("(?{flags}){pattern}")
-    }
-}
-
-const WINDASH_CHARS: [char; 5] = ['-', '/', '\u{2013}', '\u{2014}', '\u{2015}'];
-const MAX_WINDASH_DASHES: usize = 8;
-
-pub(super) fn expand_windash(input: &str) -> Result<Vec<String>> {
-    let dash_positions: Vec<usize> = input
-        .char_indices()
-        .filter(|(_, c)| *c == '-')
-        .map(|(i, _)| i)
-        .collect();
-
-    if dash_positions.is_empty() {
-        return Ok(vec![input.to_string()]);
-    }
-
-    let n = dash_positions.len();
-    if n > MAX_WINDASH_DASHES {
-        return Err(IrError::InvalidModifiers(format!(
-            "windash modifier: value contains {n} dashes, max is {MAX_WINDASH_DASHES} \
-             (would generate {} variants)",
-            5u64.saturating_pow(n as u32)
-        )));
-    }
-
-    let total = WINDASH_CHARS.len().pow(n as u32);
-    let mut variants = Vec::with_capacity(total);
-
-    for combo in 0..total {
-        let mut variant = input.to_string();
-        let mut idx = combo;
-        for &pos in dash_positions.iter().rev() {
-            let replacement = WINDASH_CHARS[idx % WINDASH_CHARS.len()];
-            variant.replace_range(pos..pos + 1, &replacement.to_string());
-            idx /= WINDASH_CHARS.len();
-        }
-        variants.push(variant);
-    }
-
-    Ok(variants)
-}
-
 /// Parse an expand template string like `C:\Users\%user%\AppData` into parts.
 pub(super) fn parse_expand_template(s: &str) -> Vec<crate::IrExpandPart> {
     use crate::IrExpandPart;
@@ -245,68 +119,4 @@ pub(super) fn parse_expand_template(s: &str) -> Vec<crate::IrExpandPart> {
     }
 
     parts
-}
-
-/// Build a regex pattern from Sigma string parts (wildcards → `.*` / `.`).
-pub(super) fn sigma_parts_to_regex_pattern(
-    parts: &[rsigma_parser::value::StringPart],
-    case_insensitive: bool,
-    contains: bool,
-    startswith: bool,
-    endswith: bool,
-) -> String {
-    use rsigma_parser::value::{SpecialChar, StringPart};
-
-    let mut pattern = String::new();
-    if case_insensitive {
-        pattern.push_str("(?i)");
-    }
-
-    if !contains && !startswith {
-        pattern.push('^');
-    }
-
-    for part in parts {
-        match part {
-            StringPart::Plain(text) => {
-                pattern.push_str(&regex::escape(text));
-            }
-            StringPart::Special(SpecialChar::WildcardMulti) => {
-                pattern.push_str(".*");
-            }
-            StringPart::Special(SpecialChar::WildcardSingle) => {
-                pattern.push('.');
-            }
-        }
-    }
-
-    if !contains && !endswith {
-        pattern.push('$');
-    }
-
-    pattern
-}
-
-/// Keywords wildcard path: contains-semantics regex anchored at both ends
-/// after converting wildcards (same as eval `sigma_string_to_regex`).
-pub(super) fn keywords_wildcard_pattern(
-    parts: &[rsigma_parser::value::StringPart],
-    case_insensitive: bool,
-) -> String {
-    use rsigma_parser::value::{SpecialChar, StringPart};
-
-    let mut pattern = String::new();
-    if case_insensitive {
-        pattern.push_str("(?i)");
-    }
-    pattern.push('^');
-    for part in parts {
-        match part {
-            StringPart::Plain(text) => pattern.push_str(&regex::escape(text)),
-            StringPart::Special(SpecialChar::WildcardMulti) => pattern.push_str(".*"),
-            StringPart::Special(SpecialChar::WildcardSingle) => pattern.push('.'),
-        }
-    }
-    pattern.push('$');
-    pattern
 }

--- a/crates/rsigma-ir/src/lower/mod.rs
+++ b/crates/rsigma-ir/src/lower/mod.rs
@@ -18,7 +18,7 @@ use rsigma_parser::{
 use crate::error::IrError;
 use crate::{
     IrCondition, IrCorrelation, IrDetection, IrDetectionItem, IrFilter, IrMatcher, IrRule,
-    IrRuleMetadata, SurfaceSpec,
+    IrRuleMetadata,
 };
 
 use helpers::{Result, yaml_to_json_map};
@@ -29,14 +29,9 @@ use value::{lower_value, lower_value_keywords};
 #[derive(Debug, Clone, Default)]
 pub struct LowerOptions {
     /// When false (default), reject string values that still contain
-    /// `${source.*}` placeholders. When true, preserve them as
-    /// `IrValue::DynamicSourceRef` (deferred specialization path).
+    /// `${source.*}` placeholders. When true, preserve them for the deferred
+    /// specialization path.
     pub permissive_placeholders: bool,
-    /// When true, record the original field spelling, modifiers, and values on
-    /// each [`IrDetectionItem`] as a [`SurfaceSpec`]. The eval compile path
-    /// ignores it, so it defaults to off to avoid cloning every value; convert
-    /// (which needs the original modifiers) opts in.
-    pub retain_surface: bool,
 }
 
 /// Lower a single parsed `SigmaRule` into its HIR form.
@@ -167,16 +162,6 @@ pub fn lower_detection_item(item: &DetectionItem, opts: &LowerOptions) -> Result
     let ctx = ModCtx::from_modifiers(&item.field.modifiers);
     validate_modifiers(&ctx, &item.field.modifiers)?;
 
-    let surface = if opts.retain_surface {
-        Some(SurfaceSpec {
-            field: item.field.name.clone(),
-            modifiers: item.field.modifiers.clone(),
-            values: item.values.clone(),
-        })
-    } else {
-        None
-    };
-
     if ctx.exists {
         let expect = match item.values.first() {
             Some(SigmaValue::Bool(b)) => *b,
@@ -191,7 +176,6 @@ pub fn lower_detection_item(item: &DetectionItem, opts: &LowerOptions) -> Result
             field: item.field.name.clone(),
             matcher: IrMatcher::Exists(expect),
             exists: Some(expect),
-            surface,
         });
     }
 
@@ -221,7 +205,6 @@ pub fn lower_detection_item(item: &DetectionItem, opts: &LowerOptions) -> Result
         field: item.field.name.clone(),
         matcher: combined,
         exists: None,
-        surface,
     })
 }
 

--- a/crates/rsigma-ir/src/lower/value.rs
+++ b/crates/rsigma-ir/src/lower/value.rs
@@ -1,29 +1,78 @@
 //! Lower a single `SigmaValue` under a modifier context into [`IrMatcher`].
+//!
+//! Lowering is purely structural: it resolves *which* comparison applies and
+//! preserves the value faithfully (original case, wildcards intact, encodings
+//! recorded as explicit [`IrEncoding`] steps). It does **not** lowercase,
+//! compile regexes, or expand encodings; those are the compile step's job in
+//! eval and are rendered structurally by convert.
 
-use base64::Engine as Base64Engine;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use rsigma_parser::value::{SpecialChar, StringPart};
 use rsigma_parser::{SigmaString, SigmaValue};
 
 use crate::error::IrError;
-use crate::{IrMatcher, IrNumber, IrValue};
+use crate::{IrEncoding, IrMatcher, IrNumber, IrPattern, IrPatternPart, IrStrOp};
 
-use super::helpers::{
-    Result, base64_offset_patterns, build_regex_pattern, expand_windash, parse_expand_template,
-    sigma_parts_to_regex_pattern, sigma_string_to_bytes, to_utf16_bom_bytes, to_utf16be_bytes,
-    to_utf16le_bytes, value_to_f64, value_to_plain_string,
-};
+use super::helpers::{Result, parse_expand_template, value_to_f64, value_to_plain_string};
 use super::mod_ctx::ModCtx;
 
-fn lit(s: impl Into<String>) -> IrValue {
-    IrValue::Literal(s.into())
+/// Build an [`IrPattern`] from a parser [`SigmaString`], preserving literal
+/// case and wildcard structure.
+fn pattern_from_sigma(s: &SigmaString) -> IrPattern {
+    let parts = s
+        .parts
+        .iter()
+        .map(|p| match p {
+            StringPart::Plain(t) => IrPatternPart::Literal(t.clone()),
+            StringPart::Special(SpecialChar::WildcardMulti) => IrPatternPart::WildcardMulti,
+            StringPart::Special(SpecialChar::WildcardSingle) => IrPatternPart::WildcardSingle,
+        })
+        .collect();
+    IrPattern { parts }
 }
 
-fn maybe_lower(plain: &str, ci: bool) -> String {
-    if ci {
-        plain.to_lowercase()
-    } else {
-        plain.to_string()
+fn plain_pattern(s: &str) -> IrPattern {
+    IrPattern {
+        parts: vec![IrPatternPart::Literal(s.to_string())],
     }
+}
+
+/// The string operator implied by the modifier context.
+fn str_op(ctx: &ModCtx) -> IrStrOp {
+    if ctx.contains {
+        IrStrOp::Contains
+    } else if ctx.startswith {
+        IrStrOp::StartsWith
+    } else if ctx.endswith {
+        IrStrOp::EndsWith
+    } else {
+        IrStrOp::Exact
+    }
+}
+
+/// Ordered encoding transforms present in the context (empty if none).
+fn encodings(ctx: &ModCtx) -> Vec<IrEncoding> {
+    let mut out = Vec::new();
+    // UTF-16 dialects (mutually exclusive, validated upstream) come first,
+    // then the base64 strategy or windash, mirroring the byte pipeline order.
+    if ctx.wide {
+        out.push(IrEncoding::Wide);
+    }
+    if ctx.utf16be {
+        out.push(IrEncoding::Utf16Be);
+    }
+    if ctx.utf16 {
+        out.push(IrEncoding::Utf16);
+    }
+    if ctx.base64 {
+        out.push(IrEncoding::Base64);
+    }
+    if ctx.base64offset {
+        out.push(IrEncoding::Base64Offset);
+    }
+    if ctx.windash {
+        out.push(IrEncoding::Windash);
+    }
+    out
 }
 
 /// Lower a single `SigmaValue` using the modifier context.
@@ -74,16 +123,17 @@ pub(super) fn lower_value(value: &SigmaValue, ctx: &ModCtx) -> Result<IrMatcher>
 
     if ctx.re {
         let pattern = value_to_plain_string(value)?;
-        let full = build_regex_pattern(&pattern, ctx.ignore_case, ctx.multiline, ctx.dotall);
-        return Ok(IrMatcher::Regex { pattern: lit(full) });
+        return Ok(IrMatcher::Regex {
+            pattern,
+            case_insensitive: ctx.ignore_case,
+            multiline: ctx.multiline,
+            dotall: ctx.dotall,
+        });
     }
 
     if ctx.cidr {
         let cidr_str = value_to_plain_string(value)?;
-        let _: ipnet::IpNet = cidr_str.parse()?;
-        return Ok(IrMatcher::Cidr {
-            network: lit(cidr_str),
-        });
+        return Ok(IrMatcher::Cidr { network: cidr_str });
     }
 
     if ctx.has_numeric_comparison() {
@@ -112,13 +162,13 @@ pub(super) fn lower_value(value: &SigmaValue, ctx: &ModCtx) -> Result<IrMatcher>
     match value {
         SigmaValue::Integer(n) => {
             if ctx.contains || ctx.startswith || ctx.endswith {
-                return lower_string_value(&n.to_string(), ctx);
+                return Ok(lower_str(plain_pattern(&n.to_string()), ctx));
             }
             return Ok(IrMatcher::NumericEq(IrNumber::Literal(*n as f64)));
         }
         SigmaValue::Float(n) => {
             if ctx.contains || ctx.startswith || ctx.endswith {
-                return lower_string_value(&n.to_string(), ctx);
+                return Ok(lower_str(plain_pattern(&n.to_string()), ctx));
             }
             return Ok(IrMatcher::NumericEq(IrNumber::Literal(*n)));
         }
@@ -132,115 +182,45 @@ pub(super) fn lower_value(value: &SigmaValue, ctx: &ModCtx) -> Result<IrMatcher>
         _ => unreachable!(),
     };
 
-    let mut bytes = sigma_string_to_bytes(sigma_str);
-
-    if ctx.wide {
-        bytes = to_utf16le_bytes(&bytes);
-    }
-    if ctx.utf16be {
-        bytes = to_utf16be_bytes(&bytes);
-    }
-    if ctx.utf16 {
-        bytes = to_utf16_bom_bytes(&bytes);
-    }
-
-    if ctx.base64 {
-        let encoded = BASE64_STANDARD.encode(&bytes);
-        return lower_string_value(&encoded, ctx);
-    }
-
-    if ctx.base64offset {
-        let patterns = base64_offset_patterns(&bytes);
-        let matchers: Vec<IrMatcher> = patterns
-            .into_iter()
-            .map(|p| IrMatcher::Contains {
-                value: lit(maybe_lower(&p, ci)),
-                case_insensitive: ci,
-            })
-            .collect();
-        return Ok(IrMatcher::AnyOf(matchers));
-    }
-
-    if ctx.windash {
+    // Encoding transforms operate on the untransformed plain text and are kept
+    // explicit for the compile/convert consumers to interpret.
+    let enc = encodings(ctx);
+    if !enc.is_empty() {
         let plain = sigma_str
             .as_plain()
             .unwrap_or_else(|| sigma_str.original.clone());
-        let variants = expand_windash(&plain)?;
-        let matchers: Result<Vec<IrMatcher>> = variants
-            .into_iter()
-            .map(|v| lower_string_value(&v, ctx))
-            .collect();
-        return Ok(IrMatcher::AnyOf(matchers?));
+        return Ok(IrMatcher::Encoded {
+            encodings: enc,
+            op: str_op(ctx),
+            value: plain,
+            case_insensitive: ci,
+        });
     }
 
-    lower_sigma_string(sigma_str, ctx)
+    Ok(lower_str(pattern_from_sigma(sigma_str), ctx))
 }
 
-fn lower_sigma_string(sigma_str: &SigmaString, ctx: &ModCtx) -> Result<IrMatcher> {
-    let ci = ctx.is_case_insensitive();
-
-    if sigma_str.is_plain() {
-        let plain = sigma_str.as_plain().unwrap_or_default();
-        return lower_string_value(&plain, ctx);
-    }
-
-    let pattern = sigma_parts_to_regex_pattern(
-        &sigma_str.parts,
-        ci,
-        ctx.contains,
-        ctx.startswith,
-        ctx.endswith,
-    );
-    Ok(IrMatcher::Regex {
-        pattern: lit(pattern),
-    })
-}
-
-fn lower_string_value(plain: &str, ctx: &ModCtx) -> Result<IrMatcher> {
-    let ci = ctx.is_case_insensitive();
-    let value = lit(maybe_lower(plain, ci));
-
-    if ctx.contains {
-        Ok(IrMatcher::Contains {
-            value,
-            case_insensitive: ci,
-        })
-    } else if ctx.startswith {
-        Ok(IrMatcher::StartsWith {
-            value,
-            case_insensitive: ci,
-        })
-    } else if ctx.endswith {
-        Ok(IrMatcher::EndsWith {
-            value,
-            case_insensitive: ci,
-        })
-    } else {
-        Ok(IrMatcher::Exact {
-            value,
-            case_insensitive: ci,
-        })
+fn lower_str(pattern: IrPattern, ctx: &ModCtx) -> IrMatcher {
+    IrMatcher::Str {
+        op: str_op(ctx),
+        pattern,
+        case_insensitive: ctx.is_case_insensitive(),
     }
 }
 
 /// Lower a keyword value (case-insensitive contains by default).
+///
+/// Keywords carry no field and match substring-wise across all event values;
+/// the faithful pattern lets eval reproduce the plain-vs-wildcard behavior and
+/// convert render the term.
 pub(super) fn lower_value_keywords(value: &SigmaValue) -> Result<IrMatcher> {
     let ci = true;
     match value {
-        SigmaValue::String(s) => {
-            if s.is_plain() {
-                let plain = s.as_plain().unwrap_or_default();
-                Ok(IrMatcher::Contains {
-                    value: lit(maybe_lower(&plain, ci)),
-                    case_insensitive: ci,
-                })
-            } else {
-                let pattern = super::helpers::keywords_wildcard_pattern(&s.parts, ci);
-                Ok(IrMatcher::Regex {
-                    pattern: lit(pattern),
-                })
-            }
-        }
+        SigmaValue::String(s) => Ok(IrMatcher::Str {
+            op: IrStrOp::Contains,
+            pattern: pattern_from_sigma(s),
+            case_insensitive: ci,
+        }),
         SigmaValue::Integer(n) => Ok(IrMatcher::NumericEq(IrNumber::Literal(*n as f64))),
         SigmaValue::Float(n) => Ok(IrMatcher::NumericEq(IrNumber::Literal(*n))),
         SigmaValue::Bool(b) => Ok(IrMatcher::BoolEq(*b)),

--- a/docs/content/library/ir.md
+++ b/docs/content/library/ir.md
@@ -29,17 +29,18 @@ The crate is sync-only (no tokio/reqwest).
 | Type / function | Purpose |
 |-----------------|---------|
 | `IrRule` / `IrDetection` / `IrMatcher` / `IrCondition` | Detection-rule HIR. `IrCondition::Selector` keeps the quantifier and name pattern. |
+| `IrMatcher::Str` + `IrPattern` | Faithful, wildcard-aware, original-case string match. |
+| `IrMatcher::Encoded` + `IrEncoding` | Explicit encoding transforms (`base64`, `wide`, `windash`, …). |
 | `IrCorrelation` / `IrFilter` | Correlation and filter HIR. |
 | `IrRuleMetadata` | Metadata superset used when projecting eval `RuleHeader`. |
-| `SurfaceSpec` | Optional sidecar on detection items for convert fidelity. |
 | `lower_rule` / `lower_detection` / `lower_condition` | AST → HIR. |
 | `lower_correlation` / `lower_filter` | Parallel walkers for those shapes. |
 | `LowerOptions` | Strict (default) vs placeholder-preserving lowering. |
 
 ## Lowering notes
 
-- Selectors such as `1 of selection_*` and `all of them` are preserved as `IrCondition::Selector`, so evaluation stays count-based and reports every matching detection. `them` skips `_`-prefixed detection names; vacuous `all of <pattern>` over zero matching names is true, matching native evaluation.
-- `them` skips detection names that begin with `_`; glob/prefix patterns that explicitly match `_`-prefixed names still include them.
+- Lowering is **purely structural**: it resolves *which* comparison applies but never lowercases, compiles regexes, or expands encodings. Eval does that at compile time; convert renders wildcards to backend tokens. This keeps the HIR lossless.
+- Selectors such as `1 of selection_*` and `all of them` are preserved as `IrCondition::Selector`, so evaluation stays count-based and reports every matching detection. `them` skips `_`-prefixed detection names; glob/prefix patterns that explicitly match them still include them. Vacuous `all of <pattern>` over zero matching names is true, matching native evaluation.
 - Modifier contradictions (`|cidr|contains`, `|base64|base64offset`, …) fail at lower time with the same error kinds eval previously surfaced from `compile_rule`.
 
 ## Related

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1753,9 +1753,6 @@ dependencies = [
 name = "rsigma-ir"
 version = "0.19.0"
 dependencies = [
- "base64",
- "ipnet",
- "regex",
  "rsigma-parser",
  "serde",
  "serde_json",


### PR DESCRIPTION
Foundation for wiring convert through the HIR (follow-up to #360). Reworks the `rsigma-ir` matcher model so it is faithful and lossless, and moves the physical work (lowercasing, regex/aho-corasick, encoding expansion) into eval's compile step.

## What changed
- `IrMatcher::Str` carries a wildcard-aware, original-case `IrPattern`; encoding modifiers stay explicit as `IrMatcher::Encoded { encodings: Vec<IrEncoding>, … }`. Lowering no longer lowercases, compiles regexes, or expands encodings.
- `compile_to_compiled` (eval) reconstructs the modifier context and reuses the existing leaf compilers, so matching is byte-identical (the `compile_rule` vs `compile_rule_legacy` differential stays green).
- Removes `SurfaceSpec` and the `regex`/`ipnet`/`base64` deps from `rsigma-ir`; keywords are lossless without a sidecar.

This is Stage 1 of the convert migration: it touches only `rsigma-ir` + `rsigma-eval`. Convert still routes conditions through `lower_conditions` and is untouched. Stage 2 will have convert render backend queries directly from the faithful matcher.

## Checks
- [x] `cargo test -p rsigma-ir -p rsigma-eval` (832 pass, differential included)
- [x] `cargo test -p rsigma-convert` (343) and CLI convert/eval/explain (72) unaffected
- [x] `cargo clippy -p rsigma-ir -p rsigma-eval --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`; `npm run docs:validate`
- [ ] CI green

xref #346 