### PR TITLE
Measure eval throughput net of rule load and republish the corpus numbers

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,29 +20,53 @@ Use the representative baseline below, not the synthetic tables, to size deploym
 **Hardware**: Apple M4 Pro (8 performance + 4 efficiency cores), macOS
 **Date captured**: 2026-07-28
 **Corpus**: SigmaHQ `rules/` at `994da166` (3,132 detection rules, the SHA pinned in CI)
-**Fixtures**: `scripts/perf/fetch-fixtures.sh` (pinned corpus + deterministic event lanes), run via `scripts/perf/baseline-eval.sh` and `scripts/perf/baseline-daemon.sh`
+**Fixtures**: `scripts/perf/fetch-fixtures.sh` (pinned corpus + deterministic event lanes), run via `scripts/perf/baseline-eval.sh` and `scripts/perf/daemon-matrix.sh`, both against the same two binaries via their `RSIGMA` override
 
-Offline `engine eval` (single-threaded; wall time includes ~0.3-0.5 s rule load over 10k events):
+**Method**: each lane is concatenated to 100,000 events and the reported rate is net of rule load. Loading the pinned corpus costs ~0.3 s, which is a fixed startup cost; leaving it in a per-event figure over a single 10k-event pass made a faster evaluator look slower than it is, and earlier captures of this section understated throughput by roughly 2x for that reason. Both columns are printed by the harness so the split stays visible. `engine eval` is single-threaded: `RAYON_NUM_THREADS` makes no measurable difference to it, so these are per-core numbers.
 
-| Lane | Default | `--logsource-routing` | `--cross-rule-ac` | Both |
-|------|--------:|----------------------:|------------------:|-----:|
-| Raw Windows blobs (2.4 KB `message`) | 7.7k events/s | 23.4k | 11.5k | 15.4k |
-| Structured Windows (Sysmon-shaped) | 11.7k events/s | 14.8k | 8.9k | 10.8k |
-| Cisco AAA syslog (raw `message` + `product`/`service` hints) | 20.9k events/s | 23.6k | 13.6k | 15.4k |
-| Sysmon file events (EventID 11, `product`/`category` hints) | 14.5k events/s | 18.9k | 10.5k | 12.9k |
+Offline `engine eval`, single core, before and after witness-based candidate indexing. Match counts are identical in every cell, which is what makes the comparison a throughput measurement rather than a behavior change:
 
