### PR TITLE
docs: enable consent-aware Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Documentation site analytics and privacy controls (#392)
+
+- The documentation site uses GA4 with explicit cookie consent, Google Consent Mode defaults that keep analytics storage disabled until acceptance, permanently disabled advertising consent, and a dedicated privacy notice.
+
 ### CLI: complete `--output-format` coverage (#389)
 
 - Structured report commands (`backend targets`/`formats`, `rule validate`, `pipeline resolve`/`diff`, `config validate`/`show`/`path`, and the existing eval/lint/fields/report family) honor `json`/`ndjson`/`table`/`csv`/`tsv` through a shared renderer backed by the `csv` crate.

--- a/docs/content/privacy.md
+++ b/docs/content/privacy.md
@@ -1,0 +1,7 @@
+# Privacy
+
+This documentation site uses Google Analytics 4 to understand how the documentation is used. Analytics cookie storage is disabled unless you accept it. Advertising storage, ad personalization, and ad user data remain disabled.
+
+Your choice is stored in your browser for 180 days. You can clear the `docmd-cookie-consent` entry from your browser's local storage to reset it.
+
+See the [Tiger Data Privacy Policy](https://www.tigerdata.com/legal/privacy) for details about how Timescale, Inc. d/b/a Tiger Data handles personal information.

--- a/docs/docmd-plugin-rsigma/index.js
+++ b/docs/docmd-plugin-rsigma/index.js
@@ -265,6 +265,56 @@ function injectSidebarLogoText(html, text) {
   );
 }
 
+/**
+ * Set Google Consent Mode before docmd's GA4 script runs, then connect it to
+ * docmd's cookie-consent event. Advertising consent remains denied because the
+ * site only uses analytics.
+ *
+ * @param {string} html
+ * @returns {string}
+ */
+function injectAnalyticsConsentMode(html) {
+  const ga4Marker = "    <!-- GA4 -->";
+  let out = html.replace(
+    /(<script async src="https:\/\/www\.googletagmanager\.com\/gtag\/js\?id=)"(G-[A-Z0-9]{6,12})"("><\/script>)/,
+    "$1$2$3",
+  );
+  if (!out.includes(ga4Marker) || out.includes("RSigma GA4 consent mode")) {
+    return out;
+  }
+  const consentScript = `    <!-- RSigma GA4 consent mode -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      window.gtag = window.gtag || function(){dataLayer.push(arguments);};
+      (function() {
+        var analyticsConsent = 'denied';
+        try {
+          var raw = localStorage.getItem('docmd-cookie-consent');
+          var choice = raw ? JSON.parse(raw) : null;
+          if (choice && choice.value === 'accept' && choice.expires > Date.now()) {
+            analyticsConsent = 'granted';
+          }
+        } catch (_) {}
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          analytics_storage: analyticsConsent
+        });
+        window.addEventListener('docmd:cookie-consent', function(event) {
+          gtag('consent', 'update', {
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            analytics_storage: event.detail.value === 'accept' ? 'granted' : 'denied'
+          });
+        });
+      })();
+    </script>
+`;
+  return out.replace(ga4Marker, `${consentScript}${ga4Marker}`);
+}
+
 /** Legacy generated/copied brand files to remove when refreshing assets. */
 const STALE_BRAND_FILES = [
   "sidebar-logo.svg",
@@ -427,6 +477,7 @@ export default {
           next = withLogoText;
         }
       }
+      next = injectAnalyticsConsentMode(next);
       const withTitles = renderMarkdownTitles(next);
       if (withTitles !== next) {
         titlesRendered += 1;

--- a/docs/docmd.config.js
+++ b/docs/docmd.config.js
@@ -29,7 +29,22 @@ export default {
       },
     },
   },
+  cookie: {
+    enabled: true,
+    message: "We use optional analytics cookies to understand how this documentation is used.",
+    acceptText: "Accept analytics",
+    declineText: "Decline",
+    policyUrl: "/privacy",
+    position: "bottom-right",
+  },
   plugins: {
+    analytics: {
+      googleV4: {
+        measurementId: "G-6XM09PXCEY",
+      },
+      autoEvents: true,
+      trackSearch: true,
+    },
     git: {
       repo: "https://github.com/timescale/rsigma",
       branch: "main",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "rsigma-docs",
       "devDependencies": {
-        "@docmd/core": "0.8.11",
-        "@docmd/plugin-git": "0.8.11",
+        "@docmd/core": "0.8.17",
+        "@docmd/plugin-git": "0.8.17",
         "docmd-plugin-rsigma": "file:docmd-plugin-rsigma"
       }
     },
@@ -20,15 +20,15 @@
       }
     },
     "node_modules/@docmd/api": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/api/-/api-0.8.11.tgz",
