### PR TITLE
ci: make crates.io publish idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
       # release event runs the real publish.
       - name: Publish rsigma-parser
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-parser
+        run: ./ci/publish-crate.sh rsigma-parser
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -80,7 +80,7 @@ jobs:
       # it and before rsigma-eval and rsigma-convert, which both depend on it.
       - name: Publish rsigma-ir
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-ir
+        run: ./ci/publish-crate.sh rsigma-ir
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Publish rsigma-eval
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-eval
+        run: ./ci/publish-crate.sh rsigma-eval
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Publish rsigma-convert
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-convert
+        run: ./ci/publish-crate.sh rsigma-convert
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -110,7 +110,7 @@ jobs:
 
       - name: Publish rsigma-runtime
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-runtime
+        run: ./ci/publish-crate.sh rsigma-runtime
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Publish rsigma-mcp
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-mcp
+        run: ./ci/publish-crate.sh rsigma-mcp
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -130,13 +130,13 @@ jobs:
 
       - name: Publish rsigma
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma
+        run: ./ci/publish-crate.sh rsigma
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish rsigma-lsp
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rsigma-lsp
+        run: ./ci/publish-crate.sh rsigma-lsp
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
@@ -144,6 +144,6 @@ jobs:
       # on no workspace crate, so no index-wait step is required afterward.
       - name: Publish rstix
         if: github.event_name != 'workflow_dispatch'
-        run: cargo publish --locked -p rstix
+        run: ./ci/publish-crate.sh rstix
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Publish a single workspace crate to crates.io, skipping the upload when the
+# target version already exists on the registry.
+#
+# This keeps the publish workflow idempotent: if an earlier run published some
+# crates and then failed partway through (a network blip, a fixable manifest
+# issue, a dependency-ordering bug), the workflow can be re-run and each crate
+# that already landed is left untouched instead of aborting the whole job on a
+# "crate version already exists" error.
+set -euo pipefail
+
+crate="${1:?usage: publish-crate.sh <crate-name>}"
+
+version="$(cargo pkgid -p "$crate" | sed 's/.*[#@]//')"
+
+# Sparse-index layout for names of four or more characters:
+# {first two}/{next two}/{name}. Every workspace crate (rsigma-*, rstix) is at
+# least five characters, so the one- to three-character layouts never apply.
+index_url="https://index.crates.io/${crate:0:2}/${crate:2:2}/${crate}"
+
+if curl -sf "$index_url" | grep -q "\"vers\":\"${version}\""; then
+  echo "::notice::${crate} ${version} is already on crates.io; skipping publish"
+  exit 0
+fi
+
+echo "Publishing ${crate} ${version}"
+cargo publish --locked -p "$crate"


### PR DESCRIPTION
## Summary

- Add `ci/publish-crate.sh`, which checks the crates.io sparse index and skips publishing a crate whose target version is already on the registry.
- Wire every publish step in `publish.yml` through the helper so a partial release can be recovered by re-running the workflow, instead of aborting on a `crate version already exists` error.

## Test plan

- `shellcheck ci/publish-crate.sh` passes.
- Verified detection locally: `rsigma-parser 0.20.0` resolves as already published (skip), while `rsigma-ir` and `rstix 0.20.0` resolve as not published (publish).