### PR TITLE
test(rstix): OASIS §3.2 Campaign Sharing interop use-case tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### rstix: OASIS §3.2 Campaign interop use-case tests
+
+- Adds `tests/interop/use_cases/campaign/` covering §3.2.1–§3.2.6 against normative §3.2.3 fixtures and non-gating `examples/campaign/` data (CSD01 has no §3.2.7).
+- §3.2.1 description scope is **TESTED**: normative fixtures expose typed Campaign “Green Group Attacks Against Finance”.
+- Producer `REQ-3.2-P-01`..`P-11`, Consumer `REQ-3.2-C-01`..`C-05`, checklist `REQ-CHK-SXP-3.2` / `REQ-CHK-SXC-3.2`, examples `REQ-3.2-EX-4.1` / `EX-4.2`.
+- Table 4 CSD01 typo (`type` = `threat-actor`) is documented; tests enforce STIX §4.2 `campaign`.
+- Not OASIS SXP/SXC certification (**2/21** use cases).
+
 ### Dependency batch (Aug 2026) (#432)
 
 Rolls up four open Dependabot PRs into a single merge. Rust (workspace `Cargo.lock`, with `ci/wasm-smoke/Cargo.lock` and `fuzz/Cargo.lock` synced for the `base64` bump): the patch group (#422) updates `pest`/`pest_derive` 2.8.7 to 2.8.8, `serde_json` 1.0.150 to 1.0.151, `jsonpath-rust` 1.0.5 to 1.0.6, `tokio-stream` 0.1.18 to 0.1.19, `time` 0.3.53 to 0.3.54, `jsonschema` 0.48.1 to 0.48.5, `clap` 4.6.2 to 4.6.4, and `rustls-pki-types` 1.15.0 to 1.15.1; standalone updates move `base64` 0.22.1 to 0.23.0 (#423) and `toml` 0.8.23 to 1.1.3+spec-1.1.0 (#424). CI (all repinned by commit SHA, batched via the `actions-updates` group, #421): `actions/checkout` v7.0.0 to v7.0.1, `taiki-e/install-action` v2.83.3 to v2.85.0, `docker/login-action` v4.4.0 to v4.5.0, `github/codeql-action/upload-sarif` v4.37.1 to v4.37.3, and `zizmorcore/zizmor-action` v0.6.0 to v0.6.1. Held back: `rusqlite` 0.40.1 (#234) requires Rust 1.89 while the workspace MSRV is Rust 1.88; `tikv-jemallocator` 0.7.0 (#425, jemalloc 5.3.1) regresses musl routed daemon throughput about 4-7% versus 0.6.1 (jemalloc 5.3.0) in same-host `scripts/perf/image-compare.sh` runs while still scaling about 4x from one to six rayon threads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 - §3.2.1 description scope is **TESTED**: normative fixtures expose typed Campaign “Green Group Attacks Against Finance”.
 - Producer `REQ-3.2-P-01`..`P-11`, Consumer `REQ-3.2-C-01`..`C-05`, checklist `REQ-CHK-SXP-3.2` / `REQ-CHK-SXC-3.2`, examples `REQ-3.2-EX-4.1` / `EX-4.2`.
 - Table 4 CSD01 typo (`type` = `threat-actor`) is documented; tests enforce STIX §4.2 `campaign`.
+- Tightens the equivalent §3.1 Attack Pattern rows in the same pass: `P-02` pins that caller selection renames exactly one object and that the selected name survives parse and re-validation, and `P-07` reads the id from the wire use-case object so its parse no longer restates a parse the typed lookup already performed. The RFC 3339 millisecond check both use cases share now lives in `tests/interop/common/timestamp.rs`.
 - Not OASIS SXP/SXC certification (**2/21** use cases).
 
 ### Dependency batch (Aug 2026) (#432)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### rstix: OASIS §3.2 Campaign interop use-case tests
+### rstix: OASIS §3.2 Campaign interop use-case tests (#433)
 
 - Adds `tests/interop/use_cases/campaign/` covering §3.2.1–§3.2.6 against normative §3.2.3 fixtures and non-gating `examples/campaign/` data (CSD01 has no §3.2.7).
 - §3.2.1 description scope is **TESTED**: normative fixtures expose typed Campaign “Green Group Attacks Against Finance”.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ### rstix: OASIS §3.2 Campaign interop use-case tests (#433)
 
-- Adds `tests/interop/use_cases/campaign/` covering §3.2.1–§3.2.6 against normative §3.2.3 fixtures and non-gating `examples/campaign/` data (CSD01 has no §3.2.7).
+- Adds `tests/interop/use_cases/campaign/` covering §3.2.1–§3.2.6 against normative §3.2.3 fixtures and non-gating `examples/campaign/` data.
 - §3.2.1 description scope is **TESTED**: normative fixtures expose typed Campaign “Green Group Attacks Against Finance”.
 - Producer `REQ-3.2-P-01`..`P-11`, Consumer `REQ-3.2-C-01`..`C-05`, checklist `REQ-CHK-SXP-3.2` / `REQ-CHK-SXC-3.2`, examples `REQ-3.2-EX-4.1` / `EX-4.2`.
 - Table 4 CSD01 typo (`type` = `threat-actor`) is documented; tests enforce STIX §4.2 `campaign`.

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -900,7 +900,7 @@ Test harness aligned with **STIX 2.1 Interoperability Version 1.0, Committee Spe
 | --------- | ---- | ---- |
 | Harness | `tests/interop/harness/` | Manifest, fixture loader + provenance, per-use-case overlay on `interop_strict`, bundle closure, containment, certification report |
 | Cross-cutting | `tests/interop/common/` | Automated checks for 18 §2.3 manifest rows, run suite-wide over **42** walkable normative fixtures |
-| Use-case tests | `tests/interop/use_cases/` | **§3.1 Attack Pattern** (§3.1.1–§3.1.7) Producer/Consumer/example tests (**1/21** OASIS use cases today) |
+| Use-case tests | `tests/interop/use_cases/` | **§3.1 Attack Pattern** (§3.1.1–§3.1.7) and **§3.2 Campaign** (§3.2.1–§3.2.6; no §3.2.7 in CSD01) Producer/Consumer/example tests (**2/21** OASIS use cases today) |
 | Manifest | `tests/fixtures/interop/manifest.toml` | `req_id` → `test_id` → fixture → §4.2 checklist row |
 | Normative fixtures | `tests/fixtures/interop/testcases/` | Gating OASIS test-case data + `.provenance.toml` sidecars (**44/44** inventory: **42** suite-walkable + **2** `BLOCKED` on §9.1 defects 16 and 19; synthetic helpers remain for intentional negatives) |
 | Examples | `tests/fixtures/interop/examples/` | Non-normative; must never fail the build |
@@ -913,7 +913,7 @@ Test harness aligned with **STIX 2.1 Interoperability Version 1.0, Committee Spe
 | `oasis_use_cases_in_spec` | The OASIS interoperability document defines 21 use cases — **not** how many are tested here. |
 | `manifest_rows_total` | Rows in `manifest.toml` (harness + placeholders + smoke). |
 | `manifest_rows_by_disposition` | Breakdown by `TESTED`, `HARNESS_SMOKE`, `REPORT_ONLY`, `BLOCKED`. |
-| `tested_rows_passed` | Executable manifest rows with `disposition = TESTED` that recorded `Pass` (**51** today: 9 harness + 18 §2.3 + **24 §3.1 Attack Pattern**) |
+| `tested_rows_passed` | Executable manifest rows with `disposition = TESTED` that recorded `Pass` (**72** today: 9 harness + 18 §2.3 + **24 §3.1 Attack Pattern** + **21 §3.2 Campaign**) |
 | `harness_smoke_executed` | Rows with `disposition = HARNESS_SMOKE` (0 today; reserved for partial checks if reintroduced) |
 | `report_only_rows` | §4.2 checklist/framework placeholders with no automated test (**7** today) |
 | `blocked_rows` | Checklist rows blocked on unrepairable published test-case data (2 today) |

--- a/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.1-campaign-uses-an-attack-pattern.json
+++ b/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.1-campaign-uses-an-attack-pattern.json
@@ -1,0 +1,56 @@
+{
+  "type": "bundle",
+  "id": "bundle--3c2b4c1d-3c2b-4c2b-8c2b-3c2b4c1d3c2b",
+  "objects": [
+    {
+      "type": "identity",
+      "id": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "spec_version": "2.1",
+      "created": "2015-04-14T13:07:49.812Z",
+      "modified": "2015-04-14T13:07:49.812Z",
+      "name": "Oscorp Industries",
+      "identity_class": "organization",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c"
+    },
+    {
+      "type": "campaign",
+      "spec_version": "2.1",
+      "id": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "created": "2016-08-08T15:50:10.983Z",
+      "modified": "2016-08-08T15:50:10.983Z",
+      "name": "Operation Bran Flakes",
+      "description": "A concerted effort to insert false information into the BPP's web pages.",
+      "aliases": ["OBF"],
+      "first_seen": "2016-01-08T12:50:40.123Z",
+      "objective": "Hack www.bpp.bn"
+    },
+    {
+      "type": "attack-pattern",
+      "spec_version": "2.1",
+      "id": "attack-pattern--19da6e1c-71ab-4c2f-886d-d620d09d3b5a",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "created": "2016-08-08T15:50:10.983Z",
+      "modified": "2017-01-30T21:15:04.127Z",
+      "name": "Content Spoofing",
+      "external_references": [
+        {
+          "source_name": "capec",
+          "url": "https://capec.mitre.org/data/definitions/148.html",
+          "external_id": "CAPEC-148"
+        }
+      ]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--33c22977-d104-45d8-be19-273f7ab03de1",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "created": "2020-02-29T17:41:44.940Z",
+      "modified": "2020-02-29T17:41:44.940Z",
+      "relationship_type": "uses",
+      "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+      "target_ref": "attack-pattern--19da6e1c-71ab-4c2f-886d-d620d09d3b5a"
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.1-campaign-uses-an-attack-pattern.provenance.toml
+++ b/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.1-campaign-uses-an-attack-pattern.provenance.toml
@@ -1,0 +1,14 @@
+fixture = "ex-3.2.4.1-campaign-uses-an-attack-pattern.json"
+source_doc = "stix-2.1-interop-v1.0-csd01"
+source_pages = "29-30"
+source_section = "3.2.4.1"
+
+[[repair]]
+authority = "MECHANICAL"
+class = "smart-quotes"
+description = "Straighten curly quote on created_by_ref key."
+
+[[repair]]
+authority = "MECHANICAL"
+class = "no-container"
+description = "Wrap identity, campaign, attack-pattern, and relationship objects in a bundle per REQ-2.3-X-02."

--- a/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.json
+++ b/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.json
@@ -1,0 +1,52 @@
+{
+  "type": "bundle",
+  "id": "bundle--3c2b4c2d-3c2b-4c2b-8c2b-3c2b4c2d3c2b",
+  "objects": [
+    {
+      "type": "identity",
+      "id": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "spec_version": "2.1",
+      "created": "2015-04-14T13:07:49.812Z",
+      "modified": "2015-04-14T13:07:49.812Z",
+      "name": "Oscorp Industries",
+      "identity_class": "organization",
+      "contact_information": "norman@oscorp.com",
+      "sectors": ["technology"]
+    },
+    {
+      "type": "campaign",
+      "spec_version": "2.1",
+      "id": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "created": "2016-08-08T15:50:10.983Z",
+      "modified": "2016-08-08T15:50:10.983Z",
+      "name": "Operation Bran Flakes",
+      "description": "A concerted effort to insert false information into the BPP's web pages.",
+      "aliases": ["OBF"],
+      "first_seen": "2016-01-08T12:50:40.123Z",
+      "objective": "Hack www.bpp.bn"
+    },
+    {
+      "type": "threat-actor",
+      "spec_version": "2.1",
+      "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "created": "2015-05-07T14:22:14.760Z",
+      "modified": "2015-05-07T14:22:14.760Z",
+      "name": "Adversary Bravo",
+      "description": "Adversary Bravo is known to use phishing attacks to deliver remote access malware to the targets.",
+      "threat_actor_types": ["spy", "criminal"]
+    },
+    {
+      "type": "relationship",
+      "spec_version": "2.1",
+      "id": "relationship--33c22977-d104-45d8-be19-273f7ab03de1",
+      "created_by_ref": "identity--987eeee1-413a-44ac-96cc-0a8acdcc2f2c",
+      "created": "2020-02-29T17:41:44.940Z",
+      "modified": "2020-02-29T17:41:44.940Z",
+      "relationship_type": "attributed-to",
+      "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+      "target_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f"
+    }
+  ]
+}

--- a/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.provenance.toml
+++ b/crates/rstix/tests/fixtures/interop/examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.provenance.toml
@@ -1,0 +1,19 @@
+fixture = "ex-3.2.4.2-campaign-attributed-to-threat-actor.json"
+source_doc = "stix-2.1-interop-v1.0-csd01"
+source_pages = "30-31"
+source_section = "3.2.4.2"
+
+[[repair]]
+authority = "MECHANICAL"
+class = "malformed-json"
+description = "Restore the opening quote omitted on the relationship id key in the published OASIS example (id\": → \"id\":)."
+
+[[repair]]
+authority = "MECHANICAL"
+class = "no-container"
+description = "Wrap identity, campaign, threat-actor, and relationship objects in a bundle per REQ-2.3-X-02."
+
+[[divergence_recorded]]
+site = "§3.2.4.2 relationship id key"
+defect = 20
+description = "Published example omits the opening quote on the relationship id JSON key (invalid JSON)."

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -497,6 +497,32 @@ checklist_row = "3.2.3"
 checklist_role = "producer"
 verification = "Optional"
 
+# --- §3.2.4 Producer Example Data (non-gating; examples/ only) ---
+
+[[requirement]]
+req_id = "REQ-3.2-EX-4.1"
+use_case = "campaign"
+section = "3.2.4.1"
+doc_page = 29
+role = "producer"
+level = "EXAMPLE"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::campaign::examples::campaign_uses_attack_pattern"
+fixture = "examples/campaign/ex-3.2.4.1-campaign-uses-an-attack-pattern.json"
+
+[[requirement]]
+req_id = "REQ-3.2-EX-4.2"
+use_case = "campaign"
+section = "3.2.4.2"
+doc_page = 30
+role = "producer"
+level = "EXAMPLE"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::campaign::examples::campaign_attributed_to_threat_actor"
+fixture = "examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.json"
+
 [[requirement]]
 req_id = "REQ-CHK-SXC-3.3"
 use_case = "confidence"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -353,6 +353,138 @@ test_id = "use_cases::campaign::description::description_scope"
 fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
 
 [[requirement]]
+req_id = "REQ-3.2-P-01"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::create_campaign"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-02"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::select_content"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-03"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::identity_compliance"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-04"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::spec_conformance"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-05"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_type"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-06"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_spec_version"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-07"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_id"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-08"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_created_by_ref"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-09"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_created"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-10"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_modified"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
+req_id = "REQ-3.2-P-11"
+use_case = "campaign"
+section = "3.2.2"
+doc_page = 27
+role = "producer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::prop_name"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
+[[requirement]]
 req_id = "REQ-CHK-SXC-3.3"
 use_case = "confidence"
 section = "3.3.6"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -339,6 +339,19 @@ checklist_row = "3.1.3"
 checklist_role = "producer"
 verification = "Optional"
 
+# --- §3.2 Campaign Sharing (normative §3.2.3 fixtures) ---
+
+[[requirement]]
+req_id = "REQ-3.2-1"
+use_case = "campaign"
+section = "3.2.1"
+doc_page = 26
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::description::description_scope"
+fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
+
 [[requirement]]
 req_id = "REQ-CHK-SXC-3.3"
 use_case = "confidence"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -584,6 +584,19 @@ test_id = "use_cases::campaign::consumer::processes_related"
 fixture = "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json"
 
 [[requirement]]
+req_id = "REQ-CHK-SXC-3.2"
+use_case = "campaign"
+section = "3.2.6"
+role = "consumer"
+level = "MUST"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::campaign::consumer::handles_producer_testcases"
+checklist_row = "3.2.6"
+checklist_role = "consumer"
+verification = "Optional"
+
+[[requirement]]
 req_id = "REQ-CHK-SXC-3.3"
 use_case = "confidence"
 section = "3.3.6"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -524,6 +524,66 @@ test_id = "use_cases::campaign::examples::campaign_attributed_to_threat_actor"
 fixture = "examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.json"
 
 [[requirement]]
+req_id = "REQ-3.2-C-01"
+use_case = "campaign"
+section = "3.2.5"
+doc_page = 31
+role = "consumer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::consumer::supports_producer_props"
+fixture = "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json"
+
+[[requirement]]
+req_id = "REQ-3.2-C-02"
+use_case = "campaign"
+section = "3.2.5"
+doc_page = 31
+role = "consumer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::consumer::receives_triad"
+fixture = "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json"
+
+[[requirement]]
+req_id = "REQ-3.2-C-03"
+use_case = "campaign"
+section = "3.2.5"
+doc_page = 31
+role = "consumer"
+level = "MUST"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::consumer::resolves_created_by_ref"
+fixture = "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json"
+
+[[requirement]]
+req_id = "REQ-3.2-C-04"
+use_case = "campaign"
+section = "3.2.5"
+doc_page = 31
+role = "consumer"
+level = "CAN"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::consumer::processes_fields"
+fixture = "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json"
+
+[[requirement]]
+req_id = "REQ-3.2-C-05"
+use_case = "campaign"
+section = "3.2.5"
+doc_page = 31
+role = "consumer"
+level = "CAN"
+gating = true
+disposition = "TESTED"
+test_id = "use_cases::campaign::consumer::processes_related"
+fixture = "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json"
+
+[[requirement]]
 req_id = "REQ-CHK-SXC-3.3"
 use_case = "confidence"
 section = "3.3.6"

--- a/crates/rstix/tests/fixtures/interop/manifest.toml
+++ b/crates/rstix/tests/fixtures/interop/manifest.toml
@@ -485,6 +485,19 @@ test_id = "use_cases::campaign::producer::prop_name"
 fixture = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json"
 
 [[requirement]]
+req_id = "REQ-CHK-SXP-3.2"
+use_case = "campaign"
+section = "3.2.3"
+role = "producer"
+level = "MUST"
+gating = false
+disposition = "TESTED"
+test_id = "use_cases::campaign::producer::producer_testcase_data"
+checklist_row = "3.2.3"
+checklist_role = "producer"
+verification = "Optional"
+
+[[requirement]]
 req_id = "REQ-CHK-SXC-3.3"
 use_case = "confidence"
 section = "3.3.6"

--- a/crates/rstix/tests/interop/common/mod.rs
+++ b/crates/rstix/tests/interop/common/mod.rs
@@ -7,5 +7,6 @@ pub mod identity;
 pub mod producer;
 pub mod relationships;
 pub mod sco;
+pub mod timestamp;
 pub mod validation;
 pub mod wire_preservation;

--- a/crates/rstix/tests/interop/common/timestamp.rs
+++ b/crates/rstix/tests/interop/common/timestamp.rs
@@ -1,0 +1,22 @@
+//! RFC 3339 millisecond checks shared by use-case producer tests.
+
+/// Interop millisecond timestamps: exactly three fractional digits before `Z`.
+pub fn assert_millisecond_rfc3339(label: &str, value: &str) {
+    let Some((_, frac_and_z)) = value.rsplit_once('.') else {
+        panic!("{label} must include fractional seconds: {value}");
+    };
+    assert!(
+        frac_and_z.ends_with('Z'),
+        "{label} must end with Z: {value}"
+    );
+    let digits = &frac_and_z[..frac_and_z.len() - 1];
+    assert_eq!(
+        digits.len(),
+        3,
+        "{label} must have exactly three subsecond digits: {value}"
+    );
+    assert!(
+        digits.chars().all(|c| c.is_ascii_digit()),
+        "{label} fractional part must be digits: {value}"
+    );
+}

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
@@ -180,15 +180,13 @@ pub fn assert_prop_spec_version() {
 pub fn assert_prop_id() {
     let fixture = load_fixture(FIXTURE_CREATE);
     let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
-    let (_, object_id) = load_attack_pattern(FIXTURE_CREATE);
-    let wire = objects
-        .iter()
-        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
-        .expect("wire attack-pattern");
-    let wire_id = wire
-        .get("id")
-        .and_then(Value::as_str)
-        .expect("wire attack-pattern id");
+    let use_case_ids = use_case_object_ids(FIXTURE_CREATE, &objects);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{FIXTURE_CREATE}: expected one attack-pattern use-case id"
+    );
+    let wire_id = &use_case_ids[0];
     assert!(
         wire_id.starts_with("attack-pattern--"),
         "id must use attack-pattern-- prefix: {wire_id}"

--- a/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/attack_pattern/producer.rs
@@ -9,32 +9,12 @@ use serde_json::Value;
 
 use crate::common::fixture_catalog::{parse_fixture_objects, use_case_object_ids};
 use crate::common::identity::assert_identity_shape;
+use crate::common::timestamp::assert_millisecond_rfc3339;
 use crate::harness::fixture::load_fixture;
 use crate::harness::interop_gate::{
     InteropGateOptions, validate_interop_fixture, validate_interop_json,
 };
 use crate::use_cases::attack_pattern::{FIXTURE_CREATE, PRODUCER_FIXTURES};
-
-/// Interop millisecond timestamps: exactly three fractional digits before `Z`.
-fn assert_millisecond_rfc3339(label: &str, value: &str) {
-    let Some((_, frac_and_z)) = value.rsplit_once('.') else {
-        panic!("{label} must include fractional seconds: {value}");
-    };
-    assert!(
-        frac_and_z.ends_with('Z'),
-        "{label} must end with Z: {value}"
-    );
-    let digits = &frac_and_z[..frac_and_z.len() - 1];
-    assert_eq!(
-        digits.len(),
-        3,
-        "{label} must have exactly three subsecond digits: {value}"
-    );
-    assert!(
-        digits.chars().all(|c| c.is_ascii_digit()),
-        "{label} fractional part must be digits: {value}"
-    );
-}
 
 fn load_attack_pattern(relative: &str) -> (AttackPattern, String) {
     let fixture = load_fixture(relative);
@@ -71,20 +51,39 @@ pub fn assert_select_content() {
         .get_mut("objects")
         .and_then(Value::as_array_mut)
         .expect("objects array");
+    let mut renamed = 0usize;
     for object in objects.iter_mut() {
         if object.get("type").and_then(Value::as_str) == Some("attack-pattern") {
             object["name"] = Value::String("Caller-selected Attack Pattern name".into());
+            renamed += 1;
         }
     }
+    assert_eq!(
+        renamed, 1,
+        "expected exactly one attack-pattern object renamed by caller selection"
+    );
     let json = serde_json::to_string(&root).expect("serialize caller-selected bundle");
     let use_case_ids = use_case_object_ids(FIXTURE_CREATE, &parse_fixture_objects(&json).unwrap());
-    validate_interop_json(
+    let bundle = validate_interop_json(
         &json,
         &InteropGateOptions {
-            use_case_object_ids: use_case_ids,
+            use_case_object_ids: use_case_ids.clone(),
         },
     )
     .expect("caller-selected bundle must pass interop gate");
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "caller-selected bundle must expose one attack-pattern use-case id"
+    );
+    let stix_id = StixId::parse(&use_case_ids[0]).expect("attack-pattern id");
+    let ap = bundle
+        .get_typed::<AttackPattern>(&stix_id)
+        .expect("typed attack-pattern after caller selection");
+    assert_eq!(
+        ap.name, "Caller-selected Attack Pattern name",
+        "caller-selected name must survive parse and re-validation"
+    );
 }
 
 /// REQ-3.1-P-03 — Identity in bundle complies with §2.3.4 (fixture-scoped; not a duplicate §2.3 proof).
@@ -179,15 +178,22 @@ pub fn assert_prop_spec_version() {
 
 /// REQ-3.1-P-07 — `id` is a UUID with `attack-pattern--` prefix.
 pub fn assert_prop_id() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
     let (_, object_id) = load_attack_pattern(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire attack-pattern");
+    let wire_id = wire
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("wire attack-pattern id");
     assert!(
-        object_id.starts_with("attack-pattern--"),
-        "id must use attack-pattern-- prefix: {object_id}"
+        wire_id.starts_with("attack-pattern--"),
+        "id must use attack-pattern-- prefix: {wire_id}"
     );
-    assert!(
-        StixId::parse(&object_id).is_ok(),
-        "id must be valid STIX id"
-    );
+    StixId::parse(wire_id).expect("wire id must be valid STIX id");
 }
 
 /// REQ-3.1-P-08 — `created_by_ref` points at the Producer Identity.

--- a/crates/rstix/tests/interop/use_cases/campaign/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/consumer.rs
@@ -208,6 +208,42 @@ pub fn assert_processes_related() {
     );
 }
 
+/// REQ-CHK-SXC-3.2 / §4.2 Table 55 — Consumer handles §3.2.3 Producer test case data.
+///
+/// Distinct from `REQ-CHK-SXP-3.2` (re-validation only): resolves each use-case Campaign
+/// as a typed SDO and closes `created_by_ref` to a typed Identity.
+pub fn assert_handles_producer_testcases() {
+    for relative in PRODUCER_FIXTURES {
+        let fixture = load_fixture(relative);
+        let objects = parse_fixture_objects(&fixture.json)
+            .unwrap_or_else(|err| panic!("{relative}: parse fixture: {err}"));
+        let use_case_ids = use_case_object_ids(relative, &objects);
+        let bundle = validate_interop_fixture(relative, &fixture.json).unwrap_or_else(|err| {
+            panic!("{relative}: §3.2 consumer must handle producer test case: {err}")
+        });
+
+        assert!(
+            !use_case_ids.is_empty(),
+            "{relative}: expected campaign use-case object(s)"
+        );
+        for object_id in use_case_ids {
+            let stix_id = StixId::parse(&object_id).expect("campaign id");
+            let campaign = bundle
+                .get_typed::<Campaign>(&stix_id)
+                .unwrap_or_else(|| panic!("{relative}: typed campaign {object_id}"));
+            let created_by = campaign.common.created_by_ref.as_ref().unwrap_or_else(|| {
+                panic!("{relative}: created_by_ref required for consumer close")
+            });
+            assert!(
+                bundle
+                    .get_typed::<Identity>(created_by.as_stix_id())
+                    .is_some(),
+                "{relative}: created_by_ref must resolve to typed Identity"
+            );
+        }
+    }
+}
+
 interop_test!(
     "REQ-3.2-C-01",
     "use_cases::campaign::consumer::supports_producer_props",
@@ -250,5 +286,14 @@ interop_test!(
     processes_related,
     {
         assert_processes_related();
+    }
+);
+
+interop_test!(
+    "REQ-CHK-SXC-3.2",
+    "use_cases::campaign::consumer::handles_producer_testcases",
+    handles_producer_testcases,
+    {
+        assert_handles_producer_testcases();
     }
 );

--- a/crates/rstix/tests/interop/use_cases/campaign/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/consumer.rs
@@ -1,0 +1,254 @@
+//! §3.2.5 Required Consumer Persona Support (REQ-3.2-C-01..C-05).
+
+use crate::interop_test;
+use rstix::core::{QueryValue, QueryableStixObject, StixId};
+use rstix::model::sdo::{Campaign, Identity, IntrusionSet};
+use rstix::model::sro::Relationship;
+use serde_json::Value;
+
+use crate::common::fixture_catalog::{
+    parse_fixture_objects, summarize_fixture_wire, use_case_object_ids,
+};
+use crate::common::wire_preservation::{
+    assert_identity_fields_preserved, assert_wire_object_preserved,
+};
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::validate_interop_fixture;
+use crate::use_cases::campaign::{FIXTURE_ATTRIBUTED, PRODUCER_FIXTURES};
+
+fn for_each_campaign_fixture(mut f: impl FnMut(&str)) {
+    for relative in PRODUCER_FIXTURES {
+        f(relative);
+    }
+}
+
+/// REQ-3.2-C-01 — Consumer supports §3.2.2 Producer Persona properties on normative fixtures.
+pub fn assert_supports_producer_props() {
+    for_each_campaign_fixture(|relative| {
+        let fixture = load_fixture(relative);
+        let objects = parse_fixture_objects(&fixture.json)
+            .unwrap_or_else(|err| panic!("{relative}: parse fixture: {err}"));
+        let use_case_ids = use_case_object_ids(relative, &objects);
+        let bundle = validate_interop_fixture(relative, &fixture.json)
+            .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+
+        for object_id in use_case_ids {
+            let wire = objects
+                .iter()
+                .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+                .unwrap_or_else(|| panic!("{relative}: wire object {object_id}"));
+            let stix_id = StixId::parse(&object_id).expect("object id");
+            let campaign = bundle
+                .get_typed::<Campaign>(&stix_id)
+                .unwrap_or_else(|| panic!("{relative}: typed campaign {object_id}"));
+            assert_eq!(wire.get("type").and_then(Value::as_str), Some("campaign"));
+            assert_eq!(
+                wire.get("spec_version").and_then(Value::as_str),
+                Some("2.1")
+            );
+            assert!(
+                campaign.common.created_by_ref.is_some(),
+                "{relative}: created_by_ref required"
+            );
+            assert!(!campaign.name.is_empty(), "{relative}: name required");
+            assert_wire_object_preserved(relative, wire, &bundle, &object_id);
+        }
+    });
+}
+
+/// REQ-3.2-C-02 — Consumer receives Identity, Campaign(s), and SROs (§3.2.3.2).
+pub fn assert_receives_triad() {
+    let relative = FIXTURE_ATTRIBUTED;
+    let fixture = load_fixture(relative);
+    let summary = summarize_fixture_wire(&fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: summarize fixture: {err}"));
+    assert_eq!(summary.identity_ids.len(), 1);
+    assert_eq!(
+        summary.primary_sdo_count, 2,
+        "campaign + intrusion-set"
+    );
+    assert_eq!(summary.relationship_count, 1);
+
+    let bundle = validate_interop_fixture(relative, &fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+    for identity_id in &summary.identity_ids {
+        let id = StixId::parse(identity_id).expect("identity id");
+        assert!(
+            bundle.get_typed::<Identity>(&id).is_some(),
+            "{relative}: Identity {identity_id} must parse"
+        );
+    }
+    assert_eq!(bundle.objects_of_type::<Campaign>().count(), 1);
+    assert_eq!(bundle.objects_of_type::<IntrusionSet>().count(), 1);
+    assert_eq!(bundle.objects_of_type::<Relationship>().count(), 1);
+}
+
+/// REQ-3.2-C-03 — Consumer resolves `created_by_ref` Identity fields (§3.2.3.2).
+pub fn assert_resolves_created_by_ref() {
+    let relative = FIXTURE_ATTRIBUTED;
+    let fixture = load_fixture(relative);
+    let bundle = validate_interop_fixture(relative, &fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+
+    let mut checked = 0usize;
+    for object in &objects {
+        let Some(created_by_ref) = object.get("created_by_ref").and_then(Value::as_str) else {
+            continue;
+        };
+        let identity_id = StixId::parse(created_by_ref).expect("created_by_ref");
+        let wire_identity = objects
+            .iter()
+            .find(|obj| obj.get("id").and_then(Value::as_str) == Some(created_by_ref))
+            .expect("wire Identity for created_by_ref");
+        assert!(
+            bundle.get_typed::<Identity>(&identity_id).is_some(),
+            "{relative}: created_by_ref `{created_by_ref}` must resolve"
+        );
+        assert_identity_fields_preserved(relative, wire_identity, &bundle, created_by_ref);
+        checked += 1;
+    }
+    assert!(checked > 0, "{relative}: expected created_by_ref usage");
+}
+
+/// REQ-3.2-C-04 — Consumer processes Campaign fields via query + typed validate.
+///
+/// Distinct from C-01 (wire re-serialize preservation of Table 4 props): uses
+/// [`QueryableStixObject::get_field`] for `name` / `created_by_ref` and runs
+/// [`Campaign::validate`], matching query results to the wire object.
+pub fn assert_processes_fields() {
+    let relative = FIXTURE_ATTRIBUTED;
+    let fixture = load_fixture(relative);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let use_case_ids = use_case_object_ids(relative, &objects);
+    let bundle = validate_interop_fixture(relative, &fixture.json).expect("interop gate");
+
+    assert_eq!(use_case_ids.len(), 1, "{relative}: one campaign use-case id");
+    let object_id = &use_case_ids[0];
+    let stix_id = StixId::parse(object_id).expect("campaign id");
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .unwrap_or_else(|| panic!("{relative}: wire campaign {object_id}"));
+    let campaign = bundle
+        .get_typed::<Campaign>(&stix_id)
+        .unwrap_or_else(|| panic!("{relative}: typed campaign {object_id}"));
+
+    campaign
+        .validate()
+        .unwrap_or_else(|err| panic!("{relative}: Campaign::validate: {err}"));
+
+    match campaign.get_field(&["name"]) {
+        Some(QueryValue::Str(name)) => {
+            assert_eq!(
+                name,
+                campaign.name.as_str(),
+                "{relative}: get_field(name) mismatch"
+            );
+            assert_eq!(
+                Some(name),
+                wire.get("name").and_then(Value::as_str),
+                "{relative}: get_field(name) must match wire"
+            );
+        }
+        other => panic!("{relative}: expected QueryValue::Str for name, got {other:?}"),
+    }
+    let created_by = campaign
+        .common
+        .created_by_ref
+        .as_ref()
+        .unwrap_or_else(|| panic!("{relative}: created_by_ref required for field processing"));
+    match campaign.get_field(&["created_by_ref"]) {
+        Some(QueryValue::Id(id)) => {
+            assert_eq!(
+                id,
+                created_by.as_stix_id(),
+                "{relative}: get_field(created_by_ref) mismatch"
+            );
+            assert_eq!(
+                Some(id.as_str()),
+                wire.get("created_by_ref").and_then(Value::as_str),
+                "{relative}: get_field(created_by_ref) must match wire"
+            );
+        }
+        other => panic!("{relative}: expected QueryValue::Id for created_by_ref, got {other:?}"),
+    }
+}
+
+/// REQ-3.2-C-05 — Consumer resolves related SDOs/SROs (§3.2.3.2 `attributed-to` relationship).
+pub fn assert_processes_related() {
+    let relative = FIXTURE_ATTRIBUTED;
+    let bundle =
+        validate_interop_fixture(relative, &load_fixture(relative).json).expect("interop gate");
+    let relationships: Vec<_> = bundle.objects_of_type::<Relationship>().collect();
+    assert_eq!(
+        relationships.len(),
+        1,
+        "{relative}: expected one relationship"
+    );
+    let relationship = &relationships[0];
+    assert_eq!(relationship.relationship_type.as_str(), "attributed-to");
+    assert!(
+        bundle.get(&relationship.source_ref).is_some(),
+        "source_ref must resolve"
+    );
+    assert!(
+        bundle.get(&relationship.target_ref).is_some(),
+        "target_ref must resolve"
+    );
+    assert!(
+        bundle
+            .get_typed::<Campaign>(&relationship.source_ref)
+            .is_some()
+    );
+    assert!(
+        bundle
+            .get_typed::<IntrusionSet>(&relationship.target_ref)
+            .is_some()
+    );
+}
+
+interop_test!(
+    "REQ-3.2-C-01",
+    "use_cases::campaign::consumer::supports_producer_props",
+    supports_producer_props,
+    {
+        assert_supports_producer_props();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-C-02",
+    "use_cases::campaign::consumer::receives_triad",
+    receives_triad,
+    {
+        assert_receives_triad();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-C-03",
+    "use_cases::campaign::consumer::resolves_created_by_ref",
+    resolves_created_by_ref,
+    {
+        assert_resolves_created_by_ref();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-C-04",
+    "use_cases::campaign::consumer::processes_fields",
+    processes_fields,
+    {
+        assert_processes_fields();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-C-05",
+    "use_cases::campaign::consumer::processes_related",
+    processes_related,
+    {
+        assert_processes_related();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/campaign/consumer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/consumer.rs
@@ -63,10 +63,7 @@ pub fn assert_receives_triad() {
     let summary = summarize_fixture_wire(&fixture.json)
         .unwrap_or_else(|err| panic!("{relative}: summarize fixture: {err}"));
     assert_eq!(summary.identity_ids.len(), 1);
-    assert_eq!(
-        summary.primary_sdo_count, 2,
-        "campaign + intrusion-set"
-    );
+    assert_eq!(summary.primary_sdo_count, 2, "campaign + intrusion-set");
     assert_eq!(summary.relationship_count, 1);
 
     let bundle = validate_interop_fixture(relative, &fixture.json)
@@ -123,7 +120,11 @@ pub fn assert_processes_fields() {
     let use_case_ids = use_case_object_ids(relative, &objects);
     let bundle = validate_interop_fixture(relative, &fixture.json).expect("interop gate");
 
-    assert_eq!(use_case_ids.len(), 1, "{relative}: one campaign use-case id");
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{relative}: one campaign use-case id"
+    );
     let object_id = &use_case_ids[0];
     let stix_id = StixId::parse(object_id).expect("campaign id");
     let wire = objects

--- a/crates/rstix/tests/interop/use_cases/campaign/description.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/description.rs
@@ -1,7 +1,7 @@
 //! §3.2.1 Description — Campaign Sharing scope.
 
 use rstix::core::StixId;
-use rstix::model::sdo::Campaign;
+use rstix::model::sdo::{Campaign, IntrusionSet};
 
 use crate::harness::fixture::load_fixture;
 use crate::harness::interop_gate::validate_interop_fixture;
@@ -37,6 +37,11 @@ pub fn assert_description_scope() {
         attributed_bundle.objects_of_type::<Campaign>().count(),
         1,
         "§3.2.3.2 must carry a Campaign SDO as described in §3.2.1"
+    );
+    assert_eq!(
+        attributed_bundle.objects_of_type::<IntrusionSet>().count(),
+        1,
+        "§3.2.3.2 must carry an Intrusion Set SDO for the attribution path in §3.2.1"
     );
 }
 

--- a/crates/rstix/tests/interop/use_cases/campaign/description.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/description.rs
@@ -1,0 +1,50 @@
+//! §3.2.1 Description — Campaign Sharing scope.
+
+use rstix::core::StixId;
+use rstix::model::sdo::Campaign;
+
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::validate_interop_fixture;
+use crate::interop_test;
+use crate::use_cases::campaign::{FIXTURE_ATTRIBUTED, FIXTURE_CREATE};
+
+/// REQ-3.2-1 — §3.2.1 Description.
+///
+/// Doc: a Campaign groups adversarial behaviors over time against a set of targets;
+/// campaigns are often attributed to an intrusion set / threat actor. The running
+/// example name in §3.2.3 is “Green Group Attacks Against Finance”. This check binds
+/// that description to normative §3.2.3 Producer fixtures: typed Campaign SDOs with
+/// that name, plus §3.2.3.2 carrying an Intrusion Set attribution path — not a
+/// prose-only REPORT_ONLY placeholder.
+pub fn assert_description_scope() {
+    let create = load_fixture(FIXTURE_CREATE);
+    let create_bundle = validate_interop_fixture(FIXTURE_CREATE, &create.json)
+        .expect("§3.2.3.1 must parse for description-scope check");
+    let campaign_id =
+        StixId::parse("campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f").expect("campaign id");
+    let campaign = create_bundle
+        .get_typed::<Campaign>(&campaign_id)
+        .expect("Green Group Campaign must be typed");
+    assert_eq!(
+        campaign.name, "Green Group Attacks Against Finance",
+        "§3.2.1 / §3.2.3 running example name must be present on normative fixture"
+    );
+
+    let attributed = load_fixture(FIXTURE_ATTRIBUTED);
+    let attributed_bundle = validate_interop_fixture(FIXTURE_ATTRIBUTED, &attributed.json)
+        .expect("§3.2.3.2 must parse for description-scope check");
+    assert_eq!(
+        attributed_bundle.objects_of_type::<Campaign>().count(),
+        1,
+        "§3.2.3.2 must carry a Campaign SDO as described in §3.2.1"
+    );
+}
+
+interop_test!(
+    "REQ-3.2-1",
+    "use_cases::campaign::description::description_scope",
+    description_scope,
+    {
+        assert_description_scope();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/campaign/examples.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/examples.rs
@@ -59,8 +59,8 @@ pub fn assert_campaign_attributed_to_threat_actor() {
         StixId::parse("campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e").expect("campaign id");
     assert!(bundle.get_typed::<Campaign>(&campaign_id).is_some());
 
-    let ta_id =
-        StixId::parse("threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f").expect("threat-actor id");
+    let ta_id = StixId::parse("threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f")
+        .expect("threat-actor id");
     assert!(bundle.get_typed::<ThreatActor>(&ta_id).is_some());
 
     let relationships: Vec<_> = bundle.objects_of_type::<Relationship>().collect();

--- a/crates/rstix/tests/interop/use_cases/campaign/examples.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/examples.rs
@@ -1,0 +1,89 @@
+//! §3.2.4 Producer Example Data (non-gating).
+
+use rstix::core::StixId;
+use rstix::model::sdo::{AttackPattern, Campaign, ThreatActor};
+use rstix::model::sro::Relationship;
+
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::{InteropGateOptions, validate_interop_json};
+use crate::interop_test;
+
+/// OASIS §3.2.4.1 non-normative example.
+pub const EXAMPLE_USES_ATTACK_PATTERN: &str =
+    "examples/campaign/ex-3.2.4.1-campaign-uses-an-attack-pattern.json";
+/// OASIS §3.2.4.2 non-normative example.
+pub const EXAMPLE_ATTRIBUTED_THREAT_ACTOR: &str =
+    "examples/campaign/ex-3.2.4.2-campaign-attributed-to-threat-actor.json";
+
+/// REQ-3.2-EX-4.1 — §3.2.4.1 loads and passes the interop gate; Campaign `uses` Attack Pattern.
+pub fn assert_campaign_uses_attack_pattern() {
+    let fixture = load_fixture(EXAMPLE_USES_ATTACK_PATTERN);
+    assert_eq!(fixture.provenance.source_section, "3.2.4.1");
+    let bundle = validate_interop_json(&fixture.json, &InteropGateOptions::default())
+        .expect("§3.2.4.1 example must parse and pass interop gate");
+
+    let campaign_id =
+        StixId::parse("campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e").expect("campaign id");
+    let campaign = bundle
+        .get_typed::<Campaign>(&campaign_id)
+        .expect("Operation Bran Flakes Campaign");
+    assert_eq!(campaign.name, "Operation Bran Flakes");
+
+    let ap_id =
+        StixId::parse("attack-pattern--19da6e1c-71ab-4c2f-886d-d620d09d3b5a").expect("ap id");
+    assert!(bundle.get_typed::<AttackPattern>(&ap_id).is_some());
+
+    let relationships: Vec<_> = bundle.objects_of_type::<Relationship>().collect();
+    assert_eq!(relationships.len(), 1);
+    assert_eq!(relationships[0].relationship_type.as_str(), "uses");
+    assert_eq!(relationships[0].source_ref, campaign_id);
+    assert_eq!(relationships[0].target_ref, ap_id);
+}
+
+/// REQ-3.2-EX-4.2 — §3.2.4.2 loads and passes the interop gate; Campaign `attributed-to` Threat Actor.
+pub fn assert_campaign_attributed_to_threat_actor() {
+    let fixture = load_fixture(EXAMPLE_ATTRIBUTED_THREAT_ACTOR);
+    assert_eq!(fixture.provenance.source_section, "3.2.4.2");
+    assert!(
+        fixture
+            .provenance
+            .divergence_recorded
+            .iter()
+            .any(|d| d.defect == 20),
+        "expected defect 20 recorded for malformed relationship id key"
+    );
+    let bundle = validate_interop_json(&fixture.json, &InteropGateOptions::default())
+        .expect("§3.2.4.2 example must parse and pass interop gate");
+
+    let campaign_id =
+        StixId::parse("campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e").expect("campaign id");
+    assert!(bundle.get_typed::<Campaign>(&campaign_id).is_some());
+
+    let ta_id =
+        StixId::parse("threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f").expect("threat-actor id");
+    assert!(bundle.get_typed::<ThreatActor>(&ta_id).is_some());
+
+    let relationships: Vec<_> = bundle.objects_of_type::<Relationship>().collect();
+    assert_eq!(relationships.len(), 1);
+    assert_eq!(relationships[0].relationship_type.as_str(), "attributed-to");
+    assert_eq!(relationships[0].source_ref, campaign_id);
+    assert_eq!(relationships[0].target_ref, ta_id);
+}
+
+interop_test!(
+    "REQ-3.2-EX-4.1",
+    "use_cases::campaign::examples::campaign_uses_attack_pattern",
+    campaign_uses_attack_pattern,
+    {
+        assert_campaign_uses_attack_pattern();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-EX-4.2",
+    "use_cases::campaign::examples::campaign_attributed_to_threat_actor",
+    campaign_attributed_to_threat_actor,
+    {
+        assert_campaign_attributed_to_threat_actor();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/campaign/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/mod.rs
@@ -1,6 +1,7 @@
 //! §3.2 Campaign Sharing — Producer and Consumer tests against normative fixtures.
 
 pub mod description;
+pub mod examples;
 pub mod producer;
 
 /// OASIS §3.2.3.1 Producer test case.

--- a/crates/rstix/tests/interop/use_cases/campaign/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/mod.rs
@@ -1,5 +1,6 @@
 //! §3.2 Campaign Sharing — Producer and Consumer tests against normative fixtures.
 
+pub mod consumer;
 pub mod description;
 pub mod examples;
 pub mod producer;

--- a/crates/rstix/tests/interop/use_cases/campaign/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/mod.rs
@@ -1,6 +1,7 @@
 //! §3.2 Campaign Sharing — Producer and Consumer tests against normative fixtures.
 
 pub mod description;
+pub mod producer;
 
 /// OASIS §3.2.3.1 Producer test case.
 pub const FIXTURE_CREATE: &str = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json";

--- a/crates/rstix/tests/interop/use_cases/campaign/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/mod.rs
@@ -1,0 +1,11 @@
+//! §3.2 Campaign Sharing — Producer and Consumer tests against normative fixtures.
+
+pub mod description;
+
+/// OASIS §3.2.3.1 Producer test case.
+pub const FIXTURE_CREATE: &str = "testcases/campaign/tc-3.2.3.1-campaign-test-case.json";
+/// OASIS §3.2.3.2 Producer test case (also Consumer triad fixture).
+pub const FIXTURE_ATTRIBUTED: &str =
+    "testcases/campaign/tc-3.2.3.2-campaign-attributed-to-intrusion-set.json";
+
+pub(crate) const PRODUCER_FIXTURES: &[&str] = &[FIXTURE_CREATE, FIXTURE_ATTRIBUTED];

--- a/crates/rstix/tests/interop/use_cases/campaign/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/producer.rs
@@ -13,32 +13,12 @@ use serde_json::Value;
 
 use crate::common::fixture_catalog::{parse_fixture_objects, use_case_object_ids};
 use crate::common::identity::assert_identity_shape;
+use crate::common::timestamp::assert_millisecond_rfc3339;
 use crate::harness::fixture::load_fixture;
 use crate::harness::interop_gate::{
     InteropGateOptions, validate_interop_fixture, validate_interop_json,
 };
 use crate::use_cases::campaign::{FIXTURE_CREATE, PRODUCER_FIXTURES};
-
-/// Interop millisecond timestamps: exactly three fractional digits before `Z`.
-fn assert_millisecond_rfc3339(label: &str, value: &str) {
-    let Some((_, frac_and_z)) = value.rsplit_once('.') else {
-        panic!("{label} must include fractional seconds: {value}");
-    };
-    assert!(
-        frac_and_z.ends_with('Z'),
-        "{label} must end with Z: {value}"
-    );
-    let digits = &frac_and_z[..frac_and_z.len() - 1];
-    assert_eq!(
-        digits.len(),
-        3,
-        "{label} must have exactly three subsecond digits: {value}"
-    );
-    assert!(
-        digits.chars().all(|c| c.is_ascii_digit()),
-        "{label} fractional part must be digits: {value}"
-    );
-}
 
 fn load_campaign(relative: &str) -> (Campaign, String) {
     let fixture = load_fixture(relative);
@@ -75,20 +55,39 @@ pub fn assert_select_content() {
         .get_mut("objects")
         .and_then(Value::as_array_mut)
         .expect("objects array");
+    let mut renamed = 0usize;
     for object in objects.iter_mut() {
         if object.get("type").and_then(Value::as_str) == Some("campaign") {
             object["name"] = Value::String("Caller-selected Campaign name".into());
+            renamed += 1;
         }
     }
+    assert_eq!(
+        renamed, 1,
+        "expected exactly one campaign object renamed by caller selection"
+    );
     let json = serde_json::to_string(&root).expect("serialize caller-selected bundle");
     let use_case_ids = use_case_object_ids(FIXTURE_CREATE, &parse_fixture_objects(&json).unwrap());
-    validate_interop_json(
+    let bundle = validate_interop_json(
         &json,
         &InteropGateOptions {
-            use_case_object_ids: use_case_ids,
+            use_case_object_ids: use_case_ids.clone(),
         },
     )
     .expect("caller-selected bundle must pass interop gate");
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "caller-selected bundle must expose one campaign use-case id"
+    );
+    let stix_id = StixId::parse(&use_case_ids[0]).expect("campaign id");
+    let campaign = bundle
+        .get_typed::<Campaign>(&stix_id)
+        .expect("typed campaign after caller selection");
+    assert_eq!(
+        campaign.name, "Caller-selected Campaign name",
+        "caller-selected name must survive parse and re-validation"
+    );
 }
 
 /// REQ-3.2-P-03 — Identity in bundle complies with §2.3.4 (fixture-scoped; not a duplicate §2.3 proof).
@@ -184,15 +183,22 @@ pub fn assert_prop_spec_version() {
 
 /// REQ-3.2-P-07 — `id` is a UUID with `campaign--` prefix.
 pub fn assert_prop_id() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
     let (_, object_id) = load_campaign(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire campaign");
+    let wire_id = wire
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("wire campaign id");
     assert!(
-        object_id.starts_with("campaign--"),
-        "id must use campaign-- prefix: {object_id}"
+        wire_id.starts_with("campaign--"),
+        "id must use campaign-- prefix: {wire_id}"
     );
-    assert!(
-        StixId::parse(&object_id).is_ok(),
-        "id must be valid STIX id"
-    );
+    StixId::parse(wire_id).expect("wire id must be valid STIX id");
 }
 
 /// REQ-3.2-P-08 — `created_by_ref` points at the Producer Identity.

--- a/crates/rstix/tests/interop/use_cases/campaign/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/producer.rs
@@ -1,0 +1,348 @@
+//! §3.2.2 Required Producer Persona Support (REQ-3.2-P-01..P-11).
+//!
+//! Table 4 (CSD01) lists Campaign producer properties. The published table text
+//! erroneously says `type` must be `threat-actor`; STIX §4.2 and the Campaign
+//! test cases require `campaign`. Tests enforce `campaign`.
+
+use crate::interop_test;
+use rstix::core::{SpecVersion, StixId};
+use rstix::model::sdo::Campaign;
+use rstix::model::{Bundle, ParseOptions};
+use rstix::validate::{Leniency, Validator};
+use serde_json::Value;
+
+use crate::common::fixture_catalog::{parse_fixture_objects, use_case_object_ids};
+use crate::common::identity::assert_identity_shape;
+use crate::harness::fixture::load_fixture;
+use crate::harness::interop_gate::{
+    InteropGateOptions, validate_interop_fixture, validate_interop_json,
+};
+use crate::use_cases::campaign::FIXTURE_CREATE;
+
+/// Interop millisecond timestamps: exactly three fractional digits before `Z`.
+fn assert_millisecond_rfc3339(label: &str, value: &str) {
+    let Some((_, frac_and_z)) = value.rsplit_once('.') else {
+        panic!("{label} must include fractional seconds: {value}");
+    };
+    assert!(
+        frac_and_z.ends_with('Z'),
+        "{label} must end with Z: {value}"
+    );
+    let digits = &frac_and_z[..frac_and_z.len() - 1];
+    assert_eq!(
+        digits.len(),
+        3,
+        "{label} must have exactly three subsecond digits: {value}"
+    );
+    assert!(
+        digits.chars().all(|c| c.is_ascii_digit()),
+        "{label} fractional part must be digits: {value}"
+    );
+}
+
+fn load_campaign(relative: &str) -> (Campaign, String) {
+    let fixture = load_fixture(relative);
+    let objects = parse_fixture_objects(&fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: parse fixture: {err}"));
+    let use_case_ids = use_case_object_ids(relative, &objects);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{relative}: expected one campaign use-case object"
+    );
+    let object_id = use_case_ids.into_iter().next().expect("campaign id");
+    let bundle = validate_interop_fixture(relative, &fixture.json)
+        .unwrap_or_else(|err| panic!("{relative}: interop gate: {err}"));
+    let stix_id = StixId::parse(&object_id).expect("campaign id");
+    let campaign = bundle
+        .get_typed::<Campaign>(&stix_id)
+        .unwrap_or_else(|| panic!("{relative}: typed campaign {object_id}"))
+        .clone();
+    (campaign, object_id)
+}
+
+/// REQ-3.2-P-01 — Producer creates Campaign content (§3.2.3.1).
+pub fn assert_create_campaign() {
+    validate_interop_fixture(FIXTURE_CREATE, &load_fixture(FIXTURE_CREATE).json)
+        .expect("§3.2.3.1 must pass interop producer gate");
+}
+
+/// REQ-3.2-P-02 — Caller-selected object set parses and re-validates (not UI-level select/specify).
+pub fn assert_select_content() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let mut root: Value = serde_json::from_str(&fixture.json).expect("parse bundle JSON");
+    let objects = root
+        .get_mut("objects")
+        .and_then(Value::as_array_mut)
+        .expect("objects array");
+    for object in objects.iter_mut() {
+        if object.get("type").and_then(Value::as_str) == Some("campaign") {
+            object["name"] = Value::String("Caller-selected Campaign name".into());
+        }
+    }
+    let json = serde_json::to_string(&root).expect("serialize caller-selected bundle");
+    let use_case_ids = use_case_object_ids(FIXTURE_CREATE, &parse_fixture_objects(&json).unwrap());
+    validate_interop_json(
+        &json,
+        &InteropGateOptions {
+            use_case_object_ids: use_case_ids,
+        },
+    )
+    .expect("caller-selected bundle must pass interop gate");
+}
+
+/// REQ-3.2-P-03 — Identity in bundle complies with §2.3.4 (fixture-scoped; not a duplicate §2.3 proof).
+pub fn assert_identity_compliance() {
+    let relative = FIXTURE_CREATE;
+    let fixture = load_fixture(relative);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let identities: Vec<_> = objects
+        .iter()
+        .filter(|obj| obj.get("type").and_then(Value::as_str) == Some("identity"))
+        .collect();
+    assert_eq!(identities.len(), 1, "{relative}: expected one Identity");
+    assert_identity_shape(relative, identities[0]);
+}
+
+/// REQ-3.2-P-04 — Campaign conforms to STIX §4.2 (typed validate + strict report).
+///
+/// Distinct from P-01: does **not** call the interop gate/overlay. Parses the fixture,
+/// runs [`Campaign::validate`], then requires [`Validator::interop_bundle_strict`]
+/// to report valid under Zero leniency (no MUST Error / Zero-failing Warning), including
+/// any diagnostic scoped to this Campaign id.
+pub fn assert_spec_conformance() {
+    let relative = FIXTURE_CREATE;
+    let fixture = load_fixture(relative);
+    let bundle = Bundle::parse_with_options(&fixture.json, &ParseOptions::new().interop_bundle())
+        .unwrap_or_else(|err| panic!("{relative}: parse for §4.2 check: {err}"));
+
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture objects");
+    let use_case_ids = use_case_object_ids(relative, &objects);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{relative}: expected one campaign use-case id"
+    );
+    let object_id = &use_case_ids[0];
+    let campaign_id = StixId::parse(object_id).expect("campaign id");
+    let campaign = bundle
+        .get_typed::<Campaign>(&campaign_id)
+        .unwrap_or_else(|| panic!("{relative}: typed campaign {object_id}"));
+    campaign
+        .validate()
+        .unwrap_or_else(|err| panic!("{relative}: Campaign::validate (§4.2): {err}"));
+
+    let report = Validator::interop_bundle_strict().validate_bundle(&bundle);
+
+    let errors: Vec<_> = report.errors().collect();
+    assert!(
+        errors.is_empty(),
+        "{relative}: MUST Error diagnostics present: {errors:?}"
+    );
+
+    // Scoped Zero failures only via structured `object_id` (no Display/message matching).
+    let scoped_zero_failures: Vec<_> = report
+        .diagnostics()
+        .filter(|d| {
+            d.object_id.as_ref() == Some(&campaign_id)
+                && Leniency::Zero.fails_validation(d.severity)
+        })
+        .collect();
+    assert!(
+        scoped_zero_failures.is_empty(),
+        "{relative}: Zero-failing diagnostics on Campaign {object_id}: {scoped_zero_failures:?}"
+    );
+
+    assert!(
+        report.is_valid(),
+        "{relative}: interop_bundle_strict (no overlay) must be valid: {:?}",
+        report.diagnostics().collect::<Vec<_>>()
+    );
+}
+
+/// REQ-3.2-P-05 — wire `type` is `campaign` (OASIS Table 4 typo says `threat-actor`).
+pub fn assert_prop_type() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let (_campaign, object_id) = load_campaign(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire campaign");
+    assert_eq!(
+        wire.get("type").and_then(Value::as_str),
+        Some("campaign"),
+        "wire type must be campaign (STIX §4.2; Table 4 CSD01 typo ignored)"
+    );
+}
+
+/// REQ-3.2-P-06 — `spec_version` is `2.1`.
+pub fn assert_prop_spec_version() {
+    let (campaign, _) = load_campaign(FIXTURE_CREATE);
+    assert_eq!(campaign.common.spec_version, SpecVersion::V2_1);
+}
+
+/// REQ-3.2-P-07 — `id` is a UUID with `campaign--` prefix.
+pub fn assert_prop_id() {
+    let (_, object_id) = load_campaign(FIXTURE_CREATE);
+    assert!(
+        object_id.starts_with("campaign--"),
+        "id must use campaign-- prefix: {object_id}"
+    );
+    assert!(
+        StixId::parse(&object_id).is_ok(),
+        "id must be valid STIX id"
+    );
+}
+
+/// REQ-3.2-P-08 — `created_by_ref` points at the Producer Identity.
+pub fn assert_prop_created_by_ref() {
+    let (campaign, _) = load_campaign(FIXTURE_CREATE);
+    let created_by = campaign
+        .common
+        .created_by_ref
+        .as_ref()
+        .expect("interop-mandatory created_by_ref");
+    assert!(
+        created_by.as_stix_id().as_str().starts_with("identity--"),
+        "created_by_ref must reference Identity: {}",
+        created_by.as_stix_id().as_str()
+    );
+}
+
+/// REQ-3.2-P-09 — `created` timestamp is present (exactly three subsecond digits).
+pub fn assert_prop_created() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let (_, object_id) = load_campaign(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire campaign");
+    let created = wire
+        .get("created")
+        .and_then(Value::as_str)
+        .expect("created timestamp");
+    assert_millisecond_rfc3339("created", created);
+}
+
+/// REQ-3.2-P-10 — `modified` timestamp is present (exactly three subsecond digits).
+pub fn assert_prop_modified() {
+    let fixture = load_fixture(FIXTURE_CREATE);
+    let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
+    let (_, object_id) = load_campaign(FIXTURE_CREATE);
+    let wire = objects
+        .iter()
+        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
+        .expect("wire campaign");
+    let modified = wire
+        .get("modified")
+        .and_then(Value::as_str)
+        .expect("modified timestamp");
+    assert_millisecond_rfc3339("modified", modified);
+}
+
+/// REQ-3.2-P-11 — `name` identifies the Campaign.
+pub fn assert_prop_name() {
+    let (campaign, _) = load_campaign(FIXTURE_CREATE);
+    assert!(!campaign.name.is_empty(), "interop-mandatory name");
+}
+
+interop_test!(
+    "REQ-3.2-P-01",
+    "use_cases::campaign::producer::create_campaign",
+    create_campaign,
+    {
+        assert_create_campaign();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-02",
+    "use_cases::campaign::producer::select_content",
+    select_content,
+    {
+        assert_select_content();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-03",
+    "use_cases::campaign::producer::identity_compliance",
+    identity_compliance,
+    {
+        assert_identity_compliance();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-04",
+    "use_cases::campaign::producer::spec_conformance",
+    spec_conformance,
+    {
+        assert_spec_conformance();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-05",
+    "use_cases::campaign::producer::prop_type",
+    prop_type,
+    {
+        assert_prop_type();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-06",
+    "use_cases::campaign::producer::prop_spec_version",
+    prop_spec_version,
+    {
+        assert_prop_spec_version();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-07",
+    "use_cases::campaign::producer::prop_id",
+    prop_id,
+    {
+        assert_prop_id();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-08",
+    "use_cases::campaign::producer::prop_created_by_ref",
+    prop_created_by_ref,
+    {
+        assert_prop_created_by_ref();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-09",
+    "use_cases::campaign::producer::prop_created",
+    prop_created,
+    {
+        assert_prop_created();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-10",
+    "use_cases::campaign::producer::prop_modified",
+    prop_modified,
+    {
+        assert_prop_modified();
+    }
+);
+
+interop_test!(
+    "REQ-3.2-P-11",
+    "use_cases::campaign::producer::prop_name",
+    prop_name,
+    {
+        assert_prop_name();
+    }
+);

--- a/crates/rstix/tests/interop/use_cases/campaign/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/producer.rs
@@ -17,7 +17,7 @@ use crate::harness::fixture::load_fixture;
 use crate::harness::interop_gate::{
     InteropGateOptions, validate_interop_fixture, validate_interop_json,
 };
-use crate::use_cases::campaign::FIXTURE_CREATE;
+use crate::use_cases::campaign::{FIXTURE_CREATE, PRODUCER_FIXTURES};
 
 /// Interop millisecond timestamps: exactly three fractional digits before `Z`.
 fn assert_millisecond_rfc3339(label: &str, value: &str) {

--- a/crates/rstix/tests/interop/use_cases/campaign/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/producer.rs
@@ -248,6 +248,15 @@ pub fn assert_prop_name() {
     assert!(!campaign.name.is_empty(), "interop-mandatory name");
 }
 
+/// REQ-CHK-SXP-3.2 / §4.2 Table 56 — Producer test case data (§3.2.3.1 and §3.2.3.2).
+pub fn assert_producer_testcase_data() {
+    for relative in PRODUCER_FIXTURES {
+        validate_interop_fixture(relative, &load_fixture(relative).json).unwrap_or_else(|err| {
+            panic!("{relative}: §3.2.3 producer test case must pass interop gate: {err}")
+        });
+    }
+}
+
 interop_test!(
     "REQ-3.2-P-01",
     "use_cases::campaign::producer::create_campaign",
@@ -344,5 +353,14 @@ interop_test!(
     prop_name,
     {
         assert_prop_name();
+    }
+);
+
+interop_test!(
+    "REQ-CHK-SXP-3.2",
+    "use_cases::campaign::producer::producer_testcase_data",
+    producer_testcase_data,
+    {
+        assert_producer_testcase_data();
     }
 );

--- a/crates/rstix/tests/interop/use_cases/campaign/producer.rs
+++ b/crates/rstix/tests/interop/use_cases/campaign/producer.rs
@@ -185,15 +185,13 @@ pub fn assert_prop_spec_version() {
 pub fn assert_prop_id() {
     let fixture = load_fixture(FIXTURE_CREATE);
     let objects = parse_fixture_objects(&fixture.json).expect("parse fixture");
-    let (_, object_id) = load_campaign(FIXTURE_CREATE);
-    let wire = objects
-        .iter()
-        .find(|obj| obj.get("id").and_then(Value::as_str) == Some(object_id.as_str()))
-        .expect("wire campaign");
-    let wire_id = wire
-        .get("id")
-        .and_then(Value::as_str)
-        .expect("wire campaign id");
+    let use_case_ids = use_case_object_ids(FIXTURE_CREATE, &objects);
+    assert_eq!(
+        use_case_ids.len(),
+        1,
+        "{FIXTURE_CREATE}: expected one campaign use-case id"
+    );
+    let wire_id = &use_case_ids[0];
     assert!(
         wire_id.starts_with("campaign--"),
         "id must use campaign-- prefix: {wire_id}"

--- a/crates/rstix/tests/interop/use_cases/mod.rs
+++ b/crates/rstix/tests/interop/use_cases/mod.rs
@@ -1,3 +1,4 @@
 //! Per-use-case OASIS §3.x Producer and Consumer tests (normative fixture bound).
 
 pub mod attack_pattern;
+pub mod campaign;


### PR DESCRIPTION
## Summary

Adds §3.2 Campaign Sharing interop tests - CSD01 §3.2.1–§3.2.6. **2/21** use cases; not OASIS SXP/SXC certification.

- Description + Producer `P-01`..`P-11` + Consumer `C-01`..`C-05`
- Checklist `REQ-CHK-SXP-3.2` / `REQ-CHK-SXC-3.2`
- Non-gating examples `EX-4.1` / `EX-4.2`
- Table 4 typo (`type` = `threat-actor`) ignored; tests enforce `campaign`

## Test plan

- [*] `cargo fmt --all -- --check`
- [*] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [*] `cargo test --workspace --all-features --locked`
- [*] `cargo +1.88.0 check --workspace --all-features --locked`
- [*] `cargo clippy -p rstix --all-targets --features validate,marking,graph --locked -- -D warnings`
- [*] `cargo test -p rstix --features validate,marking,graph --locked --test interop -- use_cases::campaign`
- [*] `summary.json` shows 72/72 TESTED passed