-Daemon HTTP end-to-end (`--input http --batch-size 512`, 4 concurrent NDJSON batch posters, throughput from the daemon's own `rsigma_events_processed_total` delta):
+| Lane | Variant | Before | After | Change |
+|------|---------|-------:|------:|-------:|
+| Raw Windows blobs (2.4 KB `message`) | default | 2,601 | 33,884 | 13.0x |
+| | `--logsource-routing` | 3,556 | 98,836 | 27.8x |
+| | `--cross-rule-ac` | 3,402 | 26,414 | 7.8x |
+| | both | 5,005 | 57,325 | 11.5x |
+| Structured Windows (Sysmon-shaped) | default | 1,112 | 19,358 | 17.4x |
+| | `--logsource-routing` | 1,695 | 29,800 | 17.6x |
+| | `--cross-rule-ac` | 1,580 | 16,322 | 10.3x |
+| | both | 2,301 | 22,644 | 9.8x |
+| Cisco AAA syslog (raw `message` + `product`/`service` hints) | default | 2,917 | 66,434 | 22.8x |
+| | `--logsource-routing` | 50,031 | 106,241 | 2.1x |
+| | `--cross-rule-ac` | 4,121 | 41,914 | 10.2x |
+| | both | 36,368 | 57,195 | 1.6x |
+| Sysmon file events (EventID 11, `product`/`category` hints) | default | 1,954 | 26,836 | 13.7x |
+| | `--logsource-routing` | 11,027 | 45,481 | 4.1x |
+| | `--cross-rule-ac` | 2,750 | 20,711 | 7.5x |
+| | both | 13,392 | 32,629 | 2.4x |
 
-| Lane | Default | `--logsource-routing --cross-rule-ac` |
-|------|--------:|--------------------------------------:|
-| Raw Windows blobs | 21.8k events/s | 40.4k |
-| Structured Windows | 8.9k events/s | 17.3k |
-| Cisco AAA syslog | 23.4k events/s | 219.5k |
-| Sysmon file events | 15.0k events/s | 80.6k |
+Daemon HTTP end-to-end (`--input http --batch-size 512`, 4 concurrent NDJSON batch posters, throughput from the daemon's own `rsigma_events_processed_total` delta, so an HTTP accept backlog cannot inflate it):
 
-`--cross-rule-ac` no longer belongs in an optimal configuration. It still beats the default on the raw-blob lane, but `--logsource-routing` on its own beats every AC configuration on all four lanes, and adding AC on top of routing costs 27-35%. The candidate index performs the same substring work over a smaller rule population, so the cross-rule automaton is a duplicated hot-path pass. The daemon table above predates witness indexing and is due a re-measurement.
+| Lane | Variant | Before | After | Change |
+|------|---------|-------:|------:|-------:|
+| Raw Windows blobs | default | 20,193 | 195,639 | 9.7x |
+| | `--logsource-routing` | 25,904 | 342,070 | 13.2x |
+| | both | 31,819 | 271,997 | 8.5x |
+| Structured Windows | default | 8,868 | 87,704 | 9.9x |
+| | `--logsource-routing` | 12,550 | 113,601 | 9.1x |
+| | both | 16,645 | 100,124 | 6.0x |
+| Cisco AAA syslog | default | 21,715 | 287,000 | 13.2x |
+| | `--logsource-routing` | 278,618 | 401,364 | 1.4x |
+| | both | 242,610 | 310,490 | 1.3x |
+| Sysmon file events | default | 14,647 | 126,001 | 8.6x |
+| | `--logsource-routing` | 72,733 | 174,550 | 2.4x |
+| | both | 84,475 | 147,196 | 1.7x |
 
-The witness audit (`cargo run --release -p rsigma-eval --example witness_audit`) shows 99.6% of the corpus carries a sound required-positive witness, with simulated candidate rates of 2-3% of loaded rules on Windows-shaped traffic and under 1.5% on the Cisco syslog and Sysmon file-event lanes. Peak RSS for load + eval is ~113 MB. Sampling profiles taken before witness indexing attributed per-event time to event field lookup and hashing (~25-45%), `std` substring search and searcher setup (~13-30%), the condition and detection tree walk (~15%), case folding, and allocator traffic; the structured lane's 10x gain came from removing most of that work rather than making it cheaper, so the remaining profile is due a re-capture.
+`--cross-rule-ac` changed sides. Before witness indexing it earned its keep on top of routing (31.8k vs 25.9k on the raw-blob lane end-to-end). After, `--logsource-routing` alone beats every AC configuration on all four lanes both offline and end-to-end, and adding AC on top of routing costs 20-35%. The candidate index performs the same substring work over a smaller rule population, so the cross-rule automaton is now a duplicated hot-path pass. It stays correct and feature-gated for pure-substring corpora at 5,000+ rules, where it should be benchmarked against routing rather than against the bare default.
+
+Parallel efficiency fell as per-event cost did, which is the expected shape and locates the next bottleneck. On the raw-blob lane the daemon delivered 7.8x its single-core rate before (20,193 over 2,601) and 5.8x after (195,639 over 33,884) on 8 performance cores. On the cheapest configurations the ratio is lower still: the Cisco lane with routing scales 3.8x (401,364 over 106,241). Detection itself does parallelize inside a batch, since `Engine::evaluate_batch` fans a batch across rayon when the `parallel` feature is on, so what the remaining gap represents is the fixed per-event pipeline cost around evaluation (HTTP framing, JSON parse, result serialization, sink write) plus the engine lock the batch is held under.
+
+The witness audit (`cargo run --release -p rsigma-eval --example witness_audit`) shows 99.6% of the corpus carries a sound required-positive witness, with simulated candidate rates of 2-3% of loaded rules on Windows-shaped traffic and under 1.5% on the Cisco syslog and Sysmon file-event lanes. Peak RSS for load + eval is ~113 MB. Sampling profiles taken before witness indexing attributed per-event time to event field lookup and hashing (~25-45%), `std` substring search and searcher setup (~13-30%), the condition and detection tree walk (~15%), case folding, and allocator traffic. Witness indexing removed most of that work rather than making it cheaper, so the remaining profile is due a re-capture before any further micro-optimization.
 
 Match volume depends on flags because logsource routing is also a correctness filter: on the raw-blob lane the default configuration reports ~3 matches per event (mostly cross-product keyword false positives), while `--logsource-routing` drops that to ~0.02 per event.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Measured on the SigmaHQ corpus at the pinned CI SHA (3,132 rules, Apple M4 Pro),
 
 `--cross-rule-ac` changed sides. It used to earn its keep on top of `--logsource-routing`; now routing alone beats every AC configuration on all four lanes both offline and end-to-end, and adding AC costs 20-35%. The candidate index does the same substring work over a smaller rule population. The flag stays correct and feature-gated but is no longer recommended, and the tuning guide says so.
 
-`scripts/perf/baseline-eval.sh` now reports throughput net of rule load and runs 100,000 events per lane instead of 10,000. Load is a fixed ~0.3 s startup cost that accounted for roughly half the wall time of a single 10k pass, so including it understated real throughput by about 2x and compressed the apparent improvement. `scripts/perf/baseline-daemon.sh` gained an `RSIGMA` override so a pre-change build can be measured with the same harness, and `scripts/perf/daemon-matrix.sh` walks the lane and flag matrix end-to-end.
+`scripts/perf/baseline-eval.sh` now reports throughput net of rule load (#407) and runs 100,000 events per lane instead of 10,000. Load is a fixed ~0.3 s startup cost that accounted for roughly half the wall time of a single 10k pass, so including it understated real throughput by about 2x and compressed the apparent improvement. `scripts/perf/baseline-daemon.sh` gained an `RSIGMA` override so a pre-change build can be measured with the same harness, and `scripts/perf/daemon-matrix.sh` walks the lane and flag matrix end-to-end.
 
 Three behavior changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,20 @@ The candidate index could only pre-filter on exact field values, so any rule bui
 
 Rules are now analyzed into witnesses: necessary conditions, at least one of which holds on every event the rule can match. The index inverts that relation across a presence list and an exact-value map per field, one Aho-Corasick automaton per field over that field's substring needles, and one automaton over keyword needles matched against every string value in the event. Rules whose conditions admit no witness, principally anything negated, remain always-evaluated.
 
-Measured on the SigmaHQ corpus at the pinned CI SHA (3,132 rules, Apple M4 Pro, single thread, `scripts/perf/baseline-eval.sh`), with match counts byte-identical to the previous release on every lane and variant:
+Measured on the SigmaHQ corpus at the pinned CI SHA (3,132 rules, Apple M4 Pro), with match counts identical before and after in every cell. Offline figures are single core over 100,000 events and net of the ~0.3 s rule load; daemon figures are HTTP end-to-end at `--batch-size 512` with four concurrent posters, read from `rsigma_events_processed_total`:
 
-| Lane | Variant | Before | After |
-|---|---|---:|---:|
-| raw_windows | default | 2,645 | 7,707 |
-| raw_windows | `--logsource-routing` | 3,576 | 23,359 |
-| structured_windows | default | 1,175 | 11,740 |
-| structured_windows | `--logsource-routing` | 1,738 | 14,785 |
-| cisco_syslog | default | 2,876 | 20,921 |
-| sysmon_file_event | default | 1,987 | 14,489 |
+| Lane | Offline before | Offline after | Daemon before | Daemon after |
+|---|---:|---:|---:|---:|
+| raw_windows | 2,601 | 33,884 | 20,193 | 195,639 |
+| raw_windows `--logsource-routing` | 3,556 | 98,836 | 25,904 | 342,070 |
+| structured_windows | 1,112 | 19,358 | 8,868 | 87,704 |
+| structured_windows `--logsource-routing` | 1,695 | 29,800 | 12,550 | 113,601 |
+| cisco_syslog | 2,917 | 66,434 | 21,715 | 287,000 |
+| sysmon_file_event | 1,954 | 26,836 | 14,647 | 126,001 |
+
+`--cross-rule-ac` changed sides. It used to earn its keep on top of `--logsource-routing`; now routing alone beats every AC configuration on all four lanes both offline and end-to-end, and adding AC costs 20-35%. The candidate index does the same substring work over a smaller rule population. The flag stays correct and feature-gated but is no longer recommended, and the tuning guide says so.
+
+`scripts/perf/baseline-eval.sh` now reports throughput net of rule load and runs 100,000 events per lane instead of 10,000. Load is a fixed ~0.3 s startup cost that accounted for roughly half the wall time of a single 10k pass, so including it understated real throughput by about 2x and compressed the apparent improvement. `scripts/perf/baseline-daemon.sh` gained an `RSIGMA` override so a pre-change build can be measured with the same harness, and `scripts/perf/daemon-matrix.sh` walks the lane and flag matrix end-to-end.
 
 Three behavior changes:
 
@@ -50,7 +54,7 @@ Fixes four cases where a pre-filter silently dropped a rule that should have mat
 
 - New reproducible performance fixtures: `scripts/perf/fetch-fixtures.sh` pins the SigmaHQ corpus to the CI SHA and `scripts/perf/gen_events.py` deterministically generates six event lanes (raw Windows blobs, structured Windows, mixed schema, no-match, low-match, match-heavy). `scripts/perf/baseline-eval.sh` runs the offline eval flag/thread matrix and `scripts/perf/baseline-daemon.sh` measures daemon HTTP end-to-end throughput from the daemon's own processed-events counter.
 - New `witness_audit` example in `rsigma-eval` (`cargo run --release -p rsigma-eval --example witness_audit`): analyzes a rule corpus at the HIR level and reports what fraction carries a sound required-positive witness (exact value, substring, keyword, regex or encoded literal, field presence), the fail-open remainder, and simulated per-lane candidate rates. On SigmaHQ at the pinned SHA: 20.8% of rules are indexable under the current exact-only index, 99.6% carry a sound witness, and simulated candidate rates are 2-3% of loaded rules on Windows-shaped traffic.
-- `BENCHMARKS.md` now separates synthetic microbenchmarks from representative corpus numbers: a new "SigmaHQ corpus baseline" section records measured offline and daemon throughput (roughly 1-4k events/s per core offline and 9-40k events/s for the daemon on a 12-core machine, depending on lane and flags), and the synthetic single-event table now says why its flat rule-count scaling does not transfer to real corpora. The performance-tuning and testing docs pages carry the same correction.
+- `BENCHMARKS.md` now separates synthetic microbenchmarks from representative corpus numbers: a new "SigmaHQ corpus baseline" section records measured offline and daemon throughput (roughly 1-4k events/s per core offline and 9-40k events/s for the daemon on a 12-core machine, depending on lane and flags), and the synthetic single-event table now says why its flat rule-count scaling does not transfer to real corpora. The performance-tuning and testing docs pages carry the same correction. Those first offline figures included the fixed ~0.3 s rule load in a 10k-event pass, which understated per-event throughput by roughly 2x; the harness and the published numbers were corrected as part of the witness indexing work below.
 
 ### Dependency bumps (#402)
 

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -651,7 +651,7 @@ let result = engine.process_event_at(&event, timestamp_secs);
 ## Benchmarks
 
 Criterion.rs benchmarks with synthetic rules and events (Apple M-series, single-threaded unless noted).
-Rules are pre-filtered at evaluation time by the witness-based candidate index. The tables below were captured against the earlier exact-value-only index, so the `Indexed` column understates current throughput on the wildcard-heavy and regex-heavy scenarios, which the witness index prunes and its predecessor did not. For measured numbers on a real corpus see the [SigmaHQ corpus baseline](../../BENCHMARKS.md#sigmahq-corpus-baseline-representative).
+Rules are pre-filtered at evaluation time by the witness-based candidate index. The tables below were captured against the earlier exact-value-only index, so the `Indexed` column understates current throughput on the wildcard-heavy and regex-heavy scenarios, which the witness index prunes and its predecessor did not. For measured numbers on a real corpus see the [SigmaHQ corpus baseline](../../BENCHMARKS.md#sigmahq-corpus-baseline-representative), which records single-core and daemon throughput before and after witness indexing on four event shapes.
 
 ### Detection Evaluation
 

--- a/docs/content/developers/testing.md
+++ b/docs/content/developers/testing.md
@@ -196,7 +196,7 @@ cargo bench -p rsigma-eval --bench correlation_memory
 
 Benchmarks are not gated in CI. The numbers in [Benchmarks](../benchmarks.md) come from a manual run on the development workstation; if a PR makes a hot-path change, attach a before/after Criterion summary in the PR description.
 
-The Criterion suites use synthetic, mostly exact-match-indexable rules, so they measure hot paths, not representative corpus throughput. For a representative before/after, materialize the pinned SigmaHQ workload with `scripts/perf/fetch-fixtures.sh` and run `scripts/perf/baseline-eval.sh` (offline eval matrix) and `scripts/perf/baseline-daemon.sh` (daemon HTTP end to end); the corpus witness audit behind the candidate-index numbers is `cargo run --release -p rsigma-eval --example witness_audit`. See the [SigmaHQ corpus baseline](../benchmarks.md#sigmahq-corpus-baseline-representative) for the recorded matrix.
+The Criterion suites use synthetic, mostly exact-match-indexable rules, so they measure hot paths, not representative corpus throughput. For a representative before/after, materialize the pinned SigmaHQ workload with `scripts/perf/fetch-fixtures.sh` and run `scripts/perf/baseline-eval.sh` (offline eval matrix, single core, net of rule load) and `scripts/perf/daemon-matrix.sh` (daemon HTTP end to end across lanes and flag variants, wrapping `scripts/perf/baseline-daemon.sh`). Both take an `RSIGMA` override, so a pre-change build can be measured through the same harness for an honest before-and-after; the corpus witness audit behind the candidate-index numbers is `cargo run --release -p rsigma-eval --example witness_audit`. See the [SigmaHQ corpus baseline](../benchmarks.md#sigmahq-corpus-baseline-representative) for the recorded matrix.
 
 ## Tips
 

--- a/docs/content/guide/performance-tuning.md
+++ b/docs/content/guide/performance-tuning.md
@@ -2,9 +2,9 @@
 
 How fast RSigma evaluates depends on how much of your corpus the candidate index can prune. The index works from rule witnesses: necessary conditions, at least one of which must hold on any event the rule can match. Exact field values, substring needles, keywords, mandatory regex literals, and bare field presence all yield witnesses, so most of a real corpus is prunable and an event is only evaluated against the rules it could plausibly match. Rules whose conditions admit no witness, in practice the ones whose only required branch is negated, are evaluated against every event and cost time linear in their count.
 
-On the full SigmaHQ ruleset (~3,100 rules) expect roughly 8-21k events/s per core for offline `engine eval`, rising to 15-24k with `--logsource-routing`. The [SigmaHQ corpus baseline](../benchmarks.md#sigmahq-corpus-baseline-representative) in Benchmarks documents the measured matrix per event shape. Small or exact-match-heavy rulesets are considerably faster still.
+On the full SigmaHQ ruleset (~3,100 rules) expect roughly 19-66k events/s per core for offline `engine eval`, rising to 30-106k with `--logsource-routing`, and 88-287k end-to-end through the daemon (342-401k with routing) on a 12-core machine. Where a workload lands in those ranges depends on event shape: wide structured events are the slow end, narrowly tagged syslog the fast end. The [SigmaHQ corpus baseline](../benchmarks.md#sigmahq-corpus-baseline-representative) in Benchmarks documents the full matrix with before-and-after numbers. Small or exact-match-heavy rulesets are considerably faster still.
 
-This page covers the cases where the defaults stop being optimal: very large rule sets, substring-heavy threat-intel feeds, high-throughput daemon ingestion, and memory-constrained deployments. For SigmaHQ-scale corpora the single biggest lever is `--logsource-routing`, which is also a correctness filter because it stops cross-product keyword false positives. `--cross-rule-ac` is no longer worth enabling alongside it: the candidate index already does that substring work over a smaller rule population, and layering the cross-rule automaton on top of routing costs 27-35% on every measured lane. The bloom pre-filter (`--bloom-prefilter`) is off by default for a reason and should be benchmarked before flipping it on.
+This page covers the cases where the defaults stop being optimal: very large rule sets, substring-heavy threat-intel feeds, high-throughput daemon ingestion, and memory-constrained deployments. For SigmaHQ-scale corpora the single biggest lever is `--logsource-routing`, which is also a correctness filter because it stops cross-product keyword false positives. `--cross-rule-ac` is no longer worth enabling alongside it: the candidate index already does that substring work over a smaller rule population, and layering the cross-rule automaton on top of routing costs 20-35% on every measured lane, offline and end-to-end. The second lever is `--batch-size`: the default of 1 leaves detection on a single core, because a batch is what `Engine::evaluate_batch` fans across rayon. The bloom pre-filter (`--bloom-prefilter`) is off by default for a reason and should be benchmarked before flipping it on.
 
 ## Always-on: the matcher optimizer
 
@@ -120,7 +120,7 @@ These two only matter for the streaming daemon, not for `engine eval`.
 | Flag | Default | Effect |
 |------|---------|--------|
 | `--buffer-size N` | `10000` | Bounded mpsc capacity for both source→engine and engine→sink queues. Higher values absorb burstier input; lower values apply back-pressure sooner. Watch `rsigma_back_pressure_events_total` to see whether the queues are filling. |
-| `--batch-size N` | `1` | Maximum events to process per engine lock acquisition. The default processes one at a time. Raise to 64 or 128 under load to amortize mutex overhead. |
+| `--batch-size N` | `1` | Maximum events to process per engine lock acquisition. The default processes one at a time, which also means detection runs on a single core: the batch is the unit `Engine::evaluate_batch` fans across rayon. Raise to 64 or 128 under load, or higher on SigmaHQ-scale corpora (the published baseline uses 512). |
 
 A typical high-throughput configuration:
 
@@ -130,7 +130,7 @@ rsigma engine daemon -r rules/ \
     --batch-size 128
 ```
 
-The trade-off: a higher `--batch-size` increases tail latency (an event waits up to `batch_size - 1` peers ahead of it before getting evaluated) in exchange for amortizing the per-batch mutex acquisition. Below ~10 k events/s the default `1` is fine; above 50 k/s you typically want 64-128.
+The trade-off: a higher `--batch-size` increases tail latency (an event waits for the rest of its batch to be collected) in exchange for amortizing the per-batch mutex acquisition and, more importantly, for parallelism across cores. Below ~10k events/s the default `1` is fine; above 50k/s you want 64-128, and on a large corpus where per-event evaluation is the dominant cost, 512 measured best.
 
 ## Memory pressure and correlation state
 
@@ -185,7 +185,7 @@ cargo bench -p rsigma-runtime --bench dynamic_pipelines
 
 Replace the synthetic Criterion inputs with rules and events that mirror your own corpus. Both the bloom and cross-rule AC wins are workload-shaped: the published numbers above are the upper bound, not what you should expect on mixed data.
 
-For an end-to-end measurement on a real corpus rather than synthetic inputs, `scripts/perf/fetch-fixtures.sh` pins the SigmaHQ ruleset and generates deterministic event lanes, and `scripts/perf/baseline-eval.sh` walks the flag matrix over them. Point them at your own rules and events to get the same table for your workload.
+For an end-to-end measurement on a real corpus rather than synthetic inputs, `scripts/perf/fetch-fixtures.sh` pins the SigmaHQ ruleset and generates deterministic event lanes, and `scripts/perf/baseline-eval.sh` and `scripts/perf/daemon-matrix.sh` walk the flag matrix over them offline and through the daemon. Point them at your own rules and events to get the same table for your workload.
 
 ## Quick decision matrix
 

--- a/scripts/perf/baseline-daemon.sh
+++ b/scripts/perf/baseline-daemon.sh
@@ -7,7 +7,8 @@
 #
 # Usage:
 #   scripts/perf/baseline-daemon.sh [FIXTURES_DIR] [LANE] [EXTRA_DAEMON_FLAGS...]
-# Environment: BATCH (500), VUS (4), DURATION (30s), BATCH_SIZE (512)
+# Environment: BATCH (500), VUS (4), DURATION (30s), BATCH_SIZE (512),
+#              RSIGMA (binary under test, default target/release/rsigma)
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,7 +17,7 @@ fixtures="$(cd "${1:-${repo_root}/target/perf-fixtures}" && pwd)"
 lane="${2:-raw_windows}"
 shift 2 2>/dev/null || shift $# || true
 
-bin="${repo_root}/target/release/rsigma"
+bin="${RSIGMA:-${repo_root}/target/release/rsigma}"
 rules="${fixtures}/sigma/rules"
 lane_file="${fixtures}/events/${lane}.ndjson"
 addr="127.0.0.1:19090"

--- a/scripts/perf/baseline-eval.sh
+++ b/scripts/perf/baseline-eval.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run the offline `engine eval` throughput matrix over the perf fixture lanes
-# and print one TSV row per run (lane, flags, threads, events, matches,
-# wall seconds, events/sec).
+# and print one TSV row per run (lane, flags, events, matches, load seconds,
+# eval seconds, events/sec).
 #
 # Usage:
 #   scripts/perf/baseline-eval.sh [FIXTURES_DIR] [LANES...]
@@ -9,6 +9,18 @@
 # FIXTURES_DIR defaults to target/perf-fixtures (see fetch-fixtures.sh).
 # LANES defaults to "raw_windows structured_windows". The binary is expected
 # at target/release/rsigma, built with --all-features.
+#
+# Environment:
+#   REPEAT    times to concatenate each lane (default 10). Loading the pinned
+#             SigmaHQ corpus costs ~0.3 s, which swamps a single 10k-event pass,
+#             so the lane is repeated to push the eval share of wall time up.
+#   RSIGMA    override the binary under test (default target/release/rsigma),
+#             so a pre-change build can be measured with the same harness.
+#
+# Reported events/sec is net of rule load: the harness times a load-only run
+# (empty stdin) and subtracts it, because load is a fixed startup cost and
+# leaving it in the per-event figure makes a faster evaluator look slower than
+# it is. Both the load and eval columns are printed so the split stays visible.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -21,8 +33,9 @@ if [ "${#lanes[@]}" -eq 1 ]; then
     read -r -a lanes <<<"${lanes[0]}"
 fi
 
-bin="${repo_root}/target/release/rsigma"
+bin="${RSIGMA:-${repo_root}/target/release/rsigma}"
 rules="${fixtures}/sigma/rules"
+repeat="${REPEAT:-10}"
 [ -x "${bin}" ] || { echo "build first: cargo build --release --all-features --bin rsigma" >&2; exit 1; }
 [ -d "${rules}" ] || { echo "fixtures missing: run scripts/perf/fetch-fixtures.sh" >&2; exit 1; }
 
@@ -33,26 +46,43 @@ variants=(
     "logsource+ac|--logsource-routing --cross-rule-ac"
 )
 
-physical_cores="$(sysctl -n hw.perflevel0.physicalcpu 2>/dev/null || nproc)"
+now() { python3 -c 'import time; print(time.time())'; }
 
-echo -e "lane\tvariant\tthreads\tevents\tmatches\twall_s\teps"
+# Median of three load-only runs, one warm-up discarded.
+"${bin}" engine eval -r "${rules}" --quiet --output-format ndjson </dev/null >/dev/null
+load_samples=()
+for _ in 1 2 3; do
+    start="$(now)"
+    "${bin}" engine eval -r "${rules}" --quiet --output-format ndjson </dev/null >/dev/null
+    end="$(now)"
+    load_samples+=("$(python3 -c "print(${end}-${start})")")
+done
+load="$(printf '%s\n' "${load_samples[@]}" | sort -g | sed -n 2p)"
+
+echo -e "lane\tvariant\tevents\tmatches\tload_s\teval_s\teps"
 for lane in "${lanes[@]}"; do
     events_file="${fixtures}/events/${lane}.ndjson"
     [ -f "${events_file}" ] || { echo "missing lane ${events_file}" >&2; continue; }
-    n_events="$(wc -l <"${events_file}" | tr -d ' ')"
-    for threads in 1 "${physical_cores}"; do
-        for spec in "${variants[@]}"; do
-            name="${spec%%|*}"
-            flags="${spec#*|}"
-            start="$(python3 -c 'import time; print(time.time())')"
-            # shellcheck disable=SC2086
-            matches="$(RAYON_NUM_THREADS="${threads}" "${bin}" engine eval \
-                -r "${rules}" ${flags} --quiet --output-format ndjson \
-                <"${events_file}" | wc -l | tr -d ' ')"
-            end="$(python3 -c 'import time; print(time.time())')"
-            wall="$(python3 -c "print(f'{${end}-${start}:.2f}')")"
-            eps="$(python3 -c "print(f'{${n_events}/max(${end}-${start},1e-9):.0f}')")"
-            echo -e "${lane}\t${name}\t${threads}\t${n_events}\t${matches}\t${wall}\t${eps}"
-        done
+    stream="${TMPDIR:-/tmp}/rsigma-perf-${lane}.ndjson"
+    : >"${stream}"
+    for _ in $(seq 1 "${repeat}"); do cat "${events_file}" >>"${stream}"; done
+    n_events="$(wc -l <"${stream}" | tr -d ' ')"
+    for spec in "${variants[@]}"; do
+        name="${spec%%|*}"
+        flags="${spec#*|}"
+        start="$(now)"
+        # shellcheck disable=SC2086
+        matches="$("${bin}" engine eval \
+            -r "${rules}" ${flags} --quiet --output-format ndjson \
+            <"${stream}" | wc -l | tr -d ' ')"
+        end="$(now)"
+        python3 - "${lane}" "${name}" "${n_events}" "${matches}" "${load}" "${start}" "${end}" <<'PY'
+import sys
+lane, name, n_events, matches = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+load, start, end = float(sys.argv[5]), float(sys.argv[6]), float(sys.argv[7])
+evaluated = max(end - start - load, 1e-9)
+print(f"{lane}\t{name}\t{n_events}\t{matches}\t{load:.2f}\t{evaluated:.2f}\t{n_events / evaluated:.0f}")
+PY
     done
+    rm -f "${stream}"
 done

--- a/scripts/perf/daemon-matrix.sh
+++ b/scripts/perf/daemon-matrix.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run baseline-daemon.sh across the vendor-shape lanes and the flag variants
+# that matter after witness indexing: bare default, logsource routing alone,
+# and routing plus the cross-rule AC pass.
+#
+# Usage: scripts/perf/daemon-matrix.sh [FIXTURES_DIR]
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixtures="${1:-$(cd "${script_dir}/../.." && pwd)/target/perf-fixtures}"
+
+for lane in raw_windows structured_windows cisco_syslog sysmon_file_event; do
+    for variant in default logsource logsource_ac; do
+        case "${variant}" in
+            default) flags=() ;;
+            logsource) flags=(--logsource-routing) ;;
+            logsource_ac) flags=(--logsource-routing --cross-rule-ac) ;;
+        esac
+        printf 'variant=%s ' "${variant}"
+        "${script_dir}/baseline-daemon.sh" "${fixtures}" "${lane}" "${flags[@]+"${flags[@]}"}"
+    done
+done


### PR DESCRIPTION
## Why

Re-running the offline harness on an unchanged binary produced numbers 2x apart between consecutive runs. The cause: `baseline-eval.sh` ran 10,000 events per lane and charged the fixed ~0.3 s corpus load to the per-event rate. On runs whose total wall time was 0.6 s, load was half the measurement, so the reported figure was mostly a measurement of process startup and was dominated by page-cache state.

That mattered because the numbers published for witness-based candidate indexing (#406) came from that harness. They understated absolute throughput by roughly 2x and, because both the before and after captures paid the same fixed cost, compressed the apparent improvement from 13-23x down to the 2.9-10x that shipped.

## What changed

- `baseline-eval.sh` runs 100,000 events per lane and subtracts a measured load-only run (median of three, one warm-up discarded). Load and eval seconds print as separate columns so the split stays visible.
- Dropped the thread loop. It measured nothing: `engine eval` is single-threaded, and `RAYON_NUM_THREADS=8` produced numbers within noise of `=1` on every lane and variant.
- Both perf scripts take an `RSIGMA` override, so a pre-change build can be measured through the same harness rather than compared against a stale recorded capture.
- New `daemon-matrix.sh` walks the four vendor-shape lanes against the three flag variants that matter (bare default, routing, routing plus AC) end-to-end.
- Republished the offline and daemon tables in `BENCHMARKS.md`, the expected ranges in the tuning guide, and the numbers in the `CHANGELOG.md` witness-indexing entry.

## Re-measured

Both binaries through the same harness, same machine, same fixtures. Match counts identical in every cell.

Offline, single core, net of load:

| Lane | Before | After | With `--logsource-routing` (before → after) |
|---|---:|---:|---:|
| raw_windows | 2,601 | 33,884 | 3,556 → 98,836 |
| structured_windows | 1,112 | 19,358 | 1,695 → 29,800 |
| cisco_syslog | 2,917 | 66,434 | 50,031 → 106,241 |
| sysmon_file_event | 1,954 | 26,836 | 11,027 → 45,481 |

Daemon HTTP end-to-end, `--batch-size 512`:

| Lane | Before | After | With `--logsource-routing` (before → after) |
|---|---:|---:|---:|
| raw_windows | 20,193 | 195,639 | 25,904 → 342,070 |
| structured_windows | 8,868 | 87,704 | 12,550 → 113,601 |
| cisco_syslog | 21,715 | 287,000 | 278,618 → 401,364 |
| sysmon_file_event | 14,647 | 126,001 | 72,733 → 174,550 |

## Three findings the corrected numbers change

- **The 10x single-core target is exceeded, not approached.** 13.0x, 17.4x, 22.8x and 13.7x on the default configuration for the four lanes.
- **The structured lane is still the slowest, not the fastest.** At 19,358 events/s default it remains below raw blobs. The earlier claim that structured events had overtaken raw was an artifact of load-dominated measurement; wide events genuinely cost more because each extra field is another index probe.
- **The daemon already parallelizes detection.** `Engine::evaluate_batch` fans a batch across rayon under the `parallel` feature, so the single locked engine task is not a serialization point for detection-only workloads. Measured 5.8x single-core on 8 performance cores after the change, 7.8x before, falling to 3.8x on the cheapest configuration. The residual is fixed per-event pipeline cost (HTTP framing, JSON parse, result serialization, sink write) plus the lock the batch is held under. Consequence for users: `--batch-size` is a first-order configuration choice rather than a tuning knob, since the default of 1 leaves detection on a single core, and the tuning guide now says so.

`--cross-rule-ac` also changed sides rather than merely losing ground. Before witness indexing it beat routing alone end-to-end (31,819 vs 25,904 on raw blobs); now routing wins on every lane in both harnesses and AC on top costs 20-35%.

## Test plan

- [x] `shellcheck` clean on all three perf scripts
- [x] Full matrix run against both binaries via the `RSIGMA` override
- [x] Load-only timing verified stable at 0.29-0.31 s across repeated runs
- [x] `npm run docs:build` and `npm run docs:validate` from `docs/`