### PR TITLE
test(rstix): STIX 2.1 interop self-certification CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,40 @@ jobs:
       - run: cargo clippy -p rstix --no-default-features --all-targets --locked -- -D warnings
       - run: cargo check -p rstix --no-default-features --features pattern --locked
 
+  rstix-interop:
+    # Dedicated self-certification path: runs every interop TESTED row, regenerates
+    # §4.2 Tables 55/56 + traceability, then fails the job if the report is missing,
+    # stale, or incomplete. Workspace `test` also executes the suite under
+    # --all-features; this job is the gated artifact producer.
+    name: rstix STIX interop self-certification
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repo for checkout
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup override set stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Record interop run start
+        run: echo "INTEROP_RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+      - name: STIX 2.1 interop self-certification suite
+        run: cargo test -p rstix --test interop --features validate,marking,graph --locked
+      - name: Gate on self-certification report
+        run: python3 scripts/interop-report-gate.py
+      - name: Upload self-certification report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: interop-report
+          path: target/interop-report/
+          if-no-files-found: error
+          retention-days: 14
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### rstix: STIX interop self-certification CI gate
+### rstix: STIX interop self-certification CI gate (#440)
 
 CI runs a dedicated `rstix STIX interop self-certification` job that executes the full interop suite (every `TESTED` manifest row), stamps `generated_at` into `summary.json`, fails on a missing/stale/incomplete report via `scripts/interop-report-gate.py`, and uploads `target/interop-report/` (CSD01 §4.2 Tables 55/56, traceability CSV, risks). That package is the operational SXP/SXC **self-certification** evidence against Interoperability **CSD01** — not an OASIS-issued certificate, and not a §4.1 product-persona claim.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ### rstix: STIX interop self-certification CI gate (#440)
 
-CI runs a dedicated `rstix STIX interop self-certification` job that executes the full interop suite (every `TESTED` manifest row), stamps `generated_at` into `summary.json`, fails on a missing/stale/incomplete report via `scripts/interop-report-gate.py`, and uploads `target/interop-report/` (CSD01 §4.2 Tables 55/56, traceability CSV, risks). That package is the operational SXP/SXC **self-certification** evidence against Interoperability **CSD01** — not an OASIS-issued certificate, and not a §4.1 product-persona claim.
+CI runs a dedicated `rstix STIX interop self-certification` job that executes the full interop suite (every `TESTED` manifest row), stamps `generated_at` into `summary.json`, fails on a missing/stale/incomplete report via `scripts/interop-report-gate.py`, and uploads `target/interop-report/` (CSD01 §4.2 Tables 55/56, traceability CSV, risks). The gate validates artifact **content** (checklist cell results, traceability CSV row order and outcomes) against committed `gate-expectations.json`, not only file presence and row counts. Export invariants in the harness panic before writing a hollow report. That package is the operational SXP/SXC **self-certification** evidence against Interoperability **CSD01** — not an OASIS-issued certificate, and not a §4.1 product-persona claim.
 
 ### rstix: OASIS §3.3–§3.21 interop use-case tests (#438)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### rstix: STIX interop self-certification CI gate
+
+CI runs a dedicated `rstix STIX interop self-certification` job that executes the full interop suite (every `TESTED` manifest row), stamps `generated_at` into `summary.json`, fails on a missing/stale/incomplete report via `scripts/interop-report-gate.py`, and uploads `target/interop-report/` (CSD01 §4.2 Tables 55/56, traceability CSV, risks). That package is the operational SXP/SXC **self-certification** evidence against Interoperability **CSD01** — not an OASIS-issued certificate, and not a §4.1 product-persona claim.
+
 ### rstix: OASIS §3.3–§3.21 interop use-case tests (#438)
 
 Completes the remaining OASIS STIX 2.1 Interoperability CSD01 use-case modules beyond §3.1 Attack Pattern and §3.2 Campaign. Adds Producer/Consumer/example tests and manifest TESTED rows for Confidence, Course of Action, Data Markings, Grouping, Indicator, Infrastructure, Intrusion Set, Location, Malware Analysis, Malware, Note, Observed Data, Opinion, Report, Sighting, Threat Actor, Tool, Versioning, and Vulnerability (**21/21** use cases; **506** TESTED rows: 9 harness + 18 §2.3 + 479 use-case). `REQ-CHK-SXP-3.12` and `REQ-CHK-SXP-3.16` stay **BLOCKED** on published defects 19 and 16. Not OASIS SXP/SXC certification.

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -951,13 +951,13 @@ cargo test -p rstix --test interop_sentinel --features validate,marking,graph --
 
 **CI:** the `rstix STIX interop self-certification` job in `.github/workflows/ci.yml` runs the full interop suite (every `TESTED` row), then `scripts/interop-report-gate.py` (report present, `generated_at` not older than `INTEROP_RUN_START`, Tables 55/56 cell content and traceability CSV rows match `gate-expectations.json`, every `TESTED` row passed, required features on), and uploads `target/interop-report/` as the `interop-report` artifact. The multi-OS `Test` matrix also executes the suite under `--all-features`; the dedicated job is the gated self-certification report producer.
 
-**Three-layer gate:**
+**Three-layer gate** (run order):
 
 | Layer | Where | What it catches |
 | ----- | ----- | ---------------- |
-| 2 — export invariants | `tests/interop/harness/certification.rs` | Empty/wrong checklist `Result`, incomplete CSV, export before coverage passes |
-| 3 — manifest sync | `tests/interop/harness/gate_expectations.rs` + committed `gate-expectations.json` | Stale golden expectations after `manifest.toml` changes |
-| 1 — CI artifact gate | `scripts/interop-report-gate.py` | Stale/missing report, wrong table cells, CSV row/order/outcome drift, summary count mismatch |
+| 1 — export invariants | `tests/interop/harness/certification.rs` | Empty/wrong checklist `Result`, incomplete CSV, export before coverage passes |
+| 2 — manifest sync | `tests/interop/harness/gate_expectations.rs` + committed `gate-expectations.json` | Stale golden expectations after `manifest.toml` changes |
+| 3 — CI artifact gate | `scripts/interop-report-gate.py` | Stale/missing report, wrong table cells, CSV row/order/outcome drift, summary count mismatch |
 
 Regenerate expectations after manifest edits:
 

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -906,6 +906,7 @@ Test harness for **STIX 2.1 Interoperability Version 1.0, Committee Specificatio
 | Cross-cutting | `tests/interop/common/` | Automated checks for 18 §2.3 manifest rows, run suite-wide over **42** walkable normative fixtures |
 | Use-case tests | `tests/interop/use_cases/` | All 21 OASIS §3.x use cases (§3.1–§3.21) with Producer/Consumer/example modules — the SXP/SXC self-certification evidence |
 | Manifest | `tests/fixtures/interop/manifest.toml` | `req_id` → `test_id` → fixture → §4.2 checklist row |
+| Gate expectations | `tests/fixtures/interop/gate-expectations.json` | Manifest-derived golden rows for Tables 55/56 and traceability CSV (regenerate with `scripts/generate-interop-gate-expectations.py` when the manifest changes) |
 | Normative fixtures | `tests/fixtures/interop/testcases/` | Gating OASIS test-case data + `.provenance.toml` sidecars (**44/44** inventory: **42** suite-walkable + **2** `BLOCKED` on §9.1 defects 16 and 19; synthetic helpers remain for intentional negatives) |
 | Examples | `tests/fixtures/interop/examples/` | Non-normative; must never fail the build |
 | Report artifacts | `target/interop-report/` | Self-certification package: `summary.json` (incl. `generated_at`), Tables 55/56 markdown, traceability CSV, risks (never committed; CI uploads as `interop-report`) |