-      "integrity": "sha512-G0ykigWSilhzuD6W/wuJRpe0cosyoVamrgiQiocgytoSSn8Ag7a8XEwi+YH8dO8KLGDlE7X7VDyRupgwKMw8ug==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/api/-/api-0.8.17.tgz",
+      "integrity": "sha512-6uEImRBa33czn87lmm4841Ws2y4o0+eoNLUTijoREMXuOS3TcHNiy8lL54sKcBAmC2S0zrLrFNmV46CMfepKqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/parser": "^0.8.11",
-        "@docmd/tui": "^0.8.11",
-        "@docmd/utils": "^0.8.11"
+        "@docmd/parser": "^0.8.17",
+        "@docmd/tui": "^0.8.17",
+        "@docmd/utils": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -37,38 +37,37 @@
         "url": "https://github.com/sponsors/mgks"
       },
       "optionalDependencies": {
-        "@docmd/engine-js": "^0.8.11",
-        "@docmd/engine-rust": "^0.8.11"
+        "@docmd/engine-js": "^0.8.17",
+        "@docmd/engine-rust": "^0.8.17"
       }
     },
     "node_modules/@docmd/core": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/core/-/core-0.8.11.tgz",
-      "integrity": "sha512-lEx+LFjbxBC+GgxHUWFcO5ALTVNaSK6I8O25/6ipqS8nM1kp3heL0se/5uO1kFBJ+64YgYdxizFrCdUUDDP8nA==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/core/-/core-0.8.17.tgz",
+      "integrity": "sha512-3KmN5DmufhIvMJ2BPV9HYi7YolxC9aWeCsvj8/TxIuw7qsMmvnNl/OD2mhQrtF/qqWkpRGzJpyVmBEER8easAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/api": "^0.8.11",
-        "@docmd/deployer": "^0.8.11",
-        "@docmd/live": "^0.8.11",
-        "@docmd/parser": "^0.8.11",
-        "@docmd/plugin-analytics": "^0.8.11",
-        "@docmd/plugin-git": "^0.8.11",
-        "@docmd/plugin-installer": "^0.8.11",
-        "@docmd/plugin-llms": "^0.8.11",
-        "@docmd/plugin-mermaid": "^0.8.11",
-        "@docmd/plugin-okf": "^0.8.11",
-        "@docmd/plugin-openapi": "^0.8.11",
-        "@docmd/plugin-pwa": "^0.8.11",
-        "@docmd/plugin-search": "^0.8.11",
-        "@docmd/plugin-seo": "^0.8.11",
-        "@docmd/plugin-sitemap": "^0.8.11",
-        "@docmd/themes": "^0.8.11",
-        "@docmd/tui": "^0.8.11",
-        "@docmd/ui": "^0.8.11",
-        "@docmd/utils": "^0.8.11",
+        "@docmd/api": "^0.8.17",
+        "@docmd/deployer": "^0.8.17",
+        "@docmd/live": "^0.8.17",
+        "@docmd/parser": "^0.8.17",
+        "@docmd/plugin-analytics": "^0.8.17",
+        "@docmd/plugin-git": "^0.8.17",
+        "@docmd/plugin-installer": "^0.8.17",
+        "@docmd/plugin-llms": "^0.8.17",
+        "@docmd/plugin-mermaid": "^0.8.17",
+        "@docmd/plugin-okf": "^0.8.17",
+        "@docmd/plugin-openapi": "^0.8.17",
+        "@docmd/plugin-search": "^0.8.17",
+        "@docmd/plugin-seo": "^0.8.17",
+        "@docmd/plugin-sitemap": "^0.8.17",
+        "@docmd/themes": "^0.8.17",
+        "@docmd/tui": "^0.8.17",
+        "@docmd/ui": "^0.8.17",
+        "@docmd/utils": "^0.8.17",
         "esbuild": "^0.28.1",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "docmd": "dist/bin/docmd.js"
@@ -81,13 +80,13 @@
       }
     },
     "node_modules/@docmd/deployer": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/deployer/-/deployer-0.8.11.tgz",
