### PR TITLE
perf(eval): ASCII case-insensitive candidate AC without fold copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ### Candidate index ASCII case-insensitive Aho-Corasick (#420)
 
-NeedleSet automata now build with ASCII case-insensitive search, so ASCII event strings are scanned without allocating a lowercase copy. Keyword probing visits string values in place instead of collecting them into a `Vec`, and field probes that need both exact and substring witnesses fold once and reuse the folded bytes. Hot index maps use `ahash` instead of SipHash.
+NeedleSet automata now build with ASCII case-insensitive search and prefer a DFA, so ASCII event strings are scanned without allocating a lowercase copy. Keyword probing visits string values in place instead of collecting them into a `Vec`, field probes that need both exact and substring witnesses fold once and reuse the folded bytes, and hot index maps use `ahash` instead of SipHash. The daemon evaluates the next batch while the previous batch's sink/ack dispatch runs, so rayon workers are not parked for the whole dispatch phase.
 
-On the pinned SigmaHQ raw Windows workload with `--logsource-routing`, `--batch-size 512`, and 16 k6 VUs, the median of three same-machine runs moved from about 102k to 106k events/s at one thread and from about 404k to 411k events/s at eight threads versus the post-#419 baseline on the same host.
+On the pinned SigmaHQ raw Windows workload with `--logsource-routing`, `--batch-size 512`, and 16 k6 VUs, the median of three same-machine runs moved from about 102k to 118k events/s at one thread and from about 404k to 467k events/s at eight threads versus the post-#419 baseline on the same host.
 
 ### Candidate index probes from event top-level keys (#419)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Candidate index ASCII case-insensitive Aho-Corasick
+### Candidate index ASCII case-insensitive Aho-Corasick (#420)
 
 NeedleSet automata now build with ASCII case-insensitive search, so ASCII event strings are scanned without allocating a lowercase copy. Keyword probing visits string values in place instead of collecting them into a `Vec`, and field probes that need both exact and substring witnesses fold once and reuse the folded bytes. Hot index maps use `ahash` instead of SipHash.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Candidate index ASCII case-insensitive Aho-Corasick
+
+NeedleSet automata now build with ASCII case-insensitive search, so ASCII event strings are scanned without allocating a lowercase copy. Keyword probing visits string values in place instead of collecting them into a `Vec`, and field probes that need both exact and substring witnesses fold once and reuse the folded bytes. Hot index maps use `ahash` instead of SipHash.
+
+On the pinned SigmaHQ raw Windows workload with `--logsource-routing`, `--batch-size 512`, and 16 k6 VUs, the median of three same-machine runs moved from about 102k to 106k events/s at one thread and from about 404k to 411k events/s at eight threads versus the post-#419 baseline on the same host.
+
 ### Candidate index probes from event top-level keys (#419)
 
 The candidate index no longer walks every indexed field on each event. When an event can report its top-level keys (`Event::top_level_keys`), the index probes only witnesses under those keys, so sparse payloads skip the miss storm over thousands of absent Sigma fields. `JsonEvent::get_field` also returns early for dotted paths whose first segment is absent at the root, avoiding path parsing on the common miss.

--- a/crates/rsigma-cli/src/daemon/server.rs
+++ b/crates/rsigma-cli/src/daemon/server.rs
@@ -14,13 +14,13 @@ use rsigma_eval::{
     load_schema_config,
 };
 use rsigma_runtime::{
-    AckToken, AlertPipeline, AlertPipelineState, DeliveryConfig, DeliveryFailure, Dispatcher,
-    EnrichmentPipeline, FieldObserver, FileSink, FormattedIncidentEnvelope, IncidentEnvelope,
-    IncidentResult, IncludeMode, InputFormat, LogProcessor, MetricsHook, OnFull, RawEvent,
-    RiskLayer, RiskState, RoutingSpec, RuntimeEngine, SchemaClassifier, SchemaObserver, Silence,
-    SilenceOrigin, SilenceSpec, Sink, SinkFormat, StdinSource, StdoutSink, build_alert_pipeline,
-    build_risk_layer, load_alert_pipeline_file, load_risk_file, load_schema_signatures,
-    spawn_source,
+    AckToken, AlertPipeline, AlertPipelineState, BatchProcessOutcome, DeliveryConfig,
+    DeliveryFailure, Dispatcher, EnrichmentPipeline, FieldObserver, FileSink,
+    FormattedIncidentEnvelope, IncidentEnvelope, IncidentResult, IncludeMode, InputFormat,
+    LogProcessor, MetricsHook, OnFull, RawEvent, RiskLayer, RiskState, RoutingSpec, RuntimeEngine,
+    SchemaClassifier, SchemaObserver, Silence, SilenceOrigin, SilenceSpec, Sink, SinkFormat,
+    StdinSource, StdoutSink, build_alert_pipeline, build_risk_layer, load_alert_pipeline_file,
+    load_risk_file, load_schema_signatures, spawn_source,
 };
 
 use super::bundle::BundleFormat;