@@ -948,7 +949,21 @@ cargo test -p rstix --test interop_sentinel --locked
 cargo test -p rstix --test interop_sentinel --features validate,marking,graph --locked
 ```
 
-**CI:** the `rstix STIX interop self-certification` job in `.github/workflows/ci.yml` runs the full interop suite (every `TESTED` row), then `scripts/interop-report-gate.py` (report present, `generated_at` not older than `INTEROP_RUN_START`, every `TESTED` row passed, required features on), and uploads `target/interop-report/` as the `interop-report` artifact. The multi-OS `Test` matrix also executes the suite under `--all-features`; the dedicated job is the gated self-certification report producer.
+**CI:** the `rstix STIX interop self-certification` job in `.github/workflows/ci.yml` runs the full interop suite (every `TESTED` row), then `scripts/interop-report-gate.py` (report present, `generated_at` not older than `INTEROP_RUN_START`, Tables 55/56 cell content and traceability CSV rows match `gate-expectations.json`, every `TESTED` row passed, required features on), and uploads `target/interop-report/` as the `interop-report` artifact. The multi-OS `Test` matrix also executes the suite under `--all-features`; the dedicated job is the gated self-certification report producer.
+
+**Three-layer gate:**
+
+| Layer | Where | What it catches |
+| ----- | ----- | ---------------- |
+| 2 — export invariants | `tests/interop/harness/certification.rs` | Empty/wrong checklist `Result`, incomplete CSV, export before coverage passes |
+| 3 — manifest sync | `tests/interop/harness/gate_expectations.rs` + committed `gate-expectations.json` | Stale golden expectations after `manifest.toml` changes |
+| 1 — CI artifact gate | `scripts/interop-report-gate.py` | Stale/missing report, wrong table cells, CSV row/order/outcome drift, summary count mismatch |
+
+Regenerate expectations after manifest edits:
+
+```bash
+python3 scripts/generate-interop-gate-expectations.py
+```
 
 Local gate (same script CI uses):
 

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -890,39 +890,45 @@ The tables above describe **implemented** behavior. Negative and rich fixtures f
 
 <a id="oasis-interop-test-suite"></a>
 
-### OASIS interop test suite
+### OASIS interop self-certification suite
 
-Test harness aligned with **STIX 2.1 Interoperability Version 1.0, Committee Specification Draft 01** (`stix-2.1-interop-v1.0-csd01`, 2021-10-23). It tracks manifest rows for all **21** use cases in that document; normative OASIS test-case JSON and per-requirement tests are added incrementally. The suite lives in `tests/interop/` (single Cargo target) with fixtures under `tests/fixtures/interop/`.
+Test harness for **STIX 2.1 Interoperability Version 1.0, Committee Specification Draft 01** (`stix-2.1-interop-v1.0-csd01`, 2021-10-23). Against that **CSD01** document, `rstix` **self-certifies** as a STIX 2.1 Producer (**SXP**) and Consumer (**SXC**) across all **21** use cases: every §4.2 Table 55/56 row is filled with a real result (`Pass`, or `BLOCKED` where a published §9.1 defect leaves no honest passing path). The suite lives in `tests/interop/` (single Cargo target) with fixtures under `tests/fixtures/interop/`.
 
-**What this suite is not:** a completed OASIS interoperability certification. The generated report is a traceability artifact — not proof that every in-scope requirement passed.
+**Claim boundaries:**
+
+- **Claimed:** SXP + SXC for the 21 CSD01 use cases, evidenced by the generated Tables 55/56, `traceability.csv`, and `summary.json` from each green interop run.
+- **Not claimed:** an OASIS-issued / third-party certificate; any of the seven §4.1 product personas (AIM, LIM, MAS, SIEM, TDS, TIP, TMS) — `rstix` is a library, not those deployed products; TAXII TXC (separate suite).
+- **Scoped degradations:** `REQ-CHK-SXP-3.12` and `REQ-CHK-SXP-3.16` render **BLOCKED** (defects 19 and 16), not `Pass`.
 
 | Component | Path | Role |
 | --------- | ---- | ---- |
-| Harness | `tests/interop/harness/` | Manifest, fixture loader + provenance, per-use-case overlay on `interop_strict`, bundle closure, containment, certification report |
+| Harness | `tests/interop/harness/` | Manifest, fixture loader + provenance, per-use-case overlay on `interop_strict`, bundle closure, containment, self-certification report |
 | Cross-cutting | `tests/interop/common/` | Automated checks for 18 §2.3 manifest rows, run suite-wide over **42** walkable normative fixtures |
-| Use-case tests | `tests/interop/use_cases/` | **All 21** OASIS §3.x use cases (§3.1–§3.21) with Producer/Consumer/example modules. **Not** OASIS SXP/SXC certification. |
+| Use-case tests | `tests/interop/use_cases/` | All 21 OASIS §3.x use cases (§3.1–§3.21) with Producer/Consumer/example modules — the SXP/SXC self-certification evidence |
 | Manifest | `tests/fixtures/interop/manifest.toml` | `req_id` → `test_id` → fixture → §4.2 checklist row |
 | Normative fixtures | `tests/fixtures/interop/testcases/` | Gating OASIS test-case data + `.provenance.toml` sidecars (**44/44** inventory: **42** suite-walkable + **2** `BLOCKED` on §9.1 defects 16 and 19; synthetic helpers remain for intentional negatives) |
 | Examples | `tests/fixtures/interop/examples/` | Non-normative; must never fail the build |
-| Report artifacts | `target/interop-report/` | `summary.json`, Tables 55/56 markdown, traceability CSV, risks (never committed) |
+| Report artifacts | `target/interop-report/` | Self-certification package: `summary.json` (incl. `generated_at`), Tables 55/56 markdown, traceability CSV, risks (never committed; CI uploads as `interop-report`) |
 
-**Certification report semantics (`summary.json`):**
+**Report semantics (`summary.json`):**
 
 | Field | Meaning |
 | ----- | ------- |
-| `oasis_use_cases_in_spec` | The OASIS interoperability document defines 21 use cases — **not** how many are tested here. |
-| `manifest_rows_total` | Rows in `manifest.toml` (harness + placeholders + smoke). |
+| `document` / `document_stage` | CSD01 authority string — must appear on any published self-certification claim. |
+| `generated_at` | UTC RFC 3339 timestamp written when the harness finalized the report (CI stale gate). |
+| `oasis_use_cases_in_spec` | The CSD01 document defines 21 use cases (all covered by this suite). |
+| `manifest_rows_total` | Rows in `manifest.toml`. |
 | `manifest_rows_by_disposition` | Breakdown by `TESTED`, `HARNESS_SMOKE`, `REPORT_ONLY`, `BLOCKED`. |
 | `tested_rows_passed` | Executable manifest rows with `disposition = TESTED` that recorded `Pass` (**506** today: 9 harness + 18 §2.3 + **479** §3.1–§3.21 use-case rows) |
 | `harness_smoke_executed` | Rows with `disposition = HARNESS_SMOKE` (0 today; reserved for partial checks if reintroduced) |
-| `report_only_rows` | §4.2 checklist/framework placeholders with no automated test (**5** today) |
+| `report_only_rows` | §4.2 framework / scoping placeholders outside the 46 Table 55/56 checklist cells (**5** today) |
 | `blocked_rows` | Checklist rows blocked on unrepairable published test-case data (**2** today: §3.12 / §3.16 SXP) |
 
-There is **no** “100% covered” field. Do not infer OASIS conformance from manifest row counts.
+`TESTED` / `Pass` means the harness recorded a passing assertion for that manifest row. It is the operational definition of self-certification evidence for that requirement — not an OASIS-issued stamp.
 
-**§2.3 manifest rows:** 18 rows use `disposition = TESTED` and run suite-wide over walkable normative fixtures. **`TESTED` here means our harness recorded `Pass` — not OASIS §2.3 requirement verification, not the full interop manifest row inventory from the engineering plan.
+**§2.3 manifest rows:** 18 rows use `disposition = TESTED` and run suite-wide over walkable normative fixtures.
 
-**§3.x use-case rows:** Modules cover all 21 OASIS use cases (§3.1–§3.21). Producer/Consumer persona rows, Table 55/56 checklist rows, and non-gating examples where CSD01 defines them. This is **not** OASIS SXP/SXC certification. `REQ-CHK-SXP-3.12` and `REQ-CHK-SXP-3.16` remain **BLOCKED** on published defects 19 and 16.
+**§3.x use-case rows:** Producer/Consumer persona support, Table 55/56 checklist rows, and non-gating examples where CSD01 defines them. SXP checklist rows for §3.12 and §3.16 stay **BLOCKED** on defects 19 and 16.
 
 **Run locally (required features explicit):**
 
@@ -930,7 +936,7 @@ There is **no** “100% covered” field. Do not infer OASIS conformance from ma
 cargo test -p rstix --test interop --features validate,marking,graph --locked
 ```
 
-The interop target uses a custom runner (`harness = false`): registered tests run in stable order, then the certification report is written. No `--test-threads=1` flag is required — parallel `cargo test --workspace --all-features` is safe because finalize no longer races other tests.
+The interop target uses a custom runner (`harness = false`): registered tests run in stable order, then the self-certification report is written. No `--test-threads=1` flag is required — parallel `cargo test --workspace --all-features` is safe because finalize no longer races other tests.
 
 **Silent-skip guard:** `tests/interop_sentinel.rs` is an ungated target that **must fail** when `validate`, `marking`, and `graph` are not enabled — that failure is correct, not a regression. It **passes** only when those three features are on (same as CI’s `cargo test --workspace --all-features`):
 
