### PR TITLE
fix(rsigma-ir): make the rsigma-eval dev-dependency path-only

### DIFF
--- a/crates/rsigma-ir/Cargo.toml
+++ b/crates/rsigma-ir/Cargo.toml
@@ -17,5 +17,10 @@ serde_json = "1"
 thiserror = "2"
 yaml_serde = "0.10"
 
+# Path-only (no version): rsigma-eval depends on rsigma-ir, so a versioned
+# dev-dependency here forms a publish-time cycle (cargo would require
+# rsigma-eval to already be on the registry). Cargo strips version-less path
+# dev-dependencies when packaging, so this keeps the tests working locally
+# without blocking `cargo publish`.
 [dev-dependencies]
-rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
+rsigma-eval = { path = "../rsigma-eval" }

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,12 @@ multiple-versions = "warn"
 # undermines lockfile reproducibility and makes supply-chain review
 # impossible. Use a concrete version or version range.
 wildcards = "deny"
+# Exempt path dependencies inside the workspace from the wildcard ban. This
+# covers version-less path dev-dependencies used to break publish-time
+# dependency cycles (e.g. rsigma-ir's dev-dependency on rsigma-eval, which
+# depends on rsigma-ir); cargo strips dev-dependencies when packaging, so the
+# published crate carries no wildcard.
+allow-wildcard-paths = true
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
## Summary

- The v0.20.0 crates.io publish failed at `rsigma-ir`: it declared a versioned dev-dependency `rsigma-eval = "0.20.0"`, but `rsigma-eval` depends on `rsigma-ir` and publishes after it, so `cargo publish` could not resolve `rsigma-eval 0.20.0` from the registry (a publish-time dev-dependency cycle).
- Drops the version pin, leaving a path-only dev-dependency. Cargo strips version-less path dev-dependencies when packaging, so the crate publishes without the cycle and the tests still build locally.

## Test plan

- [x] `cargo publish --dry-run --locked -p rsigma-ir` packages and verifies (resolves `rsigma-parser 0.20.0`, strips the dev-dependency)