### PR TITLE
docs: fix comments left stale by the IR migration

### DIFF
--- a/crates/rsigma-convert/src/backend.rs
+++ b/crates/rsigma-convert/src/backend.rs
@@ -94,10 +94,11 @@ pub(crate) fn ir_pattern_to_sigma(pattern: &IrPattern) -> SigmaString {
 
 /// Core conversion trait.
 ///
-/// Backends implement this to convert parsed Sigma AST nodes into
-/// backend-native query strings. The trait operates on **parsed** types
-/// from `rsigma-parser` because conversion needs the original field names,
-/// modifiers, and values rather than compiled matchers.
+/// Backends implement this to convert a rule's intermediate representation
+/// (`rsigma-ir`) into backend-native query strings. The value leaves consume
+/// the faithful HIR (`IrPattern`, `IrStrOp`, `IrNumber`, `RegexFlags`,
+/// `CompareOp`) rather than parser types or compiled matchers, so a backend
+/// never touches `rsigma-parser` to emit a value match.
 pub trait Backend: Send + Sync {
     fn name(&self) -> &str;
     fn formats(&self) -> &[(&str, &str)];

--- a/crates/rsigma-convert/src/backends/fibratus/config.rs
+++ b/crates/rsigma-convert/src/backends/fibratus/config.rs
@@ -26,15 +26,15 @@ pub struct FibratusConfig {
     /// The Fibratus loader rejects a rule that omits it.
     pub rule_version: String,
 
-    /// Whether to walk the condition AST and rewrite recognized
-    /// sub-trees into idiomatic Fibratus macros
-    /// (`spawn_process`/`open_file`/...). Phase 3 wires the recognition;
-    /// the knob is present from Phase 0 so output formats stay stable
-    /// when the recognition pass lands.
+    /// Whether to rewrite recognized clauses in the generated filter
+    /// expression into idiomatic Fibratus macros
+    /// (`spawn_process`/`open_file`/...). Applied by `finalize_query` via the
+    /// macro recognizer, which is a no-op on inputs that match no macros, so
+    /// disabling it yields byte-equivalent output.
     pub use_macros: bool,
 
     /// Default logsource product to assume when a Sigma rule lacks
-    /// `logsource.product`. Used by Phase 2's pipeline matching.
+    /// `logsource.product`, used when matching the rule against the pipeline.
     pub default_logsource: String,
 
     /// Emit `description:` and `labels:` blocks. Disable to produce a
@@ -42,10 +42,9 @@ pub struct FibratusConfig {
     /// from another source).
     pub emit_metadata: bool,
 
-    /// Maximum number of repeated/distinct sequence slots Phase 4 will
-    /// generate when emulating `event_count` / `value_count`. Anything
-    /// above this threshold returns `UnsupportedCorrelation` rather
-    /// than ballooning the YAML.
+    /// Maximum number of repeated/distinct sequence slots generated when
+    /// emulating `event_count` / `value_count`. Anything above this threshold
+    /// returns `UnsupportedCorrelation` rather than ballooning the YAML.
     pub max_repeated_slots: u64,
 
     /// When converting `temporal` (any-order) correlation, emit

--- a/crates/rsigma-convert/src/backends/lynxdb/mod.rs
+++ b/crates/rsigma-convert/src/backends/lynxdb/mod.rs
@@ -43,7 +43,7 @@ static LYNXDB_CONFIG: TextQueryConfig = TextQueryConfig {
     // LynxDB only supports `*` glob; `?` is a literal character.
     // Sigma's single-char wildcard is mapped to `*` here (lossy fallback);
     // patterns that actually contain `?` are deferred to a regex `where` clause
-    // in `convert_field_eq_str`.
+    // in `convert_field_str`.
     wildcard_multi: "*",
     wildcard_single: "*",
 

--- a/crates/rsigma-convert/src/condition_ir.rs
+++ b/crates/rsigma-convert/src/condition_ir.rs
@@ -1,8 +1,10 @@
-//! Convert selector-free [`IrCondition`] trees against parser AST detections.
+//! Convert [`IrCondition`] trees against a rule's [`IrDetection`] map.
 //!
-//! Detection bodies still use the existing `Backend::convert_detection` path;
-//! conditions are taken from `lower_conditions` so convert no longer resolves
-//! selectors itself.
+//! The whole rule is lowered to HIR once (`convert_rule_via_ir`); both the
+//! detection bodies and the conditions are then walked from the IR. Quantified
+//! selectors are resolved here against the IR detections, mirroring eval:
+//! an empty match set is rejected, `any` / `1 of` become OR, `all of` becomes
+//! AND, and `N of` (N > 1) is unsupported.
 
 use std::collections::HashMap;
 

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -1,11 +1,15 @@
 //! Compile parsed Sigma rules into optimized in-memory representations.
 //!
-//! The compiler transforms the parser AST (`SigmaRule`, `Detection`,
-//! `DetectionItem`) into compiled forms (`CompiledRule`, `CompiledDetection`,
-//! `CompiledDetectionItem`) that can be evaluated efficiently against events.
+//! The primary entry point, [`compile_rule`], lowers a `SigmaRule` to HIR via
+//! `rsigma_ir::lower_rule` and then materializes the physical forms
+//! (`CompiledRule`, `CompiledDetection`, `CompiledDetectionItem`) with
+//! [`compile_to_compiled`], which builds the concrete `CompiledMatcher`
+//! variants (regex, Aho-Corasick, `IpNet`, lowercased patterns) that evaluate
+//! efficiently against events. Modifier interpretation happens during lowering;
+//! this module turns the resolved matchers into executable artifacts.
 //!
-//! Modifier interpretation happens here: the compiler reads the `Vec<Modifier>`
-//! from each `FieldSpec` and produces the appropriate `CompiledMatcher` variant.
+//! [`compile_rule_legacy`] retains the pre-IR direct AST-to-`CompiledRule`
+//! compiler for the dual-path differential.
 
 mod from_ir;
 mod helpers;

--- a/crates/rsigma-ir/src/lower/mod.rs
+++ b/crates/rsigma-ir/src/lower/mod.rs
@@ -1,7 +1,8 @@
 //! Lowering: parser AST → HIR.
 //!
 //! Walks metadata, detections, and conditions after static pipeline transforms.
-//! Selectors collapse here into [`IrCondition`] trees with no `Selector` variant.
+//! Quantified selectors are preserved as [`IrCondition::Selector`] rather than
+//! being expanded, so downstream consumers keep count-based semantics.
 //! Modifier interpretation lives in private helpers alongside this module.
 
 mod helpers;
@@ -59,9 +60,9 @@ pub fn lower_rule(rule: &SigmaRule, opts: &LowerOptions) -> Result<IrRule> {
 /// Lower only the condition trees of a detection section, without lowering
 /// detection items.
 ///
-/// Convert re-walks the parser AST for detection bodies, so it only needs the
-/// selector-resolved condition trees. This avoids the cost (and eval-specific
-/// value constraints) of fully lowering every detection item.
+/// Used by filter lowering and any caller that needs the condition trees
+/// without paying to fully lower every detection item (and without the
+/// eval-specific value constraints that lowering items would impose).
 pub fn lower_conditions(section: &Detections) -> Result<Vec<IrCondition>> {
     let names: Vec<String> = section.named.keys().cloned().collect();
     section


### PR DESCRIPTION
Comment-only cleanup of docs that described pre-IR behavior after the eval and convert paths moved onto the HIR (#360, #362, #363).

## Fixed

- **`rsigma-convert` `Backend` trait doc** — said the trait "operates on parsed types from `rsigma-parser`." It is IR-native: value leaves consume `IrPattern`/`IrStrOp`/`IrNumber`/`RegexFlags`/`CompareOp`.
- **`condition_ir` module doc** — said detection bodies "still use the existing `Backend::convert_detection` path" and that conditions come from `lower_conditions`. The whole rule now lowers to HIR once and both detections and conditions are walked from the IR; selectors resolve against the IR detections.
- **`rsigma-ir` lowering docs** — said selectors "collapse into `IrCondition` trees with no `Selector` variant." They are preserved as `IrCondition::Selector`. Also dropped the stale `lower_conditions` note that it exists because convert re-walks the parser AST.
- **`rsigma-eval` compiler module doc** — said the compiler transforms the parser AST and interprets modifiers. `compile_rule` now lowers to HIR then materializes physical matchers via `compile_to_compiled`; `compile_rule_legacy` is the retained direct-AST path.
- **LynxDB config** — referenced the removed `convert_field_eq_str`; now `convert_field_str`.
- **Fibratus config** — described the macro recognizer as an AST walk and the recognizer/correlation-slot cap as future work; reworded to the shipped present-tense behavior.

Scope: comments made inaccurate by the IR migration. Left untouched the many legitimate local `Phase 1/2/3` step labels in unrelated subsystems (parse/eval/merge stages), which are accurate.

No code changes; `cargo doc` and clippy pass on the touched crates.