@@ -942,30 +948,14 @@ cargo test -p rstix --test interop_sentinel --locked
 cargo test -p rstix --test interop_sentinel --features validate,marking,graph --locked
 ```
 
-**CI job template (artifact gate):**
+**CI:** the `rstix STIX interop self-certification` job in `.github/workflows/ci.yml` runs the full interop suite (every `TESTED` row), then `scripts/interop-report-gate.py` (report present, `generated_at` not older than `INTEROP_RUN_START`, every `TESTED` row passed, required features on), and uploads `target/interop-report/` as the `interop-report` artifact. The multi-OS `Test` matrix also executes the suite under `--all-features`; the dedicated job is the gated self-certification report producer.
 
-```yaml
-- name: Record interop run start
-  run: echo "INTEROP_RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
-- name: OASIS STIX 2.1 interop test suite
-  run: cargo test -p rstix --test interop --features validate,marking,graph --locked
-- name: Gate on interop report
-  run: |
-    test -f target/interop-report/summary.json
-    python3 - <<'PY'
-    import json
-    summary = json.load(open("target/interop-report/summary.json"))
-    by = summary["manifest_rows_by_disposition"]
-    infra = summary["tested_rows_passed"]
-    smoke = summary["harness_smoke_executed"]
-    assert infra == by["tested"], f"TESTED rows not passed: {infra}/{by['tested']}"
-    assert smoke == by.get("harness_smoke", 0), f"HARNESS_SMOKE mismatch: {smoke}/{by.get('harness_smoke', 0)}"
-    print(f"tested_passed={infra}, harness_smoke={smoke}, report_only={summary['report_only_rows']}, blocked={summary['blocked_rows']}")
-    PY
-- uses: actions/upload-artifact@v4
-  with:
-    name: interop-report
-    path: target/interop-report/
+Local gate (same script CI uses):
+
+```bash
+export INTEROP_RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+cargo test -p rstix --test interop --features validate,marking,graph --locked
+python3 scripts/interop-report-gate.py
 ```
 
 `validate_conformance.rs` and `tests/fixtures/conformance/` remain unchanged — they guard the validator; the interop suite consumes `Validator::interop_strict()` as a dependency.

--- a/crates/rstix/tests/fixtures/interop/gate-expectations.json
+++ b/crates/rstix/tests/fixtures/interop/gate-expectations.json
@@ -1,0 +1,2951 @@
+{
+  "manifest_rows_total": 513,
+  "manifest_rows_by_disposition": {
+    "tested": 506,
+    "harness_smoke": 0,
+    "report_only": 5,
+    "blocked": 2,
+    "api_surface": 0
+  },
+  "traceability_header": "req_id,test_id,fixture,role,level,doc_page,disposition,outcome",
+  "checklist_row_count": 23,
+  "table_55": [
+    {
+      "req_id": "REQ-CHK-SXC-3.1",
+      "use_case": "attack_pattern",
+      "section": "3.1.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.10",
+      "use_case": "location",
+      "section": "3.10.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.11",
+      "use_case": "malware_analysis",
+      "section": "3.11.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.12",
+      "use_case": "malware",
+      "section": "3.12.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.13",
+      "use_case": "note",
+      "section": "3.13.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.14",
+      "use_case": "observed_data",
+      "section": "3.14.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.15",
+      "use_case": "opinion",
+      "section": "3.15.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.16",
+      "use_case": "report",
+      "section": "3.16.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.17",
+      "use_case": "sighting",
+      "section": "3.17.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.18",
+      "use_case": "threat_actor",
+      "section": "3.18.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.19",
+      "use_case": "tool",
+      "section": "3.19.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.2",
+      "use_case": "campaign",
+      "section": "3.2.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.20-R",
+      "use_case": "versioning",
+      "section": "3.20.13",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.20-C",
+      "use_case": "versioning",
+      "section": "3.20.5",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.20-M",
+      "use_case": "versioning",
+      "section": "3.20.9",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.21",
+      "use_case": "vulnerability",
+      "section": "3.21.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.3",
+      "use_case": "confidence",
+      "section": "3.3.6",
+      "verification": "Mandatory",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.4",
+      "use_case": "course_of_action",
+      "section": "3.4.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.5",
+      "use_case": "data_markings",
+      "section": "3.5.6",
+      "verification": "Mandatory",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.6",
+      "use_case": "grouping",
+      "section": "3.6.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.7",
+      "use_case": "indicator",
+      "section": "3.7.6",
+      "verification": "Mandatory",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.8",
+      "use_case": "infrastructure",
+      "section": "3.8.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.9",
+      "use_case": "intrusion_set",
+      "section": "3.9.6",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    }
+  ],
+  "table_56": [
+    {
+      "req_id": "REQ-CHK-SXP-3.1",
+      "use_case": "attack_pattern",
+      "section": "3.1.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.10",
+      "use_case": "location",
+      "section": "3.10.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.11",
+      "use_case": "malware_analysis",
+      "section": "3.11.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.12",
+      "use_case": "malware",
+      "section": "3.12.3",
+      "verification": "Optional",
+      "disposition": "BLOCKED",
+      "expected_result": "BLOCKED (unrepairable published test data)"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.13",
+      "use_case": "note",
+      "section": "3.13.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.14",
+      "use_case": "observed_data",
+      "section": "3.14.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.15",
+      "use_case": "opinion",
+      "section": "3.15.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.16",
+      "use_case": "report",
+      "section": "3.16.3",
+      "verification": "Optional",
+      "disposition": "BLOCKED",
+      "expected_result": "BLOCKED (unrepairable published test data)"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.17",
+      "use_case": "sighting",
+      "section": "3.17.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.18",
+      "use_case": "threat_actor",
+      "section": "3.18.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.19",
+      "use_case": "tool",
+      "section": "3.19.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.2",
+      "use_case": "campaign",
+      "section": "3.2.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.20-R",
+      "use_case": "versioning",
+      "section": "3.20.11",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.20-C",
+      "use_case": "versioning",
+      "section": "3.20.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.20-M",
+      "use_case": "versioning",
+      "section": "3.20.7",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.21",
+      "use_case": "vulnerability",
+      "section": "3.21.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.3",
+      "use_case": "confidence",
+      "section": "3.3.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.4",
+      "use_case": "course_of_action",
+      "section": "3.4.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.5",
+      "use_case": "data_markings",
+      "section": "3.5.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.6",
+      "use_case": "grouping",
+      "section": "3.6.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.7",
+      "use_case": "indicator",
+      "section": "3.7.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.8",
+      "use_case": "infrastructure",
+      "section": "3.8.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.9",
+      "use_case": "intrusion_set",
+      "section": "3.9.3",
+      "verification": "Optional",
+      "disposition": "TESTED",
+      "expected_result": "Pass"
+    }
+  ],
+  "traceability_rows": [
+    {
+      "req_id": "REQ-4.2-X-01",
+      "disposition": "REPORT_ONLY",
+      "expected_outcome": "REPORT_ONLY"
+    },
+    {
+      "req_id": "REQ-4.2-C-01",
+      "disposition": "REPORT_ONLY",
+      "expected_outcome": "REPORT_ONLY"
+    },
+    {
+      "req_id": "REQ-4.2-P-01",
+      "disposition": "REPORT_ONLY",
+      "expected_outcome": "REPORT_ONLY"
+    },
+    {
+      "req_id": "REQ-4.2-X-03",
+      "disposition": "REPORT_ONLY",
+      "expected_outcome": "REPORT_ONLY"
+    },
+    {
+      "req_id": "REQ-3.1-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.1-EX-7.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.2-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.3",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.3",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.3-EX-7.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.4",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.4-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.4",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.6",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-EX-4.3",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.6-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.6",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-P-15",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.7",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-EX-7.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-EX-7.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-EX-7.3",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-EX-7.4",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.7-EX-7.5",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.7",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.8",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.8-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.8",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.9",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.9-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.9",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.19",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.19-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.19",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.21",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.21-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.21",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-EX-4.3",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.10-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-15",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-P-16",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.11-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.13-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.5",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.5-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.5",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-15",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-16",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-P-17",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.12",
+      "disposition": "BLOCKED",
+      "expected_outcome": "BLOCKED"
+    },
+    {
+      "req_id": "REQ-3.12-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.12-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.14-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.15",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.15-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.15",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.16",
+      "disposition": "BLOCKED",
+      "expected_outcome": "BLOCKED"
+    },
+    {
+      "req_id": "REQ-3.16-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.16-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.16",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.17",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.17-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.17",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-07",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-11",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-12",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-13",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-14",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-15",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-P-16",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.18",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-EX-4.1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-EX-4.2",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.18-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.18",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-1",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.20-C",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-M-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-M-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-M-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-M-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.20-M",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-R-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-R-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-R-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-R-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-P-R-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-REV-X-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXP-3.20-R",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.20-C",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-M-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-M-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-M-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-M-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-M-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.20-M",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-R-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-R-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-R-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-R-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-3.20-C-R-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-CHK-SXC-3.20-R",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-MANIFEST-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-MANIFEST-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-FIXTURE-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-FIXTURE-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-FIXTURE-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-PROFILE-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-CONTAIN-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-CLOSURE-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-P-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-P-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-P-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-C-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-C-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-C-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-C-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-C-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-C-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-02",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-03",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-04",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-05",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-06",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-07",
+      "disposition": "REPORT_ONLY",
+      "expected_outcome": "REPORT_ONLY"
+    },
+    {
+      "req_id": "REQ-2.3-X-08",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-09",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-2.3-X-10",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    },
+    {
+      "req_id": "REQ-HARNESS-VALIDATOR-01",
+      "disposition": "TESTED",
+      "expected_outcome": "Pass"
+    }
+  ]
+}

