### PR TITLE
Fix cased substring bloom filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Cased substring bloom soundness
+
+The bloom prefilter now normalizes ASCII `|cased` substring needles into the same comparison space used for event probes, preventing uppercase patterns such as `CMD.EXE` from being rejected before evaluation. Non-ASCII cased needles conservatively disable the field's bloom filter because context-sensitive Unicode lowercasing cannot preserve every substring relation.
+
 ### Representative performance regression gates (#409)
 
 Representative SigmaHQ performance now has a checked-in CI contract. Pull requests that touch the evaluator or performance harness build the PR and its base revision on the same runner, run the same load-corrected median-of-three offline matrix, verify match counts, and reject a head/base throughput ratio below 0.5. The deliberately coarse floor catches roughly 2x regressions without treating shared-runner variance as a precise benchmark. Weekly and manually dispatched runs report bootstrap 95% confidence intervals over five samples and retain the full offline/daemon matrices and raw environment data for 90 days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Cased substring bloom soundness
+### Cased substring bloom soundness (#411)
 
 The bloom prefilter now normalizes ASCII `|cased` substring needles into the same comparison space used for event probes, preventing uppercase patterns such as `CMD.EXE` from being rejected before evaluation. Non-ASCII cased needles conservatively disable the field's bloom filter because context-sensitive Unicode lowercasing cannot preserve every substring relation.
 

--- a/crates/rsigma-eval/src/engine/bloom_index.rs
+++ b/crates/rsigma-eval/src/engine/bloom_index.rs
@@ -543,19 +543,35 @@ fn extract_from_matcher(
         return;
     }
     match m {
-        CompiledMatcher::Contains { value, .. }
-        | CompiledMatcher::StartsWith { value, .. }
-        | CompiledMatcher::EndsWith { value, .. } => {
+        CompiledMatcher::Contains {
+            value,
+            case_insensitive,
+        }
+        | CompiledMatcher::StartsWith {
+            value,
+            case_insensitive,
+        }
+        | CompiledMatcher::EndsWith {
+            value,
+            case_insensitive,
+        } => {
             out.entry(field.to_string())
                 .or_default()
-                .push(value.clone());
+                .push(bloom_needle(value, *case_insensitive));
         }
-        CompiledMatcher::AhoCorasickSet { needles, .. } => {
-            // The optimizer stores the pre-lowered needles on the variant so
-            // the bloom builder can recover them without inspecting the
-            // automaton's private state.
+        CompiledMatcher::AhoCorasickSet {
+            needles,
+            case_insensitive,
+            ..
+        } => {
+            // Case-insensitive needles are already lowered by the optimizer,
+            // while `|cased` needles retain their original spelling.
             let entry = out.entry(field.to_string()).or_default();
-            entry.extend(needles.iter().cloned());
+            entry.extend(
+                needles
+                    .iter()
+                    .map(|needle| bloom_needle(needle, *case_insensitive)),
+            );
         }
         CompiledMatcher::AnyOf(children) | CompiledMatcher::AllOf(children) => {
             for child in children {
@@ -575,6 +591,24 @@ fn extract_from_matcher(
         // is excluded deliberately so the rule index keeps its monopoly
         // there.
         _ => {}
+    }
+}
+
+/// Convert a matcher needle into the bloom's lowered comparison space.
+///
+/// Lowering an ASCII cased needle is a sound necessary condition: an exact
+/// cased match remains present after both strings are ASCII-lowered. Unicode
+/// lowercasing is context-sensitive, so separately lowering a cased needle
+/// and its containing haystack can change a character such as Greek sigma
+/// differently. Return an unrepresentable sentinel in that case, which makes
+/// [`needles_are_representable`] disable the field's filter.
+fn bloom_needle(value: &str, case_insensitive: bool) -> String {
+    if case_insensitive {
+        value.to_string()
+    } else if value.is_ascii() {
+        value.to_ascii_lowercase()
+    } else {
+        String::new()
     }
 }
 
@@ -875,6 +909,36 @@ detection:
             bloom.probe("CommandLine", "execute WHOAMI /all"),
             BloomVerdict::MaybeMatch
         );
+    }
+
+    #[test]
+    fn cased_uppercase_probe_cannot_be_rejected() {
+        let yaml = r#"
+title: Cased
+detection:
+    selection:
+        CommandLine|contains|cased: 'CMD.EXE'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        assert_eq!(
+            bloom.probe("CommandLine", "CMD.EXE"),
+            BloomVerdict::MaybeMatch
+        );
+    }
+
+    #[test]
+    fn cased_unicode_needle_disables_field_filter() {
+        let yaml = r#"
+title: UnicodeCased
+detection:
+    selection:
+        CommandLine|contains|cased: 'AΣ'
+    condition: selection
+"#;
+        let bloom = bloom_from(yaml);
+        assert_eq!(bloom.field_count(), 0);
+        assert_eq!(bloom.probe("CommandLine", "AΣX"), BloomVerdict::MaybeMatch);
     }
 
     #[test]

--- a/crates/rsigma-eval/src/engine/diff_tests.rs
+++ b/crates/rsigma-eval/src/engine/diff_tests.rs
@@ -400,6 +400,16 @@ detection:
 "#,
     ),
     (
+        "all-uppercase-cased-modifier",
+        r#"
+title: AllUppercaseCased
+detection:
+    selection:
+        CommandLine|contains|cased: 'CMD.EXE'
+    condition: selection
+"#,
+    ),
+    (
         "unicode-values",
         r#"
 title: Unicode
@@ -434,6 +444,7 @@ fn battery_events() -> Vec<Value> {
         json!({"CommandLine": "nothing interesting here"}),
         json!({"CommandLine": "PowerShell.exe -Command x"}),
         json!({"CommandLine": "powershell.exe -command x"}),
+        json!({"CommandLine": "CMD.EXE"}),
         json!({"EventID": 4688}),
         json!({"EventID": "4688"}),
         json!({"EventID": 1}),


### PR DESCRIPTION
## Summary
- normalize ASCII `|cased` substring needles into the bloom probe's comparison space
- disable bloom filtering for fields with non-ASCII cased needles whose Unicode lowercasing is context-sensitive
- add deterministic bloom and full-scan differential regressions for the `CMD.EXE` failure found on `main`

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --all-features --locked`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo doc --workspace --all-features --locked --no-deps`