### PR TITLE
test(rstix): OASIS §3.1 Attack Pattern Producer and Consumer interop tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### rstix: OASIS §3.1 Attack Pattern interop use-case tests
+
+- Adds `tests/interop/use_cases/attack_pattern/` covering §3.1.1–§3.1.7 against normative §3.1.3 fixtures and non-gating `examples/attack-pattern/` data.
+- §3.1.1 description scope is **TESTED** (not `REPORT_ONLY`): normative fixtures must expose typed Attack Pattern TTPs including the doc’s “Spear Phishing” example.
+- Producer `REQ-3.1-P-01`..`P-13`, Consumer `REQ-3.1-C-01`..`C-05`, checklist `REQ-CHK-SXC-3.1` / `REQ-CHK-SXP-3.1`, examples `REQ-3.1-EX-4.1` / `EX-4.2` / `EX-7.1`.
+- `ex-3.1.4.2` retains published truncated UUID ids (defect 21) and asserts parse rejection — no invented digits.
+- Not OASIS SXP/SXC certification (**1/21** use cases).
+
 ### rstix: OASIS STIX 2.1 Interop normative fixtures and §2.3 suite checks (#410)
 
 - Adds normative OASIS interop test-case JSON under `tests/fixtures/interop/testcases/` with provenance sidecars for the §2.3 cross-cutting and §3.x use-case inventory (44 gating fixtures; 42 exercised in the suite-wide walk; 2 recorded as `BLOCKED` on unrepairable OASIS §9.1 publisher defects).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 - §3.1.1 description scope is **TESTED** (not `REPORT_ONLY`): normative fixtures must expose typed Attack Pattern TTPs including the doc’s “Spear Phishing” example.
 - Producer `REQ-3.1-P-01`..`P-13`, Consumer `REQ-3.1-C-01`..`C-05`, checklist `REQ-CHK-SXC-3.1` / `REQ-CHK-SXP-3.1`, examples `REQ-3.1-EX-4.1` / `EX-4.2` / `EX-7.1`.
 - `ex-3.1.4.2` retains published truncated UUID ids (defect 21) and asserts parse rejection — no invented digits.
+- Review follow-up: distinct evidence for P-04 / SXC / C-04; wire `type` for P-05; EX-4.2 matches `ParseError::InvalidStixId(InvalidUuid)` via tagged `StixId` serde recovery (no Display matching / no invented repairs); exact three-digit ms for P-11/P-12.
+- Adds [`ParseError::InvalidStixId`] so truncated/invalid STIX ids survive the serde boundary as typed errors (same tagging approach as `ModelError`).
 - Not OASIS SXP/SXC certification (**1/21** use cases).
 
 ### rstix: OASIS STIX 2.1 Interop normative fixtures and §2.3 suite checks (#410)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### rstix: OASIS §3.1 Attack Pattern interop use-case tests
+### rstix: OASIS §3.1 Attack Pattern interop use-case tests (#413)
 
 - Adds `tests/interop/use_cases/attack_pattern/` covering §3.1.1–§3.1.7 against normative §3.1.3 fixtures and non-gating `examples/attack-pattern/` data.
 - §3.1.1 description scope is **TESTED** (not `REPORT_ONLY`): normative fixtures must expose typed Attack Pattern TTPs including the doc’s “Spear Phishing” example.

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -900,7 +900,7 @@ Test harness aligned with **STIX 2.1 Interoperability Version 1.0, Committee Spe
 | --------- | ---- | ---- |
 | Harness | `tests/interop/harness/` | Manifest, fixture loader + provenance, per-use-case overlay on `interop_strict`, bundle closure, containment, certification report |
 | Cross-cutting | `tests/interop/common/` | Automated checks for 18 §2.3 manifest rows, run suite-wide over **42** walkable normative fixtures |
-| Use-case tests | `tests/interop/use_cases/` (added as normative fixtures land) | Producer/Consumer checks wired to OASIS test-case JSON |
+| Use-case tests | `tests/interop/use_cases/` | **§3.1 Attack Pattern** (§3.1.1–§3.1.7) Producer/Consumer/example tests (**1/21** OASIS use cases today) |
 | Manifest | `tests/fixtures/interop/manifest.toml` | `req_id` → `test_id` → fixture → §4.2 checklist row |
 | Normative fixtures | `tests/fixtures/interop/testcases/` | Gating OASIS test-case data + `.provenance.toml` sidecars (**44/44** inventory: **42** suite-walkable + **2** `BLOCKED` on §9.1 defects 16 and 19; synthetic helpers remain for intentional negatives) |
 | Examples | `tests/fixtures/interop/examples/` | Non-normative; must never fail the build |
@@ -913,14 +913,16 @@ Test harness aligned with **STIX 2.1 Interoperability Version 1.0, Committee Spe
 | `oasis_use_cases_in_spec` | The OASIS interoperability document defines 21 use cases — **not** how many are tested here. |
 | `manifest_rows_total` | Rows in `manifest.toml` (harness + placeholders + smoke). |
 | `manifest_rows_by_disposition` | Breakdown by `TESTED`, `HARNESS_SMOKE`, `REPORT_ONLY`, `BLOCKED`. |
-| `tested_rows_passed` | Executable manifest rows with `disposition = TESTED` that recorded `Pass` (27 today: 9 harness + 18 §2.3 cross-cutting). |
+| `tested_rows_passed` | Executable manifest rows with `disposition = TESTED` that recorded `Pass` (**51** today: 9 harness + 18 §2.3 + **24 §3.1 Attack Pattern**) |
 | `harness_smoke_executed` | Rows with `disposition = HARNESS_SMOKE` (0 today; reserved for partial checks if reintroduced) |
-| `report_only_rows` | §4.2 checklist/framework placeholders with no automated test (8 today) |
+| `report_only_rows` | §4.2 checklist/framework placeholders with no automated test (**7** today) |
 | `blocked_rows` | Checklist rows blocked on unrepairable published test-case data (2 today) |
 
 There is **no** “100% covered” field. Do not infer OASIS conformance from manifest row counts.
 
-**§2.3 manifest rows:** 18 rows use `disposition = TESTED` and run suite-wide over walkable normative fixtures. **`TESTED` here means our harness recorded `Pass` — not OASIS §2.3 requirement verification, not per-use-case Producer/Consumer modules (those land under `tests/interop/use_cases/`), and not the full interop manifest row inventory from the engineering plan.
+**§2.3 manifest rows:** 18 rows use `disposition = TESTED` and run suite-wide over walkable normative fixtures. **`TESTED` here means our harness recorded `Pass` — not OASIS §2.3 requirement verification, not the full interop manifest row inventory from the engineering plan.
+
+**§3.1 use-case rows:** §3.1.1 description scope, Producer `P-01`..`P-13`, Consumer `C-01`..`C-05`, Table 55/56 checklist rows, and non-gating examples `EX-4.1` / `EX-4.2` / `EX-7.1`. This is **not** OASIS SXP/SXC certification; **20/21** other use cases remain without dedicated modules.
 
 **Run locally (required features explicit):**
 

--- a/crates/rstix/src/lib.rs
+++ b/crates/rstix/src/lib.rs
@@ -98,6 +98,9 @@ pub enum ParseError {
         /// Configured limit.
         max: usize,
     },
+    /// A STIX id string failed to parse (`type--uuid` / UUID shape).
+    #[error(transparent)]
+    InvalidStixId(#[from] core::StixIdError),
 }
 
 #[cfg(feature = "pattern")]

--- a/crates/rstix/src/model/bundle.rs
+++ b/crates/rstix/src/model/bundle.rs
@@ -12,7 +12,9 @@ use crate::model::meta::LanguageContent;
 use crate::model::meta::MetaObject;
 use crate::model::parse_options::ParseOptions;
 use crate::model::sdo::{ObservedData, ObservedDataEmbeddedObject, ObservedDataForm, SdoObject};
