### PR TITLE
test(rstix): tighten §3.1 EX-4.2 / P-04 / C-04 evidence after #413/#414

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### rstix: tighten §3.1 Attack Pattern interop evidence
+
+Closes soft gaps left after #413 / #414 : `EX-4.2` pins wire `objects[1].id` / `objects[2].id` and requires bundle parse to equal the malware id's `StixIdError`; `P-04` scopes Zero diagnostics by structured `object_id` only; `C-04` matches query/typed field cardinality to the wire object instead of a non-empty overlap with `C-01`.
+
 ### Parallel daemon parsing and single-parse DLQ routing (#415)
 
 The daemon now parses each formatted input batch in parallel before taking the engine mutex. A separate ordering lock keeps exactly one batch in flight, so raw taps still see every line before parsing, decoded taps and observers retain input order, correlations run in order, output order is unchanged, and an in-flight batch remains attached to the engine snapshot it started with. Hot reload and correlation-state import/export coordinate with the same boundary.
@@ -13,7 +17,6 @@ The processor now reports failed input indices with its batch result. DLQ-enable
 On the pinned SigmaHQ raw Windows workload with `--logsource-routing`, `--batch-size 512`, and 16 k6 VUs, the median of three same-build runs moved from 306,351 to 384,906 events/s at eight threads while one-thread throughput remained near 90,000 events/s. Eight-core scaling improved from 3.39x to 4.19x, or from 42% to 52% efficiency, and the measured parse share fell from about 40% to 27%. A zero-copy request-body span prototype did not improve throughput and was not retained.
 
 `rsigma_batch_phase_duration_seconds{phase="parse"|"evaluate"}` exposes cumulative batch time for the two measured regions. `scripts/perf/baseline-daemon.sh` reports their deltas and parse share after each run.
-
 ### jemalloc as the musl global allocator (#412)
 
 The released static binary is built against musl, whose mallocng serializes the concurrent allocation that `Engine::evaluate_batch` performs on every batch. That erased the daemon's multicore scaling in the released artifact: on the pinned SigmaHQ corpus with `--logsource-routing` the daemon reached 53,435 events/s across six cores while the same binary evaluated 57,463 events/s on one, so the fan-out returned less than nothing. musl targets now use jemalloc as the global allocator, which raises that daemon figure to 160,238 events/s on fewer cores (3.00x) and 95,505 from 36,875 without routing (2.59x). Single-threaded throughput moves only ~14%, and that disproportion is what identifies the cost as allocator contention rather than per-event work. Match counts are identical either way. Rule loading, being allocation-heavy, drops from 0.86 s to 0.49 s. glibc and macOS builds keep the system allocator since neither shows the contention, so nothing changes for a native build. Building the musl target now needs a C toolchain for `jemalloc-sys`, so the Docker builder installs `build-base`. Measured with `scripts/perf/baseline-eval.sh` and the new `scripts/perf/image-compare.sh`, which sees a class of change the native harnesses cannot.

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/consumer.rs
@@ -105,9 +105,11 @@ pub fn assert_resolves_created_by_ref() {
 
 /// REQ-3.1-C-04 — Consumer processes Attack Pattern fields via query + leaf validate.
 ///
-/// Distinct from C-01 (wire re-serialize preservation + non-empty producer props): uses
-/// [`QueryableStixObject::get_field`] and runs [`KillChainPhase::validate`] /
-/// [`ExternalReference::validate`] on typed members.
+/// Distinct from C-01 (full wire re-serialize preservation): uses
+/// [`QueryableStixObject::get_field`] for `name` / `created_by_ref`, then runs
+/// [`KillChainPhase::validate`] / [`ExternalReference::validate`] on each typed
+/// member present on this fixture (cardinality taken from the wire object, not a
+/// generic non-empty producer-prop check).
 pub fn assert_processes_fields() {
     let relative = FIXTURE_TARGETS;
     let fixture = load_fixture(relative);
@@ -122,6 +124,10 @@ pub fn assert_processes_fields() {
     );
     let object_id = &use_case_ids[0];
     let stix_id = StixId::parse(object_id).expect("attack-pattern id");
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .unwrap_or_else(|| panic!("{relative}: wire attack-pattern {object_id}"));
     let ap = bundle
         .get_typed::<AttackPattern>(&stix_id)
         .unwrap_or_else(|| panic!("{relative}: typed attack-pattern {object_id}"));
@@ -132,6 +138,11 @@ pub fn assert_processes_fields() {
                 name,
                 ap.name.as_str(),
                 "{relative}: get_field(name) mismatch"
+            );
+            assert_eq!(
+                Some(name),
+                wire.get("name").and_then(Value::as_str),
+                "{relative}: get_field(name) must match wire"
             );
         }
         other => panic!("{relative}: expected QueryValue::Str for name, got {other:?}"),
@@ -148,22 +159,40 @@ pub fn assert_processes_fields() {
                 created_by.as_stix_id(),
                 "{relative}: get_field(created_by_ref) mismatch"
             );
+            assert_eq!(
+                Some(id.as_str()),
+                wire.get("created_by_ref").and_then(Value::as_str),
+                "{relative}: get_field(created_by_ref) must match wire"
+            );
         }
         other => panic!("{relative}: expected QueryValue::Id for created_by_ref, got {other:?}"),
     }
 
