### PR TITLE
Incident bundle export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Incident bundle export
+
+- One incident can be exported as a self-contained report joining it to the [ADS](https://rsigma.io/guide/detection-strategy/) documentation of every rule that contributed and the risk entities it overlaps: `rsigma engine incidents export <ID> [--bundle-format json|markdown] [-o PATH]`, backed by `GET /api/v1/incidents/{id}/bundle`. An incident records only rule keys and counts, so previously nothing in it said what the rules looked for or why they mattered.
+- Each rule in a bundle reports how its key resolved against the currently loaded rule set: `unique`, `ambiguous` when several loaded rules carry it with differing documentation (a routed rule set compiles the same rule once per pipeline-set), or `missing` when the rule set changed while the incident was open. Risk entities join on the entity type as well as its value, and report whether the join came from a retained result's `risk.objects` enrichment or from the incident's own grouping key.
+- New `GET /api/v1/incidents/{id}` serves a single incident. Both per-incident routes return `503` when the alert pipeline has no `group:` stage, distinguishing "this daemon does not track incidents" from a `404` for an unknown or already-evicted id. The bundle route additionally returns `409` while the incident is inside `group_wait` and its contents can still change.
+- The bundle route requires a new `incident-bundles:read` permission rather than the `incidents:read` that gates the incident list, so a custom role can hand out the incident list without also handing out rule documentation and risk entities. The built-in `reader` role (`*:read`) covers both.
+- Incident snapshots gain `sample_mode` and `bundle_ready`. `sample_mode` reports which sample kinds an incident actually retained (`refs`, `results`, `mixed`, `none`), so changing `include` while an incident is open is visible instead of silently hiding one kind. Both fields are snapshot-only and never appear on emitted incidents.
+- `CompiledRule` and `CompiledCorrelation` retain `description` and `falsepositives`, and `rsigma_eval` gains a public `rule_metadata` lookup (`RuleBundleMetadata`, `RuleIdentity`, `RuleMetadataLookup`) on `Engine`, `CorrelationEngine`, `SchemaRouter`, and `RuntimeEngine`. The ADS section vocabulary is now expressed through an `AdsCarriers` trait so a compiled rule produces the same nine-section document as a parsed one.
+
 ### Support list values in `add_condition` pipeline transformation (#399)
 
 - `add_condition` accepts YAML sequences for field values (`conditions: {EventID: [12, 13, 14]}`), and the values of one field are OR-linked, matching pySigma's `AddConditionTransformation`. Pipelines no longer need one transformation per value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Incident bundle export
+### Incident bundle export (#400)
 
 - One incident can be exported as a self-contained report joining it to the [ADS](https://rsigma.io/guide/detection-strategy/) documentation of every rule that contributed and the risk entities it overlaps: `rsigma engine incidents export <ID> [--bundle-format json|markdown] [-o PATH]`, backed by `GET /api/v1/incidents/{id}/bundle`. An incident records only rule keys and counts, so previously nothing in it said what the rules looked for or why they mattered.
 - Each rule in a bundle reports how its key resolved against the currently loaded rule set: `unique`, `ambiguous` when several loaded rules carry it with differing documentation (a routed rule set compiles the same rule once per pipeline-set), or `missing` when the rule set changed while the incident was open. Risk entities join on the entity type as well as its value, and report whether the join came from a retained result's `risk.objects` enrichment or from the incident's own grouping key.

--- a/crates/rsigma-cli/src/commands/incidents.rs
+++ b/crates/rsigma-cli/src/commands/incidents.rs
@@ -1,0 +1,253 @@
+//! `rsigma engine incidents export`: fetch one incident's bundle from a running
+//! daemon and write it to stdout or a file.
+//!
+//! A read-only client, following the `engine status` conventions (`--addr`
+//! resolves from `daemon.api.addr`, synchronous `ureq` transport) so it builds
+//! without the `daemon` feature and a lightweight build can still pull a bundle
+//! from a remote daemon.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process;
+
+use clap::{Args, Subcommand, ValueEnum};
+
+use crate::config;
+use crate::exit_code;
+use crate::output::OutputCtx;
+
+/// The environment variable the API token is read from unless
+/// `--auth-token-env` names another.
+const DEFAULT_TOKEN_ENV: &str = "RSIGMA_API_TOKEN";
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum IncidentsCommands {
+    /// Export one incident's bundle (GET /api/v1/incidents/{id}/bundle)
+    Export(IncidentsExportArgs),
+}
+
+pub(crate) fn dispatch_incidents(cmd: IncidentsCommands, ctx: OutputCtx) {
+    match cmd {
+        IncidentsCommands::Export(args) => cmd_incidents_export(args, ctx),
+    }
+}
+
+/// How the daemon should render the bundle.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum BundleFormat {
+    /// The full structured document.
+    Json,
+    /// A human-readable report.
+    Markdown,
+}
+
+impl BundleFormat {
+    fn as_query(self) -> &'static str {
+        match self {
+            BundleFormat::Json => "json",
+            BundleFormat::Markdown => "markdown",
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct IncidentsExportArgs {
+    /// Incident id, as reported by `GET /api/v1/incidents`.
+    #[arg(value_name = "INCIDENT_ID")]
+    pub id: String,
+
+    /// Daemon API address as `host:port` or a full URL.
+    /// Defaults to `daemon.api.addr` from the resolved config.
+    #[arg(long)]
+    pub addr: Option<String>,
+
+    /// Explicit config file used to resolve the daemon address.
+    #[arg(short, long)]
+    pub config: Option<PathBuf>,
+
+    /// Bundle rendering to request.
+    #[arg(long, value_enum, default_value_t = BundleFormat::Json)]
+    pub bundle_format: BundleFormat,
+
+    /// Write the bundle here instead of stdout. The file is replaced only
+    /// after the whole bundle has been received.
+    #[arg(short, long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+
+    /// Environment variable holding the API bearer token. The token itself is
+    /// never taken as an argument, so it cannot leak through the process list.
+    #[arg(long, value_name = "VAR", default_value = DEFAULT_TOKEN_ENV)]
+    pub auth_token_env: String,
+}
+
+pub(crate) fn cmd_incidents_export(args: IncidentsExportArgs, ctx: OutputCtx) {
+    // The daemon renders the bundle, so the global output format has no say in
+    // how it looks; `--bundle-format` is the only control.
+    ctx.warn_unsupported("engine incidents export", "bundle");
+
+    let addr = config::resolve_daemon_addr(args.addr.clone(), args.config.as_deref());
+    let url = format!(
+        "{}?format={}",
+        config::api_url(&addr, &format!("/api/v1/incidents/{}/bundle", args.id)),
+        args.bundle_format.as_query()
+    );
+
+    // Surface non-2xx as a normal response so the daemon's JSON error hint
+    // (401/403 auth, 404 unknown id, 409 still batching, 503 grouping off)
+    // reaches the operator instead of being reduced to a status code.
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .build()
+        .into();
+
+    let mut request = agent.get(&url);
+    if let Some(token) = token_from_env(&args.auth_token_env) {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+
+    let response = match request.call() {
+        Ok(response) => response,
+        Err(e) => {
+            eprintln!("incident export failed: could not reach {url}: {e}");
+            eprintln!("(is the daemon running?)");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+    };
+
+    let status = response.status().as_u16();
+    let body = match response.into_body().read_to_string() {
+        Ok(body) => body,
+        Err(e) => {
+            eprintln!("incident export failed: could not read response from {url}: {e}");
+            process::exit(exit_code::CONFIG_ERROR);
+        }
+    };
+
+    if !(200..300).contains(&status) {
+        eprintln!("incident export failed: {url} returned HTTP {status}");
+        if !body.trim().is_empty() {
+            eprintln!("{}", describe_error(&body));
+        }
+        process::exit(exit_code::CONFIG_ERROR);
+    }
+
+    match &args.output {
+        None => print!("{body}"),
+        Some(path) => {
+            if let Err(e) = write_atomically(path, &body) {
+                eprintln!(
+                    "incident export failed: could not write {}: {e}",
+                    path.display()
+                );
+                process::exit(exit_code::CONFIG_ERROR);
+            }
+        }
+    }
+}
+
+/// The token held by `var`, or `None` when the variable is unset or empty.
+///
+/// An empty variable is treated as absent so an unset deployment secret sends
+/// no header at all rather than an obviously invalid one.
+fn token_from_env(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|t| !t.trim().is_empty())
+}
+
+/// Render the daemon's error body for the terminal: its `error` and `hint`
+/// when it is the usual JSON shape, and the raw body otherwise.
+fn describe_error(body: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return body.trim().to_string();
+    };
+    let Some(error) = value.get("error").and_then(|v| v.as_str()) else {
+        return body.trim().to_string();
+    };
+    match value.get("hint").and_then(|v| v.as_str()) {
+        Some(hint) => format!("{error}\n({hint})"),
+        None => error.to_string(),
+    }
+}
+
+/// Write `contents` to `path` by way of a sibling temporary file and a rename.
+///
+/// A bundle is commonly written over a previous export of the same incident, so
+/// a failed write must leave that previous export intact rather than truncating
+/// it. The temporary file is a sibling, which keeps the rename within one
+/// filesystem and therefore atomic.
+fn write_atomically(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    let Some(file_name) = path.file_name() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "output path has no file name",
+        ));
+    };
+    let mut temporary = path.to_path_buf();
+    temporary.set_file_name(format!(
+        ".{}.rsigma-{}.tmp",
+        file_name.to_string_lossy(),
+        process::id()
+    ));
+
+    let write = (|| {
+        let mut file = std::fs::File::create(&temporary)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()
+    })();
+    if let Err(e) = write {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(e);
+    }
+    if let Err(e) = std::fs::rename(&temporary, path) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_error_body_is_rendered_with_its_hint() {
+        let body = r#"{"error":"incident grouping disabled","hint":"configure a group stage"}"#;
+        assert_eq!(
+            describe_error(body),
+            "incident grouping disabled\n(configure a group stage)"
+        );
+    }
+
+    #[test]
+    fn a_body_that_is_not_the_usual_shape_is_shown_verbatim() {
+        assert_eq!(describe_error("upstream said no\n"), "upstream said no");
+        assert_eq!(
+            describe_error(r#"{"detail":"nope"}"#),
+            r#"{"detail":"nope"}"#
+        );
+    }
+
+    #[test]
+    fn a_blank_token_variable_sends_no_header() {
+        // SAFETY: single-threaded test with no other reader of this variable.
+        unsafe { std::env::set_var("RSIGMA_TEST_BLANK_TOKEN", "   ") };
+        assert!(token_from_env("RSIGMA_TEST_BLANK_TOKEN").is_none());
+        assert!(token_from_env("RSIGMA_TEST_UNSET_TOKEN").is_none());
+        unsafe { std::env::remove_var("RSIGMA_TEST_BLANK_TOKEN") };
+    }
+
+    #[test]
+    fn a_failed_write_leaves_the_previous_export_intact() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("bundle.json");
+        write_atomically(&path, "first").unwrap();
+        write_atomically(&path, "second").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "second");
+
+        // The temporary file is a sibling, so nothing is left behind either.
+        let leftovers: Vec<_> = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(leftovers.len(), 1, "{leftovers:?}");
+    }
+}

--- a/crates/rsigma-cli/src/commands/mod.rs
+++ b/crates/rsigma-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod eval_stream;
 mod explain;
 mod fields;
 mod hygiene;
+mod incidents;
 mod lint;
 #[cfg(feature = "mcp")]
 mod mcp;
@@ -50,6 +51,7 @@ pub(crate) use eval::{EvalArgs, apply_eval_config, cmd_eval};
 pub(crate) use explain::{ExplainArgs, cmd_explain};
 pub(crate) use fields::{FieldsArgs, cmd_fields};
 pub(crate) use hygiene::{HygieneArgs, apply_hygiene_config, cmd_hygiene};
+pub(crate) use incidents::{IncidentsCommands, dispatch_incidents};
 pub(crate) use lint::{LintArgs, LintCounts, cmd_lint};
 #[cfg(feature = "mcp")]
 pub(crate) use mcp::{McpCommands, dispatch_mcp};

--- a/crates/rsigma-cli/src/daemon/auth.rs
+++ b/crates/rsigma-cli/src/daemon/auth.rs
@@ -133,7 +133,11 @@ pub fn required_access(method: &Method, path: &str) -> Access {
         (&Method::GET, "/api/v1/correlations" | "/api/v1/correlations/state") => {
             req("correlations", "read")
         }
-        (&Method::GET, "/api/v1/incidents") => req("incidents", "read"),
+        (&Method::GET, "/api/v1/incidents" | "/api/v1/incidents/{id}") => req("incidents", "read"),
+        // The bundle joins incidents to rule documentation and risk entities,
+        // so it hands out more than `incidents:read` names. It gets its own
+        // resource rather than widening what an incident reader can see.
+        (&Method::GET, "/api/v1/incidents/{id}/bundle") => req("incident-bundles", "read"),
         (&Method::GET, "/api/v1/risk") => req("risk", "read"),
         (&Method::GET, "/api/v1/silences") => req("silences", "read"),
         (&Method::POST, "/api/v1/silences") => req("silences", "write"),
@@ -569,6 +573,8 @@ mod tests {
             (Method::GET, "/api/v1/correlations"),
             (Method::GET, "/api/v1/correlations/state"),
             (Method::GET, "/api/v1/incidents"),
+            (Method::GET, "/api/v1/incidents/{id}"),
+            (Method::GET, "/api/v1/incidents/{id}/bundle"),
             (Method::GET, "/api/v1/risk"),
             (Method::GET, "/api/v1/silences"),
             (Method::POST, "/api/v1/silences"),
@@ -602,6 +608,28 @@ mod tests {
                 "route {method} {path} fell through to the fail-closed catch-all"
             );
         }
+    }
+
+    #[test]
+    fn the_bundle_route_needs_more_than_incident_access() {
+        // A bundle joins incidents to rule documentation and risk entities, so
+        // granting someone the incident list must not also hand them that.
+        assert_eq!(
+            required_access(&Method::GET, "/api/v1/incidents/{id}"),
+            Access::Require(Permission::required("incidents", "read"))
+        );
+        let Access::Require(bundle) =
+            required_access(&Method::GET, "/api/v1/incidents/{id}/bundle")
+        else {
+            panic!("the bundle route must require a permission");
+        };
+        assert!(!Permission::parse("incidents:read").unwrap().grants(&bundle));
+        assert!(
+            Permission::parse("incident-bundles:read")
+                .unwrap()
+                .grants(&bundle)
+        );
+        assert!(Permission::parse("*:read").unwrap().grants(&bundle));
     }
 
     #[test]

--- a/crates/rsigma-cli/src/daemon/bundle.rs
+++ b/crates/rsigma-cli/src/daemon/bundle.rs
@@ -10,7 +10,7 @@
 //! generation timestamp, so a bundle is fully determined by its inputs and the
 //! HTTP layer decides how (and how consistently) those snapshots are taken.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use rsigma_eval::{RuleIdentity, RuleMetadataLookup};
 use rsigma_parser::Level;