-      "integrity": "sha512-gwnBqaC259x6/eaF/JODcjaBDz4STv7SKeBkbfaks3sHAUkRAYoDPC99nUxRXqibg3KlkEkITshaKnYHhs/rJA==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/deployer/-/deployer-0.8.17.tgz",
+      "integrity": "sha512-IwRmyvXAZtaBO9iqV8Jqm0mbZQlAGXfZVVQz6oBb7J/w39IEMk26trLioXTQ2CeFVvYv9Mrv+YqHUZ+yHkaghw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/api": "^0.8.11"
+        "@docmd/api": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -97,9 +96,9 @@
       }
     },
     "node_modules/@docmd/engine-js": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/engine-js/-/engine-js-0.8.11.tgz",
-      "integrity": "sha512-tTp18/8AnCRrSA7fmFw9D1etufToifRn50FmR5H6MI2s+Y0iK8b5OH0CcGTQJ5sfvWs40dQ0Wv3ZzZ7gtUlJlQ==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/engine-js/-/engine-js-0.8.17.tgz",
+      "integrity": "sha512-gw90zYdXhmPDElOx9Rix42p96yXjNBB2WYRDUQbvPR+fO2KQrkcJtGTYgxfXhLFR06aavQAjAFx5KkirWv8+9g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -111,9 +110,9 @@
       }
     },
     "node_modules/@docmd/engine-rust": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/engine-rust/-/engine-rust-0.8.11.tgz",
-      "integrity": "sha512-KCFwvliN6Qoe1RW3+TbBBTeRtSYZLZxT/EIFhJd4nhnlK30m2qBPPFh6xZhw6piG76LolDeAbY58yzi/IwQf+A==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/engine-rust/-/engine-rust-0.8.17.tgz",
+      "integrity": "sha512-cLXuLF9g/o6De5zzMAl57M3TKL/DTNKCwb8poTyWlDcVkc9gO4MfVqi1u5lBGeRwIk27DsuwIb4c/ZV9pYwxBA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -126,18 +125,18 @@
       }
     },
     "node_modules/@docmd/live": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/live/-/live-0.8.11.tgz",
-      "integrity": "sha512-Ljfet3UdzMmihcaWKrncGzJH3kubeYMBiN1EpDClPiDsbnpbVonIaGGqbVVxY9T7gsoFrHbJubGEPEH4gqzAWQ==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/live/-/live-0.8.17.tgz",
+      "integrity": "sha512-xX30IMMqg0JhSQnRGofBiEOob3hkXk11axPc+7yEXWObsOQzOJtFtQsJTZt+MbLDJ616COXbnOegeHv6QV9LsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/parser": "^0.8.11",
-        "@docmd/plugin-math": "^0.8.11",
-        "@docmd/plugin-mermaid": "^0.8.11",
-        "@docmd/themes": "^0.8.11",
-        "@docmd/tui": "^0.8.11",
-        "@docmd/ui": "^0.8.11",
+        "@docmd/parser": "^0.8.17",
+        "@docmd/plugin-math": "^0.8.17",
+        "@docmd/plugin-mermaid": "^0.8.17",
+        "@docmd/themes": "^0.8.17",
+        "@docmd/tui": "^0.8.17",
+        "@docmd/ui": "^0.8.17",
         "buffer": "^6.0.3",
         "esbuild": "^0.28.1",
         "katex": "^0.17.0",
@@ -154,14 +153,14 @@
       }
     },
     "node_modules/@docmd/parser": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/parser/-/parser-0.8.11.tgz",
-      "integrity": "sha512-RL1AB3rMxz2wZZ/7FcFXu0fPl8A0cMrBNMmcDdgwnhnwVXcWzJj4BASbBYSZGOq1wELXGLpfPdNjVsSExkxECg==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/parser/-/parser-0.8.17.tgz",
+      "integrity": "sha512-Vuw9WZoux6tzDNdZPbkSiNfbqoYXdGqY8BHtyYHm6mYinHZFSSCt4R08j9M9OwltASEafdZlQV+s132YT9XtJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/tui": "^0.8.11",
-        "@docmd/utils": "^0.8.11",
+        "@docmd/tui": "^0.8.17",
+        "@docmd/utils": "^0.8.17",
         "embed-lite": "^0.1.4",
         "lite-hl": "^0.1.2",
         "lite-matter": "^0.1.1",
@@ -183,13 +182,13 @@
       }
     },
     "node_modules/@docmd/plugin-analytics": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-analytics/-/plugin-analytics-0.8.11.tgz",