@@ -36,6 +36,14 @@ struct DlqEntry {
     original_event: String,
     error: String,
     timestamp: String,
+}
+
+/// One evaluated batch waiting for ordered sink/ack dispatch.
+struct EvaluatedBatch {
+    outcome: BatchProcessOutcome,
+    payloads: Vec<String>,
+    tokens: Vec<AckToken>,
+    pipeline_start: Instant,
 }
 
 use super::health::HealthState;
@@ -1459,18 +1467,83 @@ pub async fn run_daemon(config: DaemonConfig) {
         });
     }
 
-    // Engine task: reads RawEvents, evaluates rules, sends results + ack tokens
-    // to the sink channel. Events with no detections are acked immediately.
-    // Parse errors are routed to the DLQ.
+    // Engine task evaluates batches in order; a separate dispatch task drains
+    // results so batch N+1 can parse/evaluate while batch N's sink/ack work
+    // runs. Correlation and output order stay sequential because evaluate is
+    // still one batch at a time and dispatch consumes the handoff channel in
+    // order. Capacity 1 bounds how far evaluate can run ahead of dispatch.
+    let (eval_tx, mut eval_rx) = mpsc::channel::<EvaluatedBatch>(1);
+
+    let dispatch_metrics = metrics.clone();
+    let dispatch_ack_tx = ack_tx.clone();
+    let dispatch_dlq_tx = dlq_tx.clone();
+    let dispatch_dlq_enabled = config.dlq.is_some();
+    let dispatch_handle = tokio::spawn(async move {
+        while let Some(batch) = eval_rx.recv().await {
+            let dispatch_start = Instant::now();
+            let mut parse_errors = batch.outcome.parse_error_indices.into_iter().peekable();
+            let mut shutdown = false;
+            for (index, ((result, ack_token), payload)) in batch
+                .outcome
+                .results
+                .into_iter()
+                .zip(batch.tokens)
+                .zip(batch.payloads)
+                .enumerate()
+            {
+                if parse_errors.peek().copied() == Some(index) {
+                    parse_errors.next();
+                    if dispatch_dlq_enabled {
+                        tracing::debug!("Event routed to DLQ: parse error");
+                        if dispatch_dlq_tx
+                            .send(DlqEntry {
+                                original_event: payload,
+                                error: "parse error".to_string(),
+                                timestamp: chrono::Utc::now().to_rfc3339(),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            tracing::warn!("DLQ channel closed, parse-error event dropped");
+                        }
+                    }
+                    if dispatch_ack_tx.send(ack_token).is_err() {
+                        shutdown = true;
+                        break;
+                    }
+                    continue;
+                }
+                if result.is_empty() {
+                    if dispatch_ack_tx.send(ack_token).is_err() {
+                        tracing::debug!("Ack channel closed, engine shutting down");
+                        shutdown = true;
+                        break;
+                    }
+                    continue;
+                }
+                dispatch_metrics.on_output_queue_depth_change(1);
+                if sink_tx.send((result, vec![ack_token])).await.is_err() {
+                    tracing::debug!("Sink channel closed, engine shutting down");
+                    shutdown = true;
+                    break;
+                }
+            }
+            dispatch_metrics
+                .observe_batch_phase_duration("dispatch", dispatch_start.elapsed().as_secs_f64());
+            dispatch_metrics.observe_pipeline_latency(batch.pipeline_start.elapsed().as_secs_f64());
+            if shutdown {
+                break;
+            }
+        }
+    });
+
+    // Engine task: reads RawEvents, evaluates rules, hands outcomes to dispatch.
     let engine_processor = processor.clone();
     let engine_metrics = metrics.clone();
     let event_filter = config.event_filter.clone();
     let event_filter_enabled = !matches!(event_filter.as_ref(), EventFilter::None);
     let batch_size = config.batch_size;
     let input_format = config.input_format.clone();
-    let engine_ack_tx = ack_tx.clone();
-    let engine_dlq_tx = dlq_tx.clone();
-    let dlq_enabled = config.dlq.is_some();
     #[cfg(feature = "daemon-otlp")]
     let engine_source_done = source_done_notify.clone();
     let engine_handle = tokio::spawn(async move {
@@ -1480,7 +1553,7 @@ pub async fn run_daemon(config: DaemonConfig) {
         #[cfg(feature = "daemon-otlp")]
         let mut source_finished = false;
         loop {
-            let pipeline_start = std::time::Instant::now();
+            let pipeline_start = Instant::now();
 
             let first = {
                 #[cfg(feature = "daemon-otlp")]
@@ -1528,106 +1601,45 @@ pub async fn run_daemon(config: DaemonConfig) {
             }
             let initial_batch_size = batch.len();
             engine_metrics.observe_batch_size(initial_batch_size as u64);
-            let batch_span = tracing::debug_span!(
-                "process_batch",
-                batch_size = initial_batch_size,
-                input_format = ?input_format,
+
+            let mut payloads = Vec::with_capacity(batch.len());
+            let mut tokens = Vec::with_capacity(batch.len());
+            for raw_event in batch {
+                payloads.push(raw_event.payload);
+                tokens.push(raw_event.ack_token);
+            }
+
+            if payloads.is_empty() {
+                continue;
+            }
+
+            let process_start = Instant::now();
+            let filter = event_filter_enabled.then_some(&filter_fn as &rsigma_runtime::EventFilter);
+            let outcome = engine_processor.process_batch_with_format_detailed(
+                &payloads,
+                &input_format,
+                filter,
+            );
+            let process_elapsed_ms = process_start.elapsed().as_millis() as u64;
+            let match_count = outcome.results.iter().filter(|r| !r.is_empty()).count();
+            tracing::debug!(
+                batch_size = payloads.len(),
+                matches = match_count,
+                elapsed_ms = process_elapsed_ms,
+                "Batch processed",
             );
 
-            // Use Instrument rather than .enter() because the batch processing
-            // awaits on multiple channels; .enter() across .await produces
-            // confused span nesting on the multi-threaded runtime.
-            let shutdown = tracing::Instrument::instrument(
-                async {
-                    let mut payloads = Vec::with_capacity(batch.len());
-                    let mut tokens = Vec::with_capacity(batch.len());
-                    for raw_event in batch {
-                        payloads.push(raw_event.payload);
-                        tokens.push(raw_event.ack_token);
-                    }
-
-                    if payloads.is_empty() {
-                        return false;
-                    }
-
-                    let process_start = std::time::Instant::now();
-                    let filter =
-                        event_filter_enabled.then_some(&filter_fn as &rsigma_runtime::EventFilter);
-                    let outcome = engine_processor.process_batch_with_format_detailed(
-                        &payloads,
-                        &input_format,
-                        filter,
-                    );
-                    let process_elapsed_ms = process_start.elapsed().as_millis() as u64;
-                    let match_count = outcome.results.iter().filter(|r| !r.is_empty()).count();
-                    tracing::debug!(
-                        batch_size = payloads.len(),
-                        matches = match_count,
-                        elapsed_ms = process_elapsed_ms,
-                        "Batch processed",
-                    );
-
-                    let dispatch_start = std::time::Instant::now();
-                    let mut parse_errors = outcome.parse_error_indices.into_iter().peekable();
-                    let mut shutdown = false;
-                    for (index, ((result, ack_token), payload)) in outcome
-                        .results
-                        .into_iter()
-                        .zip(tokens)
-                        .zip(payloads)
-                        .enumerate()
-                    {
-                        if parse_errors.peek().copied() == Some(index) {
-                            parse_errors.next();
-                            if dlq_enabled {
-                                tracing::debug!("Event routed to DLQ: parse error");
-                                if engine_dlq_tx
-                                    .send(DlqEntry {
-                                        original_event: payload,
-                                        error: "parse error".to_string(),
-                                        timestamp: chrono::Utc::now().to_rfc3339(),
-                                    })
-                                    .await
-                                    .is_err()
-                                {
-                                    tracing::warn!("DLQ channel closed, parse-error event dropped");
-                                }
-                            }
-                            if engine_ack_tx.send(ack_token).is_err() {
-                                shutdown = true;
-                                break;
-                            }
-                            continue;
-                        }
-                        if result.is_empty() {
-                            if engine_ack_tx.send(ack_token).is_err() {
-                                tracing::debug!("Ack channel closed, engine shutting down");
-                                shutdown = true;
-                                break;
-                            }
-                            continue;
-                        }
-                        engine_metrics.on_output_queue_depth_change(1);
-                        if sink_tx.send((result, vec![ack_token])).await.is_err() {
-                            tracing::debug!("Sink channel closed, engine shutting down");
-                            shutdown = true;
-                            break;
-                        }
-                    }
-                    engine_metrics.observe_batch_phase_duration(
-                        "dispatch",
-                        dispatch_start.elapsed().as_secs_f64(),
-                    );
-
-                    shutdown
-                },
-                batch_span,
-            )
-            .await;
-
-            engine_metrics.observe_pipeline_latency(pipeline_start.elapsed().as_secs_f64());
-
-            if shutdown {
+            if eval_tx
+                .send(EvaluatedBatch {
+                    outcome,
+                    payloads,
+                    tokens,
+                    pipeline_start,
+                })
+                .await
+                .is_err()
+            {
+                tracing::debug!("Dispatch channel closed, engine shutting down");
                 break;
             }
         }
@@ -2018,7 +2030,10 @@ pub async fn run_daemon(config: DaemonConfig) {
 
     let shutdown_triggered = tokio::select! {
         _ = &mut serve_handle => true,
-        _ = engine_handle => {
+        _ = async {
+            let _ = engine_handle.await;
+            let _ = dispatch_handle.await;
+        } => {
             tracing::info!("Streaming pipeline complete");
             serve_handle.abort();
             false
@@ -2035,10 +2050,11 @@ pub async fn run_daemon(config: DaemonConfig) {
 
         // Tell the engine to stop pulling new events and drain what is already
         // buffered. The stdin reader cannot be cancelled mid-read, so without
-        // this the engine would block on `event_rx.recv()` (holding `sink_tx`
-        // open) until the drain timeout elapses, falsely warning that events
-        // were lost. The engine closes its receiver on this signal, drains the
-        // buffered events, then exits, which lets the sink/ack tasks finish.
+        // this the engine would block on `event_rx.recv()` (keeping the
+        // evaluate→dispatch handoff open) until the drain timeout elapses,
+        // falsely warning that events were lost. The engine closes its
+        // receiver on this signal, drains the buffered events, then exits,
+        // which lets the dispatch/sink/ack tasks finish.
         #[cfg(feature = "daemon-otlp")]
         source_done_notify.notify_one();
 

--- a/crates/rsigma-eval/src/candidate_index.rs
+++ b/crates/rsigma-eval/src/candidate_index.rs
@@ -27,7 +27,7 @@
 use std::borrow::Cow;
 
 use ahash::{HashMap, HashMapExt};
-use aho_corasick::{AhoCorasick, MatchKind};
+use aho_corasick::{AhoCorasick, AhoCorasickKind, MatchKind};
 use rsigma_parser::fieldpath::{first_unescaped, unescape_brackets};
 
 use crate::compiler::CompiledRule;
@@ -99,11 +99,21 @@ impl NeedleSet {
         // Witness needles are stored folded. ASCII case-insensitive search
         // lets the hot path scan the original haystack without allocating a
         // lowercase copy; non-ASCII haystacks still fold once before search.
+        // Prefer a DFA for the dense keyword/field automata; fall back if the
+        // DFA is too large to build.
         let automaton = AhoCorasick::builder()
             .match_kind(MatchKind::Standard)
             .ascii_case_insensitive(true)
+            .kind(Some(AhoCorasickKind::DFA))
             .build(&patterns)
-            .ok()?;
+            .ok()
+            .or_else(|| {
+                AhoCorasick::builder()
+                    .match_kind(MatchKind::Standard)
+                    .ascii_case_insensitive(true)
+                    .build(&patterns)
+                    .ok()
+            })?;
 
         Some(NeedleSet {
             automaton,
@@ -446,16 +456,15 @@ impl CandidateIndex {
         // When the event can name its top-level keys, probe only fields under
         // those roots. On sparse payloads (e.g. raw Windows `message`+`product`)
         // this turns an O(indexed fields) miss storm into O(event keys).
-        if let Some(keys) = event.top_level_keys() {
-            for key in keys {
-                if let Some(fields) = self.fields_for_event_key.get(key.as_ref()) {
-                    for field in fields {
-                        if let Some(entry) = self.fields.get(field) {
-                            Self::apply_field_hit(event, field, entry, set);
-                        }
+        if event.visit_top_level_keys(&mut |key| {
+            if let Some(fields) = self.fields_for_event_key.get(key) {
+                for field in fields {
+                    if let Some(entry) = self.fields.get(field) {
+                        Self::apply_field_hit(event, field, entry, set);
                     }
                 }
             }
+        }) {
             return;
         }
 
@@ -749,33 +758,173 @@ detection:
         assert!(candidates(&index, &json!({"anything": "benign"})).is_empty());
     }
 
-    /// ASCII case-insensitive automata must select on the original haystack
-    /// casing; folding is only required for non-ASCII event text.
+    /// Case matrix: index may over-approximate, but must never omit a rule the
+    /// engine would match for ASCII upper/lower, `|cased`, and non-ASCII CI.
     #[test]
-    fn substring_and_keyword_select_on_ascii_uppercase_haystack() {
-        let (_, index) = build(
-            r#"
-title: Contains
+    fn case_folding_matrix_never_drops_true_matches() {
+        let cases: &[(&str, &str, serde_json::Value, bool)] = &[
+            (
+                "ci-contains-upper",
+                r#"
+title: T
 detection:
     selection:
         CommandLine|contains: 'whoami'
     condition: selection
----
-title: Keywords
+"#,
+                json!({"CommandLine": "cmd /c WHOAMI"}),
+                true,
+            ),
+            (
+                "ci-contains-lower",
+                r#"
+title: T
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#,
+                json!({"CommandLine": "cmd /c whoami"}),
+                true,
+            ),
+            (
+                "ci-contains-miss",
+                r#"
+title: T
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+"#,
+                json!({"CommandLine": "cmd /c dir"}),
+                false,
+            ),
+            (
+                "cased-contains-exact",
+                r#"
+title: T
+detection:
+    selection:
+        CommandLine|contains|cased: 'WhoAmi'
+    condition: selection
+"#,
+                json!({"CommandLine": "prefix WhoAmi suffix"}),
+                true,
+            ),
+            (
+                "cased-contains-wrong-case",
+                r#"
+title: T
+detection:
+    selection:
+        CommandLine|contains|cased: 'WhoAmi'
+    condition: selection
+"#,
+                json!({"CommandLine": "prefix whoami suffix"}),
+                false,
+            ),
+            (
+                "ci-keyword-upper",
+                r#"
+title: T
 detection:
     keywords:
         - 'mimikatz'
     condition: keywords
 "#,
-        );
-        assert_eq!(
-            candidates(&index, &json!({"CommandLine": "WHOAMI /all"})),
-            vec![0]
-        );
-        assert_eq!(
-            candidates(&index, &json!({"payload": "MIMIKATZ.exe"})),
-            vec![1]
-        );
+                json!({"payload": "MIMIKATZ.exe"}),
+                true,
+            ),
+            (
+                "ci-keyword-lower",
+                r#"
+title: T
+detection:
+    keywords:
+        - 'mimikatz'
+    condition: keywords
+"#,
+                json!({"payload": "mimikatz.exe"}),
+                true,
+            ),
+            (
+                "ci-unicode-contains",
+                r#"
+title: T
+detection:
+    selection:
+        User|contains: 'Ärzte'
+    condition: selection
+"#,
+                json!({"User": "gruppe Ärzte west"}),
+                true,
+            ),
+            (
+                "ci-unicode-contains-folded-haystack",
+                r#"
+title: T
+detection:
+    selection:
+        User|contains: 'ärzte'
+    condition: selection
+"#,
+                json!({"User": "gruppe ÄRZTE west"}),
+                true,
+            ),
+            (
+                "ci-exact-mixed-case",
+                r#"
+title: T
+detection:
+    selection:
+        Image: 'Cmd.EXE'
+    condition: selection
+"#,
+                json!({"Image": "cmd.exe"}),
+                true,
+            ),
+            (
+                "cased-exact-match",
+                r#"
+title: T
+detection:
+    selection:
+        Image|cased: 'Cmd.exe'
+    condition: selection
+"#,
+                json!({"Image": "Cmd.exe"}),
+                true,
+            ),
+            (
+                "cased-exact-wrong-case",
+                r#"
+title: T
+detection:
+    selection:
+        Image|cased: 'Cmd.exe'
+    condition: selection
+"#,
+                json!({"Image": "cmd.exe"}),
+                false,
+            ),
+        ];
+
+        for (name, yaml, event_json, expect_match) in cases {
+            let (engine, index) = build(yaml);
+            let event = JsonEvent::borrow(event_json);
+            let matched = !engine.evaluate(&event).is_empty();
+            assert_eq!(
+                matched, *expect_match,
+                "{name}: engine match expectation drifted"
+            );
+            let selected = index.candidates(&event);
+            if matched {
+                assert!(
+                    selected.contains(&0),
+                    "{name}: index dropped a true engine match; candidates={selected:?}"
+                );
+            }
+        }
     }
 
     /// Matchers whose value space the index cannot enumerate still gate on

--- a/crates/rsigma-eval/src/candidate_index.rs
+++ b/crates/rsigma-eval/src/candidate_index.rs
@@ -25,8 +25,8 @@
 //! `engine::diff_tests` hold that line against a full scan.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 
+use ahash::{HashMap, HashMapExt};
 use aho_corasick::{AhoCorasick, MatchKind};
 use rsigma_parser::fieldpath::{first_unescaped, unescape_brackets};
 
@@ -95,8 +95,13 @@ impl NeedleSet {
         // `Standard` is the only match kind that supports overlapping
         // iteration, and overlapping is required: a needle wholly contained
         // in another must still select its own rules.
+        //
+        // Witness needles are stored folded. ASCII case-insensitive search
+        // lets the hot path scan the original haystack without allocating a
+        // lowercase copy; non-ASCII haystacks still fold once before search.
         let automaton = AhoCorasick::builder()
             .match_kind(MatchKind::Standard)
+            .ascii_case_insensitive(true)
             .build(&patterns)
             .ok()?;
 
@@ -106,7 +111,21 @@ impl NeedleSet {
         })
     }
 
+    /// Mark rules whose needles occur in `haystack`.
+    ///
+    /// ASCII haystacks are searched in place (automaton is ASCII
+    /// case-insensitive). Non-ASCII haystacks are Unicode-folded once so
+    /// already-folded Unicode needles still match.
     fn mark(&self, haystack: &str, out: &mut CandidateSet) {
+        if haystack.is_ascii() {
+            self.mark_haystack(haystack, out);
+        } else {
+            let folded = ascii_lowercase_cow(haystack);
+            self.mark_haystack(folded.as_ref(), out);
+        }
+    }
+
+    fn mark_haystack(&self, haystack: &str, out: &mut CandidateSet) {
         for m in self.automaton.find_overlapping_iter(haystack) {
             if let Some(rules) = self.pattern_to_rules.get(m.pattern().as_usize()) {
                 out.extend(rules);
@@ -460,29 +479,36 @@ impl CandidateIndex {
             return;
         }
 
+        let has_exact = !entry.exact.is_empty();
+        let needles = entry.needles.as_ref();
+
         // Every string form the matchers would compare against: scalars
         // by their textual form, arrays member by member.
-        let mut projections: Vec<Cow<'_, str>> = Vec::new();
-        collect_projections(&value, &mut projections);
-        for projection in &projections {
-            let folded = ascii_lowercase_cow(projection);
-            if let Some(rules) = entry.exact.get(folded.as_ref()) {
-                set.extend(rules);
+        for_each_projection(&value, &mut |projection| {
+            if has_exact {
+                // Exact maps are keyed by folded literals; fold once and
+                // reuse the same bytes for substring marking.
+                let folded = ascii_lowercase_cow(projection);
+                if let Some(rules) = entry.exact.get(folded.as_ref()) {
+                    set.extend(rules);
+                }
+                if let Some(needles) = needles {
+                    needles.mark_haystack(folded.as_ref(), set);
+                }
+            } else if let Some(needles) = needles {
+                // Substring-only: ASCII case-insensitive AC scans in place.
+                needles.mark(projection, set);
             }
-            if let Some(needles) = &entry.needles {
-                needles.mark(folded.as_ref(), set);
-            }
-        }
+        });
     }
 
     fn collect_keyword_hits(&self, event: &impl Event, set: &mut CandidateSet) {
         let Some(keyword) = &self.keyword else {
             return;
         };
-        for value in event.all_string_values() {
-            let folded = ascii_lowercase_cow(&value);
-            keyword.mark(folded.as_ref(), set);
-        }
+        event.visit_string_values(&mut |value| {
+            keyword.mark(value, set);
+        });
     }
 
     /// Number of always-evaluated rules an event with `event_product` skips.
@@ -561,15 +587,15 @@ fn positional_root_key(field: &str) -> Option<Cow<'_, str>> {
 /// Collect the string forms of an event value that a matcher would compare
 /// against, mirroring the evaluator's own coercion: numbers and bools by
 /// their textual form, arrays member by member, objects and nulls not at all.
-fn collect_projections<'a>(value: &'a EventValue<'a>, out: &mut Vec<Cow<'a, str>>) {
+fn for_each_projection(value: &EventValue<'_>, visit: &mut dyn FnMut(&str)) {
     match value {
-        EventValue::Str(s) => out.push(Cow::Borrowed(s.as_ref())),
-        EventValue::Int(n) => out.push(Cow::Owned(n.to_string())),
-        EventValue::Float(f) => out.push(Cow::Owned(f.to_string())),
-        EventValue::Bool(b) => out.push(Cow::Borrowed(if *b { "true" } else { "false" })),
+        EventValue::Str(s) => visit(s.as_ref()),
+        EventValue::Int(n) => visit(&n.to_string()),
+        EventValue::Float(f) => visit(&f.to_string()),
+        EventValue::Bool(b) => visit(if *b { "true" } else { "false" }),
         EventValue::Array(members) => {
             for member in members {
-                collect_projections(member, out);
+                for_each_projection(member, visit);
             }
         }
         _ => {}
@@ -721,6 +747,35 @@ detection:
             vec![0]
         );
         assert!(candidates(&index, &json!({"anything": "benign"})).is_empty());
+    }
+
+    /// ASCII case-insensitive automata must select on the original haystack
+    /// casing; folding is only required for non-ASCII event text.
+    #[test]
+    fn substring_and_keyword_select_on_ascii_uppercase_haystack() {
+        let (_, index) = build(
+            r#"
+title: Contains
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+---
+title: Keywords
+detection:
+    keywords:
+        - 'mimikatz'
+    condition: keywords
+"#,
+        );
+        assert_eq!(
+            candidates(&index, &json!({"CommandLine": "WHOAMI /all"})),
+            vec![0]
+        );
+        assert_eq!(
+            candidates(&index, &json!({"payload": "MIMIKATZ.exe"})),
+            vec![1]
+        );
     }
 
     /// Matchers whose value space the index cannot enumerate still gate on

--- a/crates/rsigma-eval/src/event/json.rs
+++ b/crates/rsigma-eval/src/event/json.rs
@@ -109,6 +109,18 @@ impl<'a> Event for JsonEvent<'a> {
         }
     }
 
+    fn visit_top_level_keys(&self, visit: &mut dyn FnMut(&str)) -> bool {
+        match self.inner.as_ref() {
+            Value::Object(map) => {
+                for key in map.keys() {
+                    visit(key.as_str());
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Check if any string value in the event satisfies a predicate.
     ///
     /// Short-circuits on the first match, avoiding the allocation of

--- a/crates/rsigma-eval/src/event/json.rs
+++ b/crates/rsigma-eval/src/event/json.rs
@@ -128,6 +128,10 @@ impl<'a> Event for JsonEvent<'a> {
         values
     }
 
+    fn visit_string_values(&self, visit: &mut dyn FnMut(&str)) {
+        visit_string_values_json(&self.inner, visit, MAX_NESTING_DEPTH);
+    }
+
     fn to_json(&self) -> Value {
         self.inner.as_ref().clone()
     }
@@ -327,6 +331,26 @@ fn collect_string_values_json<'a>(v: &'a Value, out: &mut Vec<Cow<'a, str>>, dep
         Value::Array(arr) => {
             for val in arr {
                 collect_string_values_json(val, out, depth - 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn visit_string_values_json(v: &Value, visit: &mut dyn FnMut(&str), depth: usize) {
+    if depth == 0 {
+        return;
+    }
+    match v {
+        Value::String(s) => visit(s.as_str()),
+        Value::Object(map) => {
+            for val in map.values() {
+                visit_string_values_json(val, visit, depth - 1);
+            }
+        }
+        Value::Array(arr) => {
+            for val in arr {
+                visit_string_values_json(val, visit, depth - 1);
             }
         }
         _ => {}

--- a/crates/rsigma-eval/src/event/mapped.rs
+++ b/crates/rsigma-eval/src/event/mapped.rs
@@ -61,6 +61,10 @@ impl<E: Event + ?Sized> Event for MappedEvent<'_, E> {
         self.inner.all_string_values()
     }
 
+    fn visit_string_values(&self, visit: &mut dyn FnMut(&str)) {
+        self.inner.visit_string_values(visit)
+    }
+
     fn to_json(&self) -> Value {
         self.inner.to_json()
     }

--- a/crates/rsigma-eval/src/event/mapped.rs
+++ b/crates/rsigma-eval/src/event/mapped.rs
@@ -72,6 +72,14 @@ impl<E: Event + ?Sized> Event for MappedEvent<'_, E> {
     fn field_keys(&self) -> Vec<Cow<'_, str>> {
         self.inner.field_keys()
     }
+
+    fn top_level_keys(&self) -> Option<Vec<Cow<'_, str>>> {
+        self.inner.top_level_keys()
+    }
+
+    fn visit_top_level_keys(&self, visit: &mut dyn FnMut(&str)) -> bool {
+        self.inner.visit_top_level_keys(visit)
+    }
 }
 
 #[cfg(test)]

--- a/crates/rsigma-eval/src/event/mod.rs
+++ b/crates/rsigma-eval/src/event/mod.rs
@@ -175,7 +175,7 @@ pub trait Event {
     /// Visit every string value in the event without collecting them.
     ///
     /// Used by the keyword candidate index. The default walks
-    /// [`all_string_values`]; concrete types override to avoid the `Vec`.
+    /// [`Self::all_string_values`]; concrete types override to avoid the `Vec`.
     fn visit_string_values(&self, visit: &mut dyn FnMut(&str)) {
         for value in self.all_string_values() {
             visit(value.as_ref());
@@ -212,6 +212,21 @@ pub trait Event {
     /// probed. The default is `None`.
     fn top_level_keys(&self) -> Option<Vec<Cow<'_, str>>> {
         None
+    }
+
+    /// Visit top-level object keys without collecting them.
+    ///
+    /// Returns `false` when the shape is unknown (same meaning as
+    /// [`Self::top_level_keys`] returning `None`). The default collects via
+    /// `top_level_keys`.
+    fn visit_top_level_keys(&self, visit: &mut dyn FnMut(&str)) -> bool {
+        let Some(keys) = self.top_level_keys() else {
+            return false;
+        };
+        for key in keys {
+            visit(key.as_ref());
+        }
+        true
     }
 }
 
@@ -276,6 +291,10 @@ impl<T: Event + ?Sized> Event for &T {
 
     fn top_level_keys(&self) -> Option<Vec<Cow<'_, str>>> {
         (**self).top_level_keys()
+    }
+
+    fn visit_top_level_keys(&self, visit: &mut dyn FnMut(&str)) -> bool {
+        (**self).visit_top_level_keys(visit)
     }
 }
 

--- a/crates/rsigma-eval/src/event/mod.rs
+++ b/crates/rsigma-eval/src/event/mod.rs
@@ -172,6 +172,16 @@ pub trait Event {
     /// Collect all string values in the event.
     fn all_string_values(&self) -> Vec<Cow<'_, str>>;
 
+    /// Visit every string value in the event without collecting them.
+    ///
+    /// Used by the keyword candidate index. The default walks
+    /// [`all_string_values`]; concrete types override to avoid the `Vec`.
+    fn visit_string_values(&self, visit: &mut dyn FnMut(&str)) {
+        for value in self.all_string_values() {
+            visit(value.as_ref());
+        }
+    }
+
     /// Materialize the event as a `serde_json::Value`.
     fn to_json(&self) -> Value;
 
@@ -250,6 +260,10 @@ impl<T: Event + ?Sized> Event for &T {
 
     fn all_string_values(&self) -> Vec<Cow<'_, str>> {
         (**self).all_string_values()
+    }
+
+    fn visit_string_values(&self, visit: &mut dyn FnMut(&str)) {
+        (**self).visit_string_values(visit)
     }
 
     fn to_json(&self) -> Value {


### PR DESCRIPTION
## Summary
- NeedleSet automata use ASCII case-insensitive search and prefer a DFA, so ASCII haystacks skip fold allocations; non-ASCII still folds once.
- `Event::visit_string_values` / `visit_top_level_keys` avoid collecting `Vec`s on the candidate hot path; exact+substring fields fold once; maps use `ahash`.
- Daemon evaluate→dispatch handoff (capacity 1) lets batch N+1 run while batch N dispatches, without reordering correlation or sink output.
- Case matrix: ASCII upper/lower, `|cased`, and non-ASCII CI; index never drops a true engine match. Rustdoc intra-doc link fixed.

## Measured
Pinned SigmaHQ `raw_windows --logsource-routing`, batch 512, 16 k6 VUs, median of three same-machine runs versus post-#419:

| Threads | Before | After |
|---|---:|---:|
| 1 | ~102k eps | ~118k eps |
| 8 | ~404k eps | ~467k eps |

Efficiency remains ~49%. Dispatch share at eight threads moved from ~8% to ~6% of measured batch phases.

## Test plan
- [x] `case_folding_matrix_never_drops_true_matches` (CI/cased/Unicode)
- [x] `cargo test -p rsigma-eval --lib candidate_index`
- [x] `cargo test -p rsigma-eval --lib engine::diff_tests`
- [x] `RUSTDOCFLAGS='-D warnings -D rustdoc::broken-intra-doc-links' cargo doc -p rsigma-eval --all-features --no-deps`
- [x] `cargo clippy -p rsigma-eval -p rsigma --all-targets --all-features -- -D warnings`
- [ ] CI regression gate on the PR