--- a/crates/rstix/tests/interop/harness/certification.rs
+++ b/crates/rstix/tests/interop/harness/certification.rs
@@ -177,9 +177,11 @@ fn write_report_artifacts(manifest: &Manifest) {
 struct SummaryJson {
     document: &'static str,
     document_stage: &'static str,
+    /// UTC RFC 3339 timestamp written when this report was finalized (CI stale gate).
+    generated_at: String,
     /// Personas this harness is built to support (not a certification claim).
     personas_target: Vec<&'static str>,
-    /// OASIS interoperability spec defines 21 use cases; normative tests not all present yet.
+    /// OASIS interoperability spec defines 21 use cases (§3.1–§3.21).
     oasis_use_cases_in_spec: u32,
     manifest_rows_total: usize,
     manifest_rows_by_disposition: ManifestDispositionCounts,
@@ -187,7 +189,7 @@ struct SummaryJson {
     tested_rows_passed: usize,
     /// Rows with disposition `HARNESS_SMOKE` that executed (partial checks only).
     harness_smoke_executed: usize,
-    /// Checklist/framework placeholders — no automated test in this PR.
+    /// §4.2 framework / scoping placeholders with no automated test.
     report_only_rows: usize,
     /// Rows blocked because published OASIS test-case bytes cannot be repaired without inventing data.
     blocked_rows: usize,
@@ -223,10 +225,14 @@ fn build_summary(manifest: &Manifest, recorded: &HashMap<&'static str, Outcome>)
         .filter(|row| row.disposition == Disposition::HarnessSmoke)
         .filter(|row| recorded.get(row.req_id.as_str()) == Some(&Outcome::HarnessSmoke))
         .count();
+    let generated_at = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("format generated_at as RFC 3339");
 
     SummaryJson {
         document: "STIX 2.1 Interoperability v1.0 CSD01 (stix-2.1-interop-v1.0-csd01)",
         document_stage: "Committee Specification Draft 01 (2021-10-23)",
+        generated_at,
         personas_target: vec!["SXP", "SXC"],
         oasis_use_cases_in_spec: 21,
         manifest_rows_total: manifest.requirements.len(),

--- a/crates/rstix/tests/interop/harness/certification.rs
+++ b/crates/rstix/tests/interop/harness/certification.rs
@@ -135,6 +135,8 @@ fn write_report_artifacts(manifest: &Manifest) {
     fs::create_dir_all(&dir).expect("create interop-report directory");
 
     let recorded = outcomes().lock().expect("interop outcomes lock");
+    verify_export_invariants(manifest, &recorded);
+
     let summary = build_summary(manifest, &recorded);
     fs::write(
         dir.join("summary.json"),
@@ -306,6 +308,126 @@ fn render_traceability_csv(
     lines.join("\n")
 }
 
+/// Expected checklist `Result` cell after a fully passing interop run (export + CI gate).
+pub fn checklist_result_for_export(row: &RequirementRow) -> String {
+    if row.disposition == Disposition::Blocked {
+        return "BLOCKED (unrepairable published test data)".to_owned();
+    }
+    if row.disposition == Disposition::ReportOnly {
+        return "Pending (checklist report only)".to_owned();
+    }
+    if row.disposition == Disposition::HarnessSmoke {
+        return "Harness smoke (not normative verification)".to_owned();
+    }
+    "Pass".to_owned()
+}
+
+/// Expected traceability CSV `outcome` column after a fully passing interop run.
+pub fn expected_csv_outcome(disposition: Disposition) -> String {
+    match disposition {
+        Disposition::Tested => Outcome::Pass.as_str().to_owned(),
+        Disposition::HarnessSmoke => Outcome::HarnessSmoke.as_str().to_owned(),
+        Disposition::Blocked => Outcome::Blocked.as_str().to_owned(),
+        Disposition::ReportOnly => "REPORT_ONLY".to_owned(),
+        Disposition::ApiSurface => "API_SURFACE".to_owned(),
+    }
+}
+
+fn verify_export_invariants(manifest: &Manifest, recorded: &HashMap<&'static str, Outcome>) {
+    let expectations = super::gate_expectations::from_manifest(manifest);
+    assert_eq!(
+        expectations.checklist_row_count, 23,
+        "§4.2 checklist tables must have 23 rows per role"
+    );
+
+    let consumer_rows = manifest.checklist_rows_consumer();
+    let producer_rows = manifest.checklist_rows_producer();
+    assert_eq!(
+        consumer_rows.len(),
+        expectations.checklist_row_count,
+        "Table 55 row count mismatch"
+    );
+    assert_eq!(
+        producer_rows.len(),
+        expectations.checklist_row_count,
+        "Table 56 row count mismatch"
+    );
+
+    for row in consumer_rows.iter().chain(producer_rows.iter()).copied() {
+        let result = checklist_result(row, recorded);
+        assert_exportable_checklist_result(row, &result);
+        assert_eq!(
+            result,
+            checklist_result_for_export(row),
+            "{}: checklist Result must match export contract",
+            row.req_id
+        );
+    }
+
+    let csv_lines = render_traceability_csv(manifest, recorded).lines().count();
+    assert_eq!(
+        csv_lines,
+        manifest.requirements.len() + 1,
+        "traceability.csv must have one row per manifest requirement plus header"
+    );
+
+    for row in &manifest.requirements {
+        let expected_outcome = expected_csv_outcome(row.disposition);
+        match row.disposition {
+            Disposition::Tested => {
+                assert_eq!(
+                    recorded.get(row.req_id.as_str()),
+                    Some(&Outcome::Pass),
+                    "{}: TESTED row must record Pass before export",
+                    row.req_id
+                );
+                assert_eq!(expected_outcome, "Pass");
+            }
+            Disposition::HarnessSmoke => {
+                assert_eq!(
+                    recorded.get(row.req_id.as_str()),
+                    Some(&Outcome::HarnessSmoke),
+                    "{}: HARNESS_SMOKE row must record HarnessSmoke before export",
+                    row.req_id
+                );
+            }
+            Disposition::Blocked | Disposition::ReportOnly | Disposition::ApiSurface => {}
+        }
+    }
+}
+
+fn assert_exportable_checklist_result(row: &RequirementRow, result: &str) {
+    assert!(
+        !result.is_empty(),
+        "{}: checklist Result must not be empty",
+        row.req_id
+    );
+    match row.disposition {
+        Disposition::ReportOnly => {
+            assert_eq!(result, "Pending (checklist report only)");
+        }
+        Disposition::Blocked => {
+            assert_eq!(result, "BLOCKED (unrepairable published test data)");
+        }
+        Disposition::HarnessSmoke => {
+            assert_eq!(result, "Harness smoke (not normative verification)");
+        }
+        Disposition::Tested => {
+            assert_eq!(
+                result, "Pass",
+                "{}: TESTED row must export Pass",
+                row.req_id
+            );
+        }
+        Disposition::ApiSurface => {
+            panic!(
+                "{}: API_SURFACE must not appear in §4.2 checklist tables",
+                row.req_id
+            );
+        }
+    }
+}
+
 fn render_checklist_table(
     title: &str,
     rows: &[&RequirementRow],
@@ -316,6 +438,7 @@ fn render_checklist_table(
     out.push_str("|---|---|---|---|\n");
     for row in rows {
         let result = checklist_result(row, recorded);
+        assert_exportable_checklist_result(row, &result);
         out.push_str(&format!(
             "| {} | {} | {} | {} |\n",
             row.use_case_label(),
@@ -385,6 +508,8 @@ fn render_risks(manifest: &Manifest, recorded: &HashMap<&'static str, Outcome>) 
 
 /// Helper assertions for `harness = false` runner.
 pub fn run_helper_self_tests() {
+    super::gate_expectations::assert_gate_expectations_file_current();
+
     let row = RequirementRow {
         req_id: "REQ-TEST-BLOCKED".to_owned(),
         use_case: None,

--- a/crates/rstix/tests/interop/harness/gate_expectations.rs
+++ b/crates/rstix/tests/interop/harness/gate_expectations.rs
@@ -1,8 +1,9 @@
-//! Manifest-derived expectations for self-certification report gating (Layer 3).
+//! Manifest-derived expectations for self-certification report gating (Layer 2).
 //!
 //! `gate-expectations.json` is generated from `manifest.toml` and checked into
-//! `tests/fixtures/interop/`. CI (`scripts/interop-report-gate.py`) and the interop
-//! harness both use it so table/CSV content is pinned, not only row counts.
+//! `tests/fixtures/interop/`. CI (`scripts/interop-report-gate.py`, Layer 3) and
+//! the interop harness both use it so table/CSV content is pinned, not only row
+//! counts.
 
 use std::fs;
 

--- a/crates/rstix/tests/interop/harness/gate_expectations.rs
+++ b/crates/rstix/tests/interop/harness/gate_expectations.rs
@@ -1,0 +1,143 @@
+//! Manifest-derived expectations for self-certification report gating (Layer 3).
+//!
+//! `gate-expectations.json` is generated from `manifest.toml` and checked into
+//! `tests/fixtures/interop/`. CI (`scripts/interop-report-gate.py`) and the interop
+//! harness both use it so table/CSV content is pinned, not only row counts.
+
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+use super::certification::{checklist_result_for_export, expected_csv_outcome};
+use super::fixture::interop_fixtures_root;
+use super::manifest::{Disposition, Manifest, RequirementRow};
+
+const EXPECTATIONS_FILE: &str = "gate-expectations.json";
+const TRACEABILITY_HEADER: &str = "req_id,test_id,fixture,role,level,doc_page,disposition,outcome";
+
+/// One §4.2 checklist row pinned for Table 55/56 content gates.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChecklistExpectation {
+    pub req_id: String,
+    pub use_case: String,
+    pub section: String,
+    pub verification: String,
+    pub disposition: String,
+    pub expected_result: String,
+}
+
+/// One traceability CSV row pinned for content gates (outcome after a passing run).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceabilityExpectation {
+    pub req_id: String,
+    pub disposition: String,
+    pub expected_outcome: String,
+}
+
+/// Full gate expectation bundle derived from `manifest.toml`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateExpectations {
+    pub manifest_rows_total: usize,
+    pub manifest_rows_by_disposition: DispositionCounts,
+    pub traceability_header: String,
+    pub checklist_row_count: usize,
+    pub table_55: Vec<ChecklistExpectation>,
+    pub table_56: Vec<ChecklistExpectation>,
+    pub traceability_rows: Vec<TraceabilityExpectation>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DispositionCounts {
+    pub tested: usize,
+    pub harness_smoke: usize,
+    pub report_only: usize,
+    pub blocked: usize,
+    pub api_surface: usize,
+}
+
+pub fn expectations_path() -> std::path::PathBuf {
+    interop_fixtures_root().join(EXPECTATIONS_FILE)
+}
+
+/// Build expectations from the loaded manifest (single source of truth for semantics).
+pub fn from_manifest(manifest: &Manifest) -> GateExpectations {
+    let mut counts = DispositionCounts {
+        tested: 0,
+        harness_smoke: 0,
+        report_only: 0,
+        blocked: 0,
+        api_surface: 0,
+    };
+    for row in &manifest.requirements {
+        match row.disposition {
+            Disposition::Tested => counts.tested += 1,
+            Disposition::HarnessSmoke => counts.harness_smoke += 1,
+            Disposition::ReportOnly => counts.report_only += 1,
+            Disposition::Blocked => counts.blocked += 1,
+            Disposition::ApiSurface => counts.api_surface += 1,
+        }
+    }
+
+    let table_55 = checklist_expectations(manifest.checklist_rows_consumer());
+    let table_56 = checklist_expectations(manifest.checklist_rows_producer());
+    let traceability_rows = manifest
+        .requirements
+        .iter()
+        .map(|row| TraceabilityExpectation {
+            req_id: row.req_id.clone(),
+            disposition: row.disposition.as_str().to_owned(),
+            expected_outcome: expected_csv_outcome(row.disposition),
+        })
+        .collect();
+
+    GateExpectations {
+        manifest_rows_total: manifest.requirements.len(),
+        manifest_rows_by_disposition: counts,
+        traceability_header: TRACEABILITY_HEADER.to_owned(),
+        checklist_row_count: table_55.len(),
+        table_55,
+        table_56,
+        traceability_rows,
+    }
+}
+
+fn checklist_expectations(rows: Vec<&RequirementRow>) -> Vec<ChecklistExpectation> {
+    rows.into_iter()
+        .map(|row| ChecklistExpectation {
+            req_id: row.req_id.clone(),
+            use_case: row.use_case_label().to_owned(),
+            section: row.section.clone().unwrap_or_default(),
+            verification: row.verification_label().to_owned(),
+            disposition: row.disposition.as_str().to_owned(),
+            expected_result: checklist_result_for_export(row),
+        })
+        .collect()
+}
+
+/// Committed expectations must match the manifest (regenerate when manifest changes).
+pub fn assert_gate_expectations_file_current() {
+    let manifest = super::manifest::load_manifest();
+    let computed = from_manifest(&manifest);
+    let path = expectations_path();
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    let committed: GateExpectations =
+        serde_json::from_str(&text).unwrap_or_else(|err| panic!("parse {}: {err}", path.display()));
+    assert_eq!(
+        computed, committed,
+        "gate-expectations.json is stale — regenerate with:\n  \
+         python3 scripts/generate-interop-gate-expectations.py"
+    );
+}
+
+/// Write `gate-expectations.json` when `RSTIX_WRITE_GATE_EXPECTATIONS=1`.
+pub fn maybe_write_gate_expectations_file(manifest: &Manifest) {
+    if std::env::var("RSTIX_WRITE_GATE_EXPECTATIONS").as_deref() != Ok("1") {
+        return;
+    }
+    let path = expectations_path();
+    let expectations = from_manifest(manifest);
+    let json = serde_json::to_string_pretty(&expectations).expect("serialize gate expectations");
+    fs::write(&path, format!("{json}\n")).expect("write gate expectations");
+    eprintln!("wrote {}", path.display());
+}

--- a/crates/rstix/tests/interop/harness/mod.rs
+++ b/crates/rstix/tests/interop/harness/mod.rs
@@ -2,6 +2,7 @@ pub mod certification;
 pub mod closure;
 pub mod containment;
 pub mod fixture;
+pub mod gate_expectations;
 pub mod interop_gate;
 pub mod manifest;
 pub mod profile;

--- a/crates/rstix/tests/interop/main.rs
+++ b/crates/rstix/tests/interop/main.rs
@@ -264,5 +264,6 @@ interop_test!(
 fn main() {
     harness::run_all();
     let manifest = load_manifest();
+    harness::gate_expectations::maybe_write_gate_expectations_file(&manifest);
     harness::certification::finalize(&manifest);
 }

--- a/scripts/generate-interop-gate-expectations.py
+++ b/scripts/generate-interop-gate-expectations.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Generate ``gate-expectations.json`` from ``manifest.toml``.
+
+Run from the repository root when the interop manifest changes:
+
+    python3 scripts/generate-interop-gate-expectations.py
+
+The committed JSON is checked by the interop harness (Layer 3) and
+``scripts/interop-report-gate.py`` (Layer 1). Semantics mirror
+``crates/rstix/tests/interop/harness/gate_expectations.rs``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    print("generate-interop-gate-expectations: Python 3.11+ required (tomllib)", file=sys.stderr)
+    sys.exit(1)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = REPO_ROOT / "crates/rstix/tests/fixtures/interop/manifest.toml"
+OUTPUT = REPO_ROOT / "crates/rstix/tests/fixtures/interop/gate-expectations.json"
+TRACEABILITY_HEADER = "req_id,test_id,fixture,role,level,doc_page,disposition,outcome"
+CHECKLIST_ROW_COUNT = 23
+
+
+def checklist_result_for_export(row: dict[str, object]) -> str:
+    disposition = row.get("disposition", "TESTED")
+    if disposition == "BLOCKED":
+        return "BLOCKED (unrepairable published test data)"
+    if disposition == "REPORT_ONLY":
+        return "Pending (checklist report only)"
+    if disposition == "HARNESS_SMOKE":
+        return "Harness smoke (not normative verification)"
+    return "Pass"
+
+
+def expected_csv_outcome(disposition: str) -> str:
+    return {
+        "TESTED": "Pass",
+        "HARNESS_SMOKE": "HARNESS_SMOKE",
+        "BLOCKED": "BLOCKED",
+        "REPORT_ONLY": "REPORT_ONLY",
+        "API_SURFACE": "API_SURFACE",
+    }[disposition]
+
+
+def use_case_label(row: dict[str, object]) -> str:
+    use_case = row.get("use_case")
+    return use_case if isinstance(use_case, str) and use_case else "framework"
+
+
+def verification_label(row: dict[str, object]) -> str:
+    verification = row.get("verification")
+    return verification if isinstance(verification, str) else ""
+
+
+def checklist_expectations(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        {
+            "req_id": row["req_id"],
+            "use_case": use_case_label(row),
+            "section": row.get("section") or "",
+            "verification": verification_label(row),
+            "disposition": row.get("disposition", "TESTED"),
+            "expected_result": checklist_result_for_export(row),
+        }
+        for row in rows
+    ]
+
+
+def checklist_rows_for_role(rows: list[dict[str, object]], role: str) -> list[dict[str, object]]:
+    filtered = [
+        row
+        for row in rows
+        if row.get("checklist_row") and row.get("checklist_role") == role
+    ]
+    filtered.sort(key=lambda row: row["checklist_row"])
+    return filtered
+
+
+def disposition_counts(rows: list[dict[str, object]]) -> dict[str, int]:
+    counts = {
+        "tested": 0,
+        "harness_smoke": 0,
+        "report_only": 0,
+        "blocked": 0,
+        "api_surface": 0,
+    }
+    mapping = {
+        "TESTED": "tested",
+        "HARNESS_SMOKE": "harness_smoke",
+        "REPORT_ONLY": "report_only",
+        "BLOCKED": "blocked",
+        "API_SURFACE": "api_surface",
+    }
+    for row in rows:
+        key = mapping[row.get("disposition", "TESTED")]
+        counts[key] += 1
+    return counts
+
+
+def main() -> None:
+    if not MANIFEST.is_file():
+        print(f"generate-interop-gate-expectations: missing {MANIFEST}", file=sys.stderr)
+        sys.exit(1)
+
+    rows: list[dict[str, object]] = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))[
+        "requirement"
+    ]
+    table_55 = checklist_expectations(checklist_rows_for_role(rows, "consumer"))
+    table_56 = checklist_expectations(checklist_rows_for_role(rows, "producer"))
+
+    if len(table_55) != CHECKLIST_ROW_COUNT or len(table_56) != CHECKLIST_ROW_COUNT:
+        print(
+            "generate-interop-gate-expectations: expected "
+            f"{CHECKLIST_ROW_COUNT} checklist rows per role, got "
+            f"consumer={len(table_55)} producer={len(table_56)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    expectations = {
+        "manifest_rows_total": len(rows),
+        "manifest_rows_by_disposition": disposition_counts(rows),
+        "traceability_header": TRACEABILITY_HEADER,
+        "checklist_row_count": CHECKLIST_ROW_COUNT,
+        "table_55": table_55,
+        "table_56": table_56,
+        "traceability_rows": [
+            {
+                "req_id": row["req_id"],
+                "disposition": row.get("disposition", "TESTED"),
+                "expected_outcome": expected_csv_outcome(row.get("disposition", "TESTED")),
+            }
+            for row in rows
+        ],
+    }
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(expectations, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-interop-gate-expectations.py
+++ b/scripts/generate-interop-gate-expectations.py
@@ -5,8 +5,8 @@ Run from the repository root when the interop manifest changes:
 
     python3 scripts/generate-interop-gate-expectations.py
 
-The committed JSON is checked by the interop harness (Layer 3) and
-``scripts/interop-report-gate.py`` (Layer 1). Semantics mirror
+The committed JSON is checked by the interop harness (Layer 2) and
+``scripts/interop-report-gate.py`` (Layer 3). Semantics mirror
 ``crates/rstix/tests/interop/harness/gate_expectations.rs``.
 """
 

--- a/scripts/interop-report-gate.py
+++ b/scripts/interop-report-gate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Gate on rstix STIX 2.1 interop self-certification report artifacts.
+
+Used by CI (and locally after ``cargo test -p rstix --test interop``) to ensure
+``target/interop-report/`` was produced by this run and that every ``TESTED``
+manifest row recorded ``Pass``. That report package is the operational
+SXP/SXC self-certification evidence against Interoperability CSD01.
+
+Environment:
+
+- ``INTEROP_RUN_START`` — required UTC RFC 3339 timestamp taken before the
+  interop suite ran. ``summary.json`` ``generated_at`` must be >= this value
+  so a stale report from a previous run cannot satisfy the gate.
+
+Exits 0 on success, 1 on failure. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPORT_DIR = Path("target/interop-report")
+REQUIRED_ARTIFACTS = (
+    "summary.json",
+    "traceability.csv",
+    "sxc-table-55.md",
+    "sxp-table-56.md",
+    "risks.md",
+)
+
+
+def parse_rfc3339(value: str) -> datetime:
+    # Accept trailing Z from both the harness and `date -u +%Y-%m-%dT%H:%M:%SZ`.
+    normalized = value.strip().replace("Z", "+00:00")
+    dt = datetime.fromisoformat(normalized)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def fail(message: str) -> None:
+    print(f"interop-report-gate: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    start_raw = os.environ.get("INTEROP_RUN_START")
+    if not start_raw:
+        fail("INTEROP_RUN_START is required (UTC RFC 3339 from before the suite ran)")
+
+    try:
+        run_start = parse_rfc3339(start_raw)
+    except ValueError as err:
+        fail(f"INTEROP_RUN_START is not RFC 3339: {start_raw!r} ({err})")
+
+    if not REPORT_DIR.is_dir():
+        fail(f"missing report directory {REPORT_DIR}")
+
+    for name in REQUIRED_ARTIFACTS:
+        path = REPORT_DIR / name
+        if not path.is_file():
+            fail(f"missing required artifact {path}")
+
+    summary_path = REPORT_DIR / "summary.json"
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:
+        fail(f"cannot read {summary_path}: {err}")
+
+    generated_raw = summary.get("generated_at")
+    if not isinstance(generated_raw, str) or not generated_raw:
+        fail("summary.json missing string field generated_at")
+
+    try:
+        generated_at = parse_rfc3339(generated_raw)
+    except ValueError as err:
+        fail(f"summary.json generated_at is not RFC 3339: {generated_raw!r} ({err})")
+
+    if generated_at < run_start:
+        fail(
+            "summary.json is stale: "
+            f"generated_at={generated_raw} < INTEROP_RUN_START={start_raw}"
+        )
+
+    by = summary.get("manifest_rows_by_disposition")
+    if not isinstance(by, dict):
+        fail("summary.json missing manifest_rows_by_disposition object")
+
+    tested = by.get("tested")
+    harness_smoke = by.get("harness_smoke", 0)
+    tested_passed = summary.get("tested_rows_passed")
+    smoke_executed = summary.get("harness_smoke_executed")
+    blocked = summary.get("blocked_rows")
+    report_only = summary.get("report_only_rows")
+    features = summary.get("features_enabled")
+
+    if tested_passed != tested:
+        fail(f"TESTED rows not fully passed: tested_rows_passed={tested_passed} tested={tested}")
+    if smoke_executed != harness_smoke:
+        fail(
+            "HARNESS_SMOKE mismatch: "
+            f"harness_smoke_executed={smoke_executed} harness_smoke={harness_smoke}"
+        )
+    if blocked != by.get("blocked"):
+        fail(
+            "blocked_rows mismatch: "
+            f"blocked_rows={blocked} disposition.blocked={by.get('blocked')}"
+        )
+    if report_only != by.get("report_only"):
+        fail(
+            "report_only_rows mismatch: "
+            f"report_only_rows={report_only} disposition.report_only={by.get('report_only')}"
+        )
+    if not isinstance(features, dict) or not all(
+        features.get(name) is True for name in ("validate", "marking", "graph")
+    ):
+        fail(f"features_enabled must be validate/marking/graph all true, got {features!r}")
+
+    print(
+        "interop-report-gate ok: "
+        f"generated_at={generated_raw} "
+        f"tested_passed={tested_passed} "
+        f"harness_smoke={smoke_executed} "
+        f"report_only={report_only} "
+        f"blocked={blocked}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/interop-report-gate.py
+++ b/scripts/interop-report-gate.py
@@ -6,7 +6,7 @@ Used by CI (and locally after ``cargo test -p rstix --test interop``) to ensure
 manifest row recorded ``Pass``. That report package is the operational
 SXP/SXC self-certification evidence against Interoperability CSD01.
 
-Layer 1 (this script): parse Tables 55/56 and ``traceability.csv`` against
+Layer 3 (this script): parse Tables 55/56 and ``traceability.csv`` against
 committed ``gate-expectations.json`` (manifest-derived golden expectations).
 
 Environment:

--- a/scripts/interop-report-gate.py
+++ b/scripts/interop-report-gate.py
@@ -6,6 +6,9 @@ Used by CI (and locally after ``cargo test -p rstix --test interop``) to ensure
 manifest row recorded ``Pass``. That report package is the operational
 SXP/SXC self-certification evidence against Interoperability CSD01.
 
+Layer 1 (this script): parse Tables 55/56 and ``traceability.csv`` against
+committed ``gate-expectations.json`` (manifest-derived golden expectations).
+
 Environment:
 
 - ``INTEROP_RUN_START`` — required UTC RFC 3339 timestamp taken before the
@@ -17,14 +20,20 @@ Exits 0 on success, 1 on failure. Stdlib only.
 
 from __future__ import annotations
 
+import csv
 import json
 import os
 import sys
 from datetime import datetime, timezone
+from io import StringIO
 from pathlib import Path
 
 
-REPORT_DIR = Path("target/interop-report")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPORT_DIR = REPO_ROOT / "target/interop-report"
+EXPECTATIONS_PATH = (
+    REPO_ROOT / "crates/rstix/tests/fixtures/interop/gate-expectations.json"
+)
 REQUIRED_ARTIFACTS = (
     "summary.json",
     "traceability.csv",
@@ -32,6 +41,7 @@ REQUIRED_ARTIFACTS = (
     "sxp-table-56.md",
     "risks.md",
 )
+TABLE_HEADER = ["Use case", "Section", "Verification", "Result"]
 
 
 def parse_rfc3339(value: str) -> datetime:
@@ -48,6 +58,289 @@ def fail(message: str) -> None:
     sys.exit(1)
 
 
+def require_int(data: dict[str, object], key: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int):
+        fail(f"summary.json field {key!r} must be an integer, got {value!r}")
+    return value
+
+
+def require_non_empty_file(path: Path) -> None:
+    try:
+        size = path.stat().st_size
+    except OSError as err:
+        fail(f"cannot stat artifact {path}: {err}")
+    if size <= 0:
+        fail(f"artifact is empty: {path}")
+
+
+def load_expectations() -> dict[str, object]:
+    if not EXPECTATIONS_PATH.is_file():
+        fail(
+            f"missing expectations file {EXPECTATIONS_PATH} "
+            "(run scripts/generate-interop-gate-expectations.py)"
+        )
+    try:
+        data = json.loads(EXPECTATIONS_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:
+        fail(f"cannot read {EXPECTATIONS_PATH}: {err}")
+    if not isinstance(data, dict):
+        fail(f"{EXPECTATIONS_PATH} must be a JSON object")
+    return data
+
+
+def parse_markdown_table(path: Path) -> list[dict[str, str]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as err:
+        fail(f"cannot read table artifact {path}: {err}")
+
+    table_lines = [line for line in lines if line.startswith("|")]
+    body_lines = [line for line in table_lines if not line.startswith("|---")]
+    if len(body_lines) < 2:
+        fail(f"table artifact has no header/body rows: {path}")
+
+    header = [cell.strip() for cell in body_lines[0].strip("|").split("|")]
+    if header != TABLE_HEADER:
+        fail(f"{path.name} header mismatch: expected {TABLE_HEADER}, got {header}")
+
+    rows: list[dict[str, str]] = []
+    for line in body_lines[1:]:
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) != len(TABLE_HEADER):
+            fail(f"{path.name} row has {len(cells)} cells, expected {len(TABLE_HEADER)}: {line}")
+        row = dict(zip(TABLE_HEADER, cells, strict=True))
+        rows.append(row)
+    return rows
+
+
+def checklist_key(row: dict[str, str]) -> tuple[str, str, str]:
+    return (row["Use case"], row["Section"], row["Verification"])
+
+
+def validate_checklist_table(
+    path: Path,
+    expected_rows: list[dict[str, object]],
+    label: str,
+) -> None:
+    actual_rows = parse_markdown_table(path)
+    if len(actual_rows) != len(expected_rows):
+        fail(
+            f"{label} {path.name} has {len(actual_rows)} body rows, "
+            f"expected {len(expected_rows)}"
+        )
+
+    expected_by_key = {
+        (
+            str(row["use_case"]),
+            str(row["section"]),
+            str(row["verification"]),
+        ): row
+        for row in expected_rows
+    }
+    seen_keys: set[tuple[str, str, str]] = set()
+    for actual in actual_rows:
+        key = checklist_key(actual)
+        if key in seen_keys:
+            fail(f"{path.name} duplicate checklist row: {key}")
+        seen_keys.add(key)
+
+        expected = expected_by_key.get(key)
+        if expected is None:
+            fail(f"{path.name} unexpected checklist row: {key}")
+
+        result = actual["Result"]
+        expected_result = str(expected["expected_result"])
+        if not result:
+            fail(f"{path.name} empty Result for {key}")
+        if result != expected_result:
+            fail(
+                f"{path.name} Result mismatch for {key}: "
+                f"got {result!r}, expected {expected_result!r}"
+            )
+
+    missing = set(expected_by_key.keys()) - seen_keys
+    if missing:
+        fail(f"{path.name} missing checklist rows: {sorted(missing)}")
+
+
+def validate_traceability_csv(
+    path: Path,
+    expectations: dict[str, object],
+) -> None:
+    expected_header = expectations.get("traceability_header")
+    if not isinstance(expected_header, str):
+        fail("gate-expectations.json missing traceability_header string")
+
+    expected_rows = expectations.get("traceability_rows")
+    if not isinstance(expected_rows, list):
+        fail("gate-expectations.json missing traceability_rows array")
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as err:
+        fail(f"cannot read {path}: {err}")
+
+    reader = csv.reader(StringIO(text))
+    try:
+        header = next(reader)
+    except StopIteration:
+        fail(f"{path.name} is empty")
+
+    if header != expected_header.split(","):
+        fail(
+            f"{path.name} header mismatch: expected {expected_header.split(',')}, got {header}"
+        )
+
+    actual_rows: list[dict[str, str]] = []
+    for row in reader:
+        if not row:
+            continue
+        if len(row) != 8:
+            fail(f"{path.name} row has {len(row)} columns, expected 8: {row}")
+        actual_rows.append(
+            {
+                "req_id": row[0],
+                "disposition": row[6],
+                "outcome": row[7],
+            }
+        )
+
+    if len(actual_rows) != len(expected_rows):
+        fail(
+            f"{path.name} has {len(actual_rows)} data rows, expected {len(expected_rows)}"
+        )
+
+    seen_req_ids: set[str] = set()
+    for index, (actual, expected_raw) in enumerate(zip(actual_rows, expected_rows, strict=True)):
+        if not isinstance(expected_raw, dict):
+            fail(f"gate-expectations.json traceability_rows[{index}] must be an object")
+
+        req_id = expected_raw.get("req_id")
+        expected_disposition = expected_raw.get("disposition")
+        expected_outcome = expected_raw.get("expected_outcome")
+        if not isinstance(req_id, str):
+            fail(f"gate-expectations.json traceability_rows[{index}] missing req_id")
+        if not isinstance(expected_disposition, str):
+            fail(
+                f"gate-expectations.json traceability_rows[{index}] missing disposition"
+            )
+        if not isinstance(expected_outcome, str):
+            fail(f"gate-expectations.json traceability_rows[{index}] missing expected_outcome")
+
+        if req_id in seen_req_ids:
+            fail(f"{path.name} duplicate req_id: {req_id}")
+        seen_req_ids.add(req_id)
+
+        if actual["req_id"] != req_id:
+            fail(
+                f"{path.name} row order mismatch at index {index}: "
+                f"got req_id={actual['req_id']!r}, expected {req_id!r}"
+            )
+        if actual["disposition"] != expected_disposition:
+            fail(
+                f"{path.name} disposition mismatch for {req_id}: "
+                f"got {actual['disposition']!r}, expected {expected_disposition!r}"
+            )
+        if actual["outcome"] == "MISSING":
+            fail(f"{path.name} outcome MISSING for {req_id}")
+        if actual["outcome"] == "Fail":
+            fail(f"{path.name} outcome Fail for {req_id}")
+        if actual["outcome"] != expected_outcome:
+            fail(
+                f"{path.name} outcome mismatch for {req_id}: "
+                f"got {actual['outcome']!r}, expected {expected_outcome!r}"
+            )
+
+
+def validate_summary(
+    summary: dict[str, object],
+    expectations: dict[str, object],
+) -> tuple[int, int, int, int, str]:
+    expected_total = expectations.get("manifest_rows_total")
+    if not isinstance(expected_total, int):
+        fail("gate-expectations.json manifest_rows_total must be an integer")
+
+    expected_by = expectations.get("manifest_rows_by_disposition")
+    if not isinstance(expected_by, dict):
+        fail("gate-expectations.json missing manifest_rows_by_disposition object")
+
+    generated_raw = summary.get("generated_at")
+    if not isinstance(generated_raw, str) or not generated_raw:
+        fail("summary.json missing string field generated_at")
+
+    by = summary.get("manifest_rows_by_disposition")
+    if not isinstance(by, dict):
+        fail("summary.json missing manifest_rows_by_disposition object")
+
+    tested = require_int(by, "tested")
+    harness_smoke = require_int(by, "harness_smoke")
+    disposition_blocked = require_int(by, "blocked")
+    disposition_report_only = require_int(by, "report_only")
+    tested_passed = require_int(summary, "tested_rows_passed")
+    smoke_executed = require_int(summary, "harness_smoke_executed")
+    blocked = require_int(summary, "blocked_rows")
+    report_only = require_int(summary, "report_only_rows")
+    manifest_rows_total = require_int(summary, "manifest_rows_total")
+    features = summary.get("features_enabled")
+
+    expected_tested = expected_by.get("tested")
+    expected_smoke = expected_by.get("harness_smoke")
+    expected_blocked = expected_by.get("blocked")
+    expected_report_only = expected_by.get("report_only")
+    for name, value in (
+        ("tested", expected_tested),
+        ("harness_smoke", expected_smoke),
+        ("blocked", expected_blocked),
+        ("report_only", expected_report_only),
+    ):
+        if not isinstance(value, int):
+            fail(f"gate-expectations.json manifest_rows_by_disposition.{name} must be int")
+
+    if manifest_rows_total != expected_total:
+        fail(
+            "manifest_rows_total mismatch: "
+            f"summary={manifest_rows_total} expectations={expected_total}"
+        )
+    if tested != expected_tested:
+        fail(f"tested count mismatch: summary={tested} expectations={expected_tested}")
+    if harness_smoke != expected_smoke:
+        fail(
+            f"harness_smoke count mismatch: summary={harness_smoke} "
+            f"expectations={expected_smoke}"
+        )
+    if blocked != expected_blocked:
+        fail(f"blocked count mismatch: summary={blocked} expectations={expected_blocked}")
+    if report_only != expected_report_only:
+        fail(
+            f"report_only count mismatch: summary={report_only} "
+            f"expectations={expected_report_only}"
+        )
+    if tested_passed != tested:
+        fail(f"TESTED rows not fully passed: tested_rows_passed={tested_passed} tested={tested}")
+    if smoke_executed != harness_smoke:
+        fail(
+            "HARNESS_SMOKE mismatch: "
+            f"harness_smoke_executed={smoke_executed} harness_smoke={harness_smoke}"
+        )
+    if blocked != disposition_blocked:
+        fail(
+            "blocked_rows mismatch: "
+            f"blocked_rows={blocked} disposition.blocked={disposition_blocked}"
+        )
+    if report_only != disposition_report_only:
+        fail(
+            "report_only_rows mismatch: "
+            f"report_only_rows={report_only} disposition.report_only={disposition_report_only}"
+        )
+    if not isinstance(features, dict) or not all(
+        features.get(name) is True for name in ("validate", "marking", "graph")
+    ):
+        fail(f"features_enabled must be validate/marking/graph all true, got {features!r}")
+
+    return tested_passed, smoke_executed, report_only, blocked, generated_raw
+
+
 def main() -> None:
     start_raw = os.environ.get("INTEROP_RUN_START")
     if not start_raw:
@@ -58,6 +351,8 @@ def main() -> None:
     except ValueError as err:
         fail(f"INTEROP_RUN_START is not RFC 3339: {start_raw!r} ({err})")
 
+    expectations = load_expectations()
+
     if not REPORT_DIR.is_dir():
         fail(f"missing report directory {REPORT_DIR}")
 
@@ -65,16 +360,36 @@ def main() -> None:
         path = REPORT_DIR / name
         if not path.is_file():
             fail(f"missing required artifact {path}")
+        require_non_empty_file(path)
+
+    table_55 = expectations.get("table_55")
+    table_56 = expectations.get("table_56")
+    if not isinstance(table_55, list) or not isinstance(table_56, list):
+        fail("gate-expectations.json missing table_55/table_56 arrays")
+
+    validate_checklist_table(
+        REPORT_DIR / "sxc-table-55.md",
+        table_55,
+        "Table 55",
+    )
+    validate_checklist_table(
+        REPORT_DIR / "sxp-table-56.md",
+        table_56,
+        "Table 56",
+    )
+    validate_traceability_csv(REPORT_DIR / "traceability.csv", expectations)
 
     summary_path = REPORT_DIR / "summary.json"
     try:
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary_obj = json.loads(summary_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as err:
         fail(f"cannot read {summary_path}: {err}")
+    if not isinstance(summary_obj, dict):
+        fail(f"{summary_path} must be a JSON object")
 
-    generated_raw = summary.get("generated_at")
-    if not isinstance(generated_raw, str) or not generated_raw:
-        fail("summary.json missing string field generated_at")
+    tested_passed, smoke_executed, report_only, blocked, generated_raw = validate_summary(
+        summary_obj, expectations
+    )
 
     try:
         generated_at = parse_rfc3339(generated_raw)
@@ -87,47 +402,15 @@ def main() -> None:
             f"generated_at={generated_raw} < INTEROP_RUN_START={start_raw}"
         )
 
-    by = summary.get("manifest_rows_by_disposition")
-    if not isinstance(by, dict):
-        fail("summary.json missing manifest_rows_by_disposition object")
-
-    tested = by.get("tested")
-    harness_smoke = by.get("harness_smoke", 0)
-    tested_passed = summary.get("tested_rows_passed")
-    smoke_executed = summary.get("harness_smoke_executed")
-    blocked = summary.get("blocked_rows")
-    report_only = summary.get("report_only_rows")
-    features = summary.get("features_enabled")
-
-    if tested_passed != tested:
-        fail(f"TESTED rows not fully passed: tested_rows_passed={tested_passed} tested={tested}")
-    if smoke_executed != harness_smoke:
-        fail(
-            "HARNESS_SMOKE mismatch: "
-            f"harness_smoke_executed={smoke_executed} harness_smoke={harness_smoke}"
-        )
-    if blocked != by.get("blocked"):
-        fail(
-            "blocked_rows mismatch: "
-            f"blocked_rows={blocked} disposition.blocked={by.get('blocked')}"
-        )
-    if report_only != by.get("report_only"):
-        fail(
-            "report_only_rows mismatch: "
-            f"report_only_rows={report_only} disposition.report_only={by.get('report_only')}"
-        )
-    if not isinstance(features, dict) or not all(
-        features.get(name) is True for name in ("validate", "marking", "graph")
-    ):
-        fail(f"features_enabled must be validate/marking/graph all true, got {features!r}")
-
     print(
         "interop-report-gate ok: "
         f"generated_at={generated_raw} "
         f"tested_passed={tested_passed} "
         f"harness_smoke={smoke_executed} "
         f"report_only={report_only} "
-        f"blocked={blocked}"
+        f"blocked={blocked} "
+        f"table_rows={len(table_55)} "
+        f"csv_rows={expectations.get('manifest_rows_total')}"
     )
 
 


### PR DESCRIPTION
## Summary
- Adds a dedicated CI job that runs the full rstix interop suite (`cargo test -p rstix --test interop --features validate,marking,graph`) — every `TESTED` manifest row that backs CSD01 SXP/SXC **self-certification** (21 use cases; Tables 55/56 filled with Pass or BLOCKED).
- Stamps `generated_at` into `summary.json` and gates the run with `scripts/interop-report-gate.py` so a missing, stale, or incomplete report fails CI; uploads `target/interop-report/` (`summary.json`, `sxc-table-55.md`, `sxp-table-56.md`, `traceability.csv`, `risks.md`).
- This is operational self-certification against Interoperability **CSD01** (library as SXP + SXC). 
- `REQ-CHK-SXP-3.12` / `REQ-CHK-SXP-3.16` remain BLOCKED (defects 19 / 16).

## Test plan
- [*] `cargo fmt --all -- --check`
- [*] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [*] `cargo +1.88.0 check --workspace --all-targets --all-features --locked`
- [*] `cargo clippy -p rstix --all-targets --features validate,marking,graph --locked -- -D warnings`
- [*] `cargo test -p rstix --test interop --features validate,marking,graph --locked`
- [*] `export INTEROP_RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ) && cargo test -p rstix --test interop --features validate,marking,graph --locked && python3 scripts/interop-report-gate.py`
- [*] Confirm `target/interop-report/summary.json`: `tested_rows_passed` == 506, `blocked_rows` == 2, `generated_at` present
- [*] `cargo test -p rstix --test interop_sentinel --locked` fails without features; passes with `validate,marking,graph`