-      "integrity": "sha512-DDnJDWIkrRx2567HbzDtg/I16TcxGVh1mk4567DV5b8FMnEp0eYjJ8UVGvuDdo4bdskhIa1sIHA9YGiL45r1dw==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-analytics/-/plugin-analytics-0.8.17.tgz",
+      "integrity": "sha512-NWy4OxCft2FsKEOAAurKarCgkpAlGWf7adP126HQTZK8Pu6iT6G35Be970lLHX1G7du8siI0Guj5nH/IT/6j4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/utils": "^0.8.11"
+        "@docmd/utils": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -198,13 +197,13 @@
         "url": "https://github.com/sponsors/mgks"
       },
       "peerDependencies": {
-        "@docmd/api": "^0.8.11"
+        "@docmd/api": "^0.8.17"
       }
     },
     "node_modules/@docmd/plugin-git": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-git/-/plugin-git-0.8.11.tgz",
-      "integrity": "sha512-pHhkFUJscfEOsVe+w7Q3z8HiTbBvYxcS/CH4JkrcuhY/XmSKiMagN57cGrLq4rYsI2hL5KbOVUnK+bKRPFPq8A==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-git/-/plugin-git-0.8.17.tgz",
+      "integrity": "sha512-F+DZQWMa23XSFP9QRp6Bh/qY9F3I/dO/kdcwjLw1Y2o0RuXPsMLVZuRH9ZmTjggmItmVnw6EjUASPAbVr4PKQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -214,17 +213,17 @@
         "url": "https://github.com/sponsors/mgks"
       },
       "peerDependencies": {
-        "@docmd/api": "^0.8.11"
+        "@docmd/api": "^0.8.17"
       }
     },
     "node_modules/@docmd/plugin-installer": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-installer/-/plugin-installer-0.8.11.tgz",
-      "integrity": "sha512-U5mtMP/BX53CBH8gArzKB1ssQvfTIgwi0+JW1SXeKaj70dPW/x3YYysLbhYGBbdXAqj4Ents/ZOlLQDndHOIng==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-installer/-/plugin-installer-0.8.17.tgz",
+      "integrity": "sha512-cG8PZVM+1PRW/gMQg8zN9H457Ii4v5AVTS8m2u1f/vI7E8+Wblc6AsJd3pJII0JNSM53TcIe2vQs2lKIzkT30g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/api": "^0.8.11"
+        "@docmd/api": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -234,9 +233,9 @@
       }
     },
     "node_modules/@docmd/plugin-llms": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-llms/-/plugin-llms-0.8.11.tgz",
-      "integrity": "sha512-yLu27Ru6dMLLk7S+xjWnM4PLod3vyQw5sEsjfG+M1tfKCtkjfIeokUHiLfV4QUMX21CxLBw5Bv4hDSA5VhsM2g==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-llms/-/plugin-llms-0.8.17.tgz",
+      "integrity": "sha512-OGrJbJi3QedsITygPzhEp2VqDiy5fv+Q4+qdJAWwK+D+NpenuIpJ7VT1bUHZK7+CITkgOByXbGTjcGal7V9tWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -247,9 +246,9 @@
       }
     },
     "node_modules/@docmd/plugin-math": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-math/-/plugin-math-0.8.11.tgz",
-      "integrity": "sha512-cKayBhOFNzaW45p87ORVAk9IeiezjDHdBourgnGQNRvqt7wdbLIm4WPK9+vacWlQM49y2ttHBAepg7PFDWaLZw==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-math/-/plugin-math-0.8.17.tgz",
+      "integrity": "sha512-g2FOJ47m1NDAzVjblb7SzTqN/k2yzAYSlJOyP3GEjw7hwIx/yLYTc4iIxGbnP1c/kPAQsZFLiUmBnlPBSDtr6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -264,9 +263,9 @@
       }
     },
     "node_modules/@docmd/plugin-mermaid": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-mermaid/-/plugin-mermaid-0.8.11.tgz",
-      "integrity": "sha512-GHgPyC6jVdKBpIg2r0NHiN4PmwOzcsiR/pwTNDSCbWQFsABtr5A54DPK0dnLyIP8a7xlLLJ4bgX6R3Me+E49Fw==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-mermaid/-/plugin-mermaid-0.8.17.tgz",
+      "integrity": "sha512-RgS75eJf5gaGP2d6gsCEdrah5Fu1Q/9RrkYMlPeynPUX/YWe5Nza8mjFZGBk4uByKtmSJX4plzVoGMRSfh8oow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -277,9 +276,9 @@
       }
     },
     "node_modules/@docmd/plugin-okf": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-okf/-/plugin-okf-0.8.11.tgz",
