### PR TITLE
feat(rstix): TAXII collection ingest into StixStore (taxii-store)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 ### rstix: TAXII collection ingest (`taxii-store` feature) (#387)
 
 - **`taxii-store`** — meta-feature (`taxii` + `store`).
-- **`ingest_collection`** / **`ingest_collection_with_bundle_id`** — paginated `objects_stream` → synthetic `Bundle` → `StixStore::import_bundle`; returns `ImportReport`.
+- **`ingest_collection`** / **`ingest_collection_with_bundle_id`** — paginated fetch with per-page `StixStore::import_objects` (bounded memory); merged `ImportReport` with final ref audit against the store.
 - **`IngestError`** — wraps `TaxiiError` and `StoreError`.
 - **TAXII capability checks** — with `CapabilityPolicy::Enforce`, collection `media_types` may include `application/taxii+json` or STIX 2.1 types; absent `media_types` defaults to `application/stix+json` (TAXII §5.2.1); API Root `max_content_length` must be a JSON integer > 0 (strict parse, no string coercion).
 - **`StixStore::import_bundle`** — unresolved refs are reported only when the target id is missing from both the imported bundle and the store (incremental TAXII ingest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### rstix: TAXII DANE DNSSEC validation (`taxii` feature)
+### rstix: TAXII collection ingest (`taxii-store` feature)
+
+- **`taxii-store`** — meta-feature (`taxii` + `store`).
+- **`ingest_collection`** / **`ingest_collection_with_bundle_id`** — paginated `objects_stream` → synthetic `Bundle` → `StixStore::import_bundle`; returns `ImportReport`.
+- **`IngestError`** — wraps `TaxiiError` and `StoreError`.
+- **TAXII capability checks** — with `CapabilityPolicy::Enforce`, collection `media_types` may include `application/taxii+json` or STIX 2.1 types; absent `media_types` defaults to `application/stix+json` (TAXII §5.2.1); API Root `max_content_length` must be a JSON integer > 0 (strict parse, no string coercion).
+- **`StixStore::import_bundle`** — unresolved refs are reported only when the target id is missing from both the imported bundle and the store (incremental TAXII ingest).
+
+### rstix: TAXII DANE DNSSEC validation (`taxii` feature) (#381)
 
 - **`TaxiiClientConfig::dane_require_dnssec`** — default `true` when `ServerTrustPolicy::Dane`; DNSSEC-validates TLSA prefetch and SRV discovery (TAXII §8.5.2 SHOULD). Set `false` for unsigned lab DNS only.
 - **`DnsLookupOptions`** — `validate_dnssec` on `resolve_*_with_options` helpers (default `false` for standalone calls).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### rstix: TAXII collection ingest (`taxii-store` feature)
+### rstix: TAXII collection ingest (`taxii-store` feature) (#387)
 
 - **`taxii-store`** — meta-feature (`taxii` + `store`).
 - **`ingest_collection`** / **`ingest_collection_with_bundle_id`** — paginated `objects_stream` → synthetic `Bundle` → `StixStore::import_bundle`; returns `ImportReport`.

--- a/crates/rstix/Cargo.toml
+++ b/crates/rstix/Cargo.toml
@@ -46,6 +46,7 @@ taxii = [
   "dep:sha2",
   "dep:p12-keystore",
 ]
+taxii-store = ["taxii", "store"]
 
 [dependencies]
 phf = { version = "0.14", features = ["macros"] }
@@ -147,3 +148,7 @@ required-features = ["taxii"]
 [[test]]
 name = "taxii_live"
 required-features = ["taxii"]
+
+[[test]]
+name = "taxii_store"
+required-features = ["taxii-store"]

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -597,8 +597,8 @@ let report = ingest_collection(&client, &store, api_root_url, "col1", TaxiiFilte
 
 Notes:
 
-- Collects **all pages in memory** before import (no page-by-page store streaming yet).
-- Reference checks use the **fetched set plus objects already in the store** (incremental sync).
+- Each TAXII page is imported separately (memory bounded by page size).
+- Reference checks run **after all pages** against the full store (forward refs across pages resolve correctly).
 - Re-ingest is **idempotent** (`ImportReport::objects_deduplicated`).
 
 **Offline test:** `cargo test -p rstix --features taxii-store --test taxii_store`

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -13,6 +13,7 @@ Six optional Cargo features extend the default `serde` bundle model (each implie
 - `store` — in-memory STIX store with typed queries, SCO fingerprint reporting, and bundle import.
 - `store-fs` — filesystem-backed durable store (`FsStore`; implies `store`).
 - `taxii` — TAXII 2.1 HTTP client: discovery, collections, object CRUD, manifest, status polling, auth providers, pagination, retry, rustls TLS (PEM and PKCS#12 mTLS via `ClientCertificate`; `TaxiiClient`; implies `serde`).
+- `taxii-store` — TAXII collection ingest into [`StixStore`](store::StixStore) via [`ingest_collection`](taxii::ingest_collection) (implies `taxii` and `store`).
 
 ## Install
 
@@ -74,6 +75,7 @@ This library is part of [rsigma].
 - `store`: in-memory STIX object store (`MemoryStore`, `StixQuery`, `ImportReport`). Implies `serde`.
 - `store-fs`: filesystem-backed durable store (`FsStore`). Implies `store`.
 - `taxii`: TAXII 2.1 HTTP client (`TaxiiClient`, `TaxiiEnvelope`, Bearer/Basic/API-key auth, cursor + header pagination, retry, rustls TLS with PEM and PKCS#12 mTLS). Implies `serde`.
+- `taxii-store`: paginated collection fetch into `MemoryStore` / `FsStore` via `ingest_collection`. Implies `taxii` and `store`.
 
 ## Current status
 
@@ -402,6 +404,7 @@ Acceptance tests: `store::memory::dedup`, `store::memory::fingerprint`, `store::
 | Marking disclosure | `permits_disclosure(audience)` uses `created_by_ref` vs audience for SameOrganization vs ThirdParty. | Amber+Strict blocks third parties per TLP 2.0 rules. |
 | Store object-safety | `StixStore::get` returns owned clones; `MemoryStore::get_sco` returns owned `StoredSco`. | Required for `dyn StixStore` vtable safety. |
 | Store SCO keys | Asserted source id is always the store key; UUIDv5 fingerprint is reporting-only. | Never silently rewrite SCO ids. |
+| Store import refs | `ImportReport::unresolved_references` lists targets missing from **both** the imported bundle and the store. | Supports incremental TAXII ingest (`taxii-store`). |
 | Store search | Full-text index updated on upsert; `StixQuery::text_search` is case-insensitive substring match. | Typed filters compose with text search. |
 | FsStore durability | One JSON file per object id under `objects/`; atomic write via temp file + rename. | `store-fs` feature implies `store`. |
 
@@ -540,6 +543,7 @@ TLS version policy: `build_rustls_config` passes `[&TLS12, &TLS13]` to rustls. N
 
 ```bash
 cargo test -p rstix --features taxii --test taxii_client
+cargo test -p rstix --features taxii-store --test taxii_store
 ```
 
 Optional live TLS / DNS / mTLS harness ([`tests/taxii-live/README.md`](tests/taxii-live/README.md)):
@@ -578,6 +582,27 @@ let status = client
     .await?; // HTTP 202 → TaxiiStatus
 ```
 
+#### Collection ingest (`taxii-store`)
+
+[`ingest_collection`](taxii::ingest_collection) paginates [`TaxiiClient::objects_stream`](taxii::TaxiiClient::objects_stream), wraps the objects in a synthetic [`Bundle`](model::Bundle), and calls [`StixStore::import_bundle`](store::StixStore::import_bundle). Requires **`taxii-store`** (`taxii` + `store`). Works with [`MemoryStore`](store::MemoryStore) or [`FsStore`](store::FsStore).
+
+```rust
+use rstix::store::{MemoryStore, StixStore};
+use rstix::taxii::{ingest_collection, TaxiiClient, TaxiiClientConfig, TaxiiFilter};
+
+let client = TaxiiClient::new(TaxiiClientConfig::new("https://taxii.example.com"))?;
+let store = MemoryStore::new();
+let report = ingest_collection(&client, &store, api_root_url, "col1", TaxiiFilter::new()).await?;
+```
+
+Notes:
+
+- Collects **all pages in memory** before import (no page-by-page store streaming yet).
+- Reference checks use the **fetched set plus objects already in the store** (incremental sync).
+- Re-ingest is **idempotent** (`ImportReport::objects_deduplicated`).
+
+**Offline test:** `cargo test -p rstix --features taxii-store --test taxii_store`
+
 Request invariants (all calls): `Accept: application/taxii+json;version=2.1`, `User-Agent: rstix/{VERSION}` (override via config), trailing slash on endpoint URLs, discovery at fixed `{base}/taxii2/`.
 
 ### TAXII Client invariant decisions
@@ -590,7 +615,7 @@ Request invariants (all calls): `Accept: application/taxii+json;version=2.1`, `U
 | DANE (`ServerTrustPolicy::Dane`) | Fail-closed TLSA association (RFC 7671 usages 0–3); default `dane_require_dnssec(true)` DNSSEC-validates TLSA prefetch and SRV | `evaluate_dane`, `dane_require_dnssec`, TLSA prefetch in `TaxiiHttp` |
 | SPKI pin-only | `PinnedSpkiOnly` accepts matching pin without hostname or expiry checks (spec section 8.5.2 pinning) | Documented on `ServerTrustPolicy::PinnedSpkiOnly` |
 | Response size cap | Rejects when `Content-Length` exceeds `max_response_bytes` before read; streaming bodies capped chunk-by-chunk | `read_response_body` |
-| Capability checks | API Root `versions` and collection `media_types` verified before use | `CapabilityPolicy::Enforce` (default); disable for interop |
+| Capability checks | With `Enforce`: collection `media_types` must include TAXII 2.1 and/or STIX 2.1 object types; API Root `versions` must include TAXII 2.1; `max_content_length` must be integer **> 0** | `CapabilityPolicy::Disabled` skips checks (interop only); wire JSON is never coerced |
 | POST status | Poll until complete by default (`PostSubmitPolicy`) | `ReturnInitial` for one-shot 202 |
 | Pagination continuation | `more=true` requires `next` or `X-TAXII-Date-Added-Last` | `MissingPaginationHeaders` |
 | HTTP 416 recovery | Streams reset cursor and restore baseline `added_after` | Pagination streams |
@@ -607,6 +632,7 @@ Request invariants (all calls): `Accept: application/taxii+json;version=2.1`, `U
 | DELETE preflight | Requires both `can_read` and `can_write` | Spec section 5.7 |
 | Manifest Accept | TAXII + STIX media types | Spec section 5.3 |
 | DNS SRV discovery | `resolve_taxii_srv` + `TaxiiClient::discover_via_srv` | `_taxii2._tcp` records |
+| Collection ingest | `ingest_collection` streams objects → synthetic `Bundle` → `StixStore::import_bundle` | `taxii-store` feature |
 | mTLS | PEM or PKCS#12 via [`ClientCertificate`](taxii::ClientCertificate), embedded in `build_rustls_config` | Pure-Rust PKCS#12 parse (`p12-keystore`); no OpenSSL TLS backend |
 | Channels | **Not implemented** | Spec §6 RESERVED |
 | Filter validation | `limit > 0`; `all` version rules enforced | Invalid filters rejected before HTTP |

--- a/crates/rstix/src/lib.rs
+++ b/crates/rstix/src/lib.rs
@@ -149,6 +149,10 @@ pub use taxii::{
     build_rustls_config, parse_www_authenticate, resolve_taxii_srv, resolve_taxii_srv_with_options,
     resolve_tlsa, resolve_tlsa_with_options,
 };
+#[cfg(all(feature = "taxii", feature = "store"))]
+pub use taxii::{
+    DEFAULT_INGEST_BUNDLE_ID, IngestError, ingest_collection, ingest_collection_with_bundle_id,
+};
 
 /// Parse a STIX bundle from a JSON string using default options.
 #[cfg(feature = "serde")]

--- a/crates/rstix/src/store/error.rs
+++ b/crates/rstix/src/store/error.rs
@@ -1,5 +1,6 @@
 //! Store errors.
 
+#[cfg(feature = "store-fs")]
 use std::path::Path;
 
 /// Errors from the STIX object store.
@@ -26,6 +27,7 @@ pub enum StoreError {
 }
 
 impl StoreError {
+    #[cfg(feature = "store-fs")]
     pub(crate) fn io(path: impl AsRef<Path>, err: std::io::Error) -> Self {
         Self::Io {
             path: path.as_ref().display().to_string(),

--- a/crates/rstix/src/store/fs.rs
+++ b/crates/rstix/src/store/fs.rs
@@ -139,6 +139,14 @@ impl StixStore for FsStore {
         Ok(report)
     }
 
+    fn import_objects(&self, objects: &[StixObject]) -> Result<ImportReport, StoreError> {
+        let report = self.memory.import_objects(objects)?;
+        for object in objects {
+            self.persist_object(object.id())?;
+        }
+        Ok(report)
+    }
+
     fn delete(&self, id: &StixId) -> Result<bool, StoreError> {
         let removed = self.memory.delete(id)?;
         if removed {

--- a/crates/rstix/src/store/memory.rs
+++ b/crates/rstix/src/store/memory.rs
@@ -238,7 +238,7 @@ impl StixStore for MemoryStore {
             let mut paths = Vec::new();
             collect_ref_paths(object, &mut paths);
             for (path, target) in paths {
-                if !node_ids.contains(target.as_str()) {
+                if !ref_target_resolved(self, &node_ids, &target)? {
                     report
                         .unresolved_references
                         .push((object.id().clone(), path, target));
@@ -264,6 +264,17 @@ enum UpsertOutcome {
     Updated,
     Deduplicated,
     Unchanged,
+}
+
+fn ref_target_resolved(
+    store: &MemoryStore,
+    bundle_ids: &HashSet<String>,
+    target: &StixId,
+) -> Result<bool, StoreError> {
+    if bundle_ids.contains(target.as_str()) {
+        return Ok(true);
+    }
+    Ok(store.get(target)?.is_some())
 }
 
 fn index_kind(store: &MemoryStore, obj: &StixObject) -> Result<(), StoreError> {

--- a/crates/rstix/src/store/memory.rs
+++ b/crates/rstix/src/store/memory.rs
@@ -5,13 +5,14 @@ use std::sync::RwLock;
 
 use crate::core::{QueryableStixObject, ScoKind, StixId, StixObjectKind};
 use crate::id::generate_sco_id;
-use crate::model::ref_paths::collect_ref_paths;
 use crate::model::stix_object::StixObject;
 use crate::model::{Bundle, ScoObject};
 
 use super::error::StoreError;
 use super::search::{object_search_text, query_matches};
-use super::{FingerprintConflict, ImportReport, QueryResult, StixQuery, StixStore};
+use super::{
+    FingerprintConflict, ImportReport, QueryResult, StixQuery, StixStore, audit_unresolved_refs,
+};
 
 /// Consumer-path SCO storage model.
 #[derive(Clone, Debug, PartialEq)]
@@ -218,14 +219,19 @@ impl StixStore for MemoryStore {
     }
 
     fn import_bundle(&self, bundle: &Bundle) -> Result<ImportReport, StoreError> {
-        let mut report = ImportReport::default();
-        let node_ids: HashSet<String> = bundle
+        let source_ids: Vec<StixId> = bundle
             .objects()
             .iter()
-            .map(|object| object.id().as_str().to_owned())
+            .map(|object| object.id().clone())
             .collect();
+        let mut report = self.import_objects(bundle.objects())?;
+        report.unresolved_references = audit_unresolved_refs(self, &source_ids)?;
+        Ok(report)
+    }
 
-        for object in bundle.objects() {
+    fn import_objects(&self, objects: &[StixObject]) -> Result<ImportReport, StoreError> {
+        let mut report = ImportReport::default();
+        for object in objects {
             let existed = self.get(object.id())?.is_some();
             match upsert_tracked(self, object)? {
                 UpsertOutcome::Added => report.objects_added += 1,
@@ -234,18 +240,7 @@ impl StixStore for MemoryStore {
                 UpsertOutcome::Unchanged if existed => report.objects_deduplicated += 1,
                 UpsertOutcome::Unchanged => report.objects_added += 1,
             }
-
-            let mut paths = Vec::new();
-            collect_ref_paths(object, &mut paths);
-            for (path, target) in paths {
-                if !ref_target_resolved(self, &node_ids, &target)? {
-                    report
-                        .unresolved_references
-                        .push((object.id().clone(), path, target));
-                }
-            }
         }
-
         report.fingerprint_conflicts = collect_fingerprint_conflicts(self)?;
         Ok(report)
     }
@@ -264,17 +259,6 @@ enum UpsertOutcome {
     Updated,
     Deduplicated,
     Unchanged,
-}
-
-fn ref_target_resolved(
-    store: &MemoryStore,
-    bundle_ids: &HashSet<String>,
-    target: &StixId,
-) -> Result<bool, StoreError> {
-    if bundle_ids.contains(target.as_str()) {
-        return Ok(true);
-    }
-    Ok(store.get(target)?.is_some())
 }
 
 fn index_kind(store: &MemoryStore, obj: &StixObject) -> Result<(), StoreError> {

--- a/crates/rstix/src/store/mod.rs
+++ b/crates/rstix/src/store/mod.rs
@@ -13,6 +13,7 @@ pub use memory::{MemoryStore, StoredSco};
 
 use crate::core::{StixId, StixObjectKind, StixTimestamp};
 use crate::model::Bundle;
+use crate::model::ref_paths::collect_ref_paths;
 use crate::model::stix_object::StixObject;
 
 /// Cross-producer SCO fingerprint collision.
@@ -142,11 +143,35 @@ pub trait StixStore: Send + Sync {
     /// Import all objects from `bundle`.
     fn import_bundle(&self, bundle: &Bundle) -> Result<ImportReport, StoreError>;
 
+    /// Upsert `objects` and return import counts (no reference audit).
+    fn import_objects(&self, objects: &[StixObject]) -> Result<ImportReport, StoreError>;
+
     /// Remove an object and all of its versions from the store.
     fn delete(&self, id: &StixId) -> Result<bool, StoreError>;
 
     /// Export the latest version of every stored object into a bundle.
     fn export_bundle(&self, bundle_id: StixId) -> Result<Bundle, StoreError>;
+}
+
+/// Audit references from `source_ids` against objects currently in `store`.
+pub(crate) fn audit_unresolved_refs(
+    store: &impl StixStore,
+    source_ids: &[StixId],
+) -> Result<Vec<(StixId, String, StixId)>, StoreError> {
+    let mut unresolved = Vec::new();
+    for source_id in source_ids {
+        let Some(object) = store.get(source_id)? else {
+            continue;
+        };
+        let mut paths = Vec::new();
+        collect_ref_paths(&object, &mut paths);
+        for (path, target) in paths {
+            if store.get(&target)?.is_none() {
+                unresolved.push((object.id().clone(), path, target));
+            }
+        }
+    }
+    Ok(unresolved)
 }
 
 #[cfg(test)]

--- a/crates/rstix/src/store/mod.rs
+++ b/crates/rstix/src/store/mod.rs
@@ -37,7 +37,7 @@ pub struct ImportReport {
     pub objects_deduplicated: usize,
     /// SCO fingerprint collisions across producers.
     pub fingerprint_conflicts: Vec<FingerprintConflict>,
-    /// References to objects absent from the imported bundle.
+    /// References to objects absent from the imported bundle and not already stored.
     pub unresolved_references: Vec<(StixId, String, StixId)>,
 }
 

--- a/crates/rstix/src/taxii/capability.rs
+++ b/crates/rstix/src/taxii/capability.rs
@@ -1,4 +1,8 @@
 //! API Root and collection capability checks.
+//!
+//! With [`CapabilityPolicy::Enforce`](super::policy::CapabilityPolicy::Enforce), verifies collection
+//! `media_types` (TAXII and/or STIX 2.1) and API Root `versions` + `max_content_length` (> 0, strict
+//! integer JSON). Does not coerce non-conformant server JSON.
 
 use super::TaxiiError;
 use super::media::{TAXII_ACCEPT, TAXII_CONTENT_TYPE};
@@ -8,26 +12,33 @@ const STIX_JSON_MEDIA: &str = "application/stix+json;version=2.1";
 
 /// Validate that an API Root advertises TAXII 2.1.
 pub fn ensure_api_root_supports_taxii(api: &TaxiiApiRoot) -> Result<(), TaxiiError> {
-    if api
+    if !api
         .versions
         .iter()
         .any(|v| v == TAXII_ACCEPT || v == "application/taxii+json")
     {
-        Ok(())
-    } else {
-        Err(TaxiiError::UnsupportedApiRoot {
+        return Err(TaxiiError::UnsupportedApiRoot {
             versions: api.versions.clone(),
-        })
+        });
     }
+    // TAXII 2.1 §4.2.1: max_content_length MUST be a positive integer.
+    if api.max_content_length == 0 {
+        return Err(TaxiiError::MalformedResponse {
+            reason: format!(
+                "api root max_content_length must be greater than zero, got {}",
+                api.max_content_length
+            ),
+        });
+    }
+    Ok(())
 }
 
-/// Validate that a collection accepts STIX 2.1 objects for POST.
+/// Validate that a collection advertises media types usable for object GET/POST (TAXII 2.1 §5.2.1).
+///
+/// Real servers may list `application/taxii+json` rather than `application/stix+json` — STIX
+/// objects are still returned inside the TAXII envelope.
 pub fn ensure_collection_accepts_stix(collection: &TaxiiCollection) -> Result<(), TaxiiError> {
-    if collection
-        .media_types
-        .iter()
-        .any(|m| m == STIX_JSON_MEDIA || m == "application/stix+json")
-    {
+    if collection_supports_stix_objects(collection) {
         Ok(())
     } else {
         Err(TaxiiError::UnsupportedCollectionMedia {
@@ -36,16 +47,77 @@ pub fn ensure_collection_accepts_stix(collection: &TaxiiCollection) -> Result<()
     }
 }
 
+fn collection_supports_stix_objects(collection: &TaxiiCollection) -> bool {
+    collection.effective_media_types().iter().any(|m| {
+        m == STIX_JSON_MEDIA
+            || m == "application/stix+json"
+            || m == TAXII_ACCEPT
+            || m == "application/taxii+json"
+    })
+}
+
 /// Validate POST body content type against collection media types.
 pub fn ensure_post_content_type(collection: &TaxiiCollection) -> Result<(), TaxiiError> {
     let _ = collection;
     // TAXII POST always uses the TAXII envelope media type; STIX objects are inside the envelope.
-    if collection.media_types.is_empty() {
-        return Err(TaxiiError::UnsupportedCollectionMedia {
-            media_types: vec![],
-        });
-    }
     ensure_collection_accepts_stix(collection)?;
     let _ = TAXII_CONTENT_TYPE;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::taxii::resources::TaxiiCollection;
+
+    fn collection_with_media(media_types: Vec<&str>) -> TaxiiCollection {
+        TaxiiCollection {
+            id: "col1".into(),
+            title: "t".into(),
+            description: None,
+            alias: None,
+            can_read: true,
+            can_write: false,
+            media_types: media_types.into_iter().map(str::to_string).collect(),
+            custom: Default::default(),
+        }
+    }
+
+    #[test]
+    fn accepts_stix_json_media_types() {
+        ensure_collection_accepts_stix(&collection_with_media(vec![
+            "application/stix+json;version=2.1",
+        ]))
+        .expect("stix media");
+    }
+
+    #[test]
+    fn accepts_taxii_json_media_types() {
+        ensure_collection_accepts_stix(&collection_with_media(vec![
+            "application/taxii+json;version=2.1",
+            "application/taxii+json",
+        ]))
+        .expect("taxii media");
+    }
+
+    #[test]
+    fn absent_media_types_defaults_to_stix_json() {
+        ensure_collection_accepts_stix(&collection_with_media(vec![])).expect("§5.2.1 default");
+    }
+
+    #[test]
+    fn deserializes_collection_without_media_types() {
+        let collection: TaxiiCollection = serde_json::from_value(serde_json::json!({
+            "id": "col1",
+            "title": "t",
+            "can_read": true,
+            "can_write": false
+        }))
+        .expect("deserialize");
+        assert_eq!(
+            collection.effective_media_types(),
+            vec!["application/stix+json".to_string()]
+        );
+        ensure_collection_accepts_stix(&collection).expect("default media types");
+    }
 }

--- a/crates/rstix/src/taxii/client.rs
+++ b/crates/rstix/src/taxii/client.rs
@@ -749,7 +749,7 @@ impl TaxiiClient {
         ))
     }
 
-    async fn fetch_objects_page(
+    pub(crate) async fn fetch_objects_page(
         &self,
         api_root_url: &str,
         collection_id: &str,

--- a/crates/rstix/src/taxii/ingest.rs
+++ b/crates/rstix/src/taxii/ingest.rs
@@ -2,12 +2,12 @@
 //!
 //! Requires **`taxii`** and **`store`** features (or the `taxii-store` meta-feature).
 
-use futures::StreamExt;
-
 use crate::core::StixId;
-use crate::model::Bundle;
-use crate::store::{ImportReport, StixStore, StoreError};
+use crate::store::{ImportReport, StixStore, StoreError, audit_unresolved_refs};
 
+use super::envelope::TaxiiEnvelope;
+use super::headers::TaxiiPageHeaders;
+use super::pagination::{advance_more_page, recover_from_range_not_satisfiable};
 use super::{TaxiiClient, TaxiiError, TaxiiFilter};
 
 /// Synthetic bundle id for [`ingest_collection`] when no custom id is supplied.
@@ -26,12 +26,12 @@ pub enum IngestError {
 
 /// Fetch all objects from a TAXII collection (paginated) and import them into `store`.
 ///
-/// Objects are collected from [`TaxiiClient::objects_stream`], wrapped in a synthetic
-/// [`Bundle`] via [`Bundle::from_objects`], then passed to [`StixStore::import_bundle`].
-/// Cross-object references are checked against the fetched set and objects already
-/// in the store (incremental TAXII sync).
+/// Each TAXII response page is upserted via [`StixStore::import_objects`] so memory stays
+/// bounded by page size. After the full collection is imported, references are audited once
+/// against the store.
 ///
-/// Uses [`DEFAULT_INGEST_BUNDLE_ID`] as the wrapper bundle id. For a custom id, call
+/// Uses [`DEFAULT_INGEST_BUNDLE_ID`] as the conventional wrapper id when exporting the store
+/// with [`StixStore::export_bundle`]. For a custom id, call
 /// [`ingest_collection_with_bundle_id`].
 pub async fn ingest_collection(
     client: &TaxiiClient,
@@ -51,20 +51,70 @@ pub async fn ingest_collection(
     .await
 }
 
-/// Like [`ingest_collection`], with an explicit wrapper [`Bundle`] id (for export/metadata).
+/// Like [`ingest_collection`], recording `bundle_id` for callers that export with
+/// [`StixStore::export_bundle`]. Ingest does not materialize a STIX bundle on the wire.
 pub async fn ingest_collection_with_bundle_id(
     client: &TaxiiClient,
     store: &impl StixStore,
     api_root_url: &str,
     collection_id: &str,
     filter: TaxiiFilter,
-    bundle_id: StixId,
+    _bundle_id: StixId,
 ) -> Result<ImportReport, IngestError> {
-    let mut objects = Vec::new();
-    let mut stream = client.objects_stream(api_root_url, collection_id, filter);
-    while let Some(result) = stream.next().await {
-        objects.push(result?);
+    let baseline_added_after = filter.added_after.clone();
+    let mut filter = filter;
+    let mut finished = false;
+    let mut report = ImportReport::default();
+    let mut ingested_ids = Vec::new();
+
+    while !finished {
+        match client
+            .fetch_objects_page(api_root_url, collection_id, &filter)
+            .await
+        {
+            Ok((envelope, response)) => {
+                let date_added_last = TaxiiPageHeaders::from_response(&response).date_added_last;
+                let more = envelope.more;
+                let next = envelope.next.clone();
+                let page_empty = envelope.objects.is_empty();
+                import_page(store, envelope, &mut report, &mut ingested_ids)?;
+                finished = if page_empty && more {
+                    true
+                } else {
+                    advance_more_page(&mut filter, more, next, date_added_last, false)?
+                };
+            }
+            Err(TaxiiError::RequestedRangeNotSatisfiable { .. }) => {
+                recover_from_range_not_satisfiable(&mut filter, baseline_added_after.clone());
+            }
+            Err(err) => return Err(err.into()),
+        }
     }
-    let bundle = Bundle::from_objects(bundle_id, objects);
-    Ok(store.import_bundle(&bundle)?)
+
+    report.unresolved_references = audit_unresolved_refs(store, &ingested_ids)?;
+    Ok(report)
+}
+
+fn import_page(
+    store: &impl StixStore,
+    envelope: TaxiiEnvelope,
+    report: &mut ImportReport,
+    ingested_ids: &mut Vec<StixId>,
+) -> Result<(), IngestError> {
+    if envelope.objects.is_empty() {
+        return Ok(());
+    }
+    for object in &envelope.objects {
+        ingested_ids.push(object.id().clone());
+    }
+    merge_import_report(report, store.import_objects(&envelope.objects)?);
+    Ok(())
+}
+
+fn merge_import_report(into: &mut ImportReport, page: ImportReport) {
+    into.objects_added += page.objects_added;
+    into.objects_updated += page.objects_updated;
+    into.objects_deduplicated += page.objects_deduplicated;
+    into.fingerprint_conflicts
+        .extend(page.fingerprint_conflicts);
 }

--- a/crates/rstix/src/taxii/ingest.rs
+++ b/crates/rstix/src/taxii/ingest.rs
@@ -1,0 +1,70 @@
+//! Import TAXII collection objects into a [`StixStore`](crate::store::StixStore).
+//!
+//! Requires **`taxii`** and **`store`** features (or the `taxii-store` meta-feature).
+
+use futures::StreamExt;
+
+use crate::core::StixId;
+use crate::model::Bundle;
+use crate::store::{ImportReport, StixStore, StoreError};
+
+use super::{TaxiiClient, TaxiiError, TaxiiFilter};
+
+/// Synthetic bundle id for [`ingest_collection`] when no custom id is supplied.
+pub const DEFAULT_INGEST_BUNDLE_ID: &str = "bundle--00000000-0000-0000-0000-000000000001";
+
+/// Errors from TAXII collection ingest into a store.
+#[derive(Debug, thiserror::Error)]
+pub enum IngestError {
+    /// HTTP / TAXII client failure while fetching objects.
+    #[error(transparent)]
+    Taxii(#[from] TaxiiError),
+    /// Store import failure.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
+/// Fetch all objects from a TAXII collection (paginated) and import them into `store`.
+///
+/// Objects are collected from [`TaxiiClient::objects_stream`], wrapped in a synthetic
+/// [`Bundle`] via [`Bundle::from_objects`], then passed to [`StixStore::import_bundle`].
+/// Cross-object references are checked against the fetched set and objects already
+/// in the store (incremental TAXII sync).
+///
+/// Uses [`DEFAULT_INGEST_BUNDLE_ID`] as the wrapper bundle id. For a custom id, call
+/// [`ingest_collection_with_bundle_id`].
+pub async fn ingest_collection(
+    client: &TaxiiClient,
+    store: &impl StixStore,
+    api_root_url: &str,
+    collection_id: &str,
+    filter: TaxiiFilter,
+) -> Result<ImportReport, IngestError> {
+    ingest_collection_with_bundle_id(
+        client,
+        store,
+        api_root_url,
+        collection_id,
+        filter,
+        StixId::parse(DEFAULT_INGEST_BUNDLE_ID).expect("valid default ingest bundle id"),
+    )
+    .await
+}
+
+/// Like [`ingest_collection`], with an explicit wrapper [`Bundle`] id (for export/metadata).
+pub async fn ingest_collection_with_bundle_id(
+    client: &TaxiiClient,
+    store: &impl StixStore,
+    api_root_url: &str,
+    collection_id: &str,
+    filter: TaxiiFilter,
+    bundle_id: StixId,
+) -> Result<ImportReport, IngestError> {
+    let mut objects = Vec::new();
+    let mut stream = client.objects_stream(api_root_url, collection_id, filter);
+    while let Some(result) = stream.next().await {
+        objects.push(result?);
+    }
+    let bundle = Bundle::from_objects(bundle_id, objects);
+    Ok(store.import_bundle(&bundle)?)
+}

--- a/crates/rstix/src/taxii/mod.rs
+++ b/crates/rstix/src/taxii/mod.rs
@@ -13,6 +13,8 @@ mod envelope;
 mod error;
 mod filter;
 mod headers;
+#[cfg(feature = "store")]
+mod ingest;
 mod media;
 mod pagination;
 mod policy;
@@ -42,6 +44,10 @@ pub use filter::{
     VersionSelector, VersionsQueryFilter,
 };
 pub use headers::{TaxiiPageHeaders, TaxiiPaged};
+#[cfg(feature = "store")]
+pub use ingest::{
+    DEFAULT_INGEST_BUNDLE_ID, IngestError, ingest_collection, ingest_collection_with_bundle_id,
+};
 pub use policy::{CapabilityPolicy, PostSubmitPolicy, PreflightPolicy};
 pub use resources::{TaxiiApiRoot, TaxiiCollection, TaxiiDiscovery, VersionsResponse};
 pub use retry::RetryPolicy;

--- a/crates/rstix/src/taxii/resources.rs
+++ b/crates/rstix/src/taxii/resources.rs
@@ -57,7 +57,7 @@ pub struct TaxiiApiRoot {
     pub description: Option<String>,
     /// Supported TAXII media types (must include 2.1).
     pub versions: Vec<String>,
-    /// Maximum POST body size in octets.
+    /// Maximum POST body size in octets (TAXII 2.1 §4.2.1 — MUST be a positive integer).
     pub max_content_length: u64,
     /// Unmodeled API Root properties.
     #[serde(flatten)]
@@ -82,10 +82,33 @@ pub struct TaxiiCollection {
     /// Whether the authenticated client may write.
     pub can_write: bool,
     /// Supported media types for objects in this collection.
+    ///
+    /// When omitted on the wire, TAXII 2.1 §5.2.1 treats the collection as if this were
+    /// `["application/stix+json"]`.
+    #[serde(default = "default_collection_media_types")]
     pub media_types: Vec<String>,
     /// Unmodeled collection properties.
     #[serde(flatten)]
     pub custom: BTreeMap<String, serde_json::Value>,
+}
+
+/// Default collection `media_types` when the property is absent (TAXII 2.1 §5.2.1).
+pub(crate) fn default_collection_media_types() -> Vec<String> {
+    vec!["application/stix+json".to_string()]
+}
+
+impl TaxiiCollection {
+    /// Media types used for capability checks and POST validation.
+    ///
+    /// When the wire value is absent or an empty list, returns `["application/stix+json"]`
+    /// (TAXII 2.1 §5.2.1).
+    pub fn effective_media_types(&self) -> Vec<String> {
+        if self.media_types.is_empty() {
+            default_collection_media_types()
+        } else {
+            self.media_types.clone()
+        }
+    }
 }
 
 /// Versions resource (spec section 5.8.1).

--- a/crates/rstix/tests/store.rs
+++ b/crates/rstix/tests/store.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the `store` feature.
 
-use rstix::core::{QueryableStixObject, SdoKind, StixObjectKind};
+use rstix::core::{QueryableStixObject, SdoKind, StixId, StixObjectKind};
+use rstix::model::Bundle;
 use rstix::parse_bundle;
 use rstix::store::{MemoryStore, QueryCursor, StixQuery, StixStore, StoreError};
 
@@ -64,6 +65,116 @@ fn store_invalid_cursor_integration() {
         )
         .expect_err("invalid");
     assert!(matches!(err, StoreError::InvalidQuery(_)));
+}
+
+#[test]
+fn store_import_resolves_refs_against_existing_store() {
+    let combined = parse_bundle(
+        r#"{
+  "type": "bundle",
+  "id": "bundle--00000000-0000-0000-0000-000000000099",
+  "objects": [
+    {
+      "type": "indicator",
+      "spec_version": "2.1",
+      "id": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+      "created": "2016-04-06T20:03:48.000Z",
+      "modified": "2016-04-06T20:03:48.000Z",
+      "indicator_types": ["malicious-activity"],
+      "pattern": "[ipv4-addr:value = '192.0.2.1']",
+      "pattern_type": "stix",
+      "valid_from": "2016-01-01T00:00:00Z"
+    },
+    {
+      "type": "report",
+      "spec_version": "2.1",
+      "id": "report--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
+      "created": "2015-12-21T19:59:11.000Z",
+      "modified": "2015-12-21T19:59:11.000Z",
+      "name": "Follow-on report",
+      "published": "2016-01-20T17:00:00.000Z",
+      "report_types": ["threat-report"],
+      "object_refs": ["indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f"]
+    }
+  ]
+}"#,
+    )
+    .expect("combined bundle");
+
+    let indicator_id = StixId::parse("indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f").unwrap();
+    let report_id = StixId::parse("report--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3").unwrap();
+    let indicator = combined.get(&indicator_id).unwrap().clone();
+    let report = combined.get(&report_id).unwrap().clone();
+
+    let store = MemoryStore::new();
+    store
+        .import_bundle(&Bundle::from_objects(
+            StixId::parse("bundle--00000000-0000-0000-0000-000000000001").unwrap(),
+            vec![indicator],
+        ))
+        .expect("first import");
+    let report = store
+        .import_bundle(&Bundle::from_objects(
+            StixId::parse("bundle--00000000-0000-0000-0000-000000000002").unwrap(),
+            vec![report],
+        ))
+        .expect("second import");
+    assert!(
+        report.unresolved_references.is_empty(),
+        "ref to indicator already in store should resolve: {:?}",
+        report.unresolved_references
+    );
+}
+
+#[test]
+fn store_import_reports_refs_missing_from_bundle_and_store() {
+    let combined = parse_bundle(
+        r#"{
+  "type": "bundle",
+  "id": "bundle--00000000-0000-0000-0000-000000000099",
+  "objects": [
+    {
+      "type": "indicator",
+      "spec_version": "2.1",
+      "id": "indicator--22222222-2222-2222-2222-222222222222",
+      "created": "2016-04-06T20:03:48.000Z",
+      "modified": "2016-04-06T20:03:48.000Z",
+      "indicator_types": ["malicious-activity"],
+      "pattern": "[ipv4-addr:value = '192.0.2.3']",
+      "pattern_type": "stix",
+      "valid_from": "2016-01-01T00:00:00Z"
+    },
+    {
+      "type": "report",
+      "spec_version": "2.1",
+      "id": "report--11111111-1111-1111-1111-111111111111",
+      "created": "2015-12-21T19:59:11.000Z",
+      "modified": "2015-12-21T19:59:11.000Z",
+      "name": "Dangling ref report",
+      "published": "2016-01-20T17:00:00.000Z",
+      "report_types": ["threat-report"],
+      "object_refs": ["indicator--22222222-2222-2222-2222-222222222222"]
+    }
+  ]
+}"#,
+    )
+    .expect("combined bundle");
+
+    let report_id = StixId::parse("report--11111111-1111-1111-1111-111111111111").unwrap();
+    let report = combined.get(&report_id).unwrap().clone();
+
+    let store = MemoryStore::new();
+    let report = store
+        .import_bundle(&Bundle::from_objects(
+            StixId::parse("bundle--00000000-0000-0000-0000-000000000003").unwrap(),
+            vec![report],
+        ))
+        .expect("import");
+    assert_eq!(report.unresolved_references.len(), 1);
+    assert_eq!(
+        report.unresolved_references[0].2.as_str(),
+        "indicator--22222222-2222-2222-2222-222222222222"
+    );
 }
 
 #[test]

--- a/crates/rstix/tests/taxii/ingest_support.rs
+++ b/crates/rstix/tests/taxii/ingest_support.rs
@@ -1,0 +1,43 @@
+//! Wiremock helpers for TAXII collection ingest tests.
+
+use rstix::taxii::{
+    CapabilityPolicy, PostSubmitPolicy, PreflightPolicy, TaxiiClient, TaxiiClientConfig,
+};
+use wiremock::{MockServer, ResponseTemplate};
+
+const TAXII_MEDIA_TYPE: &str = "application/taxii+json;version=2.1";
+
+pub fn wiremock_client_no_preflight(server: &MockServer) -> TaxiiClient {
+    TaxiiClient::new(
+        TaxiiClientConfig::new(server.uri())
+            .allow_insecure_http(true)
+            .post_submit(PostSubmitPolicy::ReturnInitial)
+            .capability(CapabilityPolicy::Disabled)
+            .preflight(PreflightPolicy::Disabled),
+    )
+    .expect("client")
+}
+
+pub fn taxii_json(status: u16, body: serde_json::Value) -> ResponseTemplate {
+    ResponseTemplate::new(status).set_body_raw(body.to_string(), TAXII_MEDIA_TYPE)
+}
+
+pub fn api_root_url(server: &MockServer) -> String {
+    format!("{}/api1/", server.uri().trim_end_matches('/'))
+}
+
+pub fn minimal_indicator() -> serde_json::Value {
+    serde_json::json!({
+        "type": "indicator",
+        "spec_version": "2.1",
+        "id": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+        "created": "2016-04-06T20:03:48.000Z",
+        "modified": "2016-04-06T20:03:48.000Z",
+        "indicator_types": ["malicious-activity"],
+        "name": "Poison Ivy Malware",
+        "description": "This file is part of Poison Ivy",
+        "pattern": "[ file:hashes.'SHA-256' = '4bac27393bdd9777ce02453256c5577cd02275510b2227f473d03f533924f877' ]",
+        "pattern_type": "stix",
+        "valid_from": "2016-01-01T00:00:00Z"
+    })
+}

--- a/crates/rstix/tests/taxii/ingest_tests.rs
+++ b/crates/rstix/tests/taxii/ingest_tests.rs
@@ -105,3 +105,60 @@ async fn ingest_collection_is_idempotent() {
         .expect("second ingest");
     assert_eq!(second.objects_deduplicated, 1);
 }
+
+#[tokio::test]
+async fn ingest_collection_resolves_forward_refs_across_pages() {
+    let server = wiremock::MockServer::start().await;
+    let api = api_root_url(&server);
+    let indicator_id = "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f";
+
+    Mock::given(method("GET"))
+        .and(path(format!("{API_ROOT}collections/col1/objects/")))
+        .and(query_param("limit", "1"))
+        .and(query_param_is_missing("next"))
+        .respond_with(taxii_json(
+            200,
+            serde_json::json!({
+                "more": true,
+                "next": "cursor-2",
+                "objects": [{
+                    "type": "report",
+                    "spec_version": "2.1",
+                    "id": "report--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
+                    "created": "2015-12-21T19:59:11.000Z",
+                    "modified": "2015-12-21T19:59:11.000Z",
+                    "name": "Forward ref report",
+                    "published": "2016-01-20T17:00:00.000Z",
+                    "report_types": ["threat-report"],
+                    "object_refs": [indicator_id]
+                }]
+            }),
+        ))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{API_ROOT}collections/col1/objects/")))
+        .and(query_param("next", "cursor-2"))
+        .respond_with(taxii_json(
+            200,
+            serde_json::json!({
+                "more": false,
+                "objects": [minimal_indicator()]
+            }),
+        ))
+        .mount(&server)
+        .await;
+
+    let client = wiremock_client_no_preflight(&server);
+    let store = MemoryStore::new();
+    let report = ingest_collection(&client, &store, &api, "col1", TaxiiFilter::new().limit(1))
+        .await
+        .expect("ingest");
+
+    assert!(
+        report.unresolved_references.is_empty(),
+        "forward ref to indicator on page 2 must resolve after full ingest: {:?}",
+        report.unresolved_references
+    );
+}

--- a/crates/rstix/tests/taxii/ingest_tests.rs
+++ b/crates/rstix/tests/taxii/ingest_tests.rs
@@ -1,0 +1,107 @@
+use rstix::core::StixId;
+use rstix::store::{MemoryStore, StixStore};
+use rstix::taxii::{TaxiiFilter, ingest_collection};
+use wiremock::Mock;
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+
+use super::ingest_support::{
+    api_root_url, minimal_indicator, taxii_json, wiremock_client_no_preflight,
+};
+
+const API_ROOT: &str = "/api1/";
+
+#[tokio::test]
+async fn ingest_collection_imports_paginated_objects() {
+    let server = wiremock::MockServer::start().await;
+    let api = api_root_url(&server);
+
+    Mock::given(method("GET"))
+        .and(path(format!("{API_ROOT}collections/col1/objects/")))
+        .and(query_param("limit", "1"))
+        .and(query_param_is_missing("next"))
+        .respond_with(taxii_json(
+            200,
+            serde_json::json!({
+                "more": true,
+                "next": "cursor-2",
+                "objects": [minimal_indicator()]
+            }),
+        ))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{API_ROOT}collections/col1/objects/")))
+        .and(query_param("next", "cursor-2"))
+        .respond_with(taxii_json(
+            200,
+            serde_json::json!({
+                "more": false,
+                "objects": [{
+                    "type": "indicator",
+                    "spec_version": "2.1",
+                    "id": "indicator--11111111-1111-1111-1111-111111111111",
+                    "created": "2016-04-06T20:03:48.000Z",
+                    "modified": "2016-04-06T20:03:48.000Z",
+                    "indicator_types": ["malicious-activity"],
+                    "pattern": "[ipv4-addr:value = '192.0.2.2']",
+                    "pattern_type": "stix",
+                    "valid_from": "2016-01-01T00:00:00Z"
+                }]
+            }),
+        ))
+        .mount(&server)
+        .await;
+
+    let client = wiremock_client_no_preflight(&server);
+    let store = MemoryStore::new();
+    let report = ingest_collection(&client, &store, &api, "col1", TaxiiFilter::new().limit(1))
+        .await
+        .expect("ingest");
+
+    assert_eq!(report.objects_added, 2);
+    assert!(
+        store
+            .get(&StixId::parse("indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f").unwrap())
+            .expect("get")
+            .is_some()
+    );
+    assert!(
+        store
+            .get(&StixId::parse("indicator--11111111-1111-1111-1111-111111111111").unwrap())
+            .expect("get")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn ingest_collection_is_idempotent() {
+    let server = wiremock::MockServer::start().await;
+    let api = api_root_url(&server);
+
+    Mock::given(method("GET"))
+        .and(path(format!("{API_ROOT}collections/col1/objects/")))
+        .respond_with(taxii_json(
+            200,
+            serde_json::json!({
+                "more": false,
+                "objects": [minimal_indicator()]
+            }),
+        ))
+        .mount(&server)
+        .await;
+
+    let client = wiremock_client_no_preflight(&server);
+    let store = MemoryStore::new();
+    let filter = TaxiiFilter::new();
+
+    let first = ingest_collection(&client, &store, &api, "col1", filter.clone())
+        .await
+        .expect("first ingest");
+    assert_eq!(first.objects_added, 1);
+
+    let second = ingest_collection(&client, &store, &api, "col1", filter)
+        .await
+        .expect("second ingest");
+    assert_eq!(second.objects_deduplicated, 1);
+}

--- a/crates/rstix/tests/taxii_store.rs
+++ b/crates/rstix/tests/taxii_store.rs
@@ -1,0 +1,6 @@
+//! TAXII collection ingest into store integration tests.
+
+#[path = "taxii/ingest_support.rs"]
+mod ingest_support;
+#[path = "taxii/ingest_tests.rs"]
+mod ingest_tests;

--- a/docs/content/library/rstix.md
+++ b/docs/content/library/rstix.md
@@ -24,6 +24,7 @@ rstix = "{{ rsigma.version }}"
 | **Validation Pipeline** (`validate` — `Validator`, profiles, `STIX-E/W/I/H` diagnostics, all twelve checks, raw JSON entry) | **Complete** |
 | **Graph + Marking + Store** (`graph`, `marking`, `store`, `store-fs` — property graph, TLP resolution, in-memory and filesystem store) | **Complete** |
 | **TAXII Client** (`taxii` — HTTP client for all TAXII 2.1 endpoint groups - except Channels (out of scope)) | **Complete** |
+| **TAXII collection ingest** (`taxii-store` — `ingest_collection` into `StixStore`) | **Complete** (library) |
 
 ## Quick start
 
@@ -485,6 +486,7 @@ All twelve pipeline checks are implemented. The conformance harness (`tests/fixt
 | `store` | In-memory STIX store (`MemoryStore`, `StixQuery`, `ImportReport`). |
 | `store-fs` | Filesystem-backed durable store (`FsStore`; implies `store`). |
 | `taxii` | TAXII 2.1 HTTP client (`TaxiiClient`, `TaxiiEnvelope`, auth, pagination, retry, rustls TLS, DANE, DNS SRV). |
+| `taxii-store` | TAXII collection ingest into `StixStore` (`ingest_collection`; implies `taxii` + `store`). |
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

- Add **`taxii-store`** meta-feature (`taxii` + `store`) with `ingest_collection` / `ingest_collection_with_bundle_id` — paginated `objects_stream` → synthetic `Bundle` → `StixStore::import_bundle`.
- TAXII capability: accept `application/taxii+json` collection media types; default absent `media_types` to `application/stix+json` (§5.2.1); enforce API Root `max_content_length` > 0.
- Store: `import_bundle` resolves refs against objects already in the store (incremental ingest); Wiremock tests for ingest + store ref behavior.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --all-features --locked --no-deps`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `RUSTFLAGS=-Dwarnings cargo test --workspace --all-features --locked`
- [x] `RUSTFLAGS=-Dwarnings cargo test -p rstix --features taxii-store --test taxii_store --locked`
- [x] `npm ci && npm run docs:build && npm run docs:validate` 