@@ -215,14 +215,18 @@ fn build_rule(key: &str, count: u64, lookup: Option<&RuleMetadataLookup>) -> Bun
 /// user `alice` to the host `alice`, so the fallback requires the field's last
 /// path segment to name the entity type as well.
 fn match_risk(incident: &IncidentResult, entities: &[RiskEntityView]) -> Vec<BundleRiskEntity> {
+    // Sets, not vectors: the accumulator can hold `max_open_entities` (100k by
+    // default) and an incident can retain `max_results_per_incident` samples,
+    // so a linear membership test would make this quadratic in two operator
+    // caps at once.
     let exact = risk_objects(incident);
     let from_grouping = group_key_names(incident);
     let mut out = Vec::new();
     for entity in entities {
-        let pair = (entity.entity_type.clone(), entity.entity_value.clone());
+        let pair = (entity.entity_type.as_str(), entity.entity_value.as_str());
         let matched = if exact.contains(&pair) {
             Some(RiskMatch::RiskObject)
-        } else if from_grouping.contains(&pair) {
+        } else if from_grouping.contains(&(entity.entity_type.to_lowercase(), pair.1.to_string())) {
             Some(RiskMatch::GroupKey)
         } else {
             None
@@ -239,8 +243,10 @@ fn match_risk(incident: &IncidentResult, entities: &[RiskEntityView]) -> Vec<Bun
 
 /// The `(type, value)` pairs named by the retained results' `risk.objects`
 /// enrichments.
-fn risk_objects(incident: &IncidentResult) -> Vec<(String, String)> {
-    let mut out = Vec::new();
+///
+/// Borrowed from the incident, which outlives the match.
+fn risk_objects(incident: &IncidentResult) -> HashSet<(&str, &str)> {
+    let mut out = HashSet::new();
     let Some(results) = &incident.results else {
         return out;
     };
@@ -259,10 +265,7 @@ fn risk_objects(incident: &IncidentResult) -> Vec<(String, String)> {
             ) else {
                 continue;
             };
-            let pair = (object_type.to_string(), value.to_string());
-            if !out.contains(&pair) {
-                out.push(pair);
-            }
+            out.insert((object_type, value));
         }
     }
     out
@@ -270,8 +273,12 @@ fn risk_objects(incident: &IncidentResult) -> Vec<(String, String)> {
 
 /// The `(type, value)` pairs the incident's own grouping names, reading each
 /// selector's last path segment as a candidate risk-object type.
-fn group_key_names(incident: &IncidentResult) -> Vec<(String, String)> {
-    let mut out = Vec::new();
+///
+/// The segment is lowercased because it is a field name (`event.User`) being
+/// compared against an operator-declared risk-object type (`user`), and the two
+/// are not written in the same case.
+fn group_key_names(incident: &IncidentResult) -> HashSet<(String, String)> {
+    let mut out = HashSet::new();
     let mut push = |selector: &str, value: &Value| {
         let Some(value) = value.as_str() else {
             return;
@@ -279,10 +286,7 @@ fn group_key_names(incident: &IncidentResult) -> Vec<(String, String)> {
         let Some(segment) = selector.rsplit('.').next() else {
             return;
         };
-        let pair = (segment.to_lowercase(), value.to_string());
-        if !out.contains(&pair) {
-            out.push(pair);
-        }
+        out.insert((segment.to_lowercase(), value.to_string()));
     };
     for (selector, value) in &incident.group_by {
         push(selector, value);
@@ -688,6 +692,26 @@ mod tests {
         let risk = bundle.risk.unwrap();
         assert_eq!(risk.len(), 1);
         assert_eq!(risk[0].entity.entity_type, "user");
+        assert_eq!(risk[0].matched_on, RiskMatch::GroupKey);
+    }
+
+    #[test]
+    fn the_grouping_fallback_ignores_the_case_of_the_entity_type() {
+        // The selector names a field (`match.User`) and the risk layer names a
+        // type the operator declared. Nothing forces the two to agree on case,
+        // so a `User` entity must still join a `match.User` grouping key.
+        let mut incident = incident();
+        incident.results = None;
+        incident.sample_mode = Some(SampleMode::Refs);
+
+        let bundle = build(
+            incident,
+            &metadata(),
+            Some(&[entity("User", "alice", 120)]),
+            GENERATED_AT.to_string(),
+        );
+        let risk = bundle.risk.unwrap();
+        assert_eq!(risk.len(), 1, "a differently-cased type must still join");
         assert_eq!(risk[0].matched_on, RiskMatch::GroupKey);
     }
 

--- a/crates/rsigma-cli/src/daemon/bundle.rs
+++ b/crates/rsigma-cli/src/daemon/bundle.rs
@@ -1,0 +1,784 @@
+//! Incident bundle assembly.
+//!
+//! An open incident on its own is a fingerprint, some counters, and a list of
+//! rule keys. That is enough to page someone and not much else. A bundle is the
+//! same incident joined to the two things an analyst reaches for next: the
+//! [ADS](rsigma_parser::ads) documentation of every rule that contributed, and
+//! the risk entities the incident overlaps.
+//!
+//! Assembly is pure. [`build`] takes snapshots of each component and a
+//! generation timestamp, so a bundle is fully determined by its inputs and the
+//! HTTP layer decides how (and how consistently) those snapshots are taken.
+
+use std::collections::BTreeMap;
+
+use rsigma_eval::{RuleIdentity, RuleMetadataLookup};
+use rsigma_parser::Level;
+use rsigma_parser::ads::{AdsContent, AdsDocument};
+use rsigma_runtime::alert_pipeline::IncidentResult;
+use rsigma_runtime::risk::RiskEntityView;
+use serde::Serialize;
+use serde_json::Value;
+
+/// The bundle wire-format version. Bumped when a field is removed or changes
+/// meaning; additive fields do not bump it.
+pub(super) const SCHEMA_VERSION: u32 = 1;
+
+/// Requested rendering of a bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BundleFormat {
+    /// The full structured document.
+    Json,
+    /// A human-readable report rendered from the same document.
+    Markdown,
+}
+
+impl BundleFormat {
+    /// Parse the `format` query parameter.
+    pub(super) fn parse(value: &str) -> Option<BundleFormat> {
+        match value {
+            "json" => Some(BundleFormat::Json),
+            "markdown" | "md" => Some(BundleFormat::Markdown),
+            _ => None,
+        }
+    }
+
+    /// The `Content-Type` a rendered bundle is served with.
+    pub(super) fn content_type(self) -> &'static str {
+        match self {
+            BundleFormat::Json => "application/json",
+            BundleFormat::Markdown => "text/markdown; charset=utf-8",
+        }
+    }
+}
+
+/// A self-contained incident report.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct IncidentBundle {
+    /// The bundle wire-format version.
+    pub schema_version: u32,
+    /// When the bundle was assembled (RFC 3339). Injected by the caller so a
+    /// bundle is reproducible from its inputs.
+    pub generated_at: String,
+    /// Which components the bundle could consult. A component that is not
+    /// configured is reported here rather than being silently empty.
+    pub sources: BundleSources,
+    /// The incident snapshot the bundle documents.
+    pub incident: IncidentResult,
+    /// One entry per contributing rule key, in the incident's own key order.
+    pub rules: Vec<BundleRule>,
+    /// Risk entities the incident overlaps. Absent when no risk accumulator is
+    /// configured, which is not the same as an incident with no risk overlap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk: Option<Vec<BundleRiskEntity>>,
+}
+
+/// Which components contributed to a bundle.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub(super) struct BundleSources {
+    /// Whether rule documentation was resolved against the loaded rule set.
+    pub rules: bool,
+    /// Whether a risk accumulator was configured and consulted.
+    pub risk: bool,
+}
+
+/// How a rule key resolved against the loaded rule set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum RuleResolution {
+    /// Exactly one rule carries the key.
+    Unique,
+    /// Several loaded rules carry the key with differing documentation.
+    Ambiguous,
+    /// No loaded rule carries the key, usually because the rule set changed
+    /// while the incident was open.
+    Missing,
+}
+
+/// One contributing rule key, with whatever documentation it resolved to.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct BundleRule {
+    /// The key the incident recorded: a rule id, or a title for a rule without
+    /// one.
+    pub key: String,
+    /// How many contributing results this key accounts for.
+    pub count: u64,
+    /// How the key resolved.
+    pub resolution: RuleResolution,
+    /// The resolved documentation: empty when missing, one entry when unique,
+    /// and one per differing rule when ambiguous.
+    pub documents: Vec<BundleRuleDocument>,
+}
+
+/// One rule's documentation.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct BundleRuleDocument {
+    /// The rule's kind, id, and title.
+    pub identity: RuleIdentity,
+    /// The rule's severity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<Level>,
+    /// The rule's tags.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// The nine-section ADS document assembled from the rule's carriers.
+    pub ads: AdsDocument,
+}
+
+/// How a risk entity was tied to the incident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum RiskMatch {
+    /// A retained result named the entity in its `risk.objects` enrichment, so
+    /// the type and the value both come from the risk layer.
+    RiskObject,
+    /// The incident's own grouping key names the entity. Used when the
+    /// incident retained only references, which carry no enrichments.
+    GroupKey,
+}
+
+/// A risk entity the incident overlaps.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct BundleRiskEntity {
+    /// How the entity was tied to the incident.
+    pub matched_on: RiskMatch,
+    /// The open-entity view from the risk accumulator.
+    #[serde(flatten)]
+    pub entity: RiskEntityView,
+}
+
+/// Assemble a bundle from component snapshots.
+///
+/// `metadata` is expected to answer for every key in the incident's
+/// `rule_counts`; a key it does not answer for resolves as
+/// [`RuleResolution::Missing`]. `risk` is `None` when no risk accumulator is
+/// configured.
+pub(super) fn build(
+    incident: IncidentResult,
+    metadata: &BTreeMap<String, RuleMetadataLookup>,
+    risk: Option<&[RiskEntityView]>,
+    generated_at: String,
+) -> IncidentBundle {
+    let rules = incident
+        .rule_counts
+        .iter()
+        .map(|(key, count)| build_rule(key, *count, metadata.get(key)))
+        .collect();
+
+    let matched_risk = risk.map(|entities| match_risk(&incident, entities));
+
+    IncidentBundle {
+        schema_version: SCHEMA_VERSION,
+        generated_at,
+        sources: BundleSources {
+            rules: true,
+            risk: risk.is_some(),
+        },
+        incident,
+        rules,
+        risk: matched_risk,
+    }
+}
+
+fn build_rule(key: &str, count: u64, lookup: Option<&RuleMetadataLookup>) -> BundleRule {
+    let lookup = lookup.unwrap_or(&RuleMetadataLookup::Missing);
+    let resolution = match lookup {
+        RuleMetadataLookup::Missing => RuleResolution::Missing,
+        RuleMetadataLookup::Unique(_) => RuleResolution::Unique,
+        RuleMetadataLookup::Ambiguous(_) => RuleResolution::Ambiguous,
+    };
+    let documents = lookup
+        .variants()
+        .iter()
+        .map(|meta| BundleRuleDocument {
+            identity: meta.identity.clone(),
+            level: meta.level,
+            tags: meta.tags.clone(),
+            ads: AdsDocument::from_carriers(meta),
+        })
+        .collect();
+    BundleRule {
+        key: key.to_string(),
+        count,
+        resolution,
+        documents,
+    }
+}
+
+/// Select the risk entities the incident overlaps.
+///
+/// Preference order matters. A retained result's `risk.objects` enrichment
+/// names both the entity type and its value, so it is an exact join. An
+/// incident holding only references has no enrichments to read, and the only
+/// evidence left is its own grouping key, which names a field rather than a
+/// risk-object type. Matching a bare value against every entity would tie the
+/// user `alice` to the host `alice`, so the fallback requires the field's last
+/// path segment to name the entity type as well.
+fn match_risk(incident: &IncidentResult, entities: &[RiskEntityView]) -> Vec<BundleRiskEntity> {
+    let exact = risk_objects(incident);
+    let from_grouping = group_key_names(incident);
+    let mut out = Vec::new();
+    for entity in entities {
+        let pair = (entity.entity_type.clone(), entity.entity_value.clone());
+        let matched = if exact.contains(&pair) {
+            Some(RiskMatch::RiskObject)
+        } else if from_grouping.contains(&pair) {
+            Some(RiskMatch::GroupKey)
+        } else {
+            None
+        };
+        if let Some(matched_on) = matched {
+            out.push(BundleRiskEntity {
+                matched_on,
+                entity: entity.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// The `(type, value)` pairs named by the retained results' `risk.objects`
+/// enrichments.
+fn risk_objects(incident: &IncidentResult) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let Some(results) = &incident.results else {
+        return out;
+    };
+    for result in results {
+        let Some(objects) = result
+            .get("enrichments")
+            .and_then(|e| e.get("risk.objects"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for object in objects {
+            let (Some(object_type), Some(value)) = (
+                object.get("type").and_then(Value::as_str),
+                object.get("value").and_then(Value::as_str),
+            ) else {
+                continue;
+            };
+            let pair = (object_type.to_string(), value.to_string());
+            if !out.contains(&pair) {
+                out.push(pair);
+            }
+        }
+    }
+    out
+}
+
+/// The `(type, value)` pairs the incident's own grouping names, reading each
+/// selector's last path segment as a candidate risk-object type.
+fn group_key_names(incident: &IncidentResult) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut push = |selector: &str, value: &Value| {
+        let Some(value) = value.as_str() else {
+            return;
+        };
+        let Some(segment) = selector.rsplit('.').next() else {
+            return;
+        };
+        let pair = (segment.to_lowercase(), value.to_string());
+        if !out.contains(&pair) {
+            out.push(pair);
+        }
+    };
+    for (selector, value) in &incident.group_by {
+        push(selector, value);
+    }
+    for (selector, values) in &incident.entities {
+        for value in values.as_array().into_iter().flatten() {
+            push(selector, value);
+        }
+    }
+    out
+}
+
+// =============================================================================
+// Markdown rendering
+// =============================================================================
+
+/// Render a bundle as a human-readable report.
+///
+/// Every fact in the report comes from the JSON document, so the two renderings
+/// never disagree about what the incident contains.
+pub(super) fn render_markdown(bundle: &IncidentBundle) -> String {
+    let mut out = String::new();
+    let incident = &bundle.incident;
+
+    out.push_str(&format!("# Incident {}\n\n", incident.incident_id));
+    out.push_str(&format!("- Generated: {}\n", bundle.generated_at));
+    out.push_str(&format!("- State: {}\n", incident.state));
+    if let Some(level) = &incident.max_level {
+        out.push_str(&format!("- Highest severity: {level}\n"));
+    }
+    out.push_str(&format!(
+        "- Window: {} to {}\n",
+        incident.first_seen, incident.last_seen
+    ));
+    out.push_str(&format!(
+        "- Contributing results: {}\n",
+        incident.result_count
+    ));
+    if let Some(mode) = incident.sample_mode {
+        out.push_str(&format!(
+            "- Retained samples: {}\n",
+            serde_json::to_value(mode)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_default()
+        ));
+    }
+    if incident.bundle_ready == Some(false) {
+        out.push_str("- Note: still inside `group_wait`, so the incident has not been reported yet and may still change.\n");
+    }
+    out.push('\n');
+
+    if !incident.group_by.is_empty() {
+        out.push_str("## Grouping\n\n");
+        for (selector, value) in &incident.group_by {
+            out.push_str(&format!("- `{selector}`: {}\n", scalar(value)));
+        }
+        out.push('\n');
+    }
+
+    if !incident.entities.is_empty() {
+        out.push_str("## Entities\n\n");
+        for (selector, values) in &incident.entities {
+            let joined: Vec<String> = values
+                .as_array()
+                .into_iter()
+                .flatten()
+                .map(scalar)
+                .collect();
+            out.push_str(&format!("- `{selector}`: {}\n", joined.join(", ")));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Contributing rules\n\n");
+    for rule in &bundle.rules {
+        render_rule(&mut out, rule);
+    }
+
+    match &bundle.risk {
+        None => {
+            out.push_str("## Risk\n\nNo risk accumulator is configured.\n\n");
+        }
+        Some(entities) if entities.is_empty() => {
+            out.push_str("## Risk\n\nNo tracked risk entity overlaps this incident.\n\n");
+        }
+        Some(entities) => {
+            out.push_str("## Risk\n\n");
+            for entry in entities {
+                let entity = &entry.entity;
+                out.push_str(&format!(
+                    "### {}: {}\n\n",
+                    entity.entity_type, entity.entity_value
+                ));
+                out.push_str(&format!("- Score: {}\n", entity.score));
+                out.push_str(&format!("- Distinct tactics: {}\n", entity.tactic_count));
+                out.push_str(&format!(
+                    "- Contributing sources: {}\n",
+                    entity.source_count
+                ));
+                out.push_str(&format!(
+                    "- Window: {} to {}\n",
+                    entity.window_start, entity.window_end
+                ));
+                out.push_str(&format!(
+                    "- Matched on: {}\n\n",
+                    match entry.matched_on {
+                        RiskMatch::RiskObject => "a contributing result's risk objects",
+                        RiskMatch::GroupKey => "the incident grouping key",
+                    }
+                ));
+            }
+        }
+    }
+
+    out
+}
+
+fn render_rule(out: &mut String, rule: &BundleRule) {
+    out.push_str(&format!(
+        "### `{}` ({} result{})\n\n",
+        rule.key,
+        rule.count,
+        if rule.count == 1 { "" } else { "s" }
+    ));
+
+    match rule.resolution {
+        RuleResolution::Missing => {
+            out.push_str(
+                "No loaded rule carries this key. The rule set most likely changed while the \
+                 incident was open.\n\n",
+            );
+            return;
+        }
+        RuleResolution::Ambiguous => {
+            out.push_str(&format!(
+                "{} loaded rules carry this key with differing documentation. All are shown.\n\n",
+                rule.documents.len()
+            ));
+        }
+        RuleResolution::Unique => {}
+    }
+
+    for document in &rule.documents {
+        out.push_str(&format!("**{}**\n\n", document.identity.title));
+        if let Some(level) = document.level {
+            out.push_str(&format!("- Level: {}\n", level.as_str()));
+        }
+        if !document.tags.is_empty() {
+            out.push_str(&format!("- Tags: {}\n", document.tags.join(", ")));
+        }
+        out.push('\n');
+
+        if document.ads.is_empty() {
+            out.push_str("This rule carries no ADS documentation.\n\n");
+            continue;
+        }
+        for section in &document.ads.sections {
+            let Some(content) = &section.content else {
+                continue;
+            };
+            out.push_str(&format!("*{}*\n\n", heading(section.id)));
+            match content {
+                AdsContent::Text(text) => out.push_str(&format!("{text}\n\n")),
+                AdsContent::List(items) => {
+                    for item in items {
+                        out.push_str(&format!("- {item}\n"));
+                    }
+                    out.push('\n');
+                }
+            }
+        }
+    }
+}
+
+/// A section id rendered as a heading (`blind_spots` becomes `Blind spots`).
+fn heading(id: &str) -> String {
+    let spaced = id.replace('_', " ");
+    let mut chars = spaced.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => spaced,
+    }
+}
+
+/// A JSON value rendered for prose: strings unquoted, everything else as JSON.
+fn scalar(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsigma_eval::{RuleBundleMetadata, RuleKind};
+    use rsigma_runtime::alert_pipeline::{IncidentRef, SampleMode};
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    /// A fixed generation time, so a golden is the same bytes on every run.
+    const GENERATED_AT: &str = "2026-07-26T12:00:00Z";
+
+    fn documented(id: &str, title: &str) -> RuleMetadataLookup {
+        RuleMetadataLookup::Unique(Box::new(RuleBundleMetadata {
+            identity: RuleIdentity {
+                kind: RuleKind::Detection,
+                id: Some(id.to_string()),
+                title: title.to_string(),
+            },
+            level: Some(Level::High),
+            tags: vec!["attack.discovery".to_string(), "attack.t1033".to_string()],
+            description: Some("Detects whoami execution, a common discovery step.".to_string()),
+            falsepositives: vec!["Administrators enumerating their own privileges".to_string()],
+            custom_attributes: Arc::new(
+                [
+                    (
+                        "rsigma.ads.strategy".to_string(),
+                        json!("Watch process creation for the whoami binary."),
+                    ),
+                    (
+                        "rsigma.ads.technical_context".to_string(),
+                        json!("Requires process_creation telemetry with CommandLine."),
+                    ),
+                    (
+                        "rsigma.ads.blind_spots".to_string(),
+                        json!(["A renamed binary evades the command-line match."]),
+                    ),
+                    (
+                        "rsigma.ads.validation".to_string(),
+                        json!("Run whoami in a lab and confirm the rule fires."),
+                    ),
+                    (
+                        "rsigma.ads.priority".to_string(),
+                        json!("High because discovery precedes lateral movement."),
+                    ),
+                    (
+                        "rsigma.ads.response".to_string(),
+                        json!([
+                            "Confirm the user and host.",
+                            "Correlate with other discovery."
+                        ]),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        }))
+    }
+
+    fn retained_result(rule: &str, objects: Value) -> Value {
+        json!({
+            "rule_title": rule,
+            "rule_id": rule,
+            "level": "high",
+            "enrichments": { "risk.score": 60, "risk.objects": objects },
+            "matched_fields": [{ "field": "User", "value": "alice" }],
+        })
+    }
+
+    fn incident() -> IncidentResult {
+        IncidentResult {
+            incident_id: "f8bcd62a829b1126".to_string(),
+            state: "open",
+            trigger: "snapshot",
+            first_seen: 1_767_225_000,
+            last_seen: 1_767_225_600,
+            max_level: Some("high".to_string()),
+            result_count: 3,
+            rule_counts: BTreeMap::from([
+                ("rule-whoami".to_string(), 2),
+                ("rule-retired".to_string(), 1),
+            ]),
+            group_by: serde_json::Map::from_iter([("match.User".to_string(), json!("alice"))]),
+            entities: serde_json::Map::new(),
+            refs: None,
+            results: Some(vec![retained_result(
+                "rule-whoami",
+                json!([{ "type": "user", "value": "alice" }]),
+            )]),
+            sample_mode: Some(SampleMode::Results),
+            bundle_ready: Some(true),
+        }
+    }
+
+    fn metadata() -> BTreeMap<String, RuleMetadataLookup> {
+        BTreeMap::from([
+            (
+                "rule-whoami".to_string(),
+                documented("rule-whoami", "Whoami execution"),
+            ),
+            ("rule-retired".to_string(), RuleMetadataLookup::Missing),
+        ])
+    }
+
+    fn entity(entity_type: &str, entity_value: &str, score: i64) -> RiskEntityView {
+        RiskEntityView {
+            entity_type: entity_type.to_string(),
+            entity_value: entity_value.to_string(),
+            score,
+            tactic_count: 2,
+            source_count: 2,
+            result_count: 3,
+            window_start: 1_767_225_000,
+            window_end: 1_767_225_600,
+            last_fired: None,
+        }
+    }
+
+    fn sample_bundle() -> IncidentBundle {
+        build(
+            incident(),
+            &metadata(),
+            Some(&[
+                entity("user", "alice", 120),
+                entity("host", "alice", 200),
+                entity("user", "bob", 40),
+            ]),
+            GENERATED_AT.to_string(),
+        )
+    }
+
+    // -- assembly -----------------------------------------------------------
+
+    #[test]
+    fn every_contributing_rule_key_gets_an_entry() {
+        let bundle = sample_bundle();
+        let keys: Vec<&str> = bundle.rules.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, ["rule-retired", "rule-whoami"]);
+        assert_eq!(bundle.rules[0].resolution, RuleResolution::Missing);
+        assert!(bundle.rules[0].documents.is_empty());
+        assert_eq!(bundle.rules[1].resolution, RuleResolution::Unique);
+        assert_eq!(bundle.rules[1].count, 2);
+    }
+
+    #[test]
+    fn a_documented_rule_carries_its_full_ads_document() {
+        let bundle = sample_bundle();
+        let ads = &bundle.rules[1].documents[0].ads;
+        assert!(
+            ads.missing_required().is_empty(),
+            "{:?}",
+            ads.missing_required()
+        );
+    }
+
+    #[test]
+    fn a_risk_entity_must_match_on_type_as_well_as_value() {
+        let bundle = sample_bundle();
+        let matched: Vec<(&str, &str)> = bundle
+            .risk
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|e| {
+                (
+                    e.entity.entity_type.as_str(),
+                    e.entity.entity_value.as_str(),
+                )
+            })
+            .collect();
+        // The host named `alice` shares the incident's value but not its type,
+        // and `bob` shares neither.
+        assert_eq!(matched, [("user", "alice")]);
+        assert_eq!(
+            bundle.risk.as_ref().unwrap()[0].matched_on,
+            RiskMatch::RiskObject
+        );
+    }
+
+    #[test]
+    fn a_refs_only_incident_falls_back_to_its_grouping_key() {
+        let mut incident = incident();
+        incident.results = None;
+        incident.refs = Some(vec![IncidentRef {
+            rule: "rule-whoami".to_string(),
+            level: Some("high".to_string()),
+        }]);
+        incident.sample_mode = Some(SampleMode::Refs);
+
+        let bundle = build(
+            incident,
+            &metadata(),
+            Some(&[entity("user", "alice", 120), entity("host", "alice", 200)]),
+            GENERATED_AT.to_string(),
+        );
+        let risk = bundle.risk.unwrap();
+        assert_eq!(risk.len(), 1);
+        assert_eq!(risk[0].entity.entity_type, "user");
+        assert_eq!(risk[0].matched_on, RiskMatch::GroupKey);
+    }
+
+    #[test]
+    fn an_unconfigured_risk_layer_is_reported_rather_than_shown_as_empty() {
+        let bundle = build(incident(), &metadata(), None, GENERATED_AT.to_string());
+        assert!(bundle.risk.is_none());
+        assert!(!bundle.sources.risk);
+        assert!(render_markdown(&bundle).contains("No risk accumulator is configured."));
+    }
+
+    #[test]
+    fn ambiguous_documentation_is_shown_in_full() {
+        let mut variants = Vec::new();
+        for response in ["Page the host on-call.", "Page the cloud on-call."] {
+            let RuleMetadataLookup::Unique(mut meta) =
+                documented("rule-whoami", "Whoami execution")
+            else {
+                unreachable!()
+            };
+            let mut attributes = (*meta.custom_attributes).clone();
+            attributes.insert("rsigma.ads.response".to_string(), json!(response));
+            meta.custom_attributes = Arc::new(attributes);
+            variants.push(*meta);
+        }
+        let metadata = BTreeMap::from([(
+            "rule-whoami".to_string(),
+            RuleMetadataLookup::from_variants(variants),
+        )]);
+
+        let mut incident = incident();
+        incident.rule_counts = BTreeMap::from([("rule-whoami".to_string(), 2)]);
+        let bundle = build(incident, &metadata, None, GENERATED_AT.to_string());
+
+        assert_eq!(bundle.rules[0].resolution, RuleResolution::Ambiguous);
+        assert_eq!(bundle.rules[0].documents.len(), 2);
+        let markdown = render_markdown(&bundle);
+        assert!(markdown.contains("Page the host on-call."));
+        assert!(markdown.contains("Page the cloud on-call."));
+    }
+
+    #[test]
+    fn a_batching_incident_is_flagged_in_the_report() {
+        let mut incident = incident();
+        incident.bundle_ready = Some(false);
+        let bundle = build(incident, &metadata(), None, GENERATED_AT.to_string());
+        assert!(render_markdown(&bundle).contains("group_wait"));
+    }
+
+    // -- goldens ------------------------------------------------------------
+
+    fn golden_path(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/golden")
+            .join(name)
+    }
+
+    /// Rebuild every object with its keys sorted, so a golden stays valid under
+    /// both `serde_json` map orderings (`preserve_order` is feature-unified on
+    /// in some workspace builds and off in others).
+    fn canonical(value: &Value) -> Value {
+        match value {
+            Value::Object(map) => {
+                let mut keys: Vec<&String> = map.keys().collect();
+                keys.sort();
+                Value::Object(
+                    keys.into_iter()
+                        .map(|key| (key.clone(), canonical(&map[key])))
+                        .collect(),
+                )
+            }
+            Value::Array(items) => Value::Array(items.iter().map(canonical).collect()),
+            other => other.clone(),
+        }
+    }
+
+    /// Compare rendered output to its committed golden.
+    ///
+    /// Set `RSIGMA_UPDATE_GOLDEN=1` to rewrite the goldens after an
+    /// intentional change.
+    fn check_golden(name: &str, actual: &str) {
+        let path = golden_path(name);
+        if std::env::var_os("RSIGMA_UPDATE_GOLDEN").is_some() {
+            std::fs::write(&path, actual)
+                .unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
+            return;
+        }
+        let expected = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+            .replace("\r\n", "\n");
+        assert_eq!(actual, expected, "bundle golden drifted for '{name}'");
+    }
+
+    #[test]
+    fn json_bundle_matches_golden() {
+        let value = serde_json::to_value(sample_bundle()).unwrap();
+        let actual = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&canonical(&value)).unwrap()
+        );
+        check_golden("incident_bundle.json", &actual);
+    }
+
+    #[test]
+    fn markdown_bundle_matches_golden() {
+        check_golden("incident_bundle.md", &render_markdown(&sample_bundle()));
+    }
+}

--- a/crates/rsigma-cli/src/daemon/bundle.rs
+++ b/crates/rsigma-cli/src/daemon/bundle.rs
@@ -315,7 +315,8 @@ pub(super) fn render_markdown(bundle: &IncidentBundle) -> String {
     }
     out.push_str(&format!(
         "- Window: {} to {}\n",
-        incident.first_seen, incident.last_seen
+        timestamp(incident.first_seen),
+        timestamp(incident.last_seen)
     ));
     out.push_str(&format!(
         "- Contributing results: {}\n",
@@ -385,7 +386,8 @@ pub(super) fn render_markdown(bundle: &IncidentBundle) -> String {
                 ));
                 out.push_str(&format!(
                     "- Window: {} to {}\n",
-                    entity.window_start, entity.window_end
+                    timestamp(entity.window_start),
+                    timestamp(entity.window_end)
                 ));
                 out.push_str(&format!(
                     "- Matched on: {}\n\n",
@@ -473,6 +475,18 @@ fn scalar(value: &Value) -> String {
     match value {
         Value::String(s) => s.clone(),
         other => other.to_string(),
+    }
+}
+
+/// A Unix timestamp rendered for a reader.
+///
+/// The JSON bundle keeps epoch seconds, matching every other timestamp the API
+/// serves, but nobody reads a window off two ten-digit integers. Falls back to
+/// the raw number if the value is not a representable time.
+fn timestamp(seconds: i64) -> String {
+    match chrono::DateTime::from_timestamp(seconds, 0) {
+        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        None => seconds.to_string(),
     }
 }
 

--- a/crates/rsigma-cli/src/daemon/mod.rs
+++ b/crates/rsigma-cli/src/daemon/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod audit;
 pub(crate) mod auth;
+pub(crate) mod bundle;
 pub(crate) mod dispositions;
 pub(crate) mod enrichment;
 mod health;

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -2659,7 +2659,7 @@ fn grouping_disabled() -> Response {
         StatusCode::SERVICE_UNAVAILABLE,
         Json(serde_json::json!({
             "error": "incident grouping disabled",
-            "hint": "configure an alert pipeline with a `group:` stage to enable /api/v1/incidents/{id}",
+            "hint": "configure an alert pipeline with a `group:` stage to enable the per-incident routes",
         })),
     )
         .into_response()

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -4,8 +4,8 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
-use axum::extract::State;
-use axum::http::StatusCode;
+use axum::extract::{Query, State};
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
@@ -16,11 +16,14 @@ use rsigma_eval::{
 use rsigma_runtime::{
     AckToken, AlertPipeline, AlertPipelineState, DeliveryConfig, DeliveryFailure, Dispatcher,
     EnrichmentPipeline, FieldObserver, FileSink, FormattedIncidentEnvelope, IncidentEnvelope,
-    IncludeMode, InputFormat, LogProcessor, MetricsHook, OnFull, RawEvent, RiskLayer, RiskState,
-    RoutingSpec, RuntimeEngine, SchemaClassifier, SchemaObserver, Silence, SilenceOrigin,
-    SilenceSpec, Sink, SinkFormat, StdinSource, StdoutSink, build_alert_pipeline, build_risk_layer,
-    load_alert_pipeline_file, load_risk_file, load_schema_signatures, spawn_source,
+    IncidentResult, IncludeMode, InputFormat, LogProcessor, MetricsHook, OnFull, RawEvent,
+    RiskLayer, RiskState, RoutingSpec, RuntimeEngine, SchemaClassifier, SchemaObserver, Silence,
+    SilenceOrigin, SilenceSpec, Sink, SinkFormat, StdinSource, StdoutSink, build_alert_pipeline,
+    build_risk_layer, load_alert_pipeline_file, load_risk_file, load_schema_signatures,
+    spawn_source,
 };
+
+use super::bundle::BundleFormat;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tower_http::trace::TraceLayer;
@@ -924,6 +927,8 @@ pub async fn run_daemon(config: DaemonConfig) {
         .route("/api/v1/correlations", get(list_correlations))
         .route("/api/v1/correlations/state", get(correlations_state))
         .route("/api/v1/incidents", get(list_incidents))
+        .route("/api/v1/incidents/{id}", get(get_incident))
+        .route("/api/v1/incidents/{id}/bundle", get(get_incident_bundle))
         .route("/api/v1/risk", get(list_risk_entities))
         .route("/api/v1/silences", get(list_silences).post(create_silence))
         .route("/api/v1/silences/{id}", delete(delete_silence))
@@ -2641,6 +2646,151 @@ async fn list_incidents(State(state): State<AppState>) -> impl IntoResponse {
     };
     let count = incidents.len();
     Json(serde_json::json!({ "incidents": incidents, "count": count }))
+}
+
+/// The 503 body returned by the per-incident routes when grouping is off.
+///
+/// Grouping is an optional stage, so an unconfigured daemon has no incidents to
+/// address rather than an incident that is missing. Reserving 404 for the
+/// latter keeps "you asked for the wrong id" apart from "this daemon does not
+/// do incidents".
+fn grouping_disabled() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "incident grouping disabled",
+            "hint": "configure an alert pipeline with a `group:` stage to enable /api/v1/incidents/{id}",
+        })),
+    )
+        .into_response()
+}
+
+/// The include mode of the configured grouping stage, or `None` when the alert
+/// pipeline has no grouping stage.
+fn incident_include(state: &AppState) -> Option<IncludeMode> {
+    state
+        .alert_pipeline_swap
+        .load_full()
+        .as_ref()
+        .as_ref()
+        .and_then(|p| p.incident_include())
+}
+
+/// `GET /api/v1/incidents/{id}` — one open incident, in the same shape as a
+/// list entry.
+async fn get_incident(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Response {
+    let Some(include) = incident_include(&state) else {
+        return grouping_disabled();
+    };
+    match snapshot_incident(&state, &id, include) {
+        Some(incident) => Json(incident).into_response(),
+        None => incident_not_found(&id),
+    }
+}
+
+/// Query parameters for `GET /api/v1/incidents/{id}/bundle`.
+#[derive(serde::Deserialize)]
+struct BundleQuery {
+    /// `json` (default) or `markdown`.
+    format: Option<String>,
+}
+
+/// `GET /api/v1/incidents/{id}/bundle` — the incident joined to its rules'
+/// documentation and the risk entities it overlaps.
+async fn get_incident_bundle(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    Query(query): Query<BundleQuery>,
+) -> Response {
+    let format = match query.format.as_deref() {
+        None => BundleFormat::Json,
+        Some(requested) => match BundleFormat::parse(requested) {
+            Some(format) => format,
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!("unknown bundle format `{requested}`"),
+                        "hint": "supported formats are `json` and `markdown`",
+                    })),
+                )
+                    .into_response();
+            }
+        },
+    };
+
+    let Some(include) = incident_include(&state) else {
+        return grouping_disabled();
+    };
+    let Some(incident) = snapshot_incident(&state, &id, include) else {
+        return incident_not_found(&id);
+    };
+    if incident.bundle_ready == Some(false) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "incident is still batching",
+                "hint": "the incident has not cleared `group_wait`, so its contents can still \
+                         change; retry once it has been reported",
+                "incident_id": id,
+            })),
+        )
+            .into_response();
+    }
+
+    // Each component is read in turn and released before the next is taken, so
+    // assembling a bundle can never hold two of the daemon's locks at once.
+    let keys: Vec<&str> = incident.rule_counts.keys().map(String::as_str).collect();
+    let metadata = state.processor.rule_metadata_batch(keys);
+
+    let risk_snapshot = state.risk_swap.load_full();
+    let risk = risk_snapshot
+        .as_ref()
+        .as_ref()
+        .and_then(|l| l.incident_config())
+        .map(|cfg| {
+            let now = chrono::Utc::now().timestamp();
+            let st = state.risk_state.read().unwrap_or_else(|e| e.into_inner());
+            st.views(cfg, now)
+        });
+
+    let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let bundle = super::bundle::build(incident, &metadata, risk.as_deref(), generated_at);
+
+    let body = match format {
+        BundleFormat::Json => match serde_json::to_string_pretty(&bundle) {
+            Ok(json) => json,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": format!("failed to render bundle: {e}") })),
+                )
+                    .into_response();
+            }
+        },
+        BundleFormat::Markdown => super::bundle::render_markdown(&bundle),
+    };
+    ([(header::CONTENT_TYPE, format.content_type())], body).into_response()
+}
+
+fn snapshot_incident(state: &AppState, id: &str, include: IncludeMode) -> Option<IncidentResult> {
+    let st = state.alert_state.read().unwrap_or_else(|e| e.into_inner());
+    st.incidents.snapshot_one(id, include)
+}
+
+fn incident_not_found(id: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({
+            "error": "no such open incident",
+            "hint": "the id is unknown, or the incident has already resolved and been evicted",
+            "incident_id": id,
+        })),
+    )
+        .into_response()
 }
 
 /// `GET /api/v1/risk` — open entities tracked by the risk accumulator, with

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -163,6 +163,12 @@ enum EngineCommands {
     /// Query a running daemon's status (GET /api/v1/status)
     Status(StatusArgs),
 
+    /// Work with a running daemon's open incidents
+    Incidents {
+        #[command(subcommand)]
+        cmd: commands::IncidentsCommands,
+    },
+
     /// Record a running daemon's live event stream to a replayable fixture
     /// (GET /api/v1/tap)
     Tap(TapArgs),
@@ -355,6 +361,7 @@ fn dispatch_engine(cmd: EngineCommands, matches: &ArgMatches, ctx: output::Outpu
         EngineCommands::Classify(args) => commands::cmd_classify(args, ctx),
         EngineCommands::DiscoverSchemas(args) => commands::cmd_discover(args, ctx),
         EngineCommands::Status(args) => commands::cmd_status(args, ctx),
+        EngineCommands::Incidents { cmd } => commands::dispatch_incidents(cmd, ctx),
         EngineCommands::Tap(args) => commands::cmd_tap(args, ctx),
         EngineCommands::Tail(args) => commands::cmd_tail(args, ctx),
         #[cfg(feature = "daemon")]

--- a/crates/rsigma-cli/tests/cli_daemon_incident_bundle.rs
+++ b/crates/rsigma-cli/tests/cli_daemon_incident_bundle.rs
@@ -1,0 +1,298 @@
+//! E2E tests for `GET /api/v1/incidents/{id}` and `.../bundle`.
+//!
+//! Spawns a daemon with a grouping alert pipeline, drives a detection through
+//! `--input http` until an incident opens, and then exercises the per-incident
+//! routes: the raw view, both bundle renderings, and every error path the
+//! routes distinguish.
+
+#![cfg(feature = "daemon")]
+
+mod common;
+
+use common::{DaemonProcess, http_get, http_post, poll_until, temp_file};
+use std::time::Duration;
+
+/// A documented rule, so the bundle has a full ADS document to carry.
+const DOCUMENTED_RULE: &str = r#"
+title: Malware sample execution
+id: 00000000-0000-0000-0000-0000000000ad
+status: test
+description: Detects the malware sample marker on a command line.
+logsource:
+    category: test
+    product: test
+detection:
+    selection:
+        CommandLine|contains: "malware"
+    condition: selection
+level: high
+falsepositives:
+    - A researcher replaying a sample in a lab
+tags:
+    - attack.execution
+custom_attributes:
+    rsigma.ads.strategy: Match the sample marker on process command lines.
+    rsigma.ads.technical_context: Requires command-line telemetry.
+    rsigma.ads.blind_spots:
+        - An obfuscated command line evades the substring match.
+    rsigma.ads.validation: Replay the sample and confirm the rule fires.
+    rsigma.ads.priority: High because execution is mid-kill-chain.
+    rsigma.ads.response:
+        - Isolate the host.
+"#;
+
+const GROUPING: &str = r#"
+group:
+  by:
+    - match.CommandLine
+  group_wait: 0s
+  resolve_timeout: 1h
+"#;
+
+/// A long `group_wait`, so an incident stays batching for the whole test.
+const SLOW_GROUPING: &str = r#"
+group:
+  by:
+    - match.CommandLine
+  group_wait: 1h
+  resolve_timeout: 2h
+"#;
+
+const DEDUP_ONLY: &str = r#"
+dedup:
+  fingerprint:
+    - rule
+  repeat_interval: 0
+  resolve_timeout: 1h
+"#;
+
+/// A spawned daemon plus the temporary files it reads and writes, which must
+/// outlive it.
+struct Fixture {
+    daemon: DaemonProcess,
+    _rule: tempfile::NamedTempFile,
+    _pipeline: tempfile::NamedTempFile,
+    _output: tempfile::NamedTempFile,
+}
+
+/// Spawn a daemon with the given alert pipeline.
+fn daemon_with(alert_pipeline: &str) -> Fixture {
+    let rule = temp_file(".yml", DOCUMENTED_RULE);
+    let pipeline = temp_file(".yml", alert_pipeline);
+    let output = tempfile::NamedTempFile::new().unwrap();
+    let daemon = DaemonProcess::spawn(&[
+        "engine",
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--alert-pipeline",
+        pipeline.path().to_str().unwrap(),
+        "--input",
+        "http",
+        "--api-addr",
+        "127.0.0.1:0",
+        "--output",
+        &format!("file://{}", output.path().to_str().unwrap()),
+    ]);
+    Fixture {
+        daemon,
+        _rule: rule,
+        _pipeline: pipeline,
+        _output: output,
+    }
+}
+
+/// Drive one detection and wait for its incident to open.
+fn open_incident(daemon: &DaemonProcess) -> String {
+    let body = serde_json::to_string(&serde_json::json!({"CommandLine": "malware x"})).unwrap();
+    let (status, _) = http_post(&daemon.url("/api/v1/events"), &body);
+    assert_eq!(status, 200);
+
+    poll_until(Duration::from_secs(10), || {
+        let (status, body) = http_get(&daemon.url("/api/v1/incidents"));
+        if status != 200 {
+            return None;
+        }
+        let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+        let incident = v["incidents"].as_array()?.first()?;
+        // Only usable once the incident has cleared `group_wait`.
+        if incident["bundle_ready"] != serde_json::json!(true) {
+            return None;
+        }
+        Some(incident["incident_id"].as_str()?.to_string())
+    })
+    .expect("no incident opened within 10s")
+}
+
+#[test]
+fn the_detail_route_returns_one_incident() {
+    let fixture = daemon_with(GROUPING);
+    let id = open_incident(&fixture.daemon);
+
+    let (status, body) = http_get(&fixture.daemon.url(&format!("/api/v1/incidents/{id}")));
+    assert_eq!(status, 200, "{body}");
+    let incident: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(incident["incident_id"], serde_json::json!(id));
+    assert_eq!(incident["bundle_ready"], serde_json::json!(true));
+    assert_eq!(incident["sample_mode"], serde_json::json!("refs"));
+}
+
+#[test]
+fn an_unknown_incident_is_not_found() {
+    let fixture = daemon_with(GROUPING);
+    open_incident(&fixture.daemon);
+
+    for path in ["/api/v1/incidents/nope", "/api/v1/incidents/nope/bundle"] {
+        let (status, body) = http_get(&fixture.daemon.url(path));
+        assert_eq!(status, 404, "{path}: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(error["incident_id"], serde_json::json!("nope"));
+        assert!(error["hint"].as_str().unwrap().contains("resolved"));
+    }
+}
+
+#[test]
+fn the_routes_report_grouping_as_unavailable_rather_than_missing() {
+    // Dedup only: the daemon has an alert pipeline but no grouping stage, so
+    // there are no incidents to address at all.
+    let fixture = daemon_with(DEDUP_ONLY);
+    let body = serde_json::to_string(&serde_json::json!({"CommandLine": "malware x"})).unwrap();
+    http_post(&fixture.daemon.url("/api/v1/events"), &body);
+
+    for path in ["/api/v1/incidents/any", "/api/v1/incidents/any/bundle"] {
+        let (status, body) = http_get(&fixture.daemon.url(path));
+        assert_eq!(status, 503, "{path}: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            error["error"],
+            serde_json::json!("incident grouping disabled")
+        );
+    }
+}
+
+#[test]
+fn the_json_bundle_documents_every_contributing_rule() {
+    let fixture = daemon_with(GROUPING);
+    let id = open_incident(&fixture.daemon);
+
+    let (status, body) = http_get(
+        &fixture
+            .daemon
+            .url(&format!("/api/v1/incidents/{id}/bundle")),
+    );
+    assert_eq!(status, 200, "{body}");
+    let bundle: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(bundle["schema_version"], serde_json::json!(1));
+    assert_eq!(bundle["incident"]["incident_id"], serde_json::json!(id));
+    assert!(bundle["generated_at"].as_str().unwrap().ends_with('Z'));
+
+    let rules = bundle["rules"].as_array().unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0]["resolution"], serde_json::json!("unique"));
+    assert_eq!(
+        rules[0]["documents"][0]["identity"]["title"],
+        serde_json::json!("Malware sample execution")
+    );
+
+    // Every ADS section the rule declares is present in the bundle.
+    let sections = rules[0]["documents"][0]["ads"]["sections"]
+        .as_array()
+        .unwrap();
+    assert_eq!(sections.len(), 9);
+    assert!(
+        sections
+            .iter()
+            .all(|s| s["present"] == serde_json::json!(true)),
+        "an ADS section was lost between the rule file and the bundle: {sections:#?}"
+    );
+
+    // No risk accumulator is configured, so the bundle says so rather than
+    // reporting an empty overlap.
+    assert_eq!(bundle["sources"]["risk"], serde_json::json!(false));
+    assert!(bundle.get("risk").is_none());
+}
+
+#[test]
+fn the_markdown_bundle_is_served_as_markdown() {
+    let fixture = daemon_with(GROUPING);
+    let id = open_incident(&fixture.daemon);
+
+    let url = fixture
+        .daemon
+        .url(&format!("/api/v1/incidents/{id}/bundle?format=markdown"));
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .build()
+        .into();
+    let response = agent.get(&url).call().unwrap();
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("text/markdown; charset=utf-8")
+    );
+
+    let body = response.into_body().read_to_string().unwrap();
+    assert!(body.starts_with(&format!("# Incident {id}\n")));
+    assert!(body.contains("## Contributing rules"));
+    assert!(body.contains("Isolate the host."));
+}
+
+#[test]
+fn a_batching_incident_is_readable_but_not_yet_bundleable() {
+    // Inside `group_wait` an incident can still absorb more results, so a
+    // bundle taken now could disagree with the one taken after it is first
+    // reported. The raw view stays available; only the bundle is withheld.
+    let fixture = daemon_with(SLOW_GROUPING);
+    let body = serde_json::to_string(&serde_json::json!({"CommandLine": "malware x"})).unwrap();
+    assert_eq!(
+        http_post(&fixture.daemon.url("/api/v1/events"), &body).0,
+        200
+    );
+
+    let id = poll_until(Duration::from_secs(10), || {
+        let (status, body) = http_get(&fixture.daemon.url("/api/v1/incidents"));
+        if status != 200 {
+            return None;
+        }
+        let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+        Some(
+            v["incidents"].as_array()?.first()?["incident_id"]
+                .as_str()?
+                .to_string(),
+        )
+    })
+    .expect("no incident was created within 10s");
+
+    let (status, body) = http_get(&fixture.daemon.url(&format!("/api/v1/incidents/{id}")));
+    assert_eq!(status, 200, "{body}");
+    let incident: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(incident["bundle_ready"], serde_json::json!(false));
+
+    let (status, body) = http_get(
+        &fixture
+            .daemon
+            .url(&format!("/api/v1/incidents/{id}/bundle")),
+    );
+    assert_eq!(status, 409, "{body}");
+    let error: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(error["hint"].as_str().unwrap().contains("group_wait"));
+}
+
+#[test]
+fn an_unknown_format_is_rejected() {
+    let fixture = daemon_with(GROUPING);
+    let id = open_incident(&fixture.daemon);
+
+    let (status, body) = http_get(
+        &fixture
+            .daemon
+            .url(&format!("/api/v1/incidents/{id}/bundle?format=pdf")),
+    );
+    assert_eq!(status, 400, "{body}");
+    let error: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(error["error"].as_str().unwrap().contains("pdf"));
+}