-      "integrity": "sha512-gWvE1PcbaPZFAi0qeX8V0hmDiNHxNGmp35wdkAs0VYpBJvNefYugy/iqoSoxCOwWb3AxCiuCUiosbZmUBAtx/g==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-okf/-/plugin-okf-0.8.17.tgz",
+      "integrity": "sha512-Ff4Z5BUKyJbhJIASGbcDy7NJ3PrATCWVumlzKS+IugwAzblYX8Q2vW5ShArqaArjz4KId4/EA8pcdqsO7KccSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -290,13 +289,13 @@
       }
     },
     "node_modules/@docmd/plugin-openapi": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-openapi/-/plugin-openapi-0.8.11.tgz",
-      "integrity": "sha512-Wra/oYv5YoyvG6DxmVQCkbKPMB2x3ZVK6N0PKABIkJlwZk1grxHjQqQfXKxCIF7yjriJMeZM0Qb5Nk8QHV5q1w==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-openapi/-/plugin-openapi-0.8.17.tgz",
+      "integrity": "sha512-0Tu9+TcXzSC82GNCxud3mrvW86L0hKFnGoPljc7hDoW+QmKz4wBrtsc+KoSyeUZ8cBfBLrgQYLBHmmd0+Y6QQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/utils": "^0.8.11"
+        "@docmd/utils": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -305,32 +304,13 @@
         "url": "https://github.com/sponsors/mgks"
       },
       "peerDependencies": {
-        "@docmd/api": "^0.8.11"
-      }
-    },
-    "node_modules/@docmd/plugin-pwa": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-pwa/-/plugin-pwa-0.8.11.tgz",
-      "integrity": "sha512-hIjYWJ6lZpVnbArKYZgawF5/tEI5yeItog8yZKyiNW7i+6EMbTa4TVF/qXNUiDHX5zOPFmJSOjeMIfhh97KBpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@docmd/utils": "^0.8.11"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mgks"
-      },
-      "peerDependencies": {
-        "@docmd/api": "^0.8.11"
+        "@docmd/api": "^0.8.17"
       }
     },
     "node_modules/@docmd/plugin-search": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-search/-/plugin-search-0.8.11.tgz",
-      "integrity": "sha512-/ni8OZPeFCD9Ljjj3gUNwMd7w/9MQMoOKstD3oNNgXdL30YEs0LJpiJPeXH00mrh0WNolan0n2Y9bJWWb3nCWQ==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-search/-/plugin-search-0.8.17.tgz",
+      "integrity": "sha512-lNrM8IfMWoyojAjXXbKO3G34p8j17A97ha2ptOIEIrc+xQPLAdD3EoeConf1E59e3I77e4TRU3SuaRe55NGeaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -344,7 +324,7 @@
         "url": "https://github.com/sponsors/mgks"
       },
       "peerDependencies": {
-        "docmd-search": ">=0.1.0"
+        "docmd-search": ">=0.1.1"
       },
       "peerDependenciesMeta": {
         "docmd-search": {
@@ -353,13 +333,13 @@
       }
     },
     "node_modules/@docmd/plugin-seo": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-seo/-/plugin-seo-0.8.11.tgz",
-      "integrity": "sha512-CGmmltjbgdxIgEiEDexyJvy5njbMCjeJwaT17bWPmCqcfOhSzcYj0temlyGbs3ZpIZXajvVnnugkOF9e8elH1g==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-seo/-/plugin-seo-0.8.17.tgz",
+      "integrity": "sha512-BpPr0YQpVBdKpfjcBJVyf2xTuHBhZdk3YvsZGL1ut3JLTZ6cU7FI0zIdb+gr2CuHQl4m7eYpnBN+p7ex1K0bLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/utils": "^0.8.11"
+        "@docmd/utils": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -368,13 +348,13 @@
         "url": "https://github.com/sponsors/mgks"
       },
       "peerDependencies": {
-        "@docmd/api": "^0.8.11"
+        "@docmd/api": "^0.8.17"
       }
     },
     "node_modules/@docmd/plugin-sitemap": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/plugin-sitemap/-/plugin-sitemap-0.8.11.tgz",
