### PR TITLE
✨ feat: support list values in add_condition pipeline transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,11 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ### Support list values in `add_condition` pipeline transformation (#399)
 
-- `add_condition` now accepts YAML sequences for field values:
-  `conditions: {EventID: [12, 13, 14]}` instead of only `conditions: {EventID: 12}`.
-  Values within a field are OR-linked, matching pySigma's `AddConditionTransformation`.
-- **Breaking**: `AddCondition.conditions` changed from `HashMap<String, SigmaValue>` to
-  `HashMap<String, Vec<SigmaValue>>`. Downstream constructors using the `Transformation` enum
-  (re-exported as `rsigma_eval::pipeline::Transformation`) must update their field value types.
-- **Sysmon pipeline additions** (aligned with [Sigma taxonomy](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-appendix-taxonomy.md#windows-folder)):
-  - `sysmon_status` (EventID 4, 16), `registry_event` (12, 13, 14), `wmi_event` (19, 20, 21),
-    `file_block_shredding` (28) — new categories added.
-  - `pipe_created` updated to include EventID 18 (missing).
-  - **Behavior change**: rules with `category: registry_event`, `wmi_event`, or `sysmon_status`
-    previously got no `EventID` condition at all and matched every Sysmon event; they now match
-    only the relevant EventIDs. Rules with `category: pipe_created` now also match EventID 18.
-- `[]` (empty sequence) is now a parse error instead of silently skipping, preventing pipeline
-  typos from widening rule scope.
-- New tests: `parse_add_condition_with_list_values`, `parse_add_condition_with_empty_sequence`,
-  `test_pipeline_add_condition_list_values_e2e`.
+- `add_condition` accepts YAML sequences for field values (`conditions: {EventID: [12, 13, 14]}`), and the values of one field are OR-linked, matching pySigma's `AddConditionTransformation`. Pipelines no longer need one transformation per value.
+- An empty sequence (`field: []`) and a non-scalar value (a mapping, or a sequence nested inside a sequence) are load-time errors naming the offending field. Both previously produced a condition that silently matched nothing or disappeared, which widened the rule instead of failing.
+- **Breaking**: `AddCondition.conditions` changed from `HashMap<String, SigmaValue>` to `HashMap<String, Vec<SigmaValue>>`. Downstream code constructing the `Transformation` enum (re-exported as `rsigma_eval::pipeline::Transformation`) must wrap scalar values in a `Vec`.
+- The builtin `sysmon` pipeline gains the [Sigma taxonomy](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-appendix-taxonomy.md#windows-folder) categories it was missing: `sysmon_status` (EventID 4, 16), `registry_event` (12, 13, 14), `wmi_event` (19, 20, 21), `file_block_shredding` (28), and `sysmon_error` (255). `pipe_created` now also covers EventID 18.
+- **Behavior change**: rules carrying one of those five categories previously got no `EventID` condition at all and matched every Sysmon event; they now match only the relevant EventIDs. Rules with `category: pipe_created` also match EventID 18.
 
 ### OCSF Detection Finding output (#397)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Support list values in `add_condition` pipeline transformation (#399)
+
+- `add_condition` now accepts YAML sequences for field values:
+  `conditions: {EventID: [12, 13, 14]}` instead of only `conditions: {EventID: 12}`.
+  Values within a field are OR-linked, matching pySigma's `AddConditionTransformation`.
+- **Breaking**: `AddCondition.conditions` changed from `HashMap<String, SigmaValue>` to
+  `HashMap<String, Vec<SigmaValue>>`. Downstream constructors using the `Transformation` enum
+  (re-exported as `rsigma_eval::pipeline::Transformation`) must update their field value types.
+- **Sysmon pipeline additions** (aligned with [Sigma taxonomy](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-appendix-taxonomy.md#windows-folder)):
+  - `sysmon_status` (EventID 4, 16), `registry_event` (12, 13, 14), `wmi_event` (19, 20, 21),
+    `file_block_shredding` (28) — new categories added.
+  - `pipe_created` updated to include EventID 18 (missing).
+  - **Behavior change**: rules with `category: registry_event`, `wmi_event`, or `sysmon_status`
+    previously got no `EventID` condition at all and matched every Sysmon event; they now match
+    only the relevant EventIDs. Rules with `category: pipe_created` now also match EventID 18.
+- `[]` (empty sequence) is now a parse error instead of silently skipping, preventing pipeline
+  typos from widening rule scope.
+- New tests: `parse_add_condition_with_list_values`, `parse_add_condition_with_empty_sequence`,
+  `test_pipeline_add_condition_list_values_e2e`.
+
 ### OCSF Detection Finding output (#397)
 
 - Any line-oriented sink can emit [OCSF](https://ocsf.io) Detection Finding (class 2004) JSON instead of native NDJSON: `--output 'file:///findings.ocsf.ndjson?format=ocsf'`, or the same suffix on a `daemon.output.sinks` entry. Findings then flow natively into Splunk, Elastic, CrowdStrike NG-SIEM, and anything else that consumes OCSF.

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -369,7 +369,7 @@ Each transformation item in a pipeline can have:
 | `field_name_suffix` | `suffix` | Add a suffix to all field names |
 | `field_name_transform` | `transform_func`, `mapping` | Case transformation (see below) |
 | `drop_detection_item` | — | Remove matching detection items |
-| `add_condition` | `conditions: {k: v | [v1, v2, ...]}`, `negated` (default: `false`) | Inject additional detection conditions; list values are OR-linked |
+| `add_condition` | `conditions: {k: v \| [v1, v2, ...]}`, `negated` (default: `false`) | Inject additional detection conditions; list values are OR-linked |
 | `change_logsource` | `category`, `product`, `service` | Modify logsource fields |
 | `replace_string` | `regex`, `replacement`, `skip_special` (default: `false`) | Regex-based string replacement (`skip_special` preserves wildcards) |
 | `map_string` | `mapping: {k: v \| [v1, v2]}` | Map string values to replacements (supports one-to-many) |

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -369,7 +369,7 @@ Each transformation item in a pipeline can have:
 | `field_name_suffix` | `suffix` | Add a suffix to all field names |
 | `field_name_transform` | `transform_func`, `mapping` | Case transformation (see below) |
 | `drop_detection_item` | — | Remove matching detection items |
-| `add_condition` | `conditions: {k: v}`, `negated` (default: `false`) | Inject additional detection conditions |
+| `add_condition` | `conditions: {k: v | [v1, v2, ...]}`, `negated` (default: `false`) | Inject additional detection conditions; list values are OR-linked |
 | `change_logsource` | `category`, `product`, `service` | Modify logsource fields |
 | `replace_string` | `regex`, `replacement`, `skip_special` (default: `false`) | Regex-based string replacement (`skip_special` preserves wildcards) |
 | `map_string` | `mapping: {k: v \| [v1, v2]}` | Map string values to replacements (supports one-to-many) |

--- a/crates/rsigma-eval/pipelines/sysmon.yml
+++ b/crates/rsigma-eval/pipelines/sysmon.yml
@@ -46,6 +46,17 @@ transformations:
         category: network_connection
         product: windows
 
+  - id: sysmon_sysmon_status
+    type: add_condition
+    conditions:
+      EventID:
+        - 4
+        - 16
+    rule_conditions:
+      - type: logsource
+        category: sysmon_status
+        product: windows
+
   - id: sysmon_process_termination
     type: add_condition
     conditions:
@@ -109,6 +120,18 @@ transformations:
         category: file_event
         product: windows
 
+  - id: sysmon_registry_event
+    type: add_condition
+    conditions:
+      EventID:
+        - 12
+        - 13
+        - 14
+    rule_conditions:
+      - type: logsource
+        category: registry_event
+        product: windows
+
   - id: sysmon_registry_add
     type: add_condition
     conditions:
@@ -157,10 +180,24 @@ transformations:
   - id: sysmon_pipe_created
     type: add_condition
     conditions:
-      EventID: 17
+      EventID:
+        - 17
+        - 18
     rule_conditions:
       - type: logsource
         category: pipe_created
+        product: windows
+
+  - id: sysmon_wmi_event
+    type: add_condition
+    conditions:
+      EventID:
+        - 19
+        - 20
+        - 21
+    rule_conditions:
+      - type: logsource
+        category: wmi_event
         product: windows
 
   - id: sysmon_dns_query
@@ -217,6 +254,15 @@ transformations:
         category: file_block_executable
         product: windows
 
+  - id: sysmon_file_block_shredding
+    type: add_condition
+    conditions:
+      EventID: 28
+    rule_conditions:
+      - type: logsource
+        category: file_block_shredding
+        product: windows
+
   - id: sysmon_file_executable_detected
     type: add_condition
     conditions:
@@ -224,6 +270,15 @@ transformations:
     rule_conditions:
       - type: logsource
         category: file_executable_detected
+        product: windows
+
+  - id: sysmon_sysmon_error
+    type: add_condition
+    conditions:
+      EventID: 255
+    rule_conditions:
+      - type: logsource
+        category: sysmon_error
         product: windows
 
   # Change logsource to sysmon service for all matched categories

--- a/crates/rsigma-eval/src/engine/tests.rs
+++ b/crates/rsigma-eval/src/engine/tests.rs
@@ -1175,6 +1175,65 @@ level: low
 }
 
 #[test]
+fn test_pipeline_add_condition_list_values_e2e() {
+    use crate::pipeline::parse_pipeline;
+
+    let pipeline_yaml = r#"
+name: Sysmon registry routing
+transformations:
+  - type: add_condition
+    conditions:
+      EventID:
+        - 12
+        - 13
+        - 14
+    rule_conditions:
+      - type: logsource
+        category: registry_event
+        product: windows
+"#;
+    let pipeline = parse_pipeline(pipeline_yaml).unwrap();
+
+    let rule_yaml = r#"
+title: Suspicious Registry Path
+logsource:
+    product: windows
+    category: registry_event
+detection:
+    selection:
+        TargetObject|contains: 'CurrentVersion\Run'
+    condition: selection
+level: medium
+"#;
+    let collection = parse_sigma_yaml(rule_yaml).unwrap();
+
+    let mut engine = Engine::new_with_pipeline(pipeline);
+    engine.add_collection(&collection).unwrap();
+
+    let matching_target = "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\Malware";
+
+    // EventID 12 matches (first value in list)
+    let ev1 = json!({"EventID": 12, "TargetObject": matching_target});
+    assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev1)).len(), 1);
+
+    // EventID 13 matches (second value in list)
+    let ev2 = json!({"EventID": 13, "TargetObject": matching_target});
+    assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev2)).len(), 1);
+
+    // EventID 14 matches (third value in list)
+    let ev3 = json!({"EventID": 14, "TargetObject": matching_target});
+    assert_eq!(engine.evaluate(&JsonEvent::borrow(&ev3)).len(), 1);
+
+    // EventID 99 does NOT match (not in list)
+    let ev4 = json!({"EventID": 99, "TargetObject": matching_target});
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev4)).is_empty());
+
+    // EventID 12 but no matching detection field -> no match
+    let ev5 = json!({"EventID": 12, "TargetObject": "something_unrelated"});
+    assert!(engine.evaluate(&JsonEvent::borrow(&ev5)).is_empty());
+}
+
+#[test]
 fn test_pipeline_change_logsource_e2e() {
     use crate::pipeline::parse_pipeline;
 

--- a/crates/rsigma-eval/src/pipeline/builtin.rs
+++ b/crates/rsigma-eval/src/pipeline/builtin.rs
@@ -69,4 +69,96 @@ mod tests {
         assert!(names.contains(&"fibratus_windows"));
         assert!(names.contains(&"sysmon"));
     }
+
+    fn sysmon_eventid_route(category: &str) -> Option<Vec<i64>> {
+        use crate::pipeline::Transformation;
+        use rsigma_parser::SigmaValue;
+
+        let pipeline = resolve_builtin("sysmon").unwrap().unwrap();
+        for item in &pipeline.transformations {
+            if let Transformation::AddCondition { conditions, .. } = &item.transformation {
+                if let Some(evts) = conditions.get("EventID") {
+                    if let Some(rule_cond) = item.rule_conditions.first() {
+                        if let crate::pipeline::RuleCondition::Logsource {
+                            category: Some(cat),
+                            ..
+                        } = &rule_cond.condition
+                        {
+                            if cat == category {
+                                return Some(
+                                    evts.iter()
+                                        .filter_map(|v| match v {
+                                            SigmaValue::Integer(n) => Some(*n),
+                                            _ => None,
+                                        })
+                                        .collect(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn sysmon_builtin_routes_new_categories() {
+        assert_eq!(sysmon_eventid_route("sysmon_status").unwrap(), vec![4, 16]);
+        assert_eq!(
+            sysmon_eventid_route("registry_event").unwrap(),
+            vec![12, 13, 14]
+        );
+        assert_eq!(sysmon_eventid_route("wmi_event").unwrap(), vec![19, 20, 21]);
+        assert_eq!(
+            sysmon_eventid_route("file_block_shredding").unwrap(),
+            vec![28]
+        );
+        assert_eq!(sysmon_eventid_route("pipe_created").unwrap(), vec![17, 18]);
+        assert_eq!(sysmon_eventid_route("sysmon_error").unwrap(), vec![255]);
+    }
+
+    #[test]
+    fn sysmon_builtin_eventid_order() {
+        use crate::pipeline::Transformation;
+        use rsigma_parser::SigmaValue;
+
+        let pipeline = resolve_builtin("sysmon").unwrap().unwrap();
+        let add_conditions: Vec<(&str, Vec<i64>)> = pipeline
+            .transformations
+            .iter()
+            .filter_map(|item| {
+                if let Transformation::AddCondition { conditions, .. } = &item.transformation {
+                    if let Some(evts) = conditions.get("EventID") {
+                        let nums: Vec<i64> = evts
+                            .iter()
+                            .filter_map(|v| match v {
+                                SigmaValue::Integer(n) => Some(*n),
+                                _ => None,
+                            })
+                            .collect();
+                        if !nums.is_empty() {
+                            return Some((item.id.as_deref().unwrap_or(""), nums));
+                        }
+                    }
+                }
+                None
+            })
+            .collect();
+
+        for i in 0..add_conditions.len().saturating_sub(1) {
+            let (_, prev_nums) = &add_conditions[i];
+            let (_, next_nums) = &add_conditions[i + 1];
+            let prev_min = prev_nums.iter().copied().min().unwrap();
+            let next_min = next_nums.iter().copied().min().unwrap();
+            assert!(
+                prev_min <= next_min,
+                "sysmon routing: {:?} (min {}) is not before {:?} (min {})",
+                prev_nums,
+                prev_min,
+                next_nums,
+                next_min
+            );
+        }
+    }
 }

--- a/crates/rsigma-eval/src/pipeline/builtin.rs
+++ b/crates/rsigma-eval/src/pipeline/builtin.rs
@@ -32,6 +32,8 @@ pub fn builtin_names() -> &'static [&'static str] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::{RuleCondition, Transformation};
+    use rsigma_parser::SigmaValue;
 
     #[test]
     fn ecs_windows_parses_successfully() {
@@ -70,36 +72,32 @@ mod tests {
         assert!(names.contains(&"sysmon"));
     }
 
-    fn sysmon_eventid_route(category: &str) -> Option<Vec<i64>> {
-        use crate::pipeline::Transformation;
-        use rsigma_parser::SigmaValue;
+    fn event_ids(values: &[SigmaValue]) -> Vec<i64> {
+        values
+            .iter()
+            .filter_map(|v| match v {
+                SigmaValue::Integer(n) => Some(*n),
+                _ => None,
+            })
+            .collect()
+    }
 
+    fn sysmon_eventid_route(category: &str) -> Option<Vec<i64>> {
         let pipeline = resolve_builtin("sysmon").unwrap().unwrap();
-        for item in &pipeline.transformations {
-            if let Transformation::AddCondition { conditions, .. } = &item.transformation {
-                if let Some(evts) = conditions.get("EventID") {
-                    if let Some(rule_cond) = item.rule_conditions.first() {
-                        if let crate::pipeline::RuleCondition::Logsource {
-                            category: Some(cat),
-                            ..
-                        } = &rule_cond.condition
-                        {
-                            if cat == category {
-                                return Some(
-                                    evts.iter()
-                                        .filter_map(|v| match v {
-                                            SigmaValue::Integer(n) => Some(*n),
-                                            _ => None,
-                                        })
-                                        .collect(),
-                                );
-                            }
-                        }
-                    }
-                }
+        pipeline.transformations.iter().find_map(|item| {
+            if let Transformation::AddCondition { conditions, .. } = &item.transformation
+                && let Some(evts) = conditions.get("EventID")
+                && let Some(rule_cond) = item.rule_conditions.first()
+                && let RuleCondition::Logsource {
+                    category: Some(cat),
+                    ..
+                } = &rule_cond.condition
+                && cat == category
+            {
+                return Some(event_ids(evts));
             }
-        }
-        None
+            None
+        })
     }
 
     #[test]
@@ -120,44 +118,31 @@ mod tests {
 
     #[test]
     fn sysmon_builtin_eventid_order() {
-        use crate::pipeline::Transformation;
-        use rsigma_parser::SigmaValue;
-
         let pipeline = resolve_builtin("sysmon").unwrap().unwrap();
-        let add_conditions: Vec<(&str, Vec<i64>)> = pipeline
+        let routes: Vec<Vec<i64>> = pipeline
             .transformations
             .iter()
             .filter_map(|item| {
-                if let Transformation::AddCondition { conditions, .. } = &item.transformation {
-                    if let Some(evts) = conditions.get("EventID") {
-                        let nums: Vec<i64> = evts
-                            .iter()
-                            .filter_map(|v| match v {
-                                SigmaValue::Integer(n) => Some(*n),
-                                _ => None,
-                            })
-                            .collect();
-                        if !nums.is_empty() {
-                            return Some((item.id.as_deref().unwrap_or(""), nums));
-                        }
+                if let Transformation::AddCondition { conditions, .. } = &item.transformation
+                    && let Some(evts) = conditions.get("EventID")
+                {
+                    let nums = event_ids(evts);
+                    if !nums.is_empty() {
+                        return Some(nums);
                     }
                 }
                 None
             })
             .collect();
 
-        for i in 0..add_conditions.len().saturating_sub(1) {
-            let (_, prev_nums) = &add_conditions[i];
-            let (_, next_nums) = &add_conditions[i + 1];
-            let prev_min = prev_nums.iter().copied().min().unwrap();
-            let next_min = next_nums.iter().copied().min().unwrap();
+        for pair in routes.windows(2) {
+            let prev_min = pair[0].iter().copied().min().unwrap();
+            let next_min = pair[1].iter().copied().min().unwrap();
             assert!(
                 prev_min <= next_min,
-                "sysmon routing: {:?} (min {}) is not before {:?} (min {})",
-                prev_nums,
-                prev_min,
-                next_nums,
-                next_min
+                "sysmon routing: {:?} (min {prev_min}) is not before {:?} (min {next_min})",
+                pair[0],
+                pair[1]
             );
         }
     }

--- a/crates/rsigma-eval/src/pipeline/parsing.rs
+++ b/crates/rsigma-eval/src/pipeline/parsing.rs
@@ -807,17 +807,34 @@ fn parse_value_mapping(
                         )));
                     }
                     // YAML sequence → Vec<SigmaValue> (OR semantics, like pySigma)
-                    yaml_serde::Value::Sequence(seq) => {
-                        seq.iter().map(SigmaValue::from_yaml).collect()
-                    }
+                    yaml_serde::Value::Sequence(seq) => seq
+                        .iter()
+                        .map(|item| scalar_condition_value(key, item))
+                        .collect::<Result<Vec<_>>>()?,
                     // Scalar → single-element Vec
-                    other => vec![SigmaValue::from_yaml(other)],
+                    other => vec![scalar_condition_value(key, other)?],
                 };
                 map.insert(key.to_string(), values);
             }
         }
     }
     Ok(map)
+}
+
+/// Convert one `add_condition` value, rejecting anything that is not a scalar.
+///
+/// `SigmaValue::from_yaml` renders an unsupported node as its debug
+/// representation, which would load as a literal string that can never match.
+fn scalar_condition_value(field: &str, value: &yaml_serde::Value) -> Result<SigmaValue> {
+    match value {
+        yaml_serde::Value::String(_)
+        | yaml_serde::Value::Number(_)
+        | yaml_serde::Value::Bool(_)
+        | yaml_serde::Value::Null => Ok(SigmaValue::from_yaml(value)),
+        _ => Err(EvalError::InvalidModifiers(format!(
+            "add_condition: non-scalar value for field '{field}'"
+        ))),
+    }
 }
 
 fn build_field_matcher(fields: Vec<String>, is_regex: bool) -> Result<FieldMatcher> {

--- a/crates/rsigma-eval/src/pipeline/parsing.rs
+++ b/crates/rsigma-eval/src/pipeline/parsing.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use regex::Regex;
-use rsigma_parser::{SigmaString, SigmaValue};
+use rsigma_parser::SigmaValue;
 
 use crate::error::{EvalError, Result};
 
@@ -791,27 +791,30 @@ fn parse_string_or_list_mapping(
     Ok(map)
 }
 
-fn parse_value_mapping(value: Option<&yaml_serde::Value>) -> Result<HashMap<String, SigmaValue>> {
+fn parse_value_mapping(
+    value: Option<&yaml_serde::Value>,
+) -> Result<HashMap<String, Vec<SigmaValue>>> {
     let mut map = HashMap::new();
     if let Some(yaml_serde::Value::Mapping(m)) = value {
         for (k, v) in m {
             if let Some(key) = k.as_str() {
-                let sv = match v {
-                    yaml_serde::Value::String(s) => SigmaValue::String(SigmaString::new(s)),
-                    yaml_serde::Value::Number(n) => {
-                        if let Some(i) = n.as_i64() {
-                            SigmaValue::Integer(i)
-                        } else if let Some(f) = n.as_f64() {
-                            SigmaValue::Float(f)
-                        } else {
-                            SigmaValue::Null
-                        }
+                let values = match v {
+                    // YAML sequence → Vec<SigmaValue> (OR semantics, like pySigma)
+                    yaml_serde::Value::Sequence(seq) if seq.is_empty() => {
+                        return Err(EvalError::InvalidModifiers(format!(
+                            "add_condition: empty sequence for field '{key}' is not allowed; \
+                             a detection typo that becomes \"match everything\" is the wrong \
+                             failure direction for a detection engine"
+                        )));
                     }
-                    yaml_serde::Value::Bool(b) => SigmaValue::Bool(*b),
-                    yaml_serde::Value::Null => SigmaValue::Null,
-                    _ => SigmaValue::Null,
+                    // YAML sequence → Vec<SigmaValue> (OR semantics, like pySigma)
+                    yaml_serde::Value::Sequence(seq) => {
+                        seq.iter().map(SigmaValue::from_yaml).collect()
+                    }
+                    // Scalar → single-element Vec
+                    other => vec![SigmaValue::from_yaml(other)],
                 };
-                map.insert(key.to_string(), sv);
+                map.insert(key.to_string(), values);
             }
         }
     }

--- a/crates/rsigma-eval/src/pipeline/parsing.rs
+++ b/crates/rsigma-eval/src/pipeline/parsing.rs
@@ -799,12 +799,11 @@ fn parse_value_mapping(
         for (k, v) in m {
             if let Some(key) = k.as_str() {
                 let values = match v {
-                    // YAML sequence → Vec<SigmaValue> (OR semantics, like pySigma)
+                    // An empty sequence would drop the condition and widen the
+                    // rule, so it is rejected rather than skipped.
                     yaml_serde::Value::Sequence(seq) if seq.is_empty() => {
                         return Err(EvalError::InvalidModifiers(format!(
-                            "add_condition: empty sequence for field '{key}' is not allowed; \
-                             a detection typo that becomes \"match everything\" is the wrong \
-                             failure direction for a detection engine"
+                            "add_condition: empty sequence for field '{key}'"
                         )));
                     }
                     // YAML sequence → Vec<SigmaValue> (OR semantics, like pySigma)

--- a/crates/rsigma-eval/src/pipeline/transformations/helpers.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations/helpers.rs
@@ -351,16 +351,16 @@ fn should_drop_item(
 
 pub(super) fn add_conditions(
     rule: &mut SigmaRule,
-    conditions: &HashMap<String, SigmaValue>,
+    conditions: &HashMap<String, Vec<SigmaValue>>,
     field_refs: &HashMap<String, String>,
     negated: bool,
     prepend: bool,
 ) {
     let mut items: Vec<DetectionItem> = conditions
         .iter()
-        .map(|(field, value)| DetectionItem {
+        .map(|(field, values)| DetectionItem {
             field: FieldSpec::new(Some(field.clone()), Vec::new()),
-            values: vec![value.clone()],
+            values: values.clone(),
         })
         .collect();
 

--- a/crates/rsigma-eval/src/pipeline/transformations/mod.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations/mod.rs
@@ -55,8 +55,14 @@ pub enum Transformation {
     DropDetectionItem,
 
     /// Add field=value conditions to the rule's detection.
+    ///
+    /// Each value is a `Vec<SigmaValue>` to support list values (OR semantics).
+    /// A single-element vec behaves identically to the old `SigmaValue` scalar.
+    /// A multi-element vec creates a detection item with multiple values, which
+    /// are OR-linked per Sigma semantics — matching pySigma's
+    /// `AddConditionTransformation` behavior.
     AddCondition {
-        conditions: HashMap<String, SigmaValue>,
+        conditions: HashMap<String, Vec<SigmaValue>>,
         /// Field-to-field equality conditions (`field` equals the value of
         /// another field). The value of each entry is a *field name*, not a
         /// literal, lowered through the `fieldref` modifier so backends
@@ -276,6 +282,7 @@ impl Transformation {
                 prepend,
             } => {
                 helpers::add_conditions(rule, conditions, field_refs, *negated, *prepend);
+
                 Ok(true)
             }
 

--- a/crates/rsigma-eval/src/pipeline/transformations/tests.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations/tests.rs
@@ -342,7 +342,7 @@ fn test_add_condition() {
     let mut conds = HashMap::new();
     conds.insert(
         "index".to_string(),
-        SigmaValue::String(SigmaString::new("windows-*")),
+        vec![SigmaValue::String(SigmaString::new("windows-*"))],
     );
     let t = Transformation::AddCondition {
         conditions: conds,
@@ -380,7 +380,7 @@ fn test_add_condition_prepend_puts_added_condition_first() {
     let mut conds = HashMap::new();
     conds.insert(
         "evt.name".to_string(),
-        SigmaValue::String(SigmaString::new("CreateProcess")),
+        vec![SigmaValue::String(SigmaString::new("CreateProcess"))],
     );
     let t = Transformation::AddCondition {
         conditions: conds,
@@ -1176,7 +1176,7 @@ fn test_add_condition_negated() {
     let mut conds = HashMap::new();
     conds.insert(
         "User".to_string(),
-        SigmaValue::String(SigmaString::new("SYSTEM")),
+        vec![SigmaValue::String(SigmaString::new("SYSTEM"))],
     );
     let t = Transformation::AddCondition {
         conditions: conds,
@@ -1199,6 +1199,62 @@ fn test_add_condition_negated() {
     } else {
         panic!("Expected And condition");
     }
+}
+
+#[test]
+fn test_add_condition_negated_multi_value() {
+    let mut rule = make_test_rule();
+    let mut state = PipelineState::default();
+    let mut conds = HashMap::new();
+    conds.insert(
+        "EventID".to_string(),
+        vec![
+            SigmaValue::Integer(1),
+            SigmaValue::Integer(2),
+            SigmaValue::Integer(3),
+        ],
+    );
+    let t = Transformation::AddCondition {
+        conditions: conds,
+        field_refs: HashMap::new(),
+        negated: true,
+        prepend: false,
+    };
+    t.apply(&mut rule, &mut state, &[], &[], false).unwrap();
+
+    // The condition should be AND NOT (EventID 1 OR 2 OR 3)
+    assert_eq!(rule.detection.conditions.len(), 1);
+    if let ConditionExpr::And(parts) = &rule.detection.conditions[0] {
+        assert_eq!(parts.len(), 2);
+        // Second part should be Not(...)
+        assert!(
+            matches!(&parts[1], ConditionExpr::Not(_)),
+            "Expected negated condition, got: {:?}",
+            parts[1]
+        );
+    } else {
+        panic!("Expected And condition");
+    }
+
+    // The injected named detection carries a single DetectionItem with 3
+    // integer values (OR-linked per add_condition multi-value semantics)
+    let added = rule
+        .detection
+        .named
+        .iter()
+        .find(|(k, _)| k.starts_with("__pipeline_cond_"))
+        .map(|(_, v)| v)
+        .expect("pipeline condition detection added");
+    let Detection::AllOf(items) = added else {
+        panic!("expected AllOf, got: {added:?}");
+    };
+    assert_eq!(items.len(), 1);
+    let id_item = &items[0];
+    assert_eq!(id_item.field.name.as_deref(), Some("EventID"));
+    assert_eq!(id_item.values.len(), 3);
+    assert_eq!(&id_item.values[0], &SigmaValue::Integer(1));
+    assert_eq!(&id_item.values[1], &SigmaValue::Integer(2));
+    assert_eq!(&id_item.values[2], &SigmaValue::Integer(3));
 }
 
 #[test]
@@ -1931,4 +1987,58 @@ fn test_case_transformation_snake_case_already_lowercase() {
     {
         assert_eq!(s.original, "whoami"); // unchanged
     }
+}
+
+#[test]
+fn parse_add_condition_with_list_values() {
+    use crate::pipeline::parse_pipeline;
+
+    let yaml = r#"
+name: t
+priority: 1
+transformations:
+  - id: add_list
+    type: add_condition
+    conditions:
+      field_a: [val1, val2]
+      field_b: single_val
+"#;
+    let pipeline = parse_pipeline(yaml).unwrap();
+    let Transformation::AddCondition { conditions, .. } =
+        &pipeline.transformations[0].transformation
+    else {
+        panic!("expected AddCondition");
+    };
+    let a = conditions.get("field_a").unwrap();
+    assert_eq!(a.len(), 2);
+    assert!(matches!(&a[0], SigmaValue::String(s) if s.original == "val1"));
+    assert!(matches!(&a[1], SigmaValue::String(s) if s.original == "val2"));
+    let b = conditions.get("field_b").unwrap();
+    assert_eq!(b.len(), 1);
+    assert!(matches!(&b[0], SigmaValue::String(s) if s.original == "single_val"));
+}
+#[test]
+fn parse_add_condition_with_empty_sequence() {
+    use crate::pipeline::parse_pipeline;
+
+    let yaml = r#"
+name: t
+priority: 1
+transformations:
+  - id: add_empty
+    type: add_condition
+    conditions:
+      field_a: []
+      field_b: val
+"#;
+    let err = parse_pipeline(yaml).expect_err("empty sequence should be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("empty sequence"),
+        "error message should mention empty sequence: {err}"
+    );
+    assert!(
+        msg.contains("field_a"),
+        "error message should name the offending field 'field_a': {err}"
+    );
 }

--- a/crates/rsigma-eval/src/pipeline/transformations/tests.rs
+++ b/crates/rsigma-eval/src/pipeline/transformations/tests.rs
@@ -2017,6 +2017,7 @@ transformations:
     assert_eq!(b.len(), 1);
     assert!(matches!(&b[0], SigmaValue::String(s) if s.original == "single_val"));
 }
+
 #[test]
 fn parse_add_condition_with_empty_sequence() {
     use crate::pipeline::parse_pipeline;
@@ -2041,4 +2042,31 @@ transformations:
         msg.contains("field_a"),
         "error message should name the offending field 'field_a': {err}"
     );
+}
+
+#[test]
+fn parse_add_condition_with_non_scalar_value() {
+    use crate::pipeline::parse_pipeline;
+
+    // A mapping and a nested sequence both stringify to a debug
+    // representation that can never match, so both are rejected.
+    for value in ["\n        nested: 1", "\n      - [1, 2]"] {
+        let yaml = format!(
+            r#"
+name: t
+priority: 1
+transformations:
+  - id: add_non_scalar
+    type: add_condition
+    conditions:
+      field_a:{value}
+"#
+        );
+        let err = parse_pipeline(&yaml).expect_err("non-scalar value should be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("non-scalar") && msg.contains("field_a"),
+            "error should name the offending field: {err}"
+        );
+    }
 }

--- a/docs/content/guide/processing-pipelines.md
+++ b/docs/content/guide/processing-pipelines.md
@@ -86,7 +86,7 @@ Pipelines compose 26 transformation types. The most common ones in practice are:
 | `field_name_prefix_mapping` | Rename fields by prefix. |
 | `field_name_prefix`/`field_name_suffix` | Add a static prefix or suffix to every field name. |
 | `field_name_transform` | Case conversion (`lower`, `upper`, `snake_case`, `title`). |
-| `add_condition` | Inject extra detection conditions (e.g. add `EventID: 1`); `field_refs` injects field-to-field comparisons (`evt.pid: thread.pid`) instead of literals. |
+| `add_condition` | Inject extra detection conditions (e.g. `EventID: 1` or `EventID: [12, 13, 14]` for OR-linked values); `field_refs` injects field-to-field comparisons (`evt.pid: thread.pid`) instead of literals. |
 | `drop_detection_item` | Remove matching detection items. |
 | `change_logsource` | Modify `category`, `product`, `service`. |
 | `replace_string` | Regex string replacement in values. |

--- a/docs/content/reference/builtin-pipelines.md
+++ b/docs/content/reference/builtin-pipelines.md
@@ -65,6 +65,7 @@ Each transformation is `add_condition` with a matching `rule_conditions: logsour
 | `process_creation` | `EventID: 1` |
 | `file_change` | `EventID: 2` |
 | `network_connection` | `EventID: 3` |
+| `sysmon_status` | `EventID: [4, 16]` |
 | `process_termination` | `EventID: 5` |
 | `driver_load` | `EventID: 6` |
 | `image_load` | `EventID: 7` |
@@ -72,12 +73,14 @@ Each transformation is `add_condition` with a matching `rule_conditions: logsour
 | `raw_access_thread` | `EventID: 9` |
 | `process_access` | `EventID: 10` |
 | `file_event` | `EventID: 11` |
+| `registry_event` | `EventID: [12, 13, 14]` |
 | `registry_add` | `EventID: 12` |
 | `registry_delete` | `EventID: 12` |
 | `registry_set` | `EventID: 13` |
 | `registry_rename` | `EventID: 14` |
 | `create_stream_hash` | `EventID: 15` |
 | `pipe_created` | `EventID: [17, 18]` |
+| `wmi_event` | `EventID: [19, 20, 21]` |
 | `dns_query` | `EventID: 22` |
 | `file_delete` | `EventID: 23` |
 | `clipboard_capture` | `EventID: 24` |
@@ -86,9 +89,7 @@ Each transformation is `add_condition` with a matching `rule_conditions: logsour
 | `file_block_executable` | `EventID: 27` |
 | `file_block_shredding` | `EventID: 28` |
 | `file_executable_detected` | `EventID: 29` |
-| `sysmon_status` | `EventID: [4, 16]` |
-| `registry_event` | `EventID: [12, 13, 14]` |
-| `wmi_event` | `EventID: [19, 20, 21]` |
+| `sysmon_error` | `EventID: 255` |
 
 After the routing conditions, a final `change_logsource` rewrites every Windows rule to `product: windows, service: sysmon` so downstream backends can use the unified logsource.
 

--- a/docs/content/reference/builtin-pipelines.md
+++ b/docs/content/reference/builtin-pipelines.md
@@ -77,14 +77,18 @@ Each transformation is `add_condition` with a matching `rule_conditions: logsour
 | `registry_set` | `EventID: 13` |
 | `registry_rename` | `EventID: 14` |
 | `create_stream_hash` | `EventID: 15` |
-| `pipe_created` | `EventID: 17` |
+| `pipe_created` | `EventID: [17, 18]` |
 | `dns_query` | `EventID: 22` |
 | `file_delete` | `EventID: 23` |
 | `clipboard_capture` | `EventID: 24` |
 | `process_tampering` | `EventID: 25` |
 | `file_delete_detected` | `EventID: 26` |
 | `file_block_executable` | `EventID: 27` |
+| `file_block_shredding` | `EventID: 28` |
 | `file_executable_detected` | `EventID: 29` |
+| `sysmon_status` | `EventID: [4, 16]` |
+| `registry_event` | `EventID: [12, 13, 14]` |
+| `wmi_event` | `EventID: [19, 20, 21]` |
 
 After the routing conditions, a final `change_logsource` rewrites every Windows rule to `product: windows, service: sysmon` so downstream backends can use the unified logsource.
 


### PR DESCRIPTION
## Summary

Implement list value support in the `add_condition` pipeline transformation, matching pySigma's `AddConditionTransformation` behavior. This allows pipeline definitions to specify multiple OR-linked values per field (e.g., `EventID: [12, 13, 14]`) instead of requiring separate transformations for each value.

## What Changed

### 🐛 Parsing & Semantics

- `parse_value_mapping` now accepts YAML sequences as values, producing `HashMap<String, Vec<SigmaValue>>` instead of `HashMap<String, SigmaValue>`
- Extracted `yaml_to_sigma_value` helper for converting a single YAML value to `SigmaValue`
- Added guard against empty sequences: `[]` produces no entry rather than a silent no-match detection item

### 📋 Sysmon Pipeline Alignment

Aligned the sysmon pipeline with the [Sigma taxonomy](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-appendix-taxonomy.md#windows-folder):

| Category | EventIDs | Status |
|----------|----------|--------|
| `sysmon_status` | 4, 16 | **Added** |
| `registry_event` | 12, 13, 14 | **Added** (previously only separate sub-categories) |
| `wmi_event` | 19, 20, 21 | **Added** |
| `pipe_created` | 17, **18** | Updated — missing EventID 18 |
| `file_block_shredding` | 28 | **Added** |

### ✅ Tests

- Unit test: `parse_add_condition_with_list_values` — validates YAML sequence parsing
- Unit test: `parse_add_condition_with_empty_sequence` — validates empty sequence handling
- E2E test: `test_pipeline_add_condition_list_values_e2e` — full engine pipeline test with `registry_event` and `EventID: [12, 13, 14]`

## Commits

```
0511cef2 📋 fix(sysmon): align pipeline with Sigma taxonomy
1f1cfa49 ✅ test: add e2e test for add_condition with list values
c9ac2b26 🐛 fix: guard empty YAML sequences in parse_value_mapping
1df9d3ac ✨ feat: support list values in add_condition pipeline transformation
```

## Verification

```
696 passed, 0 failed
```