--- a/crates/rsigma-cli/tests/cli_incidents_export.rs
+++ b/crates/rsigma-cli/tests/cli_incidents_export.rs
@@ -1,0 +1,259 @@
+//! E2E tests for `rsigma engine incidents export`.
+//!
+//! Spawns a daemon with a grouping alert pipeline, opens an incident, and
+//! exercises the client: both renderings, writing to a file, and the error
+//! paths where the daemon's own hint has to reach the operator.
+
+#![cfg(feature = "daemon")]
+
+mod common;
+
+use common::{DaemonProcess, http_get, http_post, poll_until, temp_file};
+use std::process::Command;
+use std::time::Duration;
+
+const RULE: &str = r#"
+title: Malware sample execution
+id: 00000000-0000-0000-0000-0000000000ad
+status: test
+description: Detects the malware sample marker on a command line.
+logsource:
+    category: test
+    product: test
+detection:
+    selection:
+        CommandLine|contains: "malware"
+    condition: selection
+level: high
+custom_attributes:
+    rsigma.ads.response:
+        - Isolate the host.
+"#;
+
+const GROUPING: &str = r#"
+group:
+  by:
+    - match.CommandLine
+  group_wait: 0s
+  resolve_timeout: 1h
+"#;
+
+struct Fixture {
+    daemon: DaemonProcess,
+    _rule: tempfile::NamedTempFile,
+    _pipeline: tempfile::NamedTempFile,
+    _output: tempfile::NamedTempFile,
+}
+
+fn fixture() -> Fixture {
+    let rule = temp_file(".yml", RULE);
+    let pipeline = temp_file(".yml", GROUPING);
+    let output = tempfile::NamedTempFile::new().unwrap();
+    let daemon = DaemonProcess::spawn(&[
+        "engine",
+        "daemon",
+        "-r",
+        rule.path().to_str().unwrap(),
+        "--alert-pipeline",
+        pipeline.path().to_str().unwrap(),
+        "--input",
+        "http",
+        "--api-addr",
+        "127.0.0.1:0",
+        "--output",
+        &format!("file://{}", output.path().to_str().unwrap()),
+    ]);
+    Fixture {
+        daemon,
+        _rule: rule,
+        _pipeline: pipeline,
+        _output: output,
+    }
+}
+
+fn open_incident(daemon: &DaemonProcess) -> String {
+    let body = serde_json::to_string(&serde_json::json!({"CommandLine": "malware x"})).unwrap();
+    assert_eq!(http_post(&daemon.url("/api/v1/events"), &body).0, 200);
+    poll_until(Duration::from_secs(10), || {
+        let (status, body) = http_get(&daemon.url("/api/v1/incidents"));
+        if status != 200 {
+            return None;
+        }
+        let v: serde_json::Value = serde_json::from_str(&body).ok()?;
+        let incident = v["incidents"].as_array()?.first()?;
+        if incident["bundle_ready"] != serde_json::json!(true) {
+            return None;
+        }
+        Some(incident["incident_id"].as_str()?.to_string())
+    })
+    .expect("no incident opened within 10s")
+}
+
+/// Run `rsigma engine incidents export` against the fixture's daemon.
+fn export(fixture: &Fixture, extra: &[&str]) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rsigma"));
+    command.args(["engine", "incidents", "export"]);
+    command.args(extra);
+    command.args(["--addr", fixture.daemon.api_addr()]);
+    command.output().expect("failed to run rsigma")
+}
+
+#[test]
+fn export_writes_the_json_bundle_to_stdout() {
+    let fixture = fixture();
+    let id = open_incident(&fixture.daemon);
+
+    let output = export(&fixture, &[&id]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bundle: serde_json::Value = serde_json::from_slice(&output.stdout).expect("invalid JSON");
+    assert_eq!(bundle["incident"]["incident_id"], serde_json::json!(id));
+    assert_eq!(bundle["schema_version"], serde_json::json!(1));
+}
+
+#[test]
+fn export_writes_the_markdown_bundle_to_a_file() {
+    let fixture = fixture();
+    let id = open_incident(&fixture.daemon);
+
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("bundle.md");
+    let output = export(
+        &fixture,
+        &[
+            &id,
+            "--bundle-format",
+            "markdown",
+            "--output",
+            path.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty(), "the bundle went to the file");
+
+    let report = std::fs::read_to_string(&path).unwrap();
+    assert!(report.starts_with(&format!("# Incident {id}\n")));
+    assert!(report.contains("Isolate the host."));
+
+    // The sibling temporary file is renamed, never left behind.
+    let entries: Vec<_> = std::fs::read_dir(directory.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    assert_eq!(entries.len(), 1, "{entries:?}");
+}
+
+#[test]
+fn export_surfaces_the_daemons_hint_for_an_unknown_incident() {
+    let fixture = fixture();
+    open_incident(&fixture.daemon);
+
+    let output = export(&fixture, &["nosuchincident"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("HTTP 404"), "{stderr}");
+    assert!(stderr.contains("no such open incident"), "{stderr}");
+    // The daemon's hint is preserved rather than reduced to a status code.
+    assert!(stderr.contains("already resolved"), "{stderr}");
+}
+
+/// Two tokens: one that can list incidents, and one that can also read
+/// bundles.
+const AUTH_CONFIG: &str = r#"
+daemon:
+  api:
+    auth:
+      roles:
+        incident-reader: ["incidents:read"]
+        bundle-reader: ["incidents:read", "incident-bundles:read"]
+      tokens:
+        - name: lister
+          role: incident-reader
+          token_env: TEST_TOKEN_LISTER
+        - name: bundler
+          role: bundle-reader
+          token_env: TEST_TOKEN_BUNDLER
+"#;
+
+#[test]
+fn reading_a_bundle_needs_more_than_reading_incidents() {
+    let rule = temp_file(".yml", RULE);
+    let pipeline = temp_file(".yml", GROUPING);
+    let config = temp_file(".yaml", AUTH_CONFIG);
+    let daemon = DaemonProcess::spawn_with_env(
+        &[
+            "engine",
+            "daemon",
+            "-r",
+            rule.path().to_str().unwrap(),
+            "--alert-pipeline",
+            pipeline.path().to_str().unwrap(),
+            "--config",
+            config.path().to_str().unwrap(),
+            "--input",
+            "http",
+            "--api-addr",
+            "127.0.0.1:0",
+        ],
+        &[
+            ("TEST_TOKEN_LISTER", "tok-lister"),
+            ("TEST_TOKEN_BUNDLER", "tok-bundler"),
+        ],
+    );
+
+    // Authorization is decided before the handler runs, so the split shows up
+    // on any id: the refused token never reaches the lookup, and the permitted
+    // one does and reports the id as unknown.
+    let export_with = |token: &str| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_rsigma"));
+        command
+            .args([
+                "engine",
+                "incidents",
+                "export",
+                "any-id",
+                "--addr",
+                daemon.api_addr(),
+            ])
+            .env("RSIGMA_API_TOKEN", token)
+            .output()
+            .expect("failed to run rsigma")
+    };
+
+    let refused = export_with("tok-lister");
+    let stderr = String::from_utf8_lossy(&refused.stderr);
+    assert!(stderr.contains("HTTP 403"), "{stderr}");
+
+    // The bundle token gets past authorization and reaches the handler, which
+    // reports the unknown id.
+    let allowed = export_with("tok-bundler");
+    let stderr = String::from_utf8_lossy(&allowed.stderr);
+    assert!(stderr.contains("HTTP 404"), "{stderr}");
+}
+
+#[test]
+fn export_fails_clearly_when_the_daemon_is_unreachable() {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rsigma"));
+    let output = command
+        .args([
+            "engine",
+            "incidents",
+            "export",
+            "abc",
+            "--addr",
+            // Port 1 on loopback: reserved and never listening.
+            "127.0.0.1:1",
+        ])
+        .output()
+        .expect("failed to run rsigma");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("is the daemon running?"), "{stderr}");
+}

--- a/crates/rsigma-cli/tests/golden/incident_bundle.json
+++ b/crates/rsigma-cli/tests/golden/incident_bundle.json
@@ -1,0 +1,165 @@
+{
+  "generated_at": "2026-07-26T12:00:00Z",
+  "incident": {
+    "bundle_ready": true,
+    "first_seen": 1767225000,
+    "group_by": {
+      "match.User": "alice"
+    },
+    "incident_id": "f8bcd62a829b1126",
+    "last_seen": 1767225600,
+    "max_level": "high",
+    "result_count": 3,
+    "results": [
+      {
+        "enrichments": {
+          "risk.objects": [
+            {
+              "type": "user",
+              "value": "alice"
+            }
+          ],
+          "risk.score": 60
+        },
+        "level": "high",
+        "matched_fields": [
+          {
+            "field": "User",
+            "value": "alice"
+          }
+        ],
+        "rule_id": "rule-whoami",
+        "rule_title": "rule-whoami"
+      }
+    ],
+    "rule_counts": {
+      "rule-retired": 1,
+      "rule-whoami": 2
+    },
+    "sample_mode": "results",
+    "state": "open",
+    "trigger": "snapshot"
+  },
+  "risk": [
+    {
+      "entity_type": "user",
+      "entity_value": "alice",
+      "matched_on": "risk_object",
+      "result_count": 3,
+      "score": 120,
+      "source_count": 2,
+      "tactic_count": 2,
+      "window_end": 1767225600,
+      "window_start": 1767225000
+    }
+  ],
+  "rules": [
+    {
+      "count": 1,
+      "documents": [],
+      "key": "rule-retired",
+      "resolution": "missing"
+    },
+    {
+      "count": 2,
+      "documents": [
+        {
+          "ads": {
+            "sections": [
+              {
+                "carrier": "description",
+                "content": "Detects whoami execution, a common discovery step.",
+                "id": "goal",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "tags",
+                "content": [
+                  "attack.discovery",
+                  "attack.t1033"
+                ],
+                "id": "categorization",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "rsigma.ads.strategy",
+                "content": "Watch process creation for the whoami binary.",
+                "id": "strategy",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "rsigma.ads.technical_context",
+                "content": "Requires process_creation telemetry with CommandLine.",
+                "id": "technical_context",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "rsigma.ads.blind_spots",
+                "content": [
+                  "A renamed binary evades the command-line match."
+                ],
+                "id": "blind_spots",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "falsepositives",
+                "content": [
+                  "Administrators enumerating their own privileges"
+                ],
+                "id": "false_positives",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "rsigma.ads.validation",
+                "content": "Run whoami in a lab and confirm the rule fires.",
+                "id": "validation",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "rsigma.ads.priority",
+                "content": "High because discovery precedes lateral movement.",
+                "id": "priority",
+                "present": true,
+                "required": true
+              },
+              {
+                "carrier": "rsigma.ads.response",
+                "content": [
+                  "Confirm the user and host.",
+                  "Correlate with other discovery."
+                ],
+                "id": "response",
+                "present": true,
+                "required": true
+              }
+            ]
+          },
+          "identity": {
+            "id": "rule-whoami",
+            "kind": "detection",
+            "title": "Whoami execution"
+          },
+          "level": "high",
+          "tags": [
+            "attack.discovery",
+            "attack.t1033"
+          ]
+        }
+      ],
+      "key": "rule-whoami",
+      "resolution": "unique"
+    }
+  ],
+  "schema_version": 1,
+  "sources": {
+    "risk": true,
+    "rules": true
+  }
+}

--- a/crates/rsigma-cli/tests/golden/incident_bundle.md
+++ b/crates/rsigma-cli/tests/golden/incident_bundle.md
@@ -1,0 +1,74 @@
+# Incident f8bcd62a829b1126
+
+- Generated: 2026-07-26T12:00:00Z
+- State: open
+- Highest severity: high
+- Window: 1767225000 to 1767225600
+- Contributing results: 3
+- Retained samples: results
+
+## Grouping
+
+- `match.User`: alice
+
+## Contributing rules
+
+### `rule-retired` (1 result)
+
+No loaded rule carries this key. The rule set most likely changed while the incident was open.
+
+### `rule-whoami` (2 results)
+
+**Whoami execution**
+
+- Level: high
+- Tags: attack.discovery, attack.t1033
+
+*Goal*
+
+Detects whoami execution, a common discovery step.
+
+*Categorization*
+
+- attack.discovery
+- attack.t1033
+
+*Strategy*
+
+Watch process creation for the whoami binary.
+
+*Technical context*
+
+Requires process_creation telemetry with CommandLine.
+
+*Blind spots*
+
+- A renamed binary evades the command-line match.
+
+*False positives*
+
+- Administrators enumerating their own privileges
+
+*Validation*
+
+Run whoami in a lab and confirm the rule fires.
+
+*Priority*
+
+High because discovery precedes lateral movement.
+
+*Response*
+
+- Confirm the user and host.
+- Correlate with other discovery.
+
+## Risk
+
+### user: alice
+
+- Score: 120
+- Distinct tactics: 2
+- Contributing sources: 2
+- Window: 1767225000 to 1767225600
+- Matched on: a contributing result's risk objects
+

--- a/crates/rsigma-cli/tests/golden/incident_bundle.md
+++ b/crates/rsigma-cli/tests/golden/incident_bundle.md
@@ -3,7 +3,7 @@
 - Generated: 2026-07-26T12:00:00Z
 - State: open
 - Highest severity: high
-- Window: 1767225000 to 1767225600
+- Window: 2025-12-31T23:50:00Z to 2026-01-01T00:00:00Z
 - Contributing results: 3
 - Retained samples: results
 
@@ -69,6 +69,6 @@ High because discovery precedes lateral movement.
 - Score: 120
 - Distinct tactics: 2
 - Contributing sources: 2
-- Window: 1767225000 to 1767225600
+- Window: 2025-12-31T23:50:00Z to 2026-01-01T00:00:00Z
 - Matched on: a contributing result's risk objects
 

--- a/crates/rsigma-eval/src/compiler/from_ir.rs
+++ b/crates/rsigma-eval/src/compiler/from_ir.rs
@@ -44,6 +44,8 @@ pub fn compile_to_compiled(ir: &IrRule) -> Result<CompiledRule> {
         id: ir.metadata.id.clone(),
         level: ir.metadata.level,
         tags: ir.metadata.tags.clone(),
+        description: ir.metadata.description.clone(),
+        falsepositives: ir.metadata.falsepositives.clone(),
         logsource: ir.logsource.clone(),
         detections,
         conditions,

--- a/crates/rsigma-eval/src/compiler/mod.rs
+++ b/crates/rsigma-eval/src/compiler/mod.rs
@@ -62,6 +62,12 @@ pub struct CompiledRule {
     pub id: Option<String>,
     pub level: Option<Level>,
     pub tags: Vec<String>,
+    /// The rule's `description`. Retained because it carries the ADS goal
+    /// section, which downstream consumers surface alongside a match.
+    pub description: Option<String>,
+    /// The rule's `falsepositives`, retained as the ADS false-positives
+    /// section carrier.
+    pub falsepositives: Vec<String>,
     pub logsource: LogSource,
     /// Compiled named detections, keyed by detection name.
     pub detections: HashMap<String, CompiledDetection>,

--- a/crates/rsigma-eval/src/correlation/compiler.rs
+++ b/crates/rsigma-eval/src/correlation/compiler.rs
@@ -104,6 +104,8 @@ pub fn compile_correlation(rule: &CorrelationRule) -> Result<CompiledCorrelation
         title: rule.title.clone(),
         level: rule.level,
         tags: rule.tags.clone(),
+        description: rule.description.clone(),
+        falsepositives: rule.falsepositives.clone(),
         correlation_type: rule.correlation_type,
         rule_refs: rule.rules.clone(),
         group_by,

--- a/crates/rsigma-eval/src/correlation/types.rs
+++ b/crates/rsigma-eval/src/correlation/types.rs
@@ -15,6 +15,11 @@ pub struct CompiledCorrelation {
     pub title: String,
     pub level: Option<Level>,
     pub tags: Vec<String>,
+    /// The correlation's `description`, retained as the ADS goal carrier.
+    pub description: Option<String>,
+    /// The correlation's `falsepositives`, retained as the ADS
+    /// false-positives carrier.
+    pub falsepositives: Vec<String>,
     pub correlation_type: CorrelationType,
     /// IDs or names of referenced rules (detection or other correlations).
     pub rule_refs: Vec<String>,

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -35,6 +35,7 @@ use crate::error::{EvalError, Result};
 use crate::event::{Event, EventValue};
 use crate::pipeline::{Pipeline, apply_pipelines, apply_pipelines_to_correlation};
 use crate::result::{CorrelationBody, EvaluationResult, ResultBody, RuleHeader};
+use crate::rule_metadata::{RuleBundleMetadata, RuleMetadataLookup};
 
 // =============================================================================
 // Correlation Engine
@@ -1204,6 +1205,20 @@ impl CorrelationEngine {
     /// Access the inner stateless engine.
     pub fn engine(&self) -> &Engine {
         &self.engine
+    }
+
+    /// Resolve a rule key (an id, or a title for a rule without one) to the
+    /// documentation of every loaded rule that carries it, across both the
+    /// detection rules and the correlations.
+    pub fn rule_metadata(&self, key: &str) -> RuleMetadataLookup {
+        let mut variants = Vec::new();
+        self.collect_rule_metadata(key, &mut variants);
+        RuleMetadataLookup::from_variants(variants)
+    }
+
+    pub(crate) fn collect_rule_metadata(&self, key: &str, out: &mut Vec<RuleBundleMetadata>) {
+        self.engine.collect_rule_metadata(key, out);
+        crate::rule_metadata::matching_correlations(&self.correlations, key, out);
     }
 
     /// Export all mutable correlation state as a serializable snapshot.

--- a/crates/rsigma-eval/src/engine/mod.rs
+++ b/crates/rsigma-eval/src/engine/mod.rs
@@ -28,6 +28,7 @@ use crate::logsource::LogSourceExtractor;
 use crate::pipeline::{Pipeline, apply_pipelines};
 use crate::result::{EvaluationResult, MatchDetailLevel};
 use crate::rule_index::RuleIndex;
+use crate::rule_metadata::{RuleBundleMetadata, RuleMetadataLookup};
 
 use bloom_index::{BloomCache, FieldBloomIndex};
 
@@ -944,6 +945,18 @@ impl Engine {
     /// Access the compiled rules.
     pub fn rules(&self) -> &[CompiledRule] {
         &self.rules
+    }
+
+    /// Resolve a rule key (an id, or a title for a rule without one) to the
+    /// documentation of every loaded rule that carries it.
+    pub fn rule_metadata(&self, key: &str) -> RuleMetadataLookup {
+        let mut variants = Vec::new();
+        self.collect_rule_metadata(key, &mut variants);
+        RuleMetadataLookup::from_variants(variants)
+    }
+
+    pub(crate) fn collect_rule_metadata(&self, key: &str, out: &mut Vec<RuleBundleMetadata>) {
+        crate::rule_metadata::matching_detections(&self.rules, key, out);
     }
 }
 

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -106,6 +106,7 @@ pub mod result;
 pub mod router;
 pub mod rule_draft;
 pub mod rule_index;
+pub mod rule_metadata;
 pub mod schema;
 pub mod schema_discovery;
 
@@ -150,6 +151,7 @@ pub use router::{RouteOutcome, RouteResult, SchemaPruning, SchemaRouter};
 pub use rule_draft::{
     DraftConfig, DraftError, DraftFieldReport, DraftReport, Stability, draft_rule,
 };
+pub use rule_metadata::{RuleBundleMetadata, RuleIdentity, RuleKind, RuleMetadataLookup};
 pub use schema::{
     FieldValueConfig, OnUnknown, PredicateOutcome, RouteDecision, RoutingConfig, RoutingPlan,
     SchemaBinding, SchemaClassifier, SchemaCountEntry, SchemaError, SchemaExplanation, SchemaMatch,

--- a/crates/rsigma-eval/src/router.rs
+++ b/crates/rsigma-eval/src/router.rs
@@ -37,6 +37,7 @@ use crate::pipeline::Pipeline;
 use crate::pipeline::transformations::Transformation;
 use crate::result::EvaluationResult;
 use crate::result::MatchDetailLevel;
+use crate::rule_metadata::RuleMetadataLookup;
 use crate::schema::{OnUnknown, RouteDecision, RoutingPlan, SchemaClassifier};
 
 /// Per-schema logsource pruning summary: how many rules a schema's events
@@ -370,6 +371,25 @@ impl SchemaRouter {
             .as_ref()
             .map(|c| c.state_count())
             .unwrap_or(0)
+    }
+
+    /// Resolve a rule key (an id, or a title for a rule without one) to the
+    /// documentation of every loaded rule that carries it.
+    ///
+    /// A rule set is compiled once per pipeline-set, so the same rule usually
+    /// yields one candidate per schema. Candidates whose post-pipeline metadata
+    /// is identical collapse to a single answer; a rule whose pipelines rewrite
+    /// its documentation differently per schema stays
+    /// [`Ambiguous`](RuleMetadataLookup::Ambiguous).
+    pub fn rule_metadata(&self, key: &str) -> RuleMetadataLookup {
+        let mut variants = Vec::new();
+        for engine in &self.engines {
+            engine.collect_rule_metadata(key, &mut variants);
+        }
+        if let Some(correlation) = &self.correlation {
+            correlation.collect_rule_metadata(key, &mut variants);
+        }
+        RuleMetadataLookup::from_variants(variants)
     }
 
     /// Introspect the shared correlation store, if any (id/group filtered).

--- a/crates/rsigma-eval/src/rule_metadata.rs
+++ b/crates/rsigma-eval/src/rule_metadata.rs
@@ -1,0 +1,460 @@
+//! Rule documentation recovered from a rule key.
+//!
+//! Downstream aggregation (incident grouping, risk accumulation) keeps only a
+//! rule *key* per contributing result: the rule id, or the title when the rule
+//! has no id. That is enough to count firings but not enough to explain them.
+//! [`RuleBundleMetadata`] closes the gap by carrying every field an
+//! [ADS](rsigma_parser::ads) document is built from, and the lookup methods on
+//! [`Engine`](crate::Engine), [`CorrelationEngine`](crate::CorrelationEngine),
+//! and [`SchemaRouter`](crate::SchemaRouter) resolve a key back to it.
+//!
+//! Two rules can share a key, and a routed rule set compiles the same rule once
+//! per pipeline-set, so a lookup answers with [`RuleMetadataLookup`] rather than
+//! a bare `Option`: variants that are byte-identical collapse to
+//! [`Unique`](RuleMetadataLookup::Unique), and genuinely differing ones stay
+//! visible as [`Ambiguous`](RuleMetadataLookup::Ambiguous) instead of silently
+//! resolving to whichever was compiled first.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rsigma_parser::Level;
+use rsigma_parser::ads::{AdsCarriers, AdsContent};
+use serde::Serialize;
+
+use crate::compiler::CompiledRule;
+use crate::correlation::CompiledCorrelation;
+
+/// Which kind of rule a metadata entry describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleKind {
+    /// A stateless detection rule.
+    Detection,
+    /// A stateful correlation rule.
+    Correlation,
+}
+
+/// A rule's identity: its kind plus the id and title it is known by.
+///
+/// Kept structured rather than flattened to a single string so a detection rule
+/// and a correlation rule that happen to share a key stay distinguishable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuleIdentity {
+    /// Whether this is a detection or a correlation rule.
+    pub kind: RuleKind,
+    /// The rule's `id`, when it declares one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// The rule's `title`.
+    pub title: String,
+}
+
+impl RuleIdentity {
+    /// The key downstream aggregation groups this rule under: the id, falling
+    /// back to the title. Mirrors how a result header is reduced to a rule key.
+    pub fn key(&self) -> &str {
+        self.id.as_deref().unwrap_or(&self.title)
+    }
+}
+
+/// Everything needed to document one rule away from the engine that compiled
+/// it: its identity, its severity and tags, and the three standard fields plus
+/// `rsigma.ads.*` attributes an ADS document is assembled from.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuleBundleMetadata {
+    /// The rule's kind, id, and title.
+    pub identity: RuleIdentity,
+    /// The rule's `level`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<Level>,
+    /// The rule's `tags` (the ADS categorization carrier).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    /// The rule's `description` (the ADS goal carrier).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The rule's `falsepositives` (the ADS false-positives carrier).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub falsepositives: Vec<String>,
+    /// The rule's custom attributes, post-pipeline. Carries the six
+    /// `rsigma.ads.*` sections that have no standard Sigma field.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub custom_attributes: Arc<HashMap<String, serde_json::Value>>,
+}
+
+impl AdsCarriers for RuleBundleMetadata {
+    fn ads_description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    fn ads_tags(&self) -> &[String] {
+        &self.tags
+    }
+
+    fn ads_falsepositives(&self) -> &[String] {
+        &self.falsepositives
+    }
+
+    fn ads_custom_attribute(&self, key: &str) -> Option<AdsContent> {
+        self.custom_attributes
+            .get(key)
+            .and_then(AdsContent::from_json)
+    }
+}
+
+/// The outcome of resolving a rule key to metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuleMetadataLookup {
+    /// No loaded rule carries the key. Expected when an incident outlives the
+    /// rule that opened it across a reload.
+    Missing,
+    /// Exactly one distinct metadata document carries the key.
+    Unique(Box<RuleBundleMetadata>),
+    /// Several rules carry the key with differing metadata, in the order the
+    /// engines were built. Callers must decide how to present the conflict
+    /// rather than being handed an arbitrary one.
+    Ambiguous(Vec<RuleBundleMetadata>),
+}
+
+impl RuleMetadataLookup {
+    /// Collapse candidate variants into a lookup outcome, treating identical
+    /// documents as one. Routed rule sets compile the same rule once per
+    /// pipeline-set, so most keys yield several byte-identical candidates.
+    pub fn from_variants(variants: Vec<RuleBundleMetadata>) -> Self {
+        let mut distinct: Vec<RuleBundleMetadata> = Vec::new();
+        for variant in variants {
+            if !distinct.contains(&variant) {
+                distinct.push(variant);
+            }
+        }
+        match distinct.len() {
+            0 => RuleMetadataLookup::Missing,
+            1 => RuleMetadataLookup::Unique(Box::new(distinct.remove(0))),
+            _ => RuleMetadataLookup::Ambiguous(distinct),
+        }
+    }
+
+    /// Every candidate document, empty when the key is unknown.
+    pub fn variants(&self) -> &[RuleBundleMetadata] {
+        match self {
+            RuleMetadataLookup::Missing => &[],
+            RuleMetadataLookup::Unique(one) => std::slice::from_ref(one),
+            RuleMetadataLookup::Ambiguous(many) => many,
+        }
+    }
+}
+
+impl CompiledRule {
+    /// This rule's identity as a detection rule.
+    pub fn identity(&self) -> RuleIdentity {
+        RuleIdentity {
+            kind: RuleKind::Detection,
+            id: self.id.clone(),
+            title: self.title.clone(),
+        }
+    }
+
+    /// The documentation fields a downstream consumer needs to explain a match.
+    pub fn bundle_metadata(&self) -> RuleBundleMetadata {
+        RuleBundleMetadata {
+            identity: self.identity(),
+            level: self.level,
+            tags: self.tags.clone(),
+            description: self.description.clone(),
+            falsepositives: self.falsepositives.clone(),
+            custom_attributes: Arc::clone(&self.custom_attributes),
+        }
+    }
+}
+
+impl CompiledCorrelation {
+    /// This correlation's identity.
+    pub fn identity(&self) -> RuleIdentity {
+        RuleIdentity {
+            kind: RuleKind::Correlation,
+            id: self.id.clone(),
+            title: self.title.clone(),
+        }
+    }
+
+    /// The documentation fields a downstream consumer needs to explain a
+    /// firing.
+    pub fn bundle_metadata(&self) -> RuleBundleMetadata {
+        RuleBundleMetadata {
+            identity: self.identity(),
+            level: self.level,
+            tags: self.tags.clone(),
+            description: self.description.clone(),
+            falsepositives: self.falsepositives.clone(),
+            custom_attributes: Arc::clone(&self.custom_attributes),
+        }
+    }
+}
+
+/// Candidate metadata from the rules in `rules` whose own key matches `key`.
+///
+/// Matching on each rule's *own* derived key (rather than testing id and title
+/// separately) is what keeps a rule whose title equals another rule's id out of
+/// the answer.
+pub(crate) fn matching_detections<'a>(
+    rules: impl IntoIterator<Item = &'a CompiledRule>,
+    key: &str,
+    out: &mut Vec<RuleBundleMetadata>,
+) {
+    for rule in rules {
+        if rule.id.as_deref().unwrap_or(&rule.title) == key {
+            out.push(rule.bundle_metadata());
+        }
+    }
+}
+
+/// Candidate metadata from the correlations whose own key matches `key`.
+pub(crate) fn matching_correlations<'a>(
+    correlations: impl IntoIterator<Item = &'a CompiledCorrelation>,
+    key: &str,
+    out: &mut Vec<RuleBundleMetadata>,
+) {
+    for corr in correlations {
+        if corr.id.as_deref().unwrap_or(&corr.title) == key {
+            out.push(corr.bundle_metadata());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::correlation_engine::{CorrelationConfig, CorrelationEngine};
+    use crate::engine::Engine;
+    use crate::pipeline::parse_pipeline;
+    use crate::router::SchemaRouter;
+    use crate::schema::{OnUnknown, RoutingConfig, RoutingPlan, SchemaBinding, SchemaClassifier};
+    use rsigma_parser::ads::AdsDocument;
+    use rsigma_parser::parse_sigma_yaml;
+
+    const DOCUMENTED: &str = r#"
+title: Whoami execution
+id: rule-whoami
+description: Detects whoami execution, a common discovery step.
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: whoami
+    condition: selection
+level: high
+falsepositives:
+    - Administrators enumerating their own privileges
+tags:
+    - attack.discovery
+    - attack.t1033
+custom_attributes:
+    rsigma.ads.strategy: Watch process creation for the whoami binary.
+    rsigma.ads.technical_context: Requires process_creation telemetry.
+    rsigma.ads.blind_spots:
+        - A renamed binary evades the command-line match.
+    rsigma.ads.validation: Run whoami in a lab and confirm the rule fires.
+    rsigma.ads.priority: High because discovery precedes lateral movement.
+    rsigma.ads.response:
+        - Confirm the user and host.
+"#;
+
+    fn engine(yaml: &str) -> Engine {
+        let mut engine = Engine::new();
+        engine
+            .add_collection(&parse_sigma_yaml(yaml).unwrap())
+            .unwrap();
+        engine
+    }
+
+    #[test]
+    fn a_detection_rule_resolves_by_its_id() {
+        let engine = engine(DOCUMENTED);
+        let RuleMetadataLookup::Unique(meta) = engine.rule_metadata("rule-whoami") else {
+            panic!("expected a unique match");
+        };
+        assert_eq!(meta.identity.kind, RuleKind::Detection);
+        assert_eq!(meta.identity.title, "Whoami execution");
+        assert_eq!(meta.identity.key(), "rule-whoami");
+    }
+
+    #[test]
+    fn every_ads_section_survives_compilation() {
+        let engine = engine(DOCUMENTED);
+        let RuleMetadataLookup::Unique(meta) = engine.rule_metadata("rule-whoami") else {
+            panic!("expected a unique match");
+        };
+        let doc = AdsDocument::from_carriers(meta.as_ref());
+        assert!(
+            doc.missing_required().is_empty(),
+            "missing: {:?}",
+            doc.missing_required()
+        );
+    }
+
+    #[test]
+    fn a_rule_without_an_id_resolves_by_its_title() {
+        let engine = engine(
+            r#"
+title: Untitled discovery
+logsource:
+    category: process_creation
+detection:
+    selection:
+        CommandLine: whoami
+    condition: selection
+"#,
+        );
+        assert!(matches!(
+            engine.rule_metadata("Untitled discovery"),
+            RuleMetadataLookup::Unique(_)
+        ));
+    }
+
+    #[test]
+    fn a_title_matching_another_rules_id_does_not_cross_match() {
+        // The second rule's title is the first rule's id. Only the rule whose
+        // own derived key is `rule-whoami` may answer, and the second rule has
+        // an id of its own so its title is never its key.
+        let engine = engine(&format!(
+            "{DOCUMENTED}---
+title: rule-whoami
+id: rule-decoy
+logsource:
+    category: process_creation
+detection:
+    selection:
+        CommandLine: decoy
+    condition: selection
+"
+        ));
+        let RuleMetadataLookup::Unique(meta) = engine.rule_metadata("rule-whoami") else {
+            panic!("expected a unique match");
+        };
+        assert_eq!(meta.identity.title, "Whoami execution");
+    }
+
+    #[test]
+    fn an_unknown_key_is_missing() {
+        let engine = engine(DOCUMENTED);
+        assert_eq!(
+            engine.rule_metadata("rule-absent"),
+            RuleMetadataLookup::Missing
+        );
+    }
+
+    #[test]
+    fn a_correlation_resolves_alongside_the_detections_it_references() {
+        let yaml = format!(
+            "{DOCUMENTED}---
+title: Repeated whoami
+id: corr-whoami
+description: Fires when whoami runs repeatedly for one user.
+correlation:
+    type: event_count
+    rules:
+        - rule-whoami
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+level: critical
+"
+        );
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        engine
+            .add_collection(&parse_sigma_yaml(&yaml).unwrap())
+            .unwrap();
+
+        let RuleMetadataLookup::Unique(corr) = engine.rule_metadata("corr-whoami") else {
+            panic!("expected a unique correlation match");
+        };
+        assert_eq!(corr.identity.kind, RuleKind::Correlation);
+        assert_eq!(
+            corr.description.as_deref(),
+            Some("Fires when whoami runs repeatedly for one user.")
+        );
+
+        let RuleMetadataLookup::Unique(detection) = engine.rule_metadata("rule-whoami") else {
+            panic!("expected a unique detection match");
+        };
+        assert_eq!(detection.identity.kind, RuleKind::Detection);
+    }
+
+    fn router(pipelines: Vec<Vec<crate::pipeline::Pipeline>>, names: &[&str]) -> SchemaRouter {
+        let plan = RoutingPlan::from_config(&RoutingConfig {
+            on_unknown: OnUnknown::Warn,
+            default_pipelines: vec![],
+            aliases: std::collections::HashMap::new(),
+            bindings: names
+                .iter()
+                .map(|n| SchemaBinding {
+                    schema: (*n).to_string(),
+                    pipelines: vec![(*n).to_string()],
+                    logsource: None,
+                })
+                .collect(),
+        });
+        SchemaRouter::build(
+            &parse_sigma_yaml(DOCUMENTED).unwrap(),
+            SchemaClassifier::builtin(),
+            plan,
+            pipelines,
+            CorrelationConfig::default(),
+            false,
+            crate::result::MatchDetailLevel::Off,
+            None,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn identical_per_schema_variants_collapse_to_one_answer() {
+        // A field-mapping pipeline rewrites detection fields but leaves the
+        // documentation alone, so every per-schema copy documents identically.
+        let ecs = parse_pipeline(
+            r#"
+name: ecs
+priority: 20
+transformations:
+  - id: map
+    type: field_name_mapping
+    mapping:
+      CommandLine: process.command_line
+"#,
+        )
+        .unwrap();
+        let router = router(vec![vec![], vec![ecs]], &["ecs"]);
+        assert!(matches!(
+            router.rule_metadata("rule-whoami"),
+            RuleMetadataLookup::Unique(_)
+        ));
+    }
+
+    #[test]
+    fn per_schema_documentation_differences_stay_visible() {
+        // This pipeline rewrites the response section for its schema only, so
+        // the two copies genuinely disagree and neither may be picked blindly.
+        let ecs = parse_pipeline(
+            r#"
+name: ecs
+priority: 20
+transformations:
+  - id: response
+    type: set_custom_attribute
+    attribute: rsigma.ads.response
+    value: Escalate to the cloud on-call rotation.
+"#,
+        )
+        .unwrap();
+        let router = router(vec![vec![], vec![ecs]], &["ecs"]);
+        let RuleMetadataLookup::Ambiguous(variants) = router.rule_metadata("rule-whoami") else {
+            panic!("expected the per-schema documents to differ");
+        };
+        assert_eq!(variants.len(), 2);
+    }
+}

--- a/crates/rsigma-parser/src/ads.rs
+++ b/crates/rsigma-parser/src/ads.rs
@@ -197,14 +197,24 @@ impl AdsSection {
     /// Extract this section's content from a rule, or `None` when the section
     /// is absent or blank.
     pub fn content(&self, rule: &SigmaRule) -> Option<AdsContent> {
+        self.content_of(rule)
+    }
+
+    /// Extract this section's content from any [`AdsCarriers`] source.
+    pub fn content_of<C: AdsCarriers + ?Sized>(&self, carriers: &C) -> Option<AdsContent> {
         match self {
-            AdsSection::Goal => rule
-                .description
-                .as_deref()
+            AdsSection::Goal => carriers
+                .ads_description()
                 .and_then(non_blank)
                 .map(|s| AdsContent::Text(s.to_string())),
             AdsSection::Categorization => {
-                let tags: Vec<String> = attack_tags(rule).map(str::to_string).collect();
+                let tags: Vec<String> = carriers
+                    .ads_tags()
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|t| t.starts_with("attack."))
+                    .map(str::to_string)
+                    .collect();
                 if tags.is_empty() {
                     None
                 } else {
@@ -212,8 +222,8 @@ impl AdsSection {
                 }
             }
             AdsSection::FalsePositives => {
-                let items: Vec<String> = rule
-                    .falsepositives
+                let items: Vec<String> = carriers
+                    .ads_falsepositives()
                     .iter()
                     .filter_map(|s| non_blank(s).map(str::to_string))
                     .collect();
@@ -223,16 +233,51 @@ impl AdsSection {
                     Some(AdsContent::List(items))
                 }
             }
-            other => {
-                let key = other.carrier_field();
-                rule.custom_attributes.get(key).and_then(content_from_value)
-            }
+            other => carriers.ads_custom_attribute(other.carrier_field()),
         }
     }
 
     /// Whether this section's content is present and non-blank on the rule.
     pub fn is_present(&self, rule: &SigmaRule) -> bool {
         self.content(rule).is_some()
+    }
+}
+
+/// A source of the rule fields ADS sections are carried on.
+///
+/// The section vocabulary is the same wherever a rule is read from, but the
+/// representations are not: a parsed [`SigmaRule`] holds YAML custom attributes
+/// while a compiled rule holds JSON ones. Implementing this trait lets both go
+/// through [`AdsSection::content_of`] and [`AdsDocument::from_carriers`]
+/// instead of reimplementing the carrier mapping.
+pub trait AdsCarriers {
+    /// The `description` field (the goal carrier).
+    fn ads_description(&self) -> Option<&str>;
+    /// The `tags` field (the categorization carrier, filtered to `attack.*`).
+    fn ads_tags(&self) -> &[String];
+    /// The `falsepositives` field (the false-positives carrier).
+    fn ads_falsepositives(&self) -> &[String];
+    /// One `rsigma.ads.*` custom attribute, already rendered to content.
+    fn ads_custom_attribute(&self, key: &str) -> Option<AdsContent>;
+}
+
+impl AdsCarriers for SigmaRule {
+    fn ads_description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    fn ads_tags(&self) -> &[String] {
+        &self.tags
+    }
+
+    fn ads_falsepositives(&self) -> &[String] {
+        &self.falsepositives
+    }
+
+    fn ads_custom_attribute(&self, key: &str) -> Option<AdsContent> {
+        self.custom_attributes
+            .get(key)
+            .and_then(AdsContent::from_yaml)
     }
 }
 
@@ -260,6 +305,26 @@ impl AdsContent {
         match self {
             AdsContent::Text(s) => vec![s.clone()],
             AdsContent::List(items) => items.clone(),
+        }
+    }
+
+    /// Render a YAML custom-attribute value as section content, or `None` when
+    /// it is blank or not a scalar (or sequence of scalars).
+    pub fn from_yaml(v: &yaml_serde::Value) -> Option<AdsContent> {
+        use yaml_serde::Value;
+        match v {
+            Value::Sequence(seq) => list_content(seq.iter().filter_map(yaml_scalar_text)),
+            other => yaml_scalar_text(other).map(AdsContent::Text),
+        }
+    }
+
+    /// Render a JSON custom-attribute value as section content, matching
+    /// [`AdsContent::from_yaml`]'s scalar and sequence handling.
+    pub fn from_json(v: &serde_json::Value) -> Option<AdsContent> {
+        use serde_json::Value;
+        match v {
+            Value::Array(items) => list_content(items.iter().filter_map(json_scalar_text)),
+            other => json_scalar_text(other).map(AdsContent::Text),
         }
     }
 }
@@ -324,10 +389,16 @@ impl AdsDocument {
     /// Assemble the ADS document for a rule from its reused fields and
     /// `rsigma.ads.*` sections.
     pub fn from_rule(rule: &SigmaRule) -> Self {
+        Self::from_carriers(rule)
+    }
+
+    /// Assemble the ADS document from any [`AdsCarriers`] source, so a compiled
+    /// rule produces the same nine-section document as a parsed one.
+    pub fn from_carriers<C: AdsCarriers + ?Sized>(carriers: &C) -> Self {
         let sections = AdsSection::all()
             .iter()
             .map(|s| {
-                let content = s.content(rule);
+                let content = s.content_of(carriers);
                 AdsSectionStatus {
                     id: s.id(),
                     required: s.default_required(),
@@ -338,6 +409,11 @@ impl AdsDocument {
             })
             .collect();
         AdsDocument { sections }
+    }
+
+    /// Whether any section carries content.
+    pub fn is_empty(&self) -> bool {
+        self.sections.iter().all(|s| !s.present)
     }
 
     /// The ids of required sections missing from the rule.
@@ -417,23 +493,27 @@ fn non_blank(s: &str) -> Option<&str> {
     if t.is_empty() { None } else { Some(t) }
 }
 
-fn content_from_value(v: &yaml_serde::Value) -> Option<AdsContent> {
-    use yaml_serde::Value;
-    match v {
-        Value::Sequence(seq) => {
-            let items: Vec<String> = seq.iter().filter_map(scalar_text).collect();
-            if items.is_empty() {
-                None
-            } else {
-                Some(AdsContent::List(items))
-            }
-        }
-        other => scalar_text(other).map(AdsContent::Text),
+fn list_content(items: impl Iterator<Item = String>) -> Option<AdsContent> {
+    let items: Vec<String> = items.collect();
+    if items.is_empty() {
+        None
+    } else {
+        Some(AdsContent::List(items))
     }
 }
 
-fn scalar_text(v: &yaml_serde::Value) -> Option<String> {
+fn yaml_scalar_text(v: &yaml_serde::Value) -> Option<String> {
     use yaml_serde::Value;
+    match v {
+        Value::String(s) => non_blank(s).map(str::to_string),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+fn json_scalar_text(v: &serde_json::Value) -> Option<String> {
+    use serde_json::Value;
     match v {
         Value::String(s) => non_blank(s).map(str::to_string),
         Value::Bool(b) => Some(b.to_string()),
@@ -564,6 +644,66 @@ detection:
         // Every section is missing: no description, no tags, no falsepositives,
         // no rsigma.ads.* keys.
         assert_eq!(missing.len(), 9);
+    }
+
+    /// A JSON-backed carrier source, standing in for a compiled rule.
+    struct JsonCarriers {
+        description: Option<String>,
+        tags: Vec<String>,
+        falsepositives: Vec<String>,
+        custom_attributes: std::collections::HashMap<String, serde_json::Value>,
+    }
+
+    impl AdsCarriers for JsonCarriers {
+        fn ads_description(&self) -> Option<&str> {
+            self.description.as_deref()
+        }
+        fn ads_tags(&self) -> &[String] {
+            &self.tags
+        }
+        fn ads_falsepositives(&self) -> &[String] {
+            &self.falsepositives
+        }
+        fn ads_custom_attribute(&self, key: &str) -> Option<AdsContent> {
+            self.custom_attributes
+                .get(key)
+                .and_then(AdsContent::from_json)
+        }
+    }
+
+    #[test]
+    fn json_carriers_produce_the_same_document_as_the_parsed_rule() {
+        let parsed = rule(FULL_RULE);
+        let json = JsonCarriers {
+            description: parsed.description.clone(),
+            tags: parsed.tags.clone(),
+            falsepositives: parsed.falsepositives.clone(),
+            custom_attributes: parsed
+                .custom_attributes
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::to_value(v).unwrap()))
+                .collect(),
+        };
+
+        let from_yaml = AdsDocument::from_rule(&parsed);
+        let from_json = AdsDocument::from_carriers(&json);
+
+        assert!(from_yaml.missing_required().is_empty());
+        assert_eq!(
+            serde_json::to_value(&from_yaml).unwrap(),
+            serde_json::to_value(&from_json).unwrap()
+        );
+    }
+
+    #[test]
+    fn an_undocumented_rule_yields_an_empty_document() {
+        let carriers = JsonCarriers {
+            description: Some("   ".to_string()),
+            tags: vec!["tlp.clear".to_string()],
+            falsepositives: Vec::new(),
+            custom_attributes: std::collections::HashMap::new(),
+        };
+        assert!(AdsDocument::from_carriers(&carriers).is_empty());
     }
 
     #[test]

--- a/crates/rsigma-runtime/src/alert_pipeline/grouping.rs
+++ b/crates/rsigma-runtime/src/alert_pipeline/grouping.rs
@@ -137,6 +137,35 @@ pub struct IncidentResult {
     /// stored as serialized JSON values.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub results: Option<Vec<Value>>,
+    /// Which sample kinds the incident actually retained. Snapshot-only: the
+    /// emission path omits it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sample_mode: Option<SampleMode>,
+    /// Whether the incident has passed `group_wait` and been emitted at least
+    /// once. Snapshot-only, and `false` means the incident is still batching
+    /// and its contents may still change before it is first reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bundle_ready: Option<bool>,
+}
+
+/// Which sample kinds an incident actually retained.
+///
+/// Normally this mirrors the configured [`IncludeMode`], but samples are
+/// retained at absorb time while the mode is read at emission time. A hot
+/// reload that flips `include` mid-incident leaves both kinds behind, and
+/// `Mixed` says so rather than hiding whichever kind the new mode does not
+/// name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SampleMode {
+    /// Nothing was retained (the per-incident sample cap is zero).
+    None,
+    /// Lightweight references only.
+    Refs,
+    /// Full contributing results only.
+    Results,
+    /// Both kinds, from an `include` change while the incident was open.
+    Mixed,
 }
 
 /// Internal per-incident state.
@@ -201,8 +230,15 @@ impl IncidentStore {
     pub fn snapshot(&self, include: IncludeMode) -> Vec<IncidentResult> {
         self.incidents
             .values()
-            .map(|inc| inc.to_result("open", "snapshot", include))
+            .map(|inc| inc.to_snapshot(include))
             .collect()
+    }
+
+    /// A snapshot of one open incident, or `None` when no incident carries the
+    /// id. A resolved incident is evicted, so it is indistinguishable from one
+    /// that never existed.
+    pub fn snapshot_one(&self, id: &str, include: IncludeMode) -> Option<IncidentResult> {
+        self.incidents.get(id).map(|inc| inc.to_snapshot(include))
     }
 
     /// Assign a result to an incident, returning the incident id to annotate
@@ -506,10 +542,14 @@ impl Incident {
                 )
             })
             .collect();
-        let (refs, results) = match include {
-            IncludeMode::Refs => (Some(self.refs.clone()), None),
-            IncludeMode::Results => (None, Some(self.results.clone())),
-        };
+        // The configured kind is always reported, even when empty, so the wire
+        // shape does not depend on how much an incident has absorbed. The other
+        // kind appears only when the incident actually retained some, which
+        // happens when `include` changed while the incident was open.
+        let refs =
+            (include == IncludeMode::Refs || !self.refs.is_empty()).then(|| self.refs.clone());
+        let results = (include == IncludeMode::Results || !self.results.is_empty())
+            .then(|| self.results.clone());
         IncidentResult {
             incident_id: self.id.clone(),
             state,
@@ -523,6 +563,26 @@ impl Incident {
             entities,
             refs,
             results,
+            sample_mode: None,
+            bundle_ready: None,
+        }
+    }
+
+    /// The read-only view served by the admin API: the emitted shape plus the
+    /// retention and lifecycle facts a caller needs to interpret it.
+    fn to_snapshot(&self, include: IncludeMode) -> IncidentResult {
+        let mut out = self.to_result("open", "snapshot", include);
+        out.sample_mode = Some(self.sample_mode());
+        out.bundle_ready = Some(self.opened);
+        out
+    }
+
+    fn sample_mode(&self) -> SampleMode {
+        match (self.refs.is_empty(), self.results.is_empty()) {
+            (false, false) => SampleMode::Mixed,
+            (false, true) => SampleMode::Refs,
+            (true, false) => SampleMode::Results,
+            (true, true) => SampleMode::None,
         }
     }
 }
@@ -639,6 +699,122 @@ mod tests {
         assert_eq!(a, b, "same SourceIp groups together across rules");
         assert_ne!(a, c, "different SourceIp is a separate incident");
         assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn snapshot_one_returns_only_the_requested_incident() {
+        let cfg = group_by_cfg();
+        let mut store = IncidentStore::default();
+        let id = store
+            .assign(
+                &cfg,
+                &detection("r1", "10.0.0.1", "alice", Level::High),
+                0,
+                |_| {},
+            )
+            .unwrap();
+        store.assign(
+            &cfg,
+            &detection("r1", "10.0.0.2", "bob", Level::Low),
+            0,
+            |_| {},
+        );
+
+        let one = store.snapshot_one(&id, cfg.include).unwrap();
+        assert_eq!(one.incident_id, id);
+        assert_eq!(one.result_count, 1);
+        assert!(store.snapshot_one("nosuchincident", cfg.include).is_none());
+    }
+
+    #[test]
+    fn a_snapshot_reports_readiness_and_a_resolved_incident_is_gone() {
+        let cfg = group_by_cfg();
+        let mut store = IncidentStore::default();
+        let id = store
+            .assign(
+                &cfg,
+                &detection("r1", "10.0.0.1", "alice", Level::High),
+                0,
+                |_| {},
+            )
+            .unwrap();
+
+        // Still inside group_wait: nothing has been emitted yet.
+        let pending = store.snapshot_one(&id, cfg.include).unwrap();
+        assert_eq!(pending.bundle_ready, Some(false));
+
+        store.tick(&cfg, 30);
+        let ready = store.snapshot_one(&id, cfg.include).unwrap();
+        assert_eq!(ready.bundle_ready, Some(true));
+
+        // Past resolve_timeout the incident is emitted once more and evicted,
+        // so a later lookup cannot tell it apart from an unknown id.
+        store.tick(&cfg, 30 + 3600);
+        assert!(store.snapshot_one(&id, cfg.include).is_none());
+    }
+
+    #[test]
+    fn an_include_change_mid_incident_keeps_both_sample_kinds() {
+        let refs_cfg = group_by_cfg();
+        let results_cfg = GroupConfig {
+            include: IncludeMode::Results,
+            ..group_by_cfg()
+        };
+        let mut store = IncidentStore::default();
+        let id = store
+            .assign(
+                &refs_cfg,
+                &detection("r1", "10.0.0.1", "alice", Level::High),
+                0,
+                |_| {},
+            )
+            .unwrap();
+        // A reload flips `include` while the incident is open.
+        store.assign(
+            &results_cfg,
+            &detection("r2", "10.0.0.1", "bob", Level::Low),
+            1,
+            |_| {},
+        );
+
+        let snap = store.snapshot_one(&id, results_cfg.include).unwrap();
+        assert_eq!(snap.sample_mode, Some(SampleMode::Mixed));
+        assert_eq!(snap.refs.as_ref().map(Vec::len), Some(1));
+        assert_eq!(snap.results.as_ref().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn a_steady_state_snapshot_reports_only_the_configured_kind() {
+        let cfg = group_by_cfg();
+        let mut store = IncidentStore::default();
+        let id = store
+            .assign(
+                &cfg,
+                &detection("r1", "10.0.0.1", "alice", Level::High),
+                0,
+                |_| {},
+            )
+            .unwrap();
+
+        let snap = store.snapshot_one(&id, cfg.include).unwrap();
+        assert_eq!(snap.sample_mode, Some(SampleMode::Refs));
+        assert!(snap.results.is_none());
+    }
+
+    #[test]
+    fn emissions_carry_no_snapshot_only_fields() {
+        let cfg = group_by_cfg();
+        let mut store = IncidentStore::default();
+        store.assign(
+            &cfg,
+            &detection("r1", "10.0.0.1", "alice", Level::High),
+            0,
+            |_| {},
+        );
+        let emissions = store.tick(&cfg, 30);
+        let emitted = serde_json::to_value(&emissions[0].result).unwrap();
+        assert!(emitted.get("sample_mode").is_none());
+        assert!(emitted.get("bundle_ready").is_none());
     }
 
     #[test]

--- a/crates/rsigma-runtime/src/alert_pipeline/mod.rs
+++ b/crates/rsigma-runtime/src/alert_pipeline/mod.rs
@@ -30,7 +30,9 @@ pub use config::{
     load_alert_pipeline_file, parse_alert_pipeline_config,
 };
 pub use dedup::DedupStore;
-pub use grouping::{GroupMode, IncidentRef, IncidentResult, IncidentStore, IncludeMode};
+pub use grouping::{
+    GroupMode, IncidentRef, IncidentResult, IncidentStore, IncludeMode, SampleMode,
+};
 pub use matcher::{MatchOp, Matcher, MatcherError, MatcherSet, MatcherSpec};
 pub use silence::{
     Silence, SilenceError, SilenceOrigin, SilenceSpec, SilenceState, SilenceStore, SilenceView,

--- a/crates/rsigma-runtime/src/engine.rs
+++ b/crates/rsigma-runtime/src/engine.rs
@@ -7,7 +7,7 @@ use rsigma_eval::pipeline::sources::DynamicSource;
 use rsigma_eval::{
     CorrelationConfig, CorrelationEngine, CorrelationSnapshot, CorrelationStateSnapshot, Engine,
     LogSourceExtractor, MatchDetailLevel, Pipeline, ProcessResult, RoutingPlan, RuleFieldSet,
-    SchemaClassifier, SchemaPruning, SchemaRouter, parse_pipeline_file,
+    RuleMetadataLookup, SchemaClassifier, SchemaPruning, SchemaRouter, parse_pipeline_file,
 };
 use rsigma_parser::SigmaCollection;
 
@@ -556,6 +556,19 @@ impl RuntimeEngine {
                 correlation_rules: router.correlation_rule_count(),
                 state_entries: router.state_count(),
             },
+        }
+    }
+
+    /// Resolve a rule key (an id, or a title for a rule without one) to the
+    /// documentation of every loaded rule that carries it.
+    ///
+    /// Aggregated output such as an incident's `rule_counts` records only the
+    /// key, so this is how a consumer recovers what the rule was for.
+    pub fn rule_metadata(&self, key: &str) -> RuleMetadataLookup {
+        match &self.engine {
+            EngineVariant::DetectionOnly(engine) => engine.rule_metadata(key),
+            EngineVariant::WithCorrelations(engine) => engine.rule_metadata(key),
+            EngineVariant::Routed(router) => router.rule_metadata(key),
         }
     }
 

--- a/crates/rsigma-runtime/src/ocsf/mod.rs
+++ b/crates/rsigma-runtime/src/ocsf/mod.rs
@@ -657,6 +657,8 @@ mod tests {
             entities: Map::new(),
             refs: None,
             results: None,
+            sample_mode: None,
+            bundle_ready: None,
         }
     }
 

--- a/crates/rsigma-runtime/src/processor.rs
+++ b/crates/rsigma-runtime/src/processor.rs
@@ -495,6 +495,23 @@ impl LogProcessor {
         engine.introspect_correlations(id, group)
     }
 
+    /// Resolve several rule keys to their documentation in one pass.
+    ///
+    /// Batched because a caller documenting an aggregate needs every key
+    /// resolved against the *same* rule set: reloading between two single-key
+    /// lookups would mix documentation from two generations of rules. Holds the
+    /// engine lock only for the lookups.
+    pub fn rule_metadata_batch<'a>(
+        &self,
+        keys: impl IntoIterator<Item = &'a str>,
+    ) -> std::collections::BTreeMap<String, rsigma_eval::RuleMetadataLookup> {
+        let snapshot = self.engine.load();
+        let engine = snapshot.lock();
+        keys.into_iter()
+            .map(|key| (key.to_string(), engine.rule_metadata(key)))
+            .collect()
+    }
+
     /// Total rule candidates pruned by logsource on the current engine.
     pub fn logsource_pruned_total(&self) -> u64 {
         let snapshot = self.engine.load();

--- a/crates/rsigma-runtime/tests/ocsf_golden.rs
+++ b/crates/rsigma-runtime/tests/ocsf_golden.rs
@@ -227,6 +227,8 @@ fn incident(state: &'static str, trigger: &'static str) -> IncidentResult {
             level: Some("high".to_string()),
         }]),
         results: None,
+        sample_mode: None,
+        bundle_ready: None,
     }
 }
 

--- a/crates/rstix/tests/spec.rs
+++ b/crates/rstix/tests/spec.rs
@@ -589,8 +589,7 @@ fn observed_data_deprecated_objects_sro_parses_in_bundle() {
     use rstix::parse_bundle;
     let object_json = load_spec_fixture("sdo/observed-data-deprecated-objects-sro.json");
     let bundle_json = format!(
-        r#"{{"type":"bundle","id":"bundle--00000000-0000-0000-0000-000000000001","objects":[{}]}}"#,
-        object_json
+        r#"{{"type":"bundle","id":"bundle--00000000-0000-0000-0000-000000000001","objects":[{object_json}]}}"#
     );
     let bundle = parse_bundle(&bundle_json).expect("bundle with embedded SRO should parse");
     assert_eq!(bundle.objects().len(), 1);

--- a/docs/content/cli/engine/incidents-export.md
+++ b/docs/content/cli/engine/incidents-export.md
@@ -1,0 +1,105 @@
+# `rsigma engine incidents export`
+
+Pull one incident's bundle from a running daemon and write it to stdout or a file.
+
+## Synopsis
+
+```text
+rsigma engine incidents export <INCIDENT_ID> [OPTIONS]
+```
+
+## Description
+
+An incident groups many detections under one id, and the grouped view alone does not say much: it carries rule *keys*, counts, and grouping values, not what those rules were looking for or why they matter. A bundle is that incident joined to the [ADS](../../guide/detection-strategy.md) documentation of every rule that contributed and the risk entities it overlaps, in one self-contained document. It is what you attach to a ticket, hand to an on-call engineer, or keep as the record of what the detection stack knew at the time.
+
+The command is the client side of [`GET /api/v1/incidents/{id}/bundle`](../../reference/http-api.md#get-apiv1incidentsidbundle). Incident ids come from [`GET /api/v1/incidents`](../../reference/http-api.md#get-apiv1incidents) or from an emitted incident's `incident_id`.
+
+Like [`engine status`](status.md), it uses a synchronous HTTP client and does not need the `daemon` build feature, so a lightweight build can pull a bundle from a remote daemon. `--addr` follows the same convention: it defaults to `daemon.api.addr` from the resolved config, and a wildcard bind address (`0.0.0.0`, `[::]`) is mapped to loopback.
+
+The daemon renders the bundle, so the global `--output-format` has no say in how it looks. `--bundle-format` is the only control, and passing an output format prints a warning and is otherwise ignored.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<INCIDENT_ID>` | required | The incident to export. |
+| `--bundle-format <FORMAT>` | `json` | `json` for the full structured document, `markdown` for a human-readable report. |
+| `-o, --output <PATH>` | stdout | Write the bundle here. The file is replaced only after the whole bundle has arrived, so a failed export leaves a previous one intact. |
+| `--addr <HOST:PORT or URL>` | from `daemon.api.addr` | Daemon API address as `host:port` or a full URL. `https://` URLs work for TLS deployments. |
+| `-c, --config <PATH>` | discovery chain | Explicit config file used to resolve the daemon address. |
+| `--auth-token-env <VAR>` | `RSIGMA_API_TOKEN` | Environment variable holding the API bearer token. |
+
+## Authentication
+
+The bundle route requires the `incident-bundles:read` permission when the daemon has [API authentication](../../reference/security.md#daemon-api-authentication) enabled. That permission is deliberately separate from the `incidents:read` that gates the incident list, because a bundle hands out rule documentation and risk entities as well.
+
+The token is read from an environment variable and never taken as an argument, so it does not appear in the process list or in shell history. An unset or empty variable sends no `Authorization` header at all, which against an authenticated daemon fails with a `401` rather than silently exporting nothing.
+
+```bash
+export RSIGMA_API_TOKEN="$(cat /run/secrets/rsigma-token)"
+rsigma engine incidents export f8bcd62a829b1126
+```
+
+## Examples
+
+### Export to stdout and pick the bundle apart
+
+```bash
+rsigma engine incidents export f8bcd62a829b1126 | jq '.rules[] | {key, count, resolution}'
+```
+
+```json
+{"key": "Suspicious PowerShell Download", "count": 4, "resolution": "unique"}
+{"key": "a1b2c3d4-0000-0000-0000-000000000001", "count": 2, "resolution": "missing"}
+```
+
+`resolution` reports how the incident's rule key resolved against the rule set loaded *now*: `unique`, `ambiguous` when several loaded rules carry the key with differing documentation, and `missing` when the rule set changed while the incident was open.
+
+### A Markdown report for a ticket
+
+```bash
+rsigma engine incidents export f8bcd62a829b1126 \
+  --bundle-format markdown \
+  --output incident-f8bcd62a.md
+```
+
+### A remote TLS daemon
+
+```bash
+rsigma engine incidents export f8bcd62a829b1126 --addr https://daemon.internal:9443
+```
+
+### Export every open incident
+
+```bash
+curl -sS http://127.0.0.1:9090/api/v1/incidents \
+  | jq -r '.incidents[] | select(.bundle_ready) | .incident_id' \
+  | while read -r id; do
+      rsigma engine incidents export "$id" --output "bundles/$id.json"
+    done
+```
+
+The `bundle_ready` filter skips incidents still inside `group_wait`; those return `409` because their contents can still change.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | The bundle was fetched and written. |
+| `3` | The daemon could not be reached, returned a non-2xx status, or the output file could not be written. |
+
+A non-2xx response is reported with its status and the daemon's own explanation, so the reason is visible without a second request:
+
+```text
+incident export failed: http://127.0.0.1:9090/api/v1/incidents/nope/bundle?format=json returned HTTP 404
+no such open incident
+(the id is unknown, or the incident has already resolved and been evicted)
+```
+
+## See also
+
+- [HTTP API: incident bundles](../../reference/http-api.md#get-apiv1incidentsidbundle) for the raw endpoint, the bundle schema, and the status codes.
+- [Alert Pipeline](../../guide/alert-pipeline.md) for how incidents are grouped in the first place.
+- [Detection Strategy](../../guide/detection-strategy.md) for the ADS sections a bundle carries.
+- [Risk-Based Alerting](../../guide/risk-based-alerting.md) for the risk entities a bundle joins.
+- [`engine daemon`](daemon.md) for the service this command queries.

--- a/docs/content/guide/alert-pipeline.md
+++ b/docs/content/guide/alert-pipeline.md
@@ -195,7 +195,21 @@ group:
 
 An `IncidentResult` is one flat NDJSON object, disambiguated downstream by the presence of an `incident_id` key. It carries the `state` (`open` / `resolved`), the `trigger` (`group_wait` / `group_interval` / `repeat` / `resolved`), the window bounds, the `max_level`, the `result_count`, per-rule `rule_counts`, the `group_by` key (group_by mode) or `entities` map (entity_graph mode), and the `refs` or `results`. Incidents are delivered to stdout/file/NATS sinks; with `nats_subject` set, incidents publish to that dedicated subject instead of the detection stream. OTLP and webhook sinks do not receive incidents.
 
-Open incidents are also readable at `GET /api/v1/incidents`.
+Open incidents are also readable at `GET /api/v1/incidents`, and one at a time at `GET /api/v1/incidents/{id}`.
+
+### Incident bundles
+
+An incident names the rules that contributed to it by key and counts them, which is enough to route and dedupe but not enough to act on: nothing in it says what those rules look for, how confident they are, or which entities were already accumulating risk. A **bundle** answers that. It is the incident joined to the [ADS](detection-strategy.md) documentation of every contributing rule and the [risk entities](risk-based-alerting.md) it overlaps, rendered as one self-contained JSON document or Markdown report.
+
+```bash
+rsigma engine incidents export f8bcd62a829b1126 --bundle-format markdown -o incident.md
+```
+
+Because the join happens at read time against the currently loaded rule set, each rule in a bundle also reports how its key resolved: `unique`, `ambiguous` when several loaded rules carry that key with differing documentation, or `missing` when the rule set changed while the incident was open. A bundle says which of the three happened rather than quietly dropping a rule it could not document.
+
+A bundle is only served once the incident has cleared `group_wait` and been reported at least once, since until then its contents can still change. The snapshot routes report that as `bundle_ready`, and the bundle route returns `409` before it.
+
+See [`engine incidents export`](../cli/engine/incidents-export.md) and [HTTP API: incident bundles](../reference/http-api.md#get-apiv1incidentsidbundle).
 
 ### Metrics
 

--- a/docs/content/guide/detection-strategy.md
+++ b/docs/content/guide/detection-strategy.md
@@ -75,9 +75,20 @@ rsigma rule doc rules/ --fail-on-missing
 
 It exits 1 when any rule whose status is enforced is below the bar, and `--missing-only` narrows the report to exactly those rules. A section whose `rsigma.ads.*` key is present but blank counts as undocumented here (the Markdown render shows "_Not documented._"), whereas `rule lint` reports it as the `info`-level `ads_empty_section`; run `rule lint --fail-level info` to make the lint step fail on blanks too.
 
+## At response time
+
+ADS content written for review is worth more when it reaches the person handling the alert. An [incident bundle](alert-pipeline.md#incident-bundles) carries the same nine sections for every rule that contributed to an incident, resolved from the rules the daemon has loaded, so the response plan and the blind spots arrive with the incident rather than waiting to be looked up:
+
+```bash
+rsigma engine incidents export f8bcd62a829b1126 --bundle-format markdown
+```
+
+The sections come out of the compiled rule, so anything a [processing pipeline](processing-pipelines.md) rewrote is reflected as the daemon actually ran it.
+
 ## See also
 
 - [`rule doc`](../cli/rule/doc.md) for every flag and exit code.
+- [`engine incidents export`](../cli/engine/incidents-export.md) for shipping these sections with an incident.
 - [Lint Rules: ADS detection-strategy metadata](../reference/lint-rules.md#ads-detection-strategy-metadata-11) for the enforcement checks and config.
 - [Custom Attributes: `rsigma.ads.*`](../reference/custom-attributes.md#ads-detection-strategy-attributes-rsigmaads) for the attribute reference.
 - [CI/CD](ci-cd.md) for wiring the gate into a pipeline.

--- a/docs/content/reference/http-api.md
+++ b/docs/content/reference/http-api.md
@@ -15,6 +15,8 @@ All bodies are JSON unless otherwise noted. All responses include a `Content-Typ
 | `/api/v1/correlations` | GET | `correlations:read` | Compiled correlation list with per-group counts. Empty when the engine has no correlation rules. |
 | `/api/v1/correlations/state` | GET | `correlations:read` | Live per-group correlation window snapshot (current aggregate vs threshold, window entries, last alert, seconds to eviction). Filter with `?id=` and `?group=`. |
 | `/api/v1/incidents` | GET | `incidents:read` | Open incidents from the alert-pipeline grouping stage. |
+| `/api/v1/incidents/{id}` | GET | `incidents:read` | One open incident, in the same shape as a list entry. |
+| `/api/v1/incidents/{id}/bundle` | GET | `incident-bundles:read` | One incident joined to its rules' ADS documentation and the risk entities it overlaps, as JSON or Markdown. |
 | `/api/v1/risk` | GET | `risk:read` | Open entities tracked by the risk accumulator, with their window score, tactic count, source count, and window bounds. |
 | `/api/v1/silences` | GET, POST | `silences:read`, `silences:write` | List silences, or create one (returns its id). |
 | `/api/v1/silences/{id}` | DELETE | `silences:write` | Remove a silence by id. |
@@ -212,13 +214,87 @@ curl -sS http://127.0.0.1:9090/api/v1/incidents
       "result_count": 2,
       "rule_counts": {"rule-1": 2},
       "group_by": {"match.CommandLine": "malware x"},
-      "refs": [{"rule": "rule-1", "level": "high"}]
+      "refs": [{"rule": "rule-1", "level": "high"}],
+      "sample_mode": "refs",
+      "bundle_ready": true
     }
   ]
 }
 ```
 
 The `include` mode configured on the `group` block decides whether each incident carries lightweight `refs` or full `results`. See the [Alert Pipeline](../guide/alert-pipeline.md) guide.
+
+Two fields appear only on snapshots, never on emitted incidents:
+
+- `sample_mode` reports which sample kinds the incident actually retained: `refs`, `results`, `mixed`, or `none`. Samples are retained when a result is absorbed but reported under the mode configured at read time, so changing `include` while an incident is open leaves both kinds behind. `mixed` says so instead of hiding one of them.
+- `bundle_ready` is `false` while the incident is still inside `group_wait` and has not been reported yet. Its contents can still change, so the bundle route withholds it until this is `true`.
+
+### `GET /api/v1/incidents/{id}`
+
+One open incident, in the same shape as a list entry. Returns `404` when the id is unknown, which includes an incident that has already resolved and been evicted, and `503` when the alert pipeline has no `group` block.
+
+```bash
+curl -sS http://127.0.0.1:9090/api/v1/incidents/f8bcd62a829b1126
+```
+
+### `GET /api/v1/incidents/{id}/bundle`
+
+A self-contained incident report: the incident joined to the [ADS](../guide/detection-strategy.md) documentation of every rule that contributed and the risk entities it overlaps. Requires `incident-bundles:read`, which is deliberately separate from `incidents:read` because a bundle hands out more than the incident list does.
+
+| Parameter | Values | Default | Description |
+|---|---|---|---|
+| `format` | `json`, `markdown` (`md`) | `json` | The rendering. JSON is served as `application/json`, Markdown as `text/markdown; charset=utf-8`. |
+
+```bash
+curl -sS http://127.0.0.1:9090/api/v1/incidents/f8bcd62a829b1126/bundle
+curl -sS 'http://127.0.0.1:9090/api/v1/incidents/f8bcd62a829b1126/bundle?format=markdown'
+```
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-07-26T12:00:00Z",
+  "sources": {"rules": true, "risk": true},
+  "incident": { "incident_id": "f8bcd62a829b1126", "...": "as above" },
+  "rules": [
+    {
+      "key": "rule-1",
+      "count": 2,
+      "resolution": "unique",
+      "documents": [
+        {
+          "identity": {"kind": "detection", "id": "rule-1", "title": "Whoami execution"},
+          "level": "high",
+          "tags": ["attack.discovery"],
+          "ads": {"sections": [{"id": "goal", "required": true, "present": true, "carrier": "description", "content": "Detects whoami execution."}]}
+        }
+      ]
+    }
+  ],
+  "risk": [
+    {"matched_on": "risk_object", "entity_type": "user", "entity_value": "alice", "score": 120, "...": "as GET /api/v1/risk"}
+  ]
+}
+```
+
+An incident records only a rule *key* per contributing result: the rule id, or the title for a rule without one. `resolution` reports how that key resolved against the currently loaded rule set:
+
+- `unique`: exactly one rule carries the key, and `documents` has one entry.
+- `ambiguous`: several loaded rules carry it with differing documentation, and every one is listed. A routed rule set compiles the same rule once per pipeline-set, so this appears when a pipeline rewrites a rule's documentation for one schema but not another.
+- `missing`: no loaded rule carries the key, and `documents` is empty. Expected when the rule set changed while the incident was open.
+
+Risk entities join on the entity type as well as its value, so the user `alice` is never tied to the host `alice`. `matched_on` says which evidence produced the join: `risk_object` when a retained result named the entity in its `risk.objects` enrichment, and `group_key` when the incident retained only references and the join came from its own grouping key. `sources.risk` is `false` when no risk accumulator is configured, which is not the same as an incident with no risk overlap.
+
+The route returns:
+
+| Status | Meaning |
+|---|---|
+| `400` | Unknown `format`. |
+| `404` | Unknown incident id, or one that has already resolved and been evicted. |
+| `409` | The incident is still inside `group_wait`, so its contents can still change. |
+| `503` | The alert pipeline has no `group` block, so the daemon tracks no incidents. |
+
+The CLI wraps this route: see [`rsigma engine incidents export`](../cli/engine/incidents-export.md).
 
 ### `GET /api/v1/risk`
 

--- a/docs/content/reference/security.md
+++ b/docs/content/reference/security.md
@@ -154,6 +154,7 @@ Design properties:
 - **Constant-time comparison.** Every presented token is compared against every configured secret in constant time, so timing cannot leak a matched prefix.
 - **Least privilege by role.** Built-in roles `reader`/`operator`/`ingest`/`admin` plus custom roles as permission lists with `*` wildcards. A log shipper's `ingest` token carries only `events:ingest` and cannot create silences or trigger reloads; `reload:execute` is deliberately excluded from `operator` so config-changing control stays with `admin` tokens.
 - **Fail-closed route table.** A route added without a permission mapping requires the full `*` grant rather than defaulting open.
+- **Aggregating routes get their own resource.** An [incident bundle](http-api.md#get-apiv1incidentsidbundle) joins an incident to rule documentation and risk entities, so it requires `incident-bundles:read` rather than the `incidents:read` that gates the incident list. A custom role can hand out the incident list without handing out what the detections look for or which entities are accumulating risk. The built-in `reader` role (`*:read`) covers both.
 - **No anonymous fallback for bad tokens.** `anonymous_permissions` applies only to requests with no `Authorization` header; a presented-but-unrecognized token is always rejected with 401.
 - **Observable rejections.** `rsigma_api_auth_failures_total{reason="unauthorized"|"forbidden"}` counts rejections, and each is logged at warn level with the route and token name; the secret is never logged.
 

--- a/docs/docmd.config.js
+++ b/docs/docmd.config.js
@@ -155,6 +155,10 @@ export default {
             { title: "classify", path: "/cli/engine/classify" },
             { title: "discover-schemas", path: "/cli/engine/discover-schemas" },
             { title: "status", path: "/cli/engine/status" },
+            {
+              title: "incidents export",
+              path: "/cli/engine/incidents-export",
+            },
             { title: "tap", path: "/cli/engine/tap" },
             { title: "tail", path: "/cli/engine/tail" },
             { title: "daemon", path: "/cli/engine/daemon" },


### PR DESCRIPTION
An incident groups many detections under one id, but the grouped view carries only rule *keys*, counts, and grouping values. Nothing in it says what those rules look for, how confident they are, or which entities were already accumulating risk, so acting on one means opening the rule files by hand and cross-referencing the risk API.

This adds a **bundle**: one incident joined to the ADS documentation of every rule that contributed and the risk entities it overlaps, as a self-contained JSON document or Markdown report.

```bash
rsigma engine incidents export f8bcd62a829b1126 --bundle-format markdown -o incident.md
```

## What it adds

- `GET /api/v1/incidents/{id}` serves a single incident, and `GET /api/v1/incidents/{id}/bundle` serves the assembled artifact in either rendering.
- `rsigma engine incidents export <ID>` wraps the bundle route, writing to stdout or atomically to a file.
- A public `rule_metadata` lookup in `rsigma-eval` resolves a rule key back to the documentation of every loaded rule that carries it, across `Engine`, `CorrelationEngine`, and `SchemaRouter`.

## Decisions worth reviewing

**Rule keys can be ambiguous, and a bundle says so.** An incident records a rule id, or a title for a rule without one. Resolving that against the rule set loaded *now* has three outcomes, and each rule in a bundle reports which one it got: `unique`, `ambiguous` when several loaded rules carry the key with differing documentation, and `missing` when the rule set changed while the incident was open. A routed rule set compiles the same rule once per pipeline-set, so identical post-pipeline documentation collapses to one answer while a pipeline that rewrites a rule's docs for one schema only stays ambiguous. Dropping the rule silently, or picking a winner, would both misrepresent what the daemon knows.

**Risk joins on the type as well as the value.** The user `alice` and the host `alice` are different entities. Matching a bare value would tie them together, so the join uses the exact `(type, value)` pair from a retained result's `risk.objects` enrichment. A `refs`-only incident has no results to read, so it falls back to its own grouping key, and `matched_on` records which evidence produced the join. `sources.risk` is `false` when no accumulator is configured, which is not the same as an incident with no risk overlap.

**The bundle route requires `incident-bundles:read`, not `incidents:read`.** It hands out rule documentation and risk entities as well as the incident, so widening what an incident reader can see would be a quiet authorization change. A custom role can now grant the incident list without granting the join. The built-in `reader` role (`*:read`) covers both, so nothing existing is affected.

**A batching incident is readable but not bundleable.** Inside `group_wait` an incident's contents can still change, so the detail route serves it with `bundle_ready: false` and the bundle route returns `409`. `503` is reserved for a daemon with no `group:` stage, keeping "this daemon does not track incidents" apart from `404` for an unknown or evicted id.

**Snapshots report what was actually retained.** Samples are retained under the `include` mode in force when a result is absorbed but reported under the mode configured at read time, so changing `include` mid-incident leaves both kinds behind. `sample_mode` reports `refs`, `results`, `mixed`, or `none` rather than hiding one of them. Both it and `bundle_ready` are snapshot-only and never appear on emitted incidents, so no sink's wire shape changes.

**One lock at a time.** Assembling a bundle reads the incident store, then the engine, then risk state, releasing each before taking the next. Rule metadata is looked up in one batch so every key resolves against the same rule set: two single-key lookups either side of a reload would mix documentation from two generations of rules.

**The CLI keeps the daemon's error body.** `ureq` is configured with `http_status_as_error(false)` so a 403, 404, 409, or 503 arrives with the hint that explains it instead of collapsing to a status code. The token is read from an environment variable (`--auth-token-env`, default `RSIGMA_API_TOKEN`) rather than an argument so it stays out of the process list, and an output file is replaced by rename only after the whole bundle has arrived.

## Supporting changes

`CompiledRule` and `CompiledCorrelation` now retain `description` and `falsepositives`, which the compiler had been discarding. The ADS section vocabulary moved behind an `AdsCarriers` trait so a compiled rule (JSON custom attributes) produces the same nine-section document as a parsed one (YAML), rather than the mapping being written twice.

## Test plan

- [x] `cargo test --workspace --all-features` (3705 passed)
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo doc --workspace --all-features --locked --no-deps`
- [x] `npm run docs:build` and `npm run docs:validate`
- [x] `scripts/mcp-smoke.py` over stdio and HTTP
- [x] Golden files for the JSON and Markdown renderings
- [x] End-to-end daemon tests for each status code, and CLI tests for stdout, file output, the authorization split, and an unreachable daemon

Closes #339 