### PR TITLE
ci(perf): gate Linux artifact scaling

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  labels:
+    - rsigma-perf-amd64-8
+    - rsigma-perf-arm64-8
+
+config-variables: null
+
+paths:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -156,3 +156,118 @@ jobs:
           path: ${{ runner.temp }}/performance/
           if-no-files-found: error
           retention-days: 90
+
+  artifact-scaling:
+    name: Artifact scaling (${{ matrix.arch }})
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ fromJSON(matrix.runner) }}
+    timeout-minutes: 90
+    env:
+      ARTIFACT_ARCH: ${{ matrix.arch }}
+    permissions:
+      contents: read # checkout the trusted scheduled/manually selected revision
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: '["non-prod"]'
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            runner: '["self-hosted","Linux","ARM64"]'
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Rust stable and target
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
+          rustup target add "${TARGET}"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Verify performance runner
+        run: |
+          cores="$(nproc)"
+          if [ "${cores}" -lt 8 ]; then
+            echo "artifact scaling requires at least 8 logical CPUs, found ${cores}" >&2
+            exit 1
+          fi
+      - name: Prepare fixtures and artifacts
+        run: |
+          mkdir -p "${RUNNER_TEMP}/performance"
+          scripts/perf/fetch-fixtures.sh "${RUNNER_TEMP}/fixtures" 2000
+      - name: Build glibc release artifact
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --all-features --locked --target "${TARGET}" -p rsigma
+      - name: Build and extract musl image artifact
+        env:
+          IMAGE: rsigma:perf-musl-${{ matrix.arch }}-${{ github.run_id }}
+        run: |
+          docker build --load -t "${IMAGE}" .
+          container="$(docker create "${IMAGE}")"
+          trap 'docker rm -f "${container}" >/dev/null 2>&1 || true' EXIT
+          docker cp "${container}:/rsigma" "${RUNNER_TEMP}/rsigma-musl"
+          chmod +x "${RUNNER_TEMP}/rsigma-musl"
+      - name: Compare glibc in-flight depths
+        env:
+          BATCH: "500"
+          BATCH_SIZE: "512"
+          DURATION: 10s
+          LOAD_DRIVER: python
+          MAX_BACKPRESSURE_DELTA: "0.008"
+          MINIMUM_RATIO: "0.98"
+          RAYON_NUM_THREADS: "8"
+          RUNS: "5"
+          VUS: "16"
+          TARGET: ${{ matrix.target }}
+        run: |
+          scripts/perf/inflight-compare.sh \
+            "${RUNNER_TEMP}/fixtures" \
+            "target/${TARGET}/release/rsigma" \
+            | tee "${RUNNER_TEMP}/performance/glibc-${ARTIFACT_ARCH}.tsv"
+      - name: Compare musl in-flight depths
+        env:
+          BATCH: "500"
+          BATCH_SIZE: "512"
+          DURATION: 10s
+          LOAD_DRIVER: python
+          MAX_BACKPRESSURE_DELTA: "0.008"
+          MINIMUM_RATIO: "0.98"
+          RAYON_NUM_THREADS: "8"
+          RUNS: "5"
+          VUS: "16"
+        run: |
+          scripts/perf/inflight-compare.sh \
+            "${RUNNER_TEMP}/fixtures" \
+            "${RUNNER_TEMP}/rsigma-musl" \
+            | tee "${RUNNER_TEMP}/performance/musl-${ARTIFACT_ARCH}.tsv"
+      - name: Record environment
+        if: always()
+        run: |
+          {
+            echo "sha=${GITHUB_SHA}"
+            uname -a
+            nproc
+            lscpu
+            rustc --version --verbose
+            docker version
+          } > "${RUNNER_TEMP}/performance/environment-${ARTIFACT_ARCH}.txt"
+      - name: Remove benchmark image
+        if: always()
+        env:
+          IMAGE: rsigma:perf-musl-${{ matrix.arch }}-${{ github.run_id }}
+        run: docker image rm -f "${IMAGE}" >/dev/null 2>&1 || true
+      - name: Upload artifact measurements
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: artifact-scaling-${{ matrix.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/performance/
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -160,7 +160,7 @@ jobs:
   artifact-scaling:
     name: Artifact scaling (${{ matrix.arch }})
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ fromJSON(matrix.runner) }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     env:
       ARTIFACT_ARCH: ${{ matrix.arch }}
@@ -171,10 +171,10 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: '["non-prod"]'
+            runner: rsigma-perf-amd64-8
             target: x86_64-unknown-linux-gnu
           - arch: arm64
-            runner: '["self-hosted","Linux","ARM64"]'
+            runner: rsigma-perf-arm64-8
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Cross-architecture artifact scaling gate
+
+The weekly/manual performance workflow now compares detection depths 4 and 5 on dedicated eight-core amd64 and arm64 runners for both native glibc release binaries and static musl image binaries. Alternating five-run samples gate on a 0.98 throughput ratio and no more than a 0.8 percentage-point increase in backpressure. The first four-row validation retained depth 5 with throughput ratios from 0.9985x to 1.0201x and lower backpressure in every row.
+
 ### Deeper concurrent detection pipeline (#428)
 
 Detection-only daemons with eight or more rayon workers now keep five batches in flight by default instead of four. The sequence-numbered reducer continues to restore sink and ack order, correlation engines remain single-batch, and `RSIGMA_DETECT_INFLIGHT` still overrides the default up to 8. On the pinned SigmaHQ raw Windows workload with `--logsource-routing`, `--batch-size 512`, eight rayon threads, and 16 k6 VUs, order-balanced same-machine runs improved median throughput from about 665k to 708k events/s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Cross-architecture artifact scaling gate
+### Cross-architecture artifact scaling gate (#429)
 
 The weekly/manual performance workflow now compares detection depths 4 and 5 on dedicated eight-core amd64 and arm64 runners for both native glibc release binaries and static musl image binaries. Alternating five-run samples gate on a 0.98 throughput ratio and no more than a 0.8 percentage-point increase in backpressure. The first four-row validation retained depth 5 with throughput ratios from 0.9985x to 1.0201x and lower backpressure in every row.
 

--- a/docs/content/developers/testing.md
+++ b/docs/content/developers/testing.md
@@ -12,7 +12,7 @@ The workspace runs six tiers of tests, all gated in CI. PRs are expected to pass
 | Snapshot / golden | `crates/rsigma-{parser,eval,convert}/tests/snapshots/`, `tests/fixtures/dynamic-pipelines/golden/` | `cargo test` plus the SigmaHQ-corpus job for the dynamic-pipelines goldens. | `test` and `sigma-corpus` jobs. |
 | SigmaHQ corpus | `.github/workflows/ci.yml` -> `sigma-corpus` | `cargo build --release --all-features --locked -p rsigma` then `target/release/rsigma rule validate /tmp/sigma/rules/ --verbose` | `sigma-corpus` job, on every PR. |
 | Coverage | `cargo-llvm-cov` (Linux) | `cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info` | `coverage` job (advisory, not gating). |
-| Representative performance | `.github/workflows/performance.yml`, `scripts/perf/` | `scripts/perf/fetch-fixtures.sh` then the offline and daemon harnesses | Coarse same-runner base/PR gate; weekly full matrix with retained artifacts. |
+| Representative performance | `.github/workflows/performance.yml`, `scripts/perf/` | `scripts/perf/fetch-fixtures.sh` then the offline and daemon harnesses | Coarse same-runner base/PR gate; weekly full matrix plus native glibc/static musl scaling on dedicated eight-core amd64/arm64 runners. |
 
 ## Unit tests
 
@@ -200,6 +200,8 @@ Criterion microbenchmarks are not gated in CI. The numbers in [Benchmarks](../be
 The Criterion suites use synthetic, mostly exact-match-indexable rules, so they measure hot paths, not representative corpus throughput. For a representative before/after, materialize the pinned SigmaHQ workload with `scripts/perf/fetch-fixtures.sh` and run `scripts/perf/baseline-eval.sh` (offline eval matrix, single core, net of rule load) and `scripts/perf/daemon-matrix.sh` (daemon HTTP end to end across lanes and flag variants, wrapping `scripts/perf/baseline-daemon.sh`). Both take an `RSIGMA` override, so a pre-change build can be measured through the same harness for an honest before-and-after. The daemon matrix includes `--include-event` variants, including the match-heavy lane where event cloning matters most, and a handcrafted event-count/value-count/value-sum/temporal-ordered correlation lane because the pinned SigmaHQ tree contains no correlation rules.
 
 The Performance workflow builds the PR and its base revision on the same GitHub-hosted runner, runs the load-corrected median-of-three offline matrix through one checked-in harness, verifies match counts, and rejects only a head/base EPS ratio below 0.5. That intentionally coarse floor catches order-of-magnitude regressions without pretending shared-runner noise can support fine-grained gating. A weekly/manual job runs five samples of the full offline matrix, reports a deterministic bootstrap 95% confidence interval, runs the daemon matrix, and retains the raw artifacts for 90 days.
+
+Weekly/manual runs also build native glibc and static musl image binaries on dedicated eight-core amd64 and arm64 runners. `scripts/perf/inflight-compare.sh` alternates five samples each at detection depths 4 and 5, then rejects a depth-5 throughput ratio below 0.98 or a backpressure-rate increase above 0.008. This gate covers the allocator and architecture behavior that the native PR comparison cannot observe.
 
 The production candidate index is measured directly, rather than inferred from the witness-audit simulation:
 

--- a/scripts/perf/baseline-daemon.sh
+++ b/scripts/perf/baseline-daemon.sh
@@ -45,6 +45,10 @@ count_processed() {
     curl -sf "${metrics}" | awk '/^rsigma_events_processed_total/ {sum += $2} END {printf "%d", sum}'
 }
 
+count_backpressure() {
+    curl -sf "${metrics}" | awk '/^rsigma_back_pressure_events_total/ {sum += $2} END {printf "%d", sum}'
+}
+
 phase_seconds() {
     curl -sf "${metrics}" | awk -v phase="$1" '
         $1 == "rsigma_batch_phase_duration_seconds_sum{phase=\"" phase "\"}" {
@@ -56,6 +60,7 @@ phase_seconds() {
 }
 
 before="$(count_processed)"
+backpressure_before="$(count_backpressure)"
 phase_before=()
 for phase in "${phases[@]}"; do
     phase_before+=("$(phase_seconds "${phase}")")
@@ -95,18 +100,22 @@ for _ in $(seq 1 60); do
 done
 end="$(python3 -c 'import time; print(time.time())')"
 after="$(count_processed)"
+backpressure_after="$(count_backpressure)"
 phase_after=()
 for phase in "${phases[@]}"; do
     phase_after+=("$(phase_seconds "${phase}")")
 done
 
-python3 - "$before" "$after" "$start" "$end" "$lane" "${phases[@]}" -- \
+python3 - "$before" "$after" "$backpressure_before" "$backpressure_after" \
+    "$start" "$end" "$lane" "${phases[@]}" -- \
     "${phase_before[@]}" -- "${phase_after[@]}" <<'PY'
 import sys
 
 args = sys.argv[1:]
 before = int(args.pop(0))
 after = int(args.pop(0))
+backpressure_before = int(args.pop(0))
+backpressure_after = int(args.pop(0))
 start = float(args.pop(0))
 end = float(args.pop(0))
 lane = args.pop(0)
@@ -119,6 +128,7 @@ before_vals = [float(v) for v in args[:sep]]
 after_vals = [float(v) for v in args[sep + 1 :]]
 
 n = after - before
+backpressure = backpressure_after - backpressure_before
 secs = end - start
 deltas = [after_vals[i] - before_vals[i] for i in range(len(phases))]
 measured = sum(deltas)
@@ -130,7 +140,7 @@ phase_parts = " ".join(
     for phase, delta, share in zip(phases, deltas, shares)
 )
 print(
-    f"lane={lane} processed={n} wall={secs:.1f}s eps={n / max(secs, 1e-9):.0f} "
-    f"{phase_parts}"
+    f"lane={lane} processed={n} backpressure={backpressure} "
+    f"wall={secs:.1f}s eps={n / max(secs, 1e-9):.0f} {phase_parts}"
 )
 PY

--- a/scripts/perf/inflight-compare.sh
+++ b/scripts/perf/inflight-compare.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Compare two detection-only in-flight depths on one release artifact.
+#
+# Usage:
+#   scripts/perf/inflight-compare.sh FIXTURES BINARY [EXTRA_DAEMON_FLAGS...]
+#
+# Environment: BASE_DEPTH (4), CANDIDATE_DEPTH (5), RUNS (5),
+#              MINIMUM_RATIO (1.0), MAX_BACKPRESSURE_DELTA (0.008), and all
+#              baseline-daemon.sh load controls.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixtures="${1:?fixtures directory required}"
+binary="${2:?release binary required}"
+shift 2
+
+base_depth="${BASE_DEPTH:-4}"
+candidate_depth="${CANDIDATE_DEPTH:-5}"
+runs="${RUNS:-5}"
+minimum_ratio="${MINIMUM_RATIO:-1.0}"
+max_backpressure_delta="${MAX_BACKPRESSURE_DELTA:-0.008}"
+results="$(mktemp)"
+trap 'rm -f "${results}"' EXIT
+
+[ -x "${binary}" ] || { echo "binary is not executable: ${binary}" >&2; exit 1; }
+
+run_one() {
+    local depth="$1" run="$2" line eps processed backpressure
+    shift 2
+    line="$(
+        RAYON_NUM_THREADS="${RAYON_NUM_THREADS:-8}" \
+        RSIGMA_DETECT_INFLIGHT="${depth}" \
+        LOAD_DRIVER="${LOAD_DRIVER:-python}" \
+        RSIGMA="${binary}" \
+            "${script_dir}/baseline-daemon.sh" \
+            "${fixtures}" raw_windows --logsource-routing "$@"
+    )"
+    echo "${line}" >&2
+    eps="$(awk '{for (i=1;i<=NF;i++) if ($i ~ /^eps=/) {sub("eps=", "", $i); print $i; exit}}' <<<"${line}")"
+    processed="$(awk '{for (i=1;i<=NF;i++) if ($i ~ /^processed=/) {sub("processed=", "", $i); print $i; exit}}' <<<"${line}")"
+    backpressure="$(awk '{for (i=1;i<=NF;i++) if ($i ~ /^backpressure=/) {sub("backpressure=", "", $i); print $i; exit}}' <<<"${line}")"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "${depth}" "${run}" "${eps}" "${processed}" "${backpressure}" >>"${results}"
+}
+
+for run in $(seq 1 "${runs}"); do
+    if ((run % 2 == 1)); then
+        run_one "${base_depth}" "${run}" "$@"
+        run_one "${candidate_depth}" "${run}" "$@"
+    else
+        run_one "${candidate_depth}" "${run}" "$@"
+        run_one "${base_depth}" "${run}" "$@"
+    fi
+done
+
+python3 - "${results}" "${base_depth}" "${candidate_depth}" \
+    "${minimum_ratio}" "${max_backpressure_delta}" <<'PY'
+import statistics
+import sys
+
+path, base_depth, candidate_depth, minimum_ratio, max_bp_delta = sys.argv[1:]
+rows = {base_depth: [], candidate_depth: []}
+with open(path, encoding="utf-8") as source:
+    for line in source:
+        depth, run, eps, processed, backpressure = line.rstrip().split("\t")
+        rows[depth].append(
+            {
+                "run": int(run),
+                "eps": float(eps),
+                "processed": int(processed),
+                "backpressure": int(backpressure),
+            }
+        )
+
+for depth, samples in rows.items():
+    if not samples:
+        raise SystemExit(f"no samples for depth {depth}")
+
+def med(depth, key):
+    return statistics.median(sample[key] for sample in rows[depth])
+
+base_eps = med(base_depth, "eps")
+candidate_eps = med(candidate_depth, "eps")
+base_bp = statistics.median(
+    sample["backpressure"] / max(sample["processed"], 1)
+    for sample in rows[base_depth]
+)
+candidate_bp = statistics.median(
+    sample["backpressure"] / max(sample["processed"], 1)
+    for sample in rows[candidate_depth]
+)
+ratio = candidate_eps / base_eps
+bp_delta = candidate_bp - base_bp
+
+print("depth\teps_median\tbackpressure_rate")
+print(f"{base_depth}\t{base_eps:.0f}\t{base_bp:.6f}")
+print(f"{candidate_depth}\t{candidate_eps:.0f}\t{candidate_bp:.6f}")
+print(f"ratio\t{ratio:.4f}\tbackpressure_delta={bp_delta:.6f}")
+
+failures = []
+if ratio < float(minimum_ratio):
+    failures.append(
+        f"throughput ratio {ratio:.4f} is below {float(minimum_ratio):.4f}"
+    )
+if bp_delta > float(max_bp_delta):
+    failures.append(
+        f"backpressure delta {bp_delta:.6f} exceeds {float(max_bp_delta):.6f}"
+    )
+if failures:
+    raise SystemExit("; ".join(failures))
+PY


### PR DESCRIPTION
## Summary
- Compare detection depths 4 and 5 on dedicated eight-core amd64 and arm64 runners for native glibc and static musl binaries.
- Gate weekly/manual runs at a 0.98 throughput ratio and a 0.8 percentage-point backpressure increase, with alternating five-run samples and retained raw measurements.
- Record the first validation: 0.9985x-1.0201x throughput and improved backpressure across all four architecture/libc rows.

## Test plan
- [x] Run the four-row artifact comparison on the dedicated runners: https://github.com/timescale/rsigma/actions/runs/30627985936
- [x] Run `actionlint .github/workflows/performance.yml`
- [x] Run `zizmor --pedantic .github/workflows/performance.yml`
- [x] Run ShellCheck on both performance scripts
- [x] Run `cargo fmt --all -- --check`
- [x] Run workspace Clippy with all targets/features and warnings denied
- [x] Build workspace documentation with all features
- [x] Build and validate the documentation site