-      "integrity": "sha512-DSC9bpQNHYlyCT04oVgtz9+H1V2myTz9g/2nbGqPIh7/l000U7X9tNjoOP5kgkxjhrip74Kaheg2hdj26xaKVw==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/plugin-sitemap/-/plugin-sitemap-0.8.17.tgz",
+      "integrity": "sha512-0mRLISM2cKKc1YFXb+WyslQVMCWo3UU2F/J72aKTksDKlb3k7sXRZ3Uh1M210Ft8F3a4kgDtWlvtyVTFRVjhDw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -385,9 +365,9 @@
       }
     },
     "node_modules/@docmd/themes": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/themes/-/themes-0.8.11.tgz",
-      "integrity": "sha512-bu3JFM18mn592IhggrwT+YyuKGFOdtXAXr9o3UAtqnKCSXYjSc2OBg/51FuRiHNhIhErQSx3Mw7sAs32mkZfXQ==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/themes/-/themes-0.8.17.tgz",
+      "integrity": "sha512-m3cT3d82ZZe4VDsqNQcmrLSJyeng4LQI4KfH0doq04xttL4OHzj6g5lWpPtLnHSs1fIjDPSw+mzrr18kNix4WA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -398,9 +378,9 @@
       }
     },
     "node_modules/@docmd/tui": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/tui/-/tui-0.8.11.tgz",
-      "integrity": "sha512-TDPZyyINBZIl7Cum404+SQIe+lm6Q+PqVtPpvJhS0qbinPtVA5d8SlT+Trh+d7qeSBgP2Vb3/NoSAfRba+yv+w==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/tui/-/tui-0.8.17.tgz",
+      "integrity": "sha512-Iy30XN7Luk/5u7JARy5qDHpcMle1VA+24qisyj4bRqNW8lgePDNSjHDzEyJ2HgVcpQZqlFgYGY0zd33Zdur2MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -414,14 +394,14 @@
       }
     },
     "node_modules/@docmd/ui": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/ui/-/ui-0.8.11.tgz",
-      "integrity": "sha512-MU345KTcAC3IX+rUrjJgRY2cZfnHyMZoDpk1y2s0vVw89z6SdMkZx6cxwEi3UT1OcrTYSayQnZKPiAxlJjnh+Q==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/ui/-/ui-0.8.17.tgz",
+      "integrity": "sha512-VNW5J83LMGbdvjzuEJV1kZFnMiCvPh+hl2BW+N2QT38VZ7783yGRfTFB1EcvuQVnEZoAB8WI8J1IZBZUIIQI7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@docmd/api": "^0.8.11",
-        "@docmd/tui": "^0.8.11"
+        "@docmd/api": "^0.8.17",
+        "@docmd/tui": "^0.8.17"
       },
       "engines": {
         "node": ">=18"
@@ -431,9 +411,9 @@
       }
     },
     "node_modules/@docmd/utils": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@docmd/utils/-/utils-0.8.11.tgz",
-      "integrity": "sha512-kBbpu8BnmC0YfthVBBa0vrNG43CL0RdCH2ru1YyUz+vkkWrDQZ/QrZqsxlK376pqTJ2wIzMVakqDdA5QvC1p4A==",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/@docmd/utils/-/utils-0.8.17.tgz",
+      "integrity": "sha512-mIB/s1EVnT9MMg4R0dWnhnJSPXs97JZuxpAq3z5f2P/3/UtkNmghpm/8Sna/e+bWIs83gPQeclg+zXu+up+yIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1810,9 +1790,9 @@
       "license": "MIT"
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1925,9 +1905,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,8 +8,8 @@
     "docs:validate": "docmd validate"
   },
   "devDependencies": {
-    "@docmd/core": "0.8.11",
-    "@docmd/plugin-git": "0.8.11",
+    "@docmd/core": "0.8.17",
+    "@docmd/plugin-git": "0.8.17",
     "docmd-plugin-rsigma": "file:docmd-plugin-rsigma"
   }
 }


### PR DESCRIPTION
## Summary
- enable GA4 tracking for the documentation site
- connect cookie choices to Google Consent Mode while keeping advertising consent disabled
- add a privacy notice and update docmd to the current patch release

## Test plan
- [x] `npm run docs:build`
- [x] `npm run docs:validate`
- [x] verify generated pages contain the GA4 tag, consent defaults, banner, and working privacy links