-    assert!(
-        !ap.kill_chain_phases.is_empty(),
-        "{relative}: kill_chain_phases required for leaf processing"
+    let wire_phase_len = wire
+        .get("kill_chain_phases")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    assert_eq!(
+        ap.kill_chain_phases.len(),
+        wire_phase_len,
+        "{relative}: typed kill_chain_phases length must match wire"
     );
     for phase in &ap.kill_chain_phases {
         phase
             .validate()
             .unwrap_or_else(|err| panic!("{relative}: kill_chain_phase.validate: {err}"));
     }
-    assert!(
-        !ap.common.external_references.is_empty(),
-        "{relative}: external_references required for leaf processing"
+
+    let wire_ref_len = wire
+        .get("external_references")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    assert_eq!(
+        ap.common.external_references.len(),
+        wire_ref_len,
+        "{relative}: typed external_references length must match wire"
     );
     for reference in &ap.common.external_references {
         reference

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/examples.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/examples.rs
@@ -3,6 +3,7 @@
 use rstix::ParseError;
 use rstix::core::{StixId, StixIdError};
 use rstix::model::{Bundle, ParseOptions};
+use serde_json::Value;
 
 use crate::harness::fixture::load_fixture;
 use crate::harness::interop_gate::{InteropGateOptions, validate_interop_json};
@@ -15,11 +16,10 @@ pub const EXAMPLE_CONTEXT: &str =
 pub const EXAMPLE_FRAMEWORK: &str =
     "examples/attack-pattern/ex-3.1.4.2-leverage-externally-defined-frameworks.json";
 
-/// Published truncated UUID ids retained from OASIS §3.1.4.2 (defect 21).
-const TRUNCATED_FRAMEWORK_IDS: &[&str] = &[
-    "malware--1121ffbc-364f-857a-9987-92fbcff24ab",
-    "relationship--11220001-3940-0405-20ff-1029b0bc922",
-];
+/// Published truncated malware id from provenance `objects[1].id` (defect 21).
+const TRUNCATED_MALWARE_ID: &str = "malware--1121ffbc-364f-857a-9987-92fbcff24ab";
+/// Published truncated relationship id from provenance `objects[2].id` (defect 21).
+const TRUNCATED_RELATIONSHIP_ID: &str = "relationship--11220001-3940-0405-20ff-1029b0bc922";
 
 /// REQ-3.1-EX-4.1 — §3.1.4.1 loads and passes the interop gate (examples are non-gating).
 pub fn assert_add_context_to_indicator() {
@@ -32,9 +32,11 @@ pub fn assert_add_context_to_indicator() {
 
 /// REQ-3.1-EX-4.2 — §3.1.4.2 retains published truncated UUID ids; parse must reject them.
 ///
-/// Pins the failure to the structured id boundary (no Display substring matching, no
-/// invented repair UUIDs): each published truncated id is [`StixIdError::InvalidUuid`],
-/// and bundle parse surfaces [`ParseError::InvalidStixId`] with that variant.
+/// Structured proof only:
+/// - both published truncated ids are [`StixIdError::InvalidUuid`];
+/// - wire `objects[1].id` / `objects[2].id` stay the published truncated values;
+/// - bundle parse fails as [`ParseError::InvalidStixId`] equal to the malware id's parse
+///   error (bundle walks identity then malware, so the first id failure is objects[1]).
 pub fn assert_framework_example_rejects_truncated_ids() {
     let fixture = load_fixture(EXAMPLE_FRAMEWORK);
     assert_eq!(fixture.provenance.source_section, "3.1.4.2");
@@ -43,26 +45,57 @@ pub fn assert_framework_example_rejects_truncated_ids() {
             .provenance
             .divergence_recorded
             .iter()
-            .any(|d| d.defect == 21),
-        "expected defect 21 recorded for truncated UUID ids"
+            .any(|d| d.defect == 21 && d.site == "objects[1].id"),
+        "expected defect 21 on objects[1].id"
     );
 
-    for truncated in TRUNCATED_FRAMEWORK_IDS {
-        assert!(
-            fixture.json.contains(truncated),
-            "fixture must retain published truncated id: {truncated}"
-        );
-        assert!(
-            matches!(StixId::parse(truncated), Err(StixIdError::InvalidUuid(_))),
-            "published truncated id must be StixIdError::InvalidUuid: {truncated}"
-        );
+    let root: Value = serde_json::from_str(&fixture.json).expect("example JSON");
+    let objects = root
+        .get("objects")
+        .and_then(Value::as_array)
+        .expect("objects array");
+    let wire_malware_id = objects
+        .get(1)
+        .and_then(|obj| obj.get("id"))
+        .and_then(Value::as_str)
+        .expect("objects[1].id");
+    assert_eq!(
+        wire_malware_id, TRUNCATED_MALWARE_ID,
+        "objects[1].id must remain the published truncated malware id"
+    );
+    let wire_relationship_id = objects
+        .get(2)
+        .and_then(|obj| obj.get("id"))
+        .and_then(Value::as_str)
+        .expect("objects[2].id");
+    assert_eq!(
+        wire_relationship_id, TRUNCATED_RELATIONSHIP_ID,
+        "objects[2].id must remain the published truncated relationship id"
+    );
+
+    let malware_err = match StixId::parse(TRUNCATED_MALWARE_ID) {
+        Err(err @ StixIdError::InvalidUuid(_)) => err,
+        other => panic!("truncated malware id must be InvalidUuid, got {other:?}"),
+    };
+    let relationship_err = match StixId::parse(TRUNCATED_RELATIONSHIP_ID) {
+        Err(err @ StixIdError::InvalidUuid(_)) => err,
+        other => panic!("truncated relationship id must be InvalidUuid, got {other:?}"),
+    };
+    match (&malware_err, &relationship_err) {
+        (StixIdError::InvalidUuid(_), StixIdError::InvalidUuid(_)) => {}
+        _ => unreachable!(),
     }
 
     let err = Bundle::parse_with_options(&fixture.json, &ParseOptions::new().interop_bundle())
         .expect_err("§3.1.4.2 truncated UUID ids must fail parse");
     match err {
-        ParseError::InvalidStixId(StixIdError::InvalidUuid(_)) => {}
-        other => panic!("expected ParseError::InvalidStixId(InvalidUuid), got: {other:?}"),
+        ParseError::InvalidStixId(got) => {
+            assert_eq!(
+                got, malware_err,
+                "bundle must fail on objects[1] malware id (first truncated id in walk order)"
+            );
+        }
+        other => panic!("expected ParseError::InvalidStixId(...), got: {other:?}"),
     }
 }
 

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
@@ -136,12 +136,11 @@ pub fn assert_spec_conformance() {
         "{relative}: MUST Error diagnostics present: {errors:?}"
     );
 
+    // Scoped Zero failures only via structured `object_id` (no Display/message matching).
     let scoped_zero_failures: Vec<_> = report
         .diagnostics()
         .filter(|d| {
-            let on_ap =
-                d.object_id.as_ref() == Some(&ap_id) || d.message.contains(object_id.as_str());
-            on_ap && Leniency::Zero.fails_validation(d.severity)
+            d.object_id.as_ref() == Some(&ap_id) && Leniency::Zero.fails_validation(d.severity)
         })
         .collect();
     assert!(


### PR DESCRIPTION
## Summary

Follow-up to #413/#414: test-only soft-gap closes — no `StixId`/serde changes (#414 already owns recovery).

- **EX-4.2** — pin wire `objects[1].id` / `objects[2].id`; require `ParseError::InvalidStixId` equals the malware id’s `StixIdError`
- **P-04** — scope Zero diagnostics by structured `object_id` only (drop `message.contains`)
- **C-04** — match query/typed fields and leaf-list lengths to wire (not a non-empty overlap with C-01)

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy -p rstix --all-targets --features validate,marking,graph --locked -- -D warnings`
- [ ] `cargo test -p rstix --features validate,marking,graph --locked --test interop -- use_cases::attack_pattern`