### PR TITLE
chore(deps): batch vscode security dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Dependency batch (Aug 2026 vscode)
+
+VS Code extension transitive security updates in `editors/vscode`: `undici` 7.29.0, `brace-expansion` 5.0.9, and `fast-uri` 3.1.5, with npm overrides floors raised to match.
+
 ### rstix: STIX interop self-certification CI gate (#440)
 
 CI runs a dedicated `rstix STIX interop self-certification` job that executes the full interop suite (every `TESTED` manifest row), stamps `generated_at` into `summary.json`, fails on a missing/stale/incomplete report via `scripts/interop-report-gate.py`, and uploads `target/interop-report/` (CSD01 §4.2 Tables 55/56, traceability CSV, risks). The gate validates artifact **content** (checklist cell results, traceability CSV row order and outcomes) against committed `gate-expectations.json`, not only file presence and row counts. Export invariants in the harness panic before writing a hollow report. That package is the operational SXP/SXC **self-certification** evidence against Interoperability **CSD01** — not an OASIS-issued certificate, and not a §4.1 product-persona claim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Dependency batch (Aug 2026 vscode)
+### Dependency batch (Aug 2026 vscode) (#444)
 
 VS Code extension transitive security updates in `editors/vscode`: `undici` 7.29.0, `brace-expansion` 5.0.9, and `fast-uri` 3.1.5, with npm overrides floors raised to match.
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1743,9 +1743,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4513,9 +4513,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -74,10 +74,10 @@
       "minimatch": "^10.2.1"
     },
     "@vscode/vsce": {
-      "undici": "^7.24.0"
+      "undici": "^7.29.0"
     },
     "@azure/msal-node": "^5.2.2",
     "lodash": "^4.17.21",
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Summary
- Rolls up Dependabot PRs #439 (`undici` 7.29.0), #441 (`brace-expansion` 5.0.9), and #443 (`fast-uri` 3.1.5) into one merge for `editors/vscode`.
- Raises the npm override floors to `undici` ^7.29.0 and `brace-expansion` ^5.0.9 so installs stay on the patched range.
- Clears Dependabot alerts [#54](https://github.com/timescale/rsigma/security/dependabot/54)–[#60](https://github.com/timescale/rsigma/security/dependabot/60) (undici, brace-expansion, fast-uri).
- Leaves `rusqlite` 0.40.1 (#234) and `tikv-jemallocator` 0.7.0 (#425) open: same holdbacks as the prior batch.

Closes #439, closes #441, closes #443.

## Test plan
- [x] `npm ci` in `editors/vscode` (0 vulnerabilities)
- [x] `npm ls undici brace-expansion fast-uri` shows 7.29.0 / 5.0.9 / 3.1.5
- [x] `npm run compile` in `editors/vscode`
- [ ] CI green