### PR TITLE
ci: publish rsigma-ir to crates.io in dependency order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,18 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: sleep 30
 
+      # rsigma-ir depends only on rsigma-parser, so it publishes right after
+      # it and before rsigma-eval and rsigma-convert, which both depend on it.
+      - name: Publish rsigma-ir
+        if: github.event_name != 'workflow_dispatch'
+        run: cargo publish --locked -p rsigma-ir
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Wait for crates.io index update (rsigma-ir)
+        if: github.event_name != 'workflow_dispatch'
+        run: sleep 30
+
       - name: Publish rsigma-eval
         if: github.event_name != 'workflow_dispatch'
         run: cargo publish --locked -p rsigma-eval


### PR DESCRIPTION
## Summary

- `rsigma-eval` and `rsigma-convert` now depend on the new `rsigma-ir` crate, but `publish.yml` never published `rsigma-ir`. A release would fail at the `rsigma-eval` step because `rsigma-ir = "0.20.0"` cannot resolve on the index.
- Publishes `rsigma-ir` right after `rsigma-parser` (its only workspace dependency) and before `rsigma-eval` and `rsigma-convert`, with an index-wait so the version is resolvable when the dependents publish.
- The `rsigma-ir` name is now reserved on crates.io (`0.0.0-reserved`) so the release's first real publish of `0.20.0` can claim it.

## Test plan

- [x] `rsigma-ir` reserved on crates.io (confirmed via the registry API)
- [x] Trusted publishing configured for `rsigma-ir` in the crates.io crate settings (repo `timescale/rsigma`, workflow `publish.yml`) before the release
- [ ] `publish.yml` `workflow_dispatch` dry-run rehearsal