### PR TITLE
fix(docs): render Markdown in page titles

### DIFF
--- a/docs/docmd-plugin-rsigma/index.js
+++ b/docs/docmd-plugin-rsigma/index.js
@@ -196,6 +196,58 @@ function escapeHtml(text) {
 }
 
 /**
+ * Render inline-code spans (`` `code` ``) in an already-HTML-escaped string as
+ * `<code>` elements. Used where HTML renders (the visible header title).
+ *
+ * @param {string} escaped
+ * @returns {string}
+ */
+function inlineCodeToHtml(escaped) {
+  return escaped.replace(/`([^`]+)`/g, "<code>$1</code>");
+}
+
+/**
+ * Drop inline-code backticks, keeping the inner text. Used in plain-text
+ * contexts (`<title>`, Open Graph / Twitter meta) where HTML does not render.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function stripInlineCode(text) {
+  return text.replace(/`([^`]+)`/g, "$1");
+}
+
+/**
+ * docmd derives the page title from the first Markdown H1 but keeps the raw
+ * text, so a heading like `` # `rsigma engine discover-schemas` `` leaves
+ * literal backticks in the header bar, the `<title>`, and the social meta. Fix
+ * that after render: the visible header title renders the code span as `<code>`
+ * (matching the in-body H1), and the plain-text `<title>` / meta strip the
+ * markers. Pages whose title has no backticks are left untouched.
+ *
+ * @param {string} html
+ * @returns {string}
+ */
+function renderMarkdownTitles(html) {
+  let out = html.replace(
+    /(<span class="header-title">)([\s\S]*?)(<\/span>)/,
+    (match, open, inner, close) =>
+      inner.includes("`") ? `${open}${inlineCodeToHtml(inner.trim())}${close}` : match,
+  );
+  out = out.replace(
+    /(<title>)([\s\S]*?)(<\/title>)/,
+    (match, open, inner, close) =>
+      inner.includes("`") ? `${open}${stripInlineCode(inner)}${close}` : match,
+  );
+  out = out.replace(
+    /(<meta (?:property="og:title"|name="twitter:title") content=")([^"]*)(">)/g,
+    (match, open, content, close) =>
+      content.includes("`") ? `${open}${stripInlineCode(content)}${close}` : match,
+  );
+  return out;
+}
+
+/**
  * Append a plain-text site label beside the sidebar logo image.
  *
  * @param {string} html
@@ -338,6 +390,7 @@ export default {
     await writeBrandImages(path.join(docsRoot, "assets", "images"), logoPng);
     let stripped = 0;
     let logoTextInjected = 0;
+    let titlesRendered = 0;
     const logoText =
       typeof ctx?.config?.logo === "object" && ctx.config.logo.text
         ? String(ctx.config.logo.text)
@@ -355,13 +408,19 @@ export default {
           next = withLogoText;
         }
       }
+      const withTitles = renderMarkdownTitles(next);
+      if (withTitles !== next) {
+        titlesRendered += 1;
+        next = withTitles;
+      }
       if (next !== html) {
         fs.writeFileSync(file, next);
       }
     }
     log(
       `docmd-plugin-rsigma: stripped <base> tag from ${stripped} pages` +
-        (logoText ? `, added logo text to ${logoTextInjected} pages` : ""),
+        (logoText ? `, added logo text to ${logoTextInjected} pages` : "") +
+        `, rendered Markdown in ${titlesRendered} page titles`,
     );
   },
 };


### PR DESCRIPTION
## Problem

On pages whose first heading is inline code, for example ``# `rsigma engine discover-schemas` ``, the top-of-page title rendered the raw Markdown, so literal backticks showed in the header bar (and in the `<title>` and social meta). docmd derives the page title from the first H1 but keeps the raw text; the in-body H1 renders correctly, only the derived title does not.

## Fix

The local `docmd-plugin-rsigma` post-build hook now normalizes derived titles per page:

- the visible `<span class="header-title">` renders the inline-code span as `<code>`, matching the in-body H1;
- the plain-text `<title>` and the Open Graph / Twitter `title` meta strip the backticks (HTML does not render there).

Pages whose title has no backticks are left untouched (this build reported 40 titles rendered). `docmd build` and `docmd validate` pass.

## Before / after

Header bar for `cli/engine/discover-schemas`:

- before: `` `rsigma engine discover-schemas` ``
- after: `rsigma engine discover-schemas` (rendered as `<code>`)
