### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-22
+
+**TL;DR**
+RSigma v0.20.0 is the "intermediate representation, reverse conversion, and rstix STIX closure" release: a new HIR crate becomes the compile and convert backbone, SIEM queries convert back to Sigma YAML, `rstix` gains a TAXII 2.1 client alongside graph, marking, and store modules, and the schema classifier learns the major cloud log sources.
+* Intermediate representation: a new `rsigma-ir` HIR crate with `lower_rule`, a serializable HIR restart cache, and opt-in optimization passes, with `rsigma-eval` compile and the `rsigma-convert` `Backend` trait now IR-native end to end while backend output stays byte-identical (#360, #362, #363, #364, #368, #370).
+* Reverse conversion: a pluggable framework that parses a SIEM query dialect into the IR, raises it to a Sigma rule, and emits canonical YAML, with Elastic Lucene as the reference frontend, exposed through `rsigma rule reverse` and the MCP `reverse_convert` tool (#348, #371).
+* `rstix` threat intel: an async TAXII 2.1 client with mTLS, pagination, auth, and resilience (#373); spec-exact STIX 2.1 closure with graph traversal, TLP marking resolution, and an object store (#327); and serde-gated wire-format validator dependencies (#352).
+* Detection routing: a built-in cloud schema signature bundle covering AWS CloudTrail and VPC Flow, Azure, GCP, Microsoft 365, GitHub, Okta, OneLogin, Kubernetes, Docker, and osquery (#318).
+* Reliability: deterministic bloom pre-filter seeding, so the per-field substring pre-filter's bit layout is stable across runs and platforms with correctness unchanged.
+* Dependencies: two rolled-up Dependabot batches across the Rust workspace, CI actions, and the VS Code extension (#354, #357).
+
 ### rstix: TAXII 2.1 Client (`taxii` feature) (#373)
 
 - **`taxii`** — async HTTP client for TAXII 2.1 endpoint groups (discovery, API Root, collections, objects, manifest, versions, status). **Channels (§6) are RESERVED in the spec and not implemented.** Includes DNS SRV via `_taxii2._tcp` and `TaxiiClientConfig::dns_nameserver()` for custom resolvers.
@@ -86,6 +97,8 @@ Adds three independent modules for Graph + Marking + Store:
 ### Cloud Schema Signature Bundle (#318)
 
 Built-in schema signatures cover AWS CloudTrail (`aws_cloudtrail`), AWS VPC Flow Logs (`aws_vpcflow`), Azure Activity/SignIn/Audit logs (`azure_activitylogs`, `azure_signinlogs`, `azure_auditlogs`), GCP Cloud Audit (`gcp_audit`), Microsoft 365 unified audit log (`m365_audit`), GitHub Audit (`github_audit`), Okta System Log (`okta_system_log`), OneLogin (`onelogin_events`), Kubernetes audit (`k8s_audit`), Docker events (`docker_events`), and osquery (`osquery_result`). Each signature uses multi-field markers (high specificity, no misfires) and implies a SigmaHQ taxonomy-compatible `product`/`service` logsource for conflict-based pruning. Off-taxonomy sources (k8s, docker, osquery) ship as `logsource.custom` dimensions to stay within the no-blessed-vocabulary line, and AWS VPC Flow Logs ships as `product: aws` plus `custom: {source: vpcflow}`. A `gcp_audit.yml` pipeline strips the `data.` prefix that SigmaHQ's `gcp.audit` rules use (`data.protoPayload.*`) so they match native Cloud Logging events (`protoPayload.*`). Per-source golden fixtures (`test_event.json` + `expected_classification.yaml`) with a walk test, an end-to-end GCP routing test, and specificity-ordering unit tests guard correctness and prevent regressions. A new cloud collection recipes guide covers Vector, OTel, and Fluent Bit configs per source.
+
+[v0.19.0...v0.20.0](https://github.com/timescale/rsigma/compare/v0.19.0...v0.20.0)
 
 ## [0.19.0] - 2026-07-13
 
@@ -2500,6 +2513,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.20.0]: https://github.com/timescale/rsigma/releases/tag/v0.20.0
 [0.19.0]: https://github.com/timescale/rsigma/releases/tag/v0.19.0
 [0.18.0]: https://github.com/timescale/rsigma/releases/tag/v0.18.0
 [0.17.0]: https://github.com/timescale/rsigma/releases/tag/v0.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "insta",
  "log",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-ir"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ciborium",
  "rsigma-eval",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "globset",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "email_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz", "ci/wasm-smoke"]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/ci/wasm-smoke/Cargo.lock
+++ b/ci/wasm-smoke/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsigma-eval"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-ir"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ciborium",
  "rsigma-parser",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "globset",
  "log",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -36,11 +36,11 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.19.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.19.0", features = ["sigma-cli"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.19.0", optional = true }
-rsigma-mcp = { path = "../rsigma-mcp", version = "0.19.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.20.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.20.0", features = ["sigma-cli"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.20.0", optional = true }
+rsigma-mcp = { path = "../rsigma-mcp", version = "0.20.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -22,9 +22,9 @@ default = []
 sigma-cli = []
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
-rsigma-ir = { path = "../rsigma-ir", version = "0.19.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
+rsigma-ir = { path = "../rsigma-ir", version = "0.20.0", default-features = false }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,8 +14,8 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0", default-features = false }
-rsigma-ir = { path = "../rsigma-ir", version = "0.19.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0", default-features = false }
+rsigma-ir = { path = "../rsigma-ir", version = "0.20.0", default-features = false }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-ir/Cargo.toml
+++ b/crates/rsigma-ir/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0", default-features = false }
 ciborium = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -18,4 +18,4 @@ thiserror = "2"
 yaml_serde = "0.10"
 
 [dev-dependencies]
-rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-mcp/Cargo.toml
+++ b/crates/rsigma-mcp/Cargo.toml
@@ -16,10 +16,10 @@ default = []
 http = ["dep:axum", "rmcp/transport-streamable-http-server"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.19.0" }
-rsigma-convert = { path = "../rsigma-convert", version = "0.19.0", features = ["sigma-cli"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.19.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
+rsigma-convert = { path = "../rsigma-convert", version = "0.20.0", features = ["sigma-cli"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.20.0" }
 rmcp = { version = "2.2", features = ["server", "macros", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -22,8 +22,8 @@ uds = ["tokio/net"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.19.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.19.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.20.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "log",
  "regex",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-ir"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ciborium",
  "rsigma-parser",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "globset",
  "log",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "email_address",


### PR DESCRIPTION
Bump the workspace and all inter-crate version pins from 0.19.0 to 0.20.0, sync the workspace, fuzz, and wasm-smoke lockfiles, and finalize the CHANGELOG by promoting the `[Unreleased]` section to `[0.20.0]` with a TL;DR summary, a compare link, and a release reference link.

Once merged, publishing the `v0.20.0` GitHub Release triggers the crates.io, binary, and Docker workflows.

## TL;DR

RSigma v0.20.0 is the "intermediate representation, reverse conversion, and rstix STIX closure" release: a new HIR crate becomes the compile and convert backbone, SIEM queries convert back to Sigma YAML, `rstix` gains a TAXII 2.1 client alongside graph, marking, and store modules, and the schema classifier learns the major cloud log sources.

- Intermediate representation: a new `rsigma-ir` HIR crate with `lower_rule`, a serializable HIR restart cache, and opt-in optimization passes, with `rsigma-eval` compile and the `rsigma-convert` `Backend` trait now IR-native end to end while backend output stays byte-identical (#360, #362, #363, #364, #368, #370).
- Reverse conversion: a pluggable framework that parses a SIEM query dialect into the IR, raises it to a Sigma rule, and emits canonical YAML, with Elastic Lucene as the reference frontend, exposed through `rsigma rule reverse` and the MCP `reverse_convert` tool (#348, #371).
- `rstix` threat intel: an async TAXII 2.1 client with mTLS, pagination, auth, and resilience (#373); spec-exact STIX 2.1 closure with graph traversal, TLP marking resolution, and an object store (#327); and serde-gated wire-format validator dependencies (#352).
- Detection routing: a built-in cloud schema signature bundle covering AWS CloudTrail and VPC Flow, Azure, GCP, Microsoft 365, GitHub, Okta, OneLogin, Kubernetes, Docker, and osquery (#318).
- Reliability: deterministic bloom pre-filter seeding, so the per-field substring pre-filter's bit layout is stable across runs and platforms with correctness unchanged.
- Dependencies: two rolled-up Dependabot batches across the Rust workspace, CI actions, and the VS Code extension (#354, #357).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo metadata --locked` for the workspace, `fuzz/`, and `ci/wasm-smoke/`
- [x] `npm run docs:build` and `npm run docs:validate`