-use crate::model::stix_object::{StixObject, deserialize_stix_object_from_value};
+use crate::model::stix_object::{
+    StixObject, deserialize_stix_object_from_value, serde_json_error_to_parse_error,
+};
 use crate::model::validate::{
     granular_markings_from_wire, language_content_translation_matches_target,
     resolve_selector_value, validate_granular_markings_semantics, validate_identity_ref,
@@ -136,7 +138,8 @@ impl Bundle {
             .get("id")
             .ok_or(crate::ParseError::MissingBundleId)
             .and_then(|value| {
-                serde_json::from_value::<StixId>(value.clone()).map_err(crate::ParseError::Json)
+                serde_json::from_value::<StixId>(value.clone())
+                    .map_err(serde_json_error_to_parse_error)
             })?;
 
         if id.type_name() != "bundle" {
@@ -176,7 +179,7 @@ impl Bundle {
                 .ok_or(crate::ParseError::MissingObjectId)
                 .and_then(|id_value| {
                     serde_json::from_value::<StixId>(id_value.clone())
-                        .map_err(crate::ParseError::Json)
+                        .map_err(serde_json_error_to_parse_error)
                 })?;
             let id_key = object_id.as_str().to_owned();
             if id_index.contains_key(&id_key) {

--- a/crates/rstix/src/model/stix_object.rs
+++ b/crates/rstix/src/model/stix_object.rs
@@ -166,13 +166,15 @@ fn capture_unmodeled_properties(
 }
 
 #[cfg(feature = "serde")]
-fn serde_json_error_to_parse_error(err: serde_json::Error) -> crate::ParseError {
+pub(crate) fn serde_json_error_to_parse_error(err: serde_json::Error) -> crate::ParseError {
     let message = err.to_string();
     if let Some(model_err) = crate::model::ModelError::from_serde_message(&message) {
-        crate::ParseError::Model(model_err)
-    } else {
-        crate::ParseError::Json(err)
+        return crate::ParseError::Model(model_err);
     }
+    if let Some(id_err) = crate::serde_impls::stix_id::stix_id_error_from_serde_message(&message) {
+        return crate::ParseError::InvalidStixId(id_err);
+    }
+    crate::ParseError::Json(err)
 }
 
 #[cfg(feature = "serde")]
@@ -238,7 +240,8 @@ pub fn deserialize_stix_object_from_value(
             .get("id")
             .ok_or(crate::ParseError::MissingObjectId)
             .and_then(|id_value| {
-                serde_json::from_value::<StixId>(id_value.clone()).map_err(crate::ParseError::Json)
+                serde_json::from_value::<StixId>(id_value.clone())
+                    .map_err(serde_json_error_to_parse_error)
             })?;
         StixObject::Custom(CustomStixObject {
             type_name: type_name.to_owned(),
@@ -251,7 +254,8 @@ pub fn deserialize_stix_object_from_value(
             .get("id")
             .ok_or(crate::ParseError::MissingObjectId)
             .and_then(|id_value| {
-                serde_json::from_value::<StixId>(id_value.clone()).map_err(crate::ParseError::Json)
+                serde_json::from_value::<StixId>(id_value.clone())
+                    .map_err(serde_json_error_to_parse_error)
             })?;
         StixObject::Custom(CustomStixObject {
             type_name: type_name.to_owned(),

--- a/crates/rstix/src/serde_impls/mod.rs
+++ b/crates/rstix/src/serde_impls/mod.rs
@@ -11,5 +11,5 @@
 //! readers are implemented in this module.
 
 mod confidence;
-mod stix_id;
+pub(crate) mod stix_id;
 mod timestamp;

--- a/crates/rstix/src/serde_impls/stix_id.rs
+++ b/crates/rstix/src/serde_impls/stix_id.rs
@@ -1,6 +1,70 @@
 //! [`StixId`](crate::core::StixId) JSON string serialization.
+//!
+//! Deserialize failures are tagged so [`crate::ParseError`] can recover
+//! [`StixIdError`](crate::core::StixIdError) without Display-string matching
+//! (same approach as [`crate::model::serde_error`] for `ModelError`).
 
-use crate::core::StixId;
+use serde::{Deserialize, Serialize};
+
+use crate::core::{StixId, StixIdError};
+
+/// Prefix embedded in serde custom messages.
+const TAG: &str = "\u{001e}rstix-stix-id\u{001e}";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StixIdErrorWire {
+    MissingDelimiter,
+    EmptyTypeName,
+    InvalidUuid { detail: String },
+    TypeMismatch { expected: String, found: String },
+}
+
+impl From<&StixIdError> for StixIdErrorWire {
+    fn from(err: &StixIdError) -> Self {
+        match err {
+            StixIdError::MissingDelimiter => Self::MissingDelimiter,
+            StixIdError::EmptyTypeName => Self::EmptyTypeName,
+            StixIdError::InvalidUuid(inner) => Self::InvalidUuid {
+                detail: inner.to_string(),
+            },
+            StixIdError::TypeMismatch { expected, found } => Self::TypeMismatch {
+                expected: (*expected).to_owned(),
+                found: found.clone(),
+            },
+        }
+    }
+}
+
+fn encode_for_serde(err: &StixIdError) -> String {
+    let payload =
+        serde_json::to_string(&StixIdErrorWire::from(err)).expect("stix id error wire json");
+    format!("{TAG}{payload}{TAG}{err}")
+}
+
+fn decode_from_serde(message: &str) -> Option<StixIdError> {
+    let rest = message.strip_prefix(TAG)?;
+    let json_end = rest.find(TAG)?;
+    let json = &rest[..json_end];
+    let wire: StixIdErrorWire = serde_json::from_str(json).ok()?;
+    Some(match wire {
+        StixIdErrorWire::MissingDelimiter => StixIdError::MissingDelimiter,
+        StixIdErrorWire::EmptyTypeName => StixIdError::EmptyTypeName,
+        StixIdErrorWire::InvalidUuid { .. } => match StixId::parse("x--not-a-uuid") {
+            Err(err @ StixIdError::InvalidUuid(_)) => err,
+            other => panic!("expected InvalidUuid placeholder, got {other:?}"),
+        },
+        StixIdErrorWire::TypeMismatch { expected, found } => StixIdError::TypeMismatch {
+            expected: Box::leak(expected.into_boxed_str()),
+            found,
+        },
+    })
+}
+
+/// Recover a [`StixIdError`] from a serde/`serde_json` error message when tagged.
+pub(crate) fn stix_id_error_from_serde_message(message: &str) -> Option<StixIdError> {
+    decode_from_serde(message)
+}
 
 impl serde::Serialize for StixId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -17,6 +81,29 @@ impl<'de> serde::Deserialize<'de> for StixId {
         D: serde::Deserializer<'de>,
     {
         let raw = <String as serde::Deserialize>::deserialize(deserializer)?;
-        Self::parse(&raw).map_err(serde::de::Error::custom)
+        Self::parse(&raw).map_err(|err| serde::de::Error::custom(encode_for_serde(&err)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tagged_roundtrip_preserves_invalid_uuid_variant() {
+        let err = match StixId::parse("malware--deadbeef") {
+            Err(e @ StixIdError::InvalidUuid(_)) => e,
+            other => panic!("expected InvalidUuid, got {other:?}"),
+        };
+        let message = encode_for_serde(&err);
+        let recovered = decode_from_serde(&message).expect("decode");
+        assert!(matches!(recovered, StixIdError::InvalidUuid(_)));
+    }
+
+    #[test]
+    fn deserialize_invalid_uuid_is_recoverable_from_serde_message() {
+        let err = serde_json::from_str::<StixId>("\"malware--deadbeef\"").expect_err("must fail");
+        let recovered = stix_id_error_from_serde_message(&err.to_string()).expect("tagged");
+        assert!(matches!(recovered, StixIdError::InvalidUuid(_)));
     }
 }

--- a/crates/rstix/src/validate/parse_bridge.rs
+++ b/crates/rstix/src/validate/parse_bridge.rs
@@ -49,6 +49,13 @@ pub(crate) fn diagnostics_from_parse_error(
             .with_fix_suggestion("Ensure every object in the bundle has a unique id."),
         ],
         ParseError::Model(model_err) => vec![diagnostic_from_model_error(model_err, None, None)],
+        ParseError::InvalidStixId(err) => vec![
+            Diagnostic::new(DiagnosticCode::E0003, err.to_string())
+                .with_property_path("id")
+                .with_fix_suggestion(
+                    "Use a STIX id of the form `{type}--{uuid}` with a valid UUID.",
+                ),
+        ],
         ParseError::Json(err) => diagnostics_from_json_error(err),
         ParseError::ObjectLimitExceeded { count, max } => vec![
             Diagnostic::new(
@@ -83,6 +90,15 @@ fn diagnostics_from_json_error(err: &serde_json::Error) -> Vec<Diagnostic> {
     let message = err.to_string();
     if let Some(model_err) = crate::model::ModelError::from_serde_message(&message) {
         return vec![diagnostic_from_model_error(&model_err, None, None)];
+    }
+    if let Some(id_err) = crate::serde_impls::stix_id::stix_id_error_from_serde_message(&message) {
+        return vec![
+            Diagnostic::new(DiagnosticCode::E0003, id_err.to_string())
+                .with_property_path("id")
+                .with_fix_suggestion(
+                    "Use a STIX id of the form `{type}--{uuid}` with a valid UUID.",
+                ),
+        ];
     }
     if err.is_syntax() || err.is_eof() {
         vec![Diagnostic::new(DiagnosticCode::E0001, message)]

--- a/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.1-add-context-to-indicator.json
+++ b/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.1-add-context-to-indicator.json
@@ -1,0 +1,55 @@
+{
+  "type": "bundle",
+  "id": "bundle--3a1b4c1d-3a1b-4a1b-8a1b-3a1b4c1d3a1b",
+  "objects": [
+    {
+      "type": "identity",
+      "id": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "spec_version": "2.1",
+      "identity_class": "organization",
+      "name": "ACME Corp, Inc.",
+      "created": "2018-01-17T11:11:13.000Z",
+      "modified": "2018-01-17T11:11:13.000Z",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff"
+    },
+    {
+      "type": "indicator",
+      "spec_version": "2.1",
+      "id": "indicator--0c7e22ad-b099-4dc3-b0df-2ea3f49ae2e6",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "created": "2019-05-12T08:17:27.000Z",
+      "modified": "2019-05-12T08:17:27.000Z",
+      "indicator_types": ["malicious-activity"],
+      "pattern": "[url:value = 'http://badsite.com/foo' OR url:value = 'http://badsite.com/bar']",
+      "pattern_type": "stix",
+      "valid_from": "2019-01-01T00:00:00Z"
+    },
+    {
+      "type": "attack-pattern",
+      "spec_version": "2.1",
+      "id": "attack-pattern--7e33a43e-e34b-40ec-89da-36c9bb2cacd5",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "created": "2019-05-12T08:17:27.000Z",
+      "modified": "2019-05-12T08:17:27.000Z",
+      "name": "Spear Phishing as Practiced by Adversary X",
+      "description": "Spear phishing where the attacker includes personal details in the email and claims that the target had won a contest.",
+      "external_references": [
+        {
+          "source_name": "capec",
+          "external_id": "CAPEC-163"
+        }
+      ]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--57b56a43-b8b0-4cba-9deb-34e3e1faed9e",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "created": "2019-05-12T08:17:27.000Z",
+      "modified": "2019-05-12T08:17:27.000Z",
+      "relationship_type": "indicates",
+      "source_ref": "indicator--0c7e22ad-b099-4dc3-b0df-2ea3f49ae2e6",
+      "target_ref": "attack-pattern--7e33a43e-e34b-40ec-89da-36c9bb2cacd5"
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.1-add-context-to-indicator.provenance.toml
+++ b/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.1-add-context-to-indicator.provenance.toml
@@ -1,0 +1,19 @@
+fixture = "ex-3.1.4.1-add-context-to-indicator.json"
+source_doc = "stix-2.1-interop-v1.0-csd01"
+source_pages = "22-24"
+source_section = "3.1.4.1"
+
+[[repair]]
+authority = "MECHANICAL"
+class = "malformed-json"
+description = "Close the indicator pattern string quote omitted in the published OASIS example."
+
+[[repair]]
+authority = "MECHANICAL"
+class = "no-container"
+description = "Wrap identity, indicator, attack-pattern, and relationship objects in a bundle per REQ-2.3-X-02."
+
+[[divergence_recorded]]
+site = "§3.1.4.1 indicator.pattern"
+defect = 20
+description = "Published example omits the closing quote on the indicator pattern string (invalid JSON)."

--- a/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json
+++ b/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json
@@ -1,0 +1,56 @@
+{
+  "type": "bundle",
+  "id": "bundle--3a1b4c2d-3a1b-4a1b-8a1b-3a1b4c2d3a1b",
+  "objects": [
+    {
+      "type": "identity",
+      "id": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "spec_version": "2.1",
+      "identity_class": "organization",
+      "name": "ACME Corp, Inc.",
+      "created": "2018-01-17T11:11:13.000Z",
+      "modified": "2018-01-17T11:11:13.000Z",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff"
+    },
+    {
+      "type": "malware",
+      "spec_version": "2.1",
+      "id": "malware--1121ffbc-364f-857a-9987-92fbcff24ab",
+      "created": "2019-05-12T08:17:27.000Z",
+      "modified": "2019-05-12T08:17:27.000Z",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "name": "Cryptolocker",
+      "description": "A variant of the cryptolocker family",
+      "malware_types": ["ransomware"],
+      "is_family": false
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--11220001-3940-0405-20ff-1029b0bc922",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "created": "2020-01-16T18:52:24.277Z",
+      "modified": "2020-01-16T18:52:24.277Z",
+      "relationship_type": "uses",
+      "source_ref": "malware--1121ffbc-364f-857a-9987-92fbcff24ab",
+      "target_ref": "attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0",
+      "object_marking_refs": ["marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9"]
+    },
+    {
+      "type": "attack-pattern",
+      "id": "attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0",
+      "spec_version": "2.1",
+      "created": "2019-03-15T13:59:30.390Z",
+      "modified": "2019-03-15T13:59:30.390Z",
+      "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+      "kill_chain_phases": [
+        {
+          "kill_chain_name": "mitre-attack",
+          "phase_name": "impact"
+        }
+      ],
+      "name": "Data Encrypted for Impact",
+      "description": "Adversaries may encrypt data on target systems or on large numbers of systems in a network to interrupt availability to system and network resources..."
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.provenance.toml
+++ b/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.provenance.toml
@@ -1,0 +1,29 @@
+fixture = "ex-3.1.4.2-leverage-externally-defined-frameworks.json"
+source_doc = "stix-2.1-interop-v1.0-csd01"
+source_pages = "24"
+source_section = "3.1.4.2"
+
+[[repair]]
+authority = "MECHANICAL"
+class = "smart-quotes"
+description = "Straighten curly quotes on created_by_ref and description."
+
+[[repair]]
+authority = "MECHANICAL"
+class = "no-container"
+description = "Wrap identity, malware, relationship, and attack-pattern objects in a bundle per REQ-2.3-X-02."
+
+[[divergence_recorded]]
+site = "objects[1].id"
+defect = 21
+description = "Published malware id malware--1121ffbc-364f-857a-9987-92fbcff24ab has an 11-hex final UUID group (need 12). Not repaired — would invent a digit. Expected to fail STIX id parse."
+
+[[divergence_recorded]]
+site = "objects[2].id"
+defect = 21
+description = "Published relationship id relationship--11220001-3940-0405-20ff-1029b0bc922 has an 11-hex final UUID group (need 12). Not repaired — would invent a digit. Expected to fail STIX id parse."
+
+[[divergence_recorded]]
+site = "objects[2].source_ref"
+defect = 21
+description = "source_ref repeats the truncated malware id (same defect 21)."

--- a/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.7.1-ingest-external-framework.json
+++ b/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.7.1-ingest-external-framework.json
@@ -1,0 +1,44 @@
+{
+  "type": "bundle",
+  "id": "bundle--3a1b7c1d-3a1b-4a1b-8a1b-3a1b7c1d3a1b",
+  "objects": [
+    {
+      "type": "identity",
+      "id": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "spec_version": "2.1",
+      "identity_class": "organization",
+      "name": "The MITRE Corporation",
+      "created": "2017-06-01T00:00:00.000Z",
+      "modified": "2017-06-01T00:00:00.000Z",
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5"
+    },
+    {
+      "type": "attack-pattern",
+      "id": "attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0",
+      "spec_version": "2.1",
+      "created_by_ref": "identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5",
+      "created": "2019-03-15T13:59:30.390Z",
+      "modified": "2019-07-19T14:35:12.349Z",
+      "name": "Data Encrypted for Impact",
+      "description": "Adversaries may encrypt data on target systems or on large numbers of systems in a network to interrupt availability to system and network resources...",
+      "kill_chain_phases": [
+        {
+          "kill_chain_name": "mitre-attack",
+          "phase_name": "impact"
+        }
+      ],
+      "external_references": [
+        {
+          "source_name": "mitre-attack",
+          "external_id": "T1486",
+          "url": "https://attack.mitre.org/techniques/T1486"
+        },
+        {
+          "source_name": "US-CERT Ransomware 2016",
+          "description": "US-CERT. (2016, March 31). Alert (TA16-091A): Ransomware and Recent Variants. Retrieved March 15, 2019.",
+          "url": "https://www.us-cert.gov/ncas/alerts/TA16-091A"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.7.1-ingest-external-framework.provenance.toml
+++ b/crates/rstix/tests/fixtures/interop/examples/attack-pattern/ex-3.1.7.1-ingest-external-framework.provenance.toml
@@ -1,0 +1,14 @@
+fixture = "ex-3.1.7.1-ingest-external-framework.json"
+source_doc = "stix-2.1-interop-v1.0-csd01"
+source_pages = "25-26"
+source_section = "3.1.7.1"
+
+[[repair]]
+authority = "MECHANICAL"
+class = "smart-quotes"
+description = "Straighten curly quotes on identity created_by_ref."
+
+[[repair]]
+authority = "MECHANICAL"
+class = "no-container"
+description = "Wrap identity and attack-pattern objects in a bundle per REQ-2.3-X-02."

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -44,6 +44,19 @@ level = "MUST"
 gating = false
 disposition = "REPORT_ONLY"
 
+# --- §3.1 Attack Pattern Sharing ---
+
+[[requirement]]
+req_id = "REQ-3.1-1"
+use_case = "attack_pattern"
+section = "3.1.1"
+doc_page = 20
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::description::description_scope"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
 # --- §4.2 Table 55/56 checklist rows (46) — REPORT_ONLY until use-case tests land ---
 
 [[requirement]]

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -44,7 +44,7 @@ level = "MUST"
 gating = false
 disposition = "REPORT_ONLY"
 
-# --- §3.1 Attack Pattern Sharing ---
+# --- §3.1 Attack Pattern Sharing (normative §3.1.3 fixtures) ---
 
 [[requirement]]
 req_id = "REQ-3.1-1"
@@ -276,32 +276,6 @@ fixture = "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerabil
 # --- §3.1.4 Producer Example Data (non-gating; examples/ only) ---
 
 [[requirement]]
-req_id = "REQ-CHK-SXP-3.1"
-use_case = "attack_pattern"
-section = "3.1.3"
-role = "producer"
-level = "MUST"
-gating = false
-disposition = "TESTED"
-test_id = "use_cases::attack_pattern::producer::producer_testcase_data"
-checklist_row = "3.1.3"
-checklist_role = "producer"
-verification = "Optional"
-
-[[requirement]]
-req_id = "REQ-CHK-SXC-3.1"
-use_case = "attack_pattern"
-section = "3.1.6"
-role = "consumer"
-level = "MUST"
-gating = false
-disposition = "TESTED"
-test_id = "use_cases::attack_pattern::consumer::handles_producer_testcases"
-checklist_row = "3.1.6"
-checklist_role = "consumer"
-verification = "Optional"
-
-[[requirement]]
 req_id = "REQ-3.1-EX-4.1"
 use_case = "attack_pattern"
 section = "3.1.4.1"
@@ -325,6 +299,18 @@ disposition = "TESTED"
 test_id = "use_cases::attack_pattern::examples::framework_example_rejects_truncated_ids"
 fixture = "examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json"
 
+[[requirement]]
+req_id = "REQ-3.1-EX-7.1"
+use_case = "attack_pattern"
+section = "3.1.7.1"
+doc_page = 25
+role = "consumer"
+level = "EXAMPLE"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer_examples::ingest_external_framework"
+fixture = "examples/attack-pattern/ex-3.1.7.1-ingest-external-framework.json"
+
 # --- §4.2 Table 55/56 checklist rows (46) — REPORT_ONLY until use-case tests land ---
 
 [[requirement]]
@@ -334,9 +320,23 @@ section = "3.1.6"
 role = "consumer"
 level = "MUST"
 gating = false
-disposition = "REPORT_ONLY"
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::handles_producer_testcases"
 checklist_row = "3.1.6"
 checklist_role = "consumer"
+verification = "Optional"
+
+[[requirement]]
+req_id = "REQ-CHK-SXP-3.1"
+use_case = "attack_pattern"
+section = "3.1.3"
+role = "producer"
+level = "MUST"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::producer_testcase_data"
+checklist_row = "3.1.3"
+checklist_role = "producer"
 verification = "Optional"
 
 [[requirement]]

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -57,6 +57,162 @@ disposition = "TESTED"
 test_id = "use_cases::attack_pattern::description::description_scope"
 fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
 
+[[requirement]]
+req_id = "REQ-3.1-P-01"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::create_attack_pattern"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-02"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::select_content"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-03"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::identity_compliance"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-04"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::spec_conformance"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-05"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_type"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-06"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_spec_version"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-07"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_id"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-08"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_created_by_ref"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-09"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_external_references"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-10"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_kill_chain_phases"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-11"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_created"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-12"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_modified"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.1-P-13"
+use_case = "attack_pattern"
+section = "3.1.2"
+doc_page = 20
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::prop_name"
+fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
+
 # --- §4.2 Table 55/56 checklist rows (46) — REPORT_ONLY until use-case tests land ---
 
 [[requirement]]

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -289,6 +289,19 @@ checklist_role = "producer"
 verification = "Optional"
 
 [[requirement]]
+req_id = "REQ-CHK-SXC-3.1"
+use_case = "attack_pattern"
+section = "3.1.6"
+role = "consumer"
+level = "MUST"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::handles_producer_testcases"
+checklist_row = "3.1.6"
+checklist_role = "consumer"
+verification = "Optional"
+
+[[requirement]]
 req_id = "REQ-3.1-EX-4.1"
 use_case = "attack_pattern"
 section = "3.1.4.1"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -226,6 +226,30 @@ checklist_row = "3.1.3"
 checklist_role = "producer"
 verification = "Optional"
 
+[[requirement]]
+req_id = "REQ-3.1-EX-4.1"
+use_case = "attack_pattern"
+section = "3.1.4.1"
+doc_page = 22
+role = "producer"
+level = "EXAMPLE"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::examples::add_context_to_indicator"
+fixture = "examples/attack-pattern/ex-3.1.4.1-add-context-to-indicator.json"
+
+[[requirement]]
+req_id = "REQ-3.1-EX-4.2"
+use_case = "attack_pattern"
+section = "3.1.4.2"
+doc_page = 24
+role = "producer"
+level = "EXAMPLE"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::examples::framework_example_rejects_truncated_ids"
+fixture = "examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json"
+
 # --- §4.2 Table 55/56 checklist rows (46) — REPORT_ONLY until use-case tests land ---
 
 [[requirement]]

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -214,6 +214,68 @@ test_id = "use_cases::attack_pattern::producer::prop_name"
 fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
 
 [[requirement]]
+req_id = "REQ-3.1-C-01"
+use_case = "attack_pattern"
+section = "3.1.5"
+doc_page = 25
+role = "consumer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::supports_producer_props"
+fixture = "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerability.json"
+
+[[requirement]]
+req_id = "REQ-3.1-C-02"
+use_case = "attack_pattern"
+section = "3.1.5"
+doc_page = 25
+role = "consumer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::receives_triad"
+fixture = "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerability.json"
+
+[[requirement]]
+req_id = "REQ-3.1-C-03"
+use_case = "attack_pattern"
+section = "3.1.5"
+doc_page = 25
+role = "consumer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::resolves_created_by_ref"
+fixture = "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerability.json"
+
+[[requirement]]
+req_id = "REQ-3.1-C-04"
+use_case = "attack_pattern"
+section = "3.1.5"
+doc_page = 25
+role = "consumer"
+level = "CAN"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::processes_fields"
+fixture = "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerability.json"
+
+[[requirement]]
+req_id = "REQ-3.1-C-05"
+use_case = "attack_pattern"
+section = "3.1.5"
+doc_page = 25
+role = "consumer"
+level = "CAN"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::consumer::processes_related"
+fixture = "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerability.json"
+
+# --- §3.1.4 Producer Example Data (non-gating; examples/ only) ---
+
+[[requirement]]
 req_id = "REQ-CHK-SXP-3.1"
 use_case = "attack_pattern"
 section = "3.1.3"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -213,6 +213,19 @@ disposition = "TESTED"
 test_id = "use_cases::attack_pattern::producer::prop_name"
 fixture = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json"
 
+[[requirement]]
+req_id = "REQ-CHK-SXP-3.1"
+use_case = "attack_pattern"
+section = "3.1.3"
+role = "producer"
+level = "MUST"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::attack_pattern::producer::producer_testcase_data"
+checklist_row = "3.1.3"
+checklist_role = "producer"
+verification = "Optional"
+
 # --- §4.2 Table 55/56 checklist rows (46) — REPORT_ONLY until use-case tests land ---
 
 [[requirement]]

--- a/crates/rstix/tests/interop/common/gating.rs
+++ b/crates/rstix/tests/interop/common/gating.rs
@@ -38,17 +38,16 @@ pub fn assert_testcases_use_bundle_wrapper() {
     for_each_testcase_fixture(|relative| {
         let fixture = load_fixture(relative);
         let value: Value = serde_json::from_str(&fixture.json)
-            .unwrap_or_else(|e| panic!("{} must be valid JSON: {e}", relative));
+            .unwrap_or_else(|e| panic!("{relative} must be valid JSON: {e}"));
         assert_eq!(
             value.get("type"),
             Some(&Value::String("bundle".into())),
-            "{} must use a bundle wrapper",
-            relative
+            "{relative} must use a bundle wrapper"
         );
         let objects = value
             .get("objects")
             .and_then(Value::as_array)
-            .unwrap_or_else(|| panic!("{} bundle must contain objects array", relative));
+            .unwrap_or_else(|| panic!("{relative} bundle must contain objects array"));
         assert!(
             !objects.is_empty(),
             "{relative}: bundle wrapper must contain objects"

--- a/crates/rstix/tests/interop/main.rs
+++ b/crates/rstix/tests/interop/main.rs
@@ -2,6 +2,7 @@
 
 mod common;
 mod harness;
+mod use_cases;
 
 use harness::manifest::load_manifest;
 

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
@@ -1,0 +1,155 @@
+//! §3.1.5 Required Consumer Persona Support (REQ-3.1-C-01..C-05).
+
+use crate::interop_test;
+use rstix::core::StixId;
+use rstix::model::sdo::{AttackPattern, Identity, Vulnerability};
+use rstix::model::sro::Relationship;
+use serde_json::Value;
+
+use crate::common::fixture_catalog::{
+    parse_fixture_objects, summarize_fixture_wire, use_case_object_ids,
+};
+use crate::common::wire_preservation::{
+    assert_identity_fields_preserved, assert_wire_object_preserved,
+};
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::validate_interop_fixture;
+use crate::use_cases::attack_pattern::{FIXTURE_TARGETS, PRODUCER_FIXTURES};
+
+fn for_each_attack_pattern_fixture(mut f: impl FnMut(&str)) {
+    for relative in PRODUCER_FIXTURES {
+        f(relative);
+    }
+}
+
+/// REQ-3.1-C-01 — Consumer supports §3.1.2 Producer Persona properties on normative fixtures.
+pub fn assert_supports_producer_props() {
+    for_each_attack_pattern_fixture(|relative| {
+        let fixture = load_fixture(relative);
+        let objects = parse_fixture_objects(&fixture.json)
+            .unwrap_or_else(|err| panic!("{relative}: parse fixture: {err}"));
+        let use_case_ids = use_case_object_ids(relative, &objects);
+        let bundle = validate_interop_fixture(relative, &fixture.json)
+            .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+
+        for object_id in use_case_ids {
+            let wire = objects
+                .iter()
+                .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+                .unwrap_or_else(|| panic!("{relative}: wire object {object_id}"));
+            let stix_id = StixId::parse(&object_id).expect("object id");
+            let ap = bundle
+                .get_typed::<AttackPattern>(&stix_id)
+                .unwrap_or_else(|| panic!("{relative}: typed attack-pattern {object_id}"));
+            assert!(!ap.common.external_references.is_empty());
+            assert!(!ap.kill_chain_phases.is_empty());
+            assert_wire_object_preserved(relative, wire, &bundle, &object_id);
+        }
+    });
+}
+
+/// REQ-3.1-C-02 — Consumer receives Identity, Attack Pattern(s), and SROs (§3.1.3.2).
+pub fn assert_receives_triad() {
+    let relative = FIXTURE_TARGETS;
+    let fixture = load_fixture(relative);
+    let summary = summarize_fixture_wire(&fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: summarize fixture: {err}"));
+    assert_eq!(summary.identity_ids.len(), 1);
+    assert_eq!(
+        summary.primary_sdo_count, 2,
+        "attack-pattern + vulnerability"
+    );
+    assert_eq!(summary.relationship_count, 1);
+
+    let bundle = validate_interop_fixture(relative, &fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+    for identity_id in &summary.identity_ids {
+        let id = StixId::parse(identity_id).expect("identity id");
+        assert!(
+            bundle.get_typed::<Identity>(&id).is_some(),
+            "{relative}: Identity {identity_id} must parse"
+        );
+    }
+    assert_eq!(bundle.objects_of_type::<AttackPattern>().count(), 1);
+    assert_eq!(bundle.objects_of_type::<Vulnerability>().count(), 1);
+    assert_eq!(bundle.objects_of_type::<Relationship>().count(), 1);
+}
+
+/// REQ-3.1-C-03 — Consumer resolves `created_by_ref` Identity fields (§3.1.3.2).
+pub fn assert_resolves_created_by_ref() {
+    let relative = FIXTURE_TARGETS;
+    let fixture = load_fixture(relative);
+    let bundle = validate_interop_fixture(relative, &fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+
+    let mut checked = 0usize;
+    for object in &objects {
+        let Some(created_by_ref) = object.get("created_by_ref").and_then(Value::as_str) else {
+            continue;
+        };
+        let identity_id = StixId::parse(created_by_ref).expect("created_by_ref");
+        let wire_identity = objects
+            .iter()
+            .find(|obj| obj.get("id").and_then(Value::as_str) == Some(created_by_ref))
+            .expect("wire Identity for created_by_ref");
+        assert!(
+            bundle.get_typed::<Identity>(&identity_id).is_some(),
+            "{relative}: created_by_ref `{created_by_ref}` must resolve"
+        );
+        assert_identity_fields_preserved(relative, wire_identity, &bundle, created_by_ref);
+        checked += 1;
+    }
+    assert!(checked > 0, "{relative}: expected created_by_ref usage");
+}
+
+/// REQ-3.1-C-04 — Consumer preserves Attack Pattern wire fields (§3.1.3.2; CAN-level in doc).
+pub fn assert_processes_fields() {
+    let relative = FIXTURE_TARGETS;
+    let fixture = load_fixture(relative);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let use_case_ids = use_case_object_ids(relative, &objects);
+    let bundle = validate_interop_fixture(relative, &fixture.json).expect("interop gate");
+
+    for object_id in use_case_ids {
+        let wire = objects
+            .iter()
+            .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+            .unwrap_or_else(|| panic!("wire object {object_id}"));
+        assert_wire_object_preserved(relative, wire, &bundle, &object_id);
+    }
+}
+
+/// REQ-3.1-C-05 — Consumer resolves related SDOs/SROs (§3.1.3.2 `targets` relationship).
+pub fn assert_processes_related() {
+    let relative = FIXTURE_TARGETS;
+    let bundle =
+        validate_interop_fixture(relative, &load_fixture(relative).json).expect("interop gate");
+    let relationships: Vec<_> = bundle.objects_of_type::<Relationship>().collect();
+    assert_eq!(
+        relationships.len(),
+        1,
+        "{relative}: expected one relationship"
+    );
+    let relationship = &relationships[0];
+    assert_eq!(relationship.relationship_type.as_str(), "targets");
+    assert!(
+        bundle.get(&relationship.source_ref).is_some(),
+        "source_ref must resolve"
+    );
+    assert!(
+        bundle.get(&relationship.target_ref).is_some(),
+        "target_ref must resolve"
+    );
+    assert!(
+        bundle
+            .get_typed::<AttackPattern>(&relationship.source_ref)
+            .is_some()
+    );
+    assert!(
+        bundle
+            .get_typed::<Vulnerability>(&relationship.target_ref)
+            .is_some()
+    );
+}
+

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
@@ -153,3 +153,65 @@ pub fn assert_processes_related() {
     );
 }
 
+/// REQ-CHK-SXC-3.1 / §4.2 Table 55 — Consumer handles §3.1.3 Producer test case data.
+pub fn assert_handles_producer_testcases() {
+    for relative in PRODUCER_FIXTURES {
+        validate_interop_fixture(relative, &load_fixture(relative).json).unwrap_or_else(|err| {
+            panic!("{relative}: §3.1 consumer must handle producer test case: {err}")
+        });
+    }
+}
+
+interop_test!(
+    "REQ-3.1-C-01",
+    "use_cases::attack_pattern::consumer::supports_producer_props",
+    supports_producer_props,
+    {
+        assert_supports_producer_props();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-C-02",
+    "use_cases::attack_pattern::consumer::receives_triad",
+    receives_triad,
+    {
+        assert_receives_triad();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-C-03",
+    "use_cases::attack_pattern::consumer::resolves_created_by_ref",
+    resolves_created_by_ref,
+    {
+        assert_resolves_created_by_ref();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-C-04",
+    "use_cases::attack_pattern::consumer::processes_fields",
+    processes_fields,
+    {
+        assert_processes_fields();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-C-05",
+    "use_cases::attack_pattern::consumer::processes_related",
+    processes_related,
+    {
+        assert_processes_related();
+    }
+);
+
+interop_test!(
+    "REQ-CHK-SXC-3.1",
+    "use_cases::attack_pattern::consumer::handles_producer_testcases",
+    handles_producer_testcases,
+    {
+        assert_handles_producer_testcases();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
@@ -1,7 +1,7 @@
 //! §3.1.5 Required Consumer Persona Support (REQ-3.1-C-01..C-05).
 
 use crate::interop_test;
-use rstix::core::StixId;
+use rstix::core::{QueryValue, QueryableStixObject, StixId};
 use rstix::model::sdo::{AttackPattern, Identity, Vulnerability};
 use rstix::model::sro::Relationship;
 use serde_json::Value;
@@ -103,7 +103,11 @@ pub fn assert_resolves_created_by_ref() {
     assert!(checked > 0, "{relative}: expected created_by_ref usage");
 }
 
-/// REQ-3.1-C-04 — Consumer preserves Attack Pattern wire fields (§3.1.3.2; CAN-level in doc).
+/// REQ-3.1-C-04 — Consumer processes Attack Pattern fields via query + leaf validate.
+///
+/// Distinct from C-01 (wire re-serialize preservation + non-empty producer props): uses
+/// [`QueryableStixObject::get_field`] and runs [`KillChainPhase::validate`] /
+/// [`ExternalReference::validate`] on typed members.
 pub fn assert_processes_fields() {
     let relative = FIXTURE_TARGETS;
     let fixture = load_fixture(relative);
@@ -111,12 +115,60 @@ pub fn assert_processes_fields() {
     let use_case_ids = use_case_object_ids(relative, &objects);
     let bundle = validate_interop_fixture(relative, &fixture.json).expect("interop gate");
 
-    for object_id in use_case_ids {
-        let wire = objects
-            .iter()
-            .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
-            .unwrap_or_else(|| panic!("wire object {object_id}"));
-        assert_wire_object_preserved(relative, wire, &bundle, &object_id);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{relative}: one attack-pattern use-case id"
+    );
+    let object_id = &use_case_ids[0];
+    let stix_id = StixId::parse(object_id).expect("attack-pattern id");
+    let ap = bundle
+        .get_typed::<AttackPattern>(&stix_id)
+        .unwrap_or_else(|| panic!("{relative}: typed attack-pattern {object_id}"));
+
+    match ap.get_field(&["name"]) {
+        Some(QueryValue::Str(name)) => {
+            assert_eq!(
+                name,
+                ap.name.as_str(),
+                "{relative}: get_field(name) mismatch"
+            );
+        }
+        other => panic!("{relative}: expected QueryValue::Str for name, got {other:?}"),
+    }
+    let created_by = ap
+        .common
+        .created_by_ref
+        .as_ref()
+        .unwrap_or_else(|| panic!("{relative}: created_by_ref required for field processing"));
+    match ap.get_field(&["created_by_ref"]) {
+        Some(QueryValue::Id(id)) => {
+            assert_eq!(
+                id,
+                created_by.as_stix_id(),
+                "{relative}: get_field(created_by_ref) mismatch"
+            );
+        }
+        other => panic!("{relative}: expected QueryValue::Id for created_by_ref, got {other:?}"),
+    }
+
+    assert!(
+        !ap.kill_chain_phases.is_empty(),
+        "{relative}: kill_chain_phases required for leaf processing"
+    );
+    for phase in &ap.kill_chain_phases {
+        phase
+            .validate()
+            .unwrap_or_else(|err| panic!("{relative}: kill_chain_phase.validate: {err}"));
+    }
+    assert!(
+        !ap.common.external_references.is_empty(),
+        "{relative}: external_references required for leaf processing"
+    );
+    for reference in &ap.common.external_references {
+        reference
+            .validate()
+            .unwrap_or_else(|err| panic!("{relative}: external_reference.validate: {err}"));
     }
 }
 
@@ -154,11 +206,38 @@ pub fn assert_processes_related() {
 }
 
 /// REQ-CHK-SXC-3.1 / §4.2 Table 55 — Consumer handles §3.1.3 Producer test case data.
+///
+/// Distinct from `REQ-CHK-SXP-3.1` (re-validation only): resolves each use-case Attack
+/// Pattern as a typed SDO and closes `created_by_ref` to a typed Identity.
 pub fn assert_handles_producer_testcases() {
     for relative in PRODUCER_FIXTURES {
-        validate_interop_fixture(relative, &load_fixture(relative).json).unwrap_or_else(|err| {
+        let fixture = load_fixture(relative);
+        let objects = parse_fixture_objects(&fixture.json)
+            .unwrap_or_else(|err| panic!("{relative}: parse fixture: {err}"));
+        let use_case_ids = use_case_object_ids(relative, &objects);
+        let bundle = validate_interop_fixture(relative, &fixture.json).unwrap_or_else(|err| {
             panic!("{relative}: §3.1 consumer must handle producer test case: {err}")
         });
+
+        assert!(
+            !use_case_ids.is_empty(),
+            "{relative}: expected attack-pattern use-case object(s)"
+        );
+        for object_id in use_case_ids {
+            let stix_id = StixId::parse(&object_id).expect("attack-pattern id");
+            let ap = bundle
+                .get_typed::<AttackPattern>(&stix_id)
+                .unwrap_or_else(|| panic!("{relative}: typed attack-pattern {object_id}"));
+            let created_by = ap.common.created_by_ref.as_ref().unwrap_or_else(|| {
+                panic!("{relative}: created_by_ref required for consumer close")
+            });
+            assert!(
+                bundle
+                    .get_typed::<Identity>(created_by.as_stix_id())
+                    .is_some(),
+                "{relative}: created_by_ref must resolve to typed Identity"
+            );
+        }
     }
 }
 

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/consumer_examples.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/consumer_examples.rs
@@ -1,0 +1,55 @@
+//! §3.1.7 Consumer Example Data (non-gating).
+
+use rstix::core::StixId;
+use rstix::model::sdo::{AttackPattern, Identity};
+
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::{InteropGateOptions, validate_interop_json};
+use crate::interop_test;
+
+/// OASIS §3.1.7.1 non-normative Consumer example (ATT&CK technique, no custom properties).
+pub const EXAMPLE_INGEST: &str =
+    "examples/attack-pattern/ex-3.1.7.1-ingest-external-framework.json";
+
+/// REQ-3.1-EX-7.1 — Consumer can ingest external-framework Attack Pattern example (§3.1.7.1).
+///
+/// Doc: Consumer is not required to ingest custom properties (none present). Example uses a
+/// distinct Identity (`identity--c78cb6e5-…`, MITRE), not the ACME Corp normative identity.
+pub fn assert_ingest_external_framework() {
+    let fixture = load_fixture(EXAMPLE_INGEST);
+    assert_eq!(fixture.provenance.source_section, "3.1.7.1");
+
+    let bundle = validate_interop_json(&fixture.json, &InteropGateOptions::default())
+        .expect("§3.1.7.1 example must parse and pass interop gate");
+
+    let mitre = StixId::parse("identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5").expect("identity");
+    let identity = bundle
+        .get_typed::<Identity>(&mitre)
+        .expect("MITRE Identity must parse");
+    assert_eq!(identity.name, "The MITRE Corporation");
+
+    let ap_id =
+        StixId::parse("attack-pattern--b80d107d-fa0d-4b60-9684-b0433e8bdba0").expect("ap id");
+    let ap = bundle
+        .get_typed::<AttackPattern>(&ap_id)
+        .expect("ATT&CK Attack Pattern must parse");
+    assert_eq!(ap.name, "Data Encrypted for Impact");
+    assert!(!ap.kill_chain_phases.is_empty());
+    assert!(!ap.common.external_references.is_empty());
+    assert!(
+        ap.common
+            .external_references
+            .iter()
+            .any(|r| { r.external_id.as_deref() == Some("T1486") }),
+        "expected mitre-attack external_id T1486"
+    );
+}
+
+interop_test!(
+    "REQ-3.1-EX-7.1",
+    "use_cases::attack_pattern::consumer_examples::ingest_external_framework",
+    ingest_external_framework,
+    {
+        assert_ingest_external_framework();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/description.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/description.rs
@@ -1,0 +1,52 @@
+//! §3.1.1 Description — Attack Pattern Sharing scope.
+
+use rstix::core::StixId;
+use rstix::model::sdo::AttackPattern;
+
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::validate_interop_fixture;
+use crate::interop_test;
+use crate::use_cases::attack_pattern::{FIXTURE_CREATE, FIXTURE_TARGETS};
+
+/// REQ-3.1-1 — §3.1.1 Description.
+///
+/// Doc: Attack Patterns are TTPs that describe ways adversaries attempt to compromise targets;
+/// spear phishing is the running example. This check binds that description to normative
+/// §3.1.3 Producer fixtures: typed Attack Pattern SDOs with identifying names (including the
+/// doc’s “Spear Phishing” example), not a prose-only REPORT_ONLY placeholder.
+pub fn assert_description_scope() {
+    let create = load_fixture(FIXTURE_CREATE);
+    let create_bundle = validate_interop_fixture(FIXTURE_CREATE, &create.json)
+        .expect("§3.1.3.1 must parse for description-scope check");
+    let spear_id =
+        StixId::parse("attack-pattern--0c7b5b88-8ff7-4a4d-aa9d-feb398cd0061").expect("ap id");
+    let spear = create_bundle
+        .get_typed::<AttackPattern>(&spear_id)
+        .expect("Spear Phishing Attack Pattern must be typed");
+    assert_eq!(
+        spear.name, "Spear Phishing",
+        "§3.1.1 description example name must be present on normative fixture"
+    );
+    assert!(
+        !spear.common.external_references.is_empty(),
+        "Attack Pattern TTP context includes external_references in normative data"
+    );
+
+    let targets = load_fixture(FIXTURE_TARGETS);
+    let targets_bundle = validate_interop_fixture(FIXTURE_TARGETS, &targets.json)
+        .expect("§3.1.3.2 must parse for description-scope check");
+    assert_eq!(
+        targets_bundle.objects_of_type::<AttackPattern>().count(),
+        1,
+        "§3.1.3.2 must carry an Attack Pattern SDO as described in §3.1.1"
+    );
+}
+
+interop_test!(
+    "REQ-3.1-1",
+    "use_cases::attack_pattern::description::description_scope",
+    description_scope,
+    {
+        assert_description_scope();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/examples.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/examples.rs
@@ -1,0 +1,62 @@
+//! §3.1.4 Producer Example Data (non-gating).
+
+use rstix::model::{Bundle, ParseOptions};
+
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::{InteropGateOptions, validate_interop_json};
+use crate::interop_test;
+
+/// OASIS §3.1.4.1 non-normative example.
+pub const EXAMPLE_CONTEXT: &str =
+    "examples/attack-pattern/ex-3.1.4.1-add-context-to-indicator.json";
+/// OASIS §3.1.4.2 non-normative example (published truncated UUID ids).
+pub const EXAMPLE_FRAMEWORK: &str =
+    "examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json";
+
+/// REQ-3.1-EX-4.1 — §3.1.4.1 loads and passes the interop gate (examples are non-gating).
+pub fn assert_add_context_to_indicator() {
+    let fixture = load_fixture(EXAMPLE_CONTEXT);
+    assert_eq!(fixture.provenance.source_section, "3.1.4.1");
+    // Empty use-case ids: example is not a §3.1.3 normative Producer test case.
+    validate_interop_json(&fixture.json, &InteropGateOptions::default())
+        .expect("§3.1.4.1 example must parse and pass interop gate");
+}
+
+/// REQ-3.1-EX-4.2 — §3.1.4.2 retains published truncated UUID ids; parse must reject them.
+pub fn assert_framework_example_rejects_truncated_ids() {
+    let fixture = load_fixture(EXAMPLE_FRAMEWORK);
+    assert_eq!(fixture.provenance.source_section, "3.1.4.2");
+    assert!(
+        fixture
+            .provenance
+            .divergence_recorded
+            .iter()
+            .any(|d| d.defect == 21),
+        "expected defect 21 recorded for truncated UUID ids"
+    );
+    let err = Bundle::parse_with_options(&fixture.json, &ParseOptions::new().interop_bundle())
+        .expect_err("§3.1.4.2 truncated UUID ids must fail parse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("uuid") || msg.contains("UUID") || msg.contains("id"),
+        "unexpected parse error for truncated ids: {msg}"
+    );
+}
+
+interop_test!(
+    "REQ-3.1-EX-4.1",
+    "use_cases::attack_pattern::examples::add_context_to_indicator",
+    add_context_to_indicator,
+    {
+        assert_add_context_to_indicator();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-EX-4.2",
+    "use_cases::attack_pattern::examples::framework_example_rejects_truncated_ids",
+    framework_example_rejects_truncated_ids,
+    {
+        assert_framework_example_rejects_truncated_ids();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/examples.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/examples.rs
@@ -1,5 +1,7 @@
 //! §3.1.4 Producer Example Data (non-gating).
 
+use rstix::ParseError;
+use rstix::core::{StixId, StixIdError};
 use rstix::model::{Bundle, ParseOptions};
 
 use crate::harness::fixture::load_fixture;
@@ -13,6 +15,12 @@ pub const EXAMPLE_CONTEXT: &str =
 pub const EXAMPLE_FRAMEWORK: &str =
     "examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json";
 
+/// Published truncated UUID ids retained from OASIS §3.1.4.2 (defect 21).
+const TRUNCATED_FRAMEWORK_IDS: &[&str] = &[
+    "malware--1121ffbc-364f-857a-9987-92fbcff24ab",
+    "relationship--11220001-3940-0405-20ff-1029b0bc922",
+];
+
 /// REQ-3.1-EX-4.1 — §3.1.4.1 loads and passes the interop gate (examples are non-gating).
 pub fn assert_add_context_to_indicator() {
     let fixture = load_fixture(EXAMPLE_CONTEXT);
@@ -23,6 +31,10 @@ pub fn assert_add_context_to_indicator() {
 }
 
 /// REQ-3.1-EX-4.2 — §3.1.4.2 retains published truncated UUID ids; parse must reject them.
+///
+/// Pins the failure to the structured id boundary (no Display substring matching, no
+/// invented repair UUIDs): each published truncated id is [`StixIdError::InvalidUuid`],
+/// and bundle parse surfaces [`ParseError::InvalidStixId`] with that variant.
 pub fn assert_framework_example_rejects_truncated_ids() {
     let fixture = load_fixture(EXAMPLE_FRAMEWORK);
     assert_eq!(fixture.provenance.source_section, "3.1.4.2");
@@ -34,13 +46,24 @@ pub fn assert_framework_example_rejects_truncated_ids() {
             .any(|d| d.defect == 21),
         "expected defect 21 recorded for truncated UUID ids"
     );
+
+    for truncated in TRUNCATED_FRAMEWORK_IDS {
+        assert!(
+            fixture.json.contains(truncated),
+            "fixture must retain published truncated id: {truncated}"
+        );
+        assert!(
+            matches!(StixId::parse(truncated), Err(StixIdError::InvalidUuid(_))),
+            "published truncated id must be StixIdError::InvalidUuid: {truncated}"
+        );
+    }
+
     let err = Bundle::parse_with_options(&fixture.json, &ParseOptions::new().interop_bundle())
         .expect_err("§3.1.4.2 truncated UUID ids must fail parse");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("uuid") || msg.contains("UUID") || msg.contains("id"),
-        "unexpected parse error for truncated ids: {msg}"
-    );
+    match err {
+        ParseError::InvalidStixId(StixIdError::InvalidUuid(_)) => {}
+        other => panic!("expected ParseError::InvalidStixId(InvalidUuid), got: {other:?}"),
+    }
 }
 
 interop_test!(

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
@@ -1,0 +1,11 @@
+//! §3.1 Attack Pattern Sharing — Producer and Consumer tests against normative fixtures.
+
+pub mod description;
+
+/// OASIS §3.1.3.1 Producer test case.
+pub const FIXTURE_CREATE: &str = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json";
+/// OASIS §3.1.3.2 Producer test case (also Consumer triad fixture).
+pub const FIXTURE_TARGETS: &str =
+    "testcases/attack-pattern/tc-3.1.3.2-attack-pattern-targets-vulnerability.json";
+
+pub(crate) const PRODUCER_FIXTURES: &[&str] = &[FIXTURE_CREATE, FIXTURE_TARGETS];

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
@@ -1,5 +1,6 @@
 //! §3.1 Attack Pattern Sharing — Producer and Consumer tests against normative fixtures.
 
+pub mod consumer;
 pub mod description;
 pub mod examples;
 pub mod producer;

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
@@ -1,6 +1,7 @@
 //! §3.1 Attack Pattern Sharing — Producer and Consumer tests against normative fixtures.
 
 pub mod description;
+pub mod examples;
 pub mod producer;
 
 /// OASIS §3.1.3.1 Producer test case.

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
@@ -1,6 +1,7 @@
 //! §3.1 Attack Pattern Sharing — Producer and Consumer tests against normative fixtures.
 
 pub mod description;
+pub mod producer;
 
 /// OASIS §3.1.3.1 Producer test case.
 pub const FIXTURE_CREATE: &str = "testcases/attack-pattern/tc-3.1.3.1-create-attack-pattern.json";

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/mod.rs
@@ -1,6 +1,7 @@
 //! §3.1 Attack Pattern Sharing — Producer and Consumer tests against normative fixtures.
 
 pub mod consumer;
+pub mod consumer_examples;
 pub mod description;
 pub mod examples;
 pub mod producer;

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
@@ -3,6 +3,8 @@
 use crate::interop_test;
 use rstix::core::{SpecVersion, StixId};
 use rstix::model::sdo::AttackPattern;
+use rstix::model::{Bundle, ParseOptions};
+use rstix::validate::{Leniency, Validator};
 use serde_json::Value;
 
 use crate::common::fixture_catalog::{parse_fixture_objects, use_case_object_ids};
@@ -12,6 +14,27 @@ use crate::harness::interop_gate::{
     InteropGateOptions, validate_interop_fixture, validate_interop_json,
 };
 use crate::use_cases::attack_pattern::{FIXTURE_CREATE, PRODUCER_FIXTURES};
+
+/// Interop millisecond timestamps: exactly three fractional digits before `Z`.
+fn assert_millisecond_rfc3339(label: &str, value: &str) {
+    let Some((_, frac_and_z)) = value.rsplit_once('.') else {
+        panic!("{label} must include fractional seconds: {value}");
+    };
+    assert!(
+        frac_and_z.ends_with('Z'),
+        "{label} must end with Z: {value}"
+    );
+    let digits = &frac_and_z[..frac_and_z.len() - 1];
+    assert_eq!(
+        digits.len(),
+        3,
+        "{label} must have exactly three subsecond digits: {value}"
+    );
+    assert!(
+        digits.chars().all(|c| c.is_ascii_digit()),
+        "{label} fractional part must be digits: {value}"
+    );
+}
 
 fn load_attack_pattern(relative: &str) -> (AttackPattern, String) {
     let fixture = load_fixture(relative);
@@ -77,15 +100,78 @@ pub fn assert_identity_compliance() {
     assert_identity_shape(relative, identities[0]);
 }
 
-/// REQ-3.1-P-04 — Attack Pattern conforms to STIX §4.1 via interop gate on §3.1.3.1.
+/// REQ-3.1-P-04 — Attack Pattern conforms to STIX §4.1 (typed validate + strict report).
+///
+/// Distinct from P-01: does **not** call the interop gate/overlay. Parses the fixture,
+/// runs [`AttackPattern::validate`], then requires [`Validator::interop_bundle_strict`]
+/// to report valid under Zero leniency (no MUST Error / Zero-failing Warning), including
+/// any diagnostic scoped to this Attack Pattern id.
 pub fn assert_spec_conformance() {
-    assert_create_attack_pattern();
+    let relative = FIXTURE_CREATE;
+    let fixture = load_fixture(relative);
+    let bundle = Bundle::parse_with_options(&fixture.json, &ParseOptions::new().interop_bundle())
+        .unwrap_or_else(|err| panic!("{relative}: parse for §4.1 check: {err}"));
+
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture objects");
+    let use_case_ids = use_case_object_ids(relative, &objects);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{relative}: expected one attack-pattern use-case id"
+    );
+    let object_id = &use_case_ids[0];
+    let ap_id = StixId::parse(object_id).expect("attack-pattern id");
+    let ap = bundle
+        .get_typed::<AttackPattern>(&ap_id)
+        .unwrap_or_else(|| panic!("{relative}: typed attack-pattern {object_id}"));
+    ap.validate()
+        .unwrap_or_else(|err| panic!("{relative}: AttackPattern::validate (§4.1): {err}"));
+
+    let report = Validator::interop_bundle_strict().validate_bundle(&bundle);
+
+    // Non-vacuous MUST channel: Error diagnostics fail regardless of object_id attachment.
+    let errors: Vec<_> = report.errors().collect();
+    assert!(
+        errors.is_empty(),
+        "{relative}: MUST Error diagnostics present: {errors:?}"
+    );
+
+    let scoped_zero_failures: Vec<_> = report
+        .diagnostics()
+        .filter(|d| {
+            let on_ap =
+                d.object_id.as_ref() == Some(&ap_id) || d.message.contains(object_id.as_str());
+            on_ap && Leniency::Zero.fails_validation(d.severity)
+        })
+        .collect();
+    assert!(
+        scoped_zero_failures.is_empty(),
+        "{relative}: Zero-failing diagnostics on Attack Pattern {object_id}: {scoped_zero_failures:?}"
+    );
+
+    assert!(
+        report.is_valid(),
+        "{relative}: interop_bundle_strict (no overlay) must be valid: {:?}",
+        report.diagnostics().collect::<Vec<_>>()
+    );
 }
 
-/// REQ-3.1-P-05 — `type` is `attack-pattern`.
+/// REQ-3.1-P-05 — wire `type` is `attack-pattern` (typed lookup is supporting evidence).
 pub fn assert_prop_type() {
-    let (_ap, _) = load_attack_pattern(FIXTURE_CREATE);
-    assert_eq!(AttackPattern::TYPE_NAME, "attack-pattern");
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let (ap, object_id) = load_attack_pattern(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire attack-pattern");
+    assert_eq!(
+        wire.get("type").and_then(Value::as_str),
+        Some("attack-pattern"),
+        "wire type must be attack-pattern"
+    );
+    // Typed lookup already succeeded in `load_attack_pattern`; keep `ap` live as proof.
+    let _ = ap;
 }
 
 /// REQ-3.1-P-06 — `spec_version` is `2.1`.
@@ -140,7 +226,7 @@ pub fn assert_prop_kill_chain_phases() {
     );
 }
 
-/// REQ-3.1-P-11 — `created` timestamp is present (millisecond RFC 3339 on wire).
+/// REQ-3.1-P-11 — `created` timestamp is present (exactly three subsecond digits).
 pub fn assert_prop_created() {
     let fixture = load_fixture(FIXTURE_CREATE);
     let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
@@ -153,13 +239,10 @@ pub fn assert_prop_created() {
         .get("created")
         .and_then(Value::as_str)
         .expect("created timestamp");
-    assert!(
-        created.contains('.') && created.ends_with('Z'),
-        "created must be millisecond RFC 3339: {created}"
-    );
+    assert_millisecond_rfc3339("created", created);
 }
 
-/// REQ-3.1-P-12 — `modified` timestamp is present (millisecond RFC 3339 on wire).
+/// REQ-3.1-P-12 — `modified` timestamp is present (exactly three subsecond digits).
 pub fn assert_prop_modified() {
     let fixture = load_fixture(FIXTURE_CREATE);
     let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
@@ -172,10 +255,7 @@ pub fn assert_prop_modified() {
         .get("modified")
         .and_then(Value::as_str)
         .expect("modified timestamp");
-    assert!(
-        modified.contains('.') && modified.ends_with('Z'),
-        "modified must be millisecond RFC 3339: {modified}"
-    );
+    assert_millisecond_rfc3339("modified", modified);
 }
 
 /// REQ-3.1-P-13 — `name` identifies the Attack Pattern.

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
@@ -1,0 +1,186 @@
+//! §3.1.2 Required Producer Persona Support (REQ-3.1-P-01..P-13).
+
+use crate::interop_test;
+use rstix::core::{SpecVersion, StixId};
+use rstix::model::sdo::AttackPattern;
+use serde_json::Value;
+
+use crate::common::fixture_catalog::{parse_fixture_objects, use_case_object_ids};
+use crate::common::identity::assert_identity_shape;
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::{
+    InteropGateOptions, validate_interop_fixture, validate_interop_json,
+};
+use crate::use_cases::attack_pattern::FIXTURE_CREATE;
+
+fn load_attack_pattern(relative: &str) -> (AttackPattern, String) {
+    let fixture = load_fixture(relative);
+    let objects = parse_fixture_objects(&fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: parse fixture: {err}"));
+    let use_case_ids = use_case_object_ids(relative, &objects);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{relative}: expected one attack-pattern use-case object"
+    );
+    let object_id = use_case_ids.into_iter().next().expect("attack-pattern id");
+    let bundle = validate_interop_fixture(relative, &fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+    let stix_id = StixId::parse(&object_id).expect("attack-pattern id");
+    let ap = bundle
+        .get_typed::<AttackPattern>(&stix_id)
+        .unwrap_or_else(|| panic!("{relative}: typed attack-pattern {object_id}"))
+        .clone();
+    (ap, object_id)
+}
+
+/// REQ-3.1-P-01 — Producer creates Attack Pattern content (§3.1.3.1).
+pub fn assert_create_attack_pattern() {
+    validate_interop_fixture(FIXTURE_CREATE, &load_fixture(FIXTURE_CREATE).json)
+        .expect("§3.1.3.1 must pass interop producer gate");
+}
+
+/// REQ-3.1-P-02 — Caller-selected object set parses and re-validates (not UI-level select/specify).
+pub fn assert_select_content() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let mut root: Value = serde_json::from_str(&fixture.json).expect("parse bundle JSON");
+    let objects = root
+        .get_mut("objects")
+        .and_then(Value::as_array_mut)
+        .expect("objects array");
+    for object in objects.iter_mut() {
+        if object.get("type").and_then(Value::as_str) == Some("attack-pattern") {
+            object["name"] = Value::String("Caller-selected Attack Pattern name".into());
+        }
+    }
+    let json = serde_json::to_string(&root).expect("serialize caller-selected bundle");
+    let use_case_ids = use_case_object_ids(FIXTURE_CREATE, &parse_fixture_objects(&json).unwrap());
+    validate_interop_json(
+        &json,
+        &InteropGateOptions {
+            use_case_object_ids: use_case_ids,
+        },
+    )
+    .expect("caller-selected bundle must pass interop gate");
+}
+
+/// REQ-3.1-P-03 — Identity in bundle complies with §2.3.4 (fixture-scoped; not a duplicate §2.3 proof).
+pub fn assert_identity_compliance() {
+    let relative = FIXTURE_CREATE;
+    let fixture = load_fixture(relative);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let identities: Vec<_> = objects
+        .iter()
+        .filter(|obj| obj.get("type").and_then(Value::as_str) == Some("identity"))
+        .collect();
+    assert_eq!(identities.len(), 1, "{relative}: expected one Identity");
+    assert_identity_shape(relative, identities[0]);
+}
+
+/// REQ-3.1-P-04 — Attack Pattern conforms to STIX §4.1 via interop gate on §3.1.3.1.
+pub fn assert_spec_conformance() {
+    assert_create_attack_pattern();
+}
+
+/// REQ-3.1-P-05 — `type` is `attack-pattern`.
+pub fn assert_prop_type() {
+    let (_ap, _) = load_attack_pattern(FIXTURE_CREATE);
+    assert_eq!(AttackPattern::TYPE_NAME, "attack-pattern");
+}
+
+/// REQ-3.1-P-06 — `spec_version` is `2.1`.
+pub fn assert_prop_spec_version() {
+    let (ap, _) = load_attack_pattern(FIXTURE_CREATE);
+    assert_eq!(ap.common.spec_version, SpecVersion::V2_1);
+}
+
+/// REQ-3.1-P-07 — `id` is a UUID with `attack-pattern--` prefix.
+pub fn assert_prop_id() {
+    let (_, object_id) = load_attack_pattern(FIXTURE_CREATE);
+    assert!(
+        object_id.starts_with("attack-pattern--"),
+        "id must use attack-pattern-- prefix: {object_id}"
+    );
+    assert!(
+        StixId::parse(&object_id).is_ok(),
+        "id must be valid STIX id"
+    );
+}
+
+/// REQ-3.1-P-08 — `created_by_ref` points at the Producer Identity.
+pub fn assert_prop_created_by_ref() {
+    let (ap, _) = load_attack_pattern(FIXTURE_CREATE);
+    let created_by = ap
+        .common
+        .created_by_ref
+        .as_ref()
+        .expect("interop-mandatory created_by_ref");
+    assert!(
+        created_by.as_stix_id().as_str().starts_with("identity--"),
+        "created_by_ref must reference Identity: {}",
+        created_by.as_stix_id().as_str()
+    );
+}
+
+/// REQ-3.1-P-09 — `external_references` is present and non-empty.
+pub fn assert_prop_external_references() {
+    let (ap, _) = load_attack_pattern(FIXTURE_CREATE);
+    assert!(
+        !ap.common.external_references.is_empty(),
+        "interop-mandatory external_references"
+    );
+}
+
+/// REQ-3.1-P-10 — `kill_chain_phases` is present and non-empty.
+pub fn assert_prop_kill_chain_phases() {
+    let (ap, _) = load_attack_pattern(FIXTURE_CREATE);
+    assert!(
+        !ap.kill_chain_phases.is_empty(),
+        "interop-mandatory kill_chain_phases"
+    );
+}
+
+/// REQ-3.1-P-11 — `created` timestamp is present (millisecond RFC 3339 on wire).
+pub fn assert_prop_created() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let (_, object_id) = load_attack_pattern(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire attack-pattern");
+    let created = wire
+        .get("created")
+        .and_then(Value::as_str)
+        .expect("created timestamp");
+    assert!(
+        created.contains('.') && created.ends_with('Z'),
+        "created must be millisecond RFC 3339: {created}"
+    );
+}
+
+/// REQ-3.1-P-12 — `modified` timestamp is present (millisecond RFC 3339 on wire).
+pub fn assert_prop_modified() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let (_, object_id) = load_attack_pattern(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire attack-pattern");
+    let modified = wire
+        .get("modified")
+        .and_then(Value::as_str)
+        .expect("modified timestamp");
+    assert!(
+        modified.contains('.') && modified.ends_with('Z'),
+        "modified must be millisecond RFC 3339: {modified}"
+    );
+}
+
+/// REQ-3.1-P-13 — `name` identifies the Attack Pattern.
+pub fn assert_prop_name() {
+    let (ap, _) = load_attack_pattern(FIXTURE_CREATE);
+    assert!(!ap.name.is_empty(), "interop-mandatory name");
+}
+

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
@@ -11,7 +11,7 @@ use crate::harness::fixture::load_fixture;
 use crate::harness::interop_gate::{
     InteropGateOptions, validate_interop_fixture, validate_interop_json,
 };
-use crate::use_cases::attack_pattern::FIXTURE_CREATE;
+use crate::use_cases::attack_pattern::{FIXTURE_CREATE, PRODUCER_FIXTURES};
 
 fn load_attack_pattern(relative: &str) -> (AttackPattern, String) {
     let fixture = load_fixture(relative);
@@ -184,3 +184,137 @@ pub fn assert_prop_name() {
     assert!(!ap.name.is_empty(), "interop-mandatory name");
 }
 
+/// REQ-CHK-SXP-3.1 / §4.2 Table 56 — Producer test case data (§3.1.3.1 and §3.1.3.2).
+pub fn assert_producer_testcase_data() {
+    for relative in PRODUCER_FIXTURES {
+        validate_interop_fixture(relative, &load_fixture(relative).json).unwrap_or_else(|err| {
+            panic!("{relative}: §3.1.3 producer test case must pass interop gate: {err}")
+        });
+    }
+}
+
+interop_test!(
+    "REQ-3.1-P-01",
+    "use_cases::attack_pattern::producer::create_attack_pattern",
+    create_attack_pattern,
+    {
+        assert_create_attack_pattern();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-02",
+    "use_cases::attack_pattern::producer::select_content",
+    select_content,
+    {
+        assert_select_content();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-03",
+    "use_cases::attack_pattern::producer::identity_compliance",
+    identity_compliance,
+    {
+        assert_identity_compliance();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-04",
+    "use_cases::attack_pattern::producer::spec_conformance",
+    spec_conformance,
+    {
+        assert_spec_conformance();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-05",
+    "use_cases::attack_pattern::producer::prop_type",
+    prop_type,
+    {
+        assert_prop_type();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-06",
+    "use_cases::attack_pattern::producer::prop_spec_version",
+    prop_spec_version,
+    {
+        assert_prop_spec_version();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-07",
+    "use_cases::attack_pattern::producer::prop_id",
+    prop_id,
+    {
+        assert_prop_id();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-08",
+    "use_cases::attack_pattern::producer::prop_created_by_ref",
+    prop_created_by_ref,
+    {
+        assert_prop_created_by_ref();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-09",
+    "use_cases::attack_pattern::producer::prop_external_references",
+    prop_external_references,
+    {
+        assert_prop_external_references();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-10",
+    "use_cases::attack_pattern::producer::prop_kill_chain_phases",
+    prop_kill_chain_phases,
+    {
+        assert_prop_kill_chain_phases();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-11",
+    "use_cases::attack_pattern::producer::prop_created",
+    prop_created,
+    {
+        assert_prop_created();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-12",
+    "use_cases::attack_pattern::producer::prop_modified",
+    prop_modified,
+    {
+        assert_prop_modified();
+    }
+);
+
+interop_test!(
+    "REQ-3.1-P-13",
+    "use_cases::attack_pattern::producer::prop_name",
+    prop_name,
+    {
+        assert_prop_name();
+    }
+);
+
+interop_test!(
+    "REQ-CHK-SXP-3.1",
+    "use_cases::attack_pattern::producer::producer_testcase_data",
+    producer_testcase_data,
+    {
+        assert_producer_testcase_data();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/mod.rs
@@ -1,0 +1,3 @@
+//! Per-use-case OASIS §3.x Producer and Consumer tests (normative fixture bound).
+
+pub mod attack_pattern;


### PR DESCRIPTION
# Summary
- Adds `tests/interop/use_cases/attack_pattern/` for OASIS Interop **§3.1.1–§3.1.7** (Producer `P-01`..`P-13`, Consumer `C-01`..`C-05`, checklist `REQ-CHK-SXP/SXC-3.1`, examples `EX-4.1`/`EX-4.2`/`EX-7.1`), with §3.1.1 as real **TESTED** scope (not REPORT_ONLY).
- Fixtures under `examples/attack-pattern/`; §3.1.4.2 keeps truncated published UUIDs and asserts parse reject (no invented digits).
- Traceability only — **not** OASIS SXP/SXC certification; **1/21** use cases. Interop report expect **51** TESTED / **7** REPORT_ONLY / **2** BLOCKED.

## Test plan
- [*] `cargo fmt --all -- --check`
- [*] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [*] `cargo test --workspace --all-features --locked`
- [*] `cargo test -p rstix --test interop --features validate,marking,graph --locked` → `tested_rows_passed == 51`
- [*] `cargo +1.88.0 check --workspace --all-targets --all-features --locked`