### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-05
+
+**TL;DR**
+RSigma v0.21.0 is the "daemon throughput and STIX interop" release: the evaluation and daemon path gain witness-based candidate indexing, parallel parsing, multicore batching, and jemalloc on musl; `rstix` completes OASIS STIX 2.1 Interoperability use-case coverage with a self-certification CI gate; and detection engineering gains verified rule tuning, OCSF findings, and post-pipeline rule inspection.
+* Daemon throughput: jemalloc for the musl allocator (#412, thanks to @alltilla), parallel batch parsing and single-parse DLQ (#415), default multicore batching (#408), witness-based candidate indexing with pre-filter soundness fixes (#406), concurrent multi-batch detection (#426, #428), short-circuit condition evaluation (#427), ASCII case-insensitive Aho-Corasick and top-level key probes (#420, #419), plus representative performance baselines and cross-architecture gates (#404, #409, #429).
+* `rstix` STIX interop: OASIS CSD01 golden harness through all 21 use cases (#403, #410, #413, #433, #438), self-certification CI gate (#440), STIX 2.1 wire conformance (#388), and TAXII collection ingest with DANE DNSSEC (#387, #381), thanks to @SecurityEnthusiast.
+* Detection engineering: verified false-positive-driven `rule tune` (#431), post-pipeline rule retrieval for embedders (#437), OCSF Detection Finding output (#397), incident bundle export (#400), and list-valued `add_condition` (#399, thanks to @frack113).
+* Operator surfaces: per-sink output formats (#396), complete `--output-format` coverage (#389), and a documentation accuracy overhaul (#435).
+* Dependencies: Dependabot batches across Rust, CI actions, and the VS Code extension (#402, #432, #444).
+
 ### Dependency batch (Aug 2026 vscode) (#444)
 
 VS Code extension transitive security updates in `editors/vscode`: `undici` 7.29.0, `brace-expansion` 5.0.9, and `fast-uri` 3.1.5, with npm overrides floors raised to match.
@@ -290,6 +300,8 @@ Rolls up six open Dependabot PRs into a single merge. Rust (workspace `Cargo.loc
 
 - **`TaxiiClientConfig::dane_require_dnssec`** — default `true` when `ServerTrustPolicy::Dane`; DNSSEC-validates TLSA prefetch and SRV discovery (TAXII §8.5.2 SHOULD). Set `false` for unsigned lab DNS only.
 - **`DnsLookupOptions`** — `validate_dnssec` on `resolve_*_with_options` helpers (default `false` for standalone calls).
+
+[v0.20.0...v0.21.0](https://github.com/timescale/rsigma/compare/v0.20.0...v0.21.0)
 
 ## [0.20.0] - 2026-07-22
 
@@ -2800,6 +2812,7 @@ First release of rsigma -- a Sigma detection toolkit in Rust. Ships a parser, ev
 
 Initial crates.io publish. Reserved the `rsigma` crate name with a minimal CLI binary (parser + evaluator only, no linter/LSP/pipelines/correlation). Superseded the same day by v0.2.0, which is the first feature-complete release.
 
+[0.21.0]: https://github.com/timescale/rsigma/releases/tag/v0.21.0
 [0.20.0]: https://github.com/timescale/rsigma/releases/tag/v0.20.0
 [0.19.0]: https://github.com/timescale/rsigma/releases/tag/v0.19.0
 [0.18.0]: https://github.com/timescale/rsigma/releases/tag/v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4431,7 +4431,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "insta",
  "log",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-ir"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ciborium",
  "rsigma-eval",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-lsp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "globset",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-nats",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.23.0",
  "email_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz", "ci/wasm-smoke"]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"

--- a/ci/wasm-smoke/Cargo.lock
+++ b/ci/wasm-smoke/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsigma-eval"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-ir"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ciborium",
  "rsigma-parser",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "globset",
  "log",

--- a/crates/rsigma-cli/Cargo.toml
+++ b/crates/rsigma-cli/Cargo.toml
@@ -36,11 +36,11 @@ evtx = ["rsigma-runtime/evtx"]
 daachorse-index = ["rsigma-eval/daachorse-index", "rsigma-runtime?/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.20.0", features = ["parallel"] }
-rsigma-convert = { path = "../rsigma-convert", version = "0.20.0", features = ["sigma-cli"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.20.0", optional = true }
-rsigma-mcp = { path = "../rsigma-mcp", version = "0.20.0", optional = true }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.21.0", features = ["parallel"] }
+rsigma-convert = { path = "../rsigma-convert", version = "0.21.0", features = ["sigma-cli"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.21.0", optional = true }
+rsigma-mcp = { path = "../rsigma-mcp", version = "0.21.0", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-convert/Cargo.toml
+++ b/crates/rsigma-convert/Cargo.toml
@@ -22,9 +22,9 @@ default = []
 sigma-cli = []
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
-rsigma-ir = { path = "../rsigma-ir", version = "0.20.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.21.0" }
+rsigma-ir = { path = "../rsigma-ir", version = "0.21.0", default-features = false }
 thiserror = "2"
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -14,8 +14,8 @@ parallel = ["rayon"]
 daachorse-index = ["dep:daachorse"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0", default-features = false }
-rsigma-ir = { path = "../rsigma-ir", version = "0.20.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0", default-features = false }
+rsigma-ir = { path = "../rsigma-ir", version = "0.21.0", default-features = false }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 yaml_serde = "0.10"

--- a/crates/rsigma-ir/Cargo.toml
+++ b/crates/rsigma-ir/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0", default-features = false }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0", default-features = false }
 ciborium = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-lsp/Cargo.toml
+++ b/crates/rsigma-lsp/Cargo.toml
@@ -14,8 +14,8 @@ name = "rsigma-lsp"
 path = "src/main.rs"
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.21.0" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time", "sync"] }
 log = "0.4"

--- a/crates/rsigma-mcp/Cargo.toml
+++ b/crates/rsigma-mcp/Cargo.toml
@@ -16,10 +16,10 @@ default = []
 http = ["dep:axum", "rmcp/transport-streamable-http-server"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.20.0" }
-rsigma-convert = { path = "../rsigma-convert", version = "0.20.0", features = ["sigma-cli"] }
-rsigma-runtime = { path = "../rsigma-runtime", version = "0.20.0" }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.21.0" }
+rsigma-convert = { path = "../rsigma-convert", version = "0.21.0", features = ["sigma-cli"] }
+rsigma-runtime = { path = "../rsigma-runtime", version = "0.21.0" }
 rmcp = { version = "2.2", features = ["server", "macros", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/rsigma-runtime/Cargo.toml
+++ b/crates/rsigma-runtime/Cargo.toml
@@ -22,8 +22,8 @@ uds = ["tokio/net"]
 daachorse-index = ["rsigma-eval/daachorse-index"]
 
 [dependencies]
-rsigma-parser = { path = "../rsigma-parser", version = "0.20.0" }
-rsigma-eval = { path = "../rsigma-eval", version = "0.20.0", features = ["parallel"] }
+rsigma-parser = { path = "../rsigma-parser", version = "0.21.0" }
+rsigma-eval = { path = "../rsigma-eval", version = "0.21.0", features = ["parallel"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "io-util", "io-std", "process", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rsigma-runtime/tests/golden/ocsf/correlation.json
+++ b/crates/rsigma-runtime/tests/golden/ocsf/correlation.json
@@ -30,7 +30,7 @@
     "product": {
       "name": "rsigma",
       "vendor_name": "rsigma",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     "uid": "00000000-0000-4000-8000-000000000002",
     "version": "1.1.0"

--- a/crates/rsigma-runtime/tests/golden/ocsf/detection.json
+++ b/crates/rsigma-runtime/tests/golden/ocsf/detection.json
@@ -53,7 +53,7 @@
     "product": {
       "name": "rsigma",
       "vendor_name": "rsigma",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     "uid": "00000000-0000-4000-8000-000000000002",
     "version": "1.1.0"

--- a/crates/rsigma-runtime/tests/golden/ocsf/incident_open.json
+++ b/crates/rsigma-runtime/tests/golden/ocsf/incident_open.json
@@ -35,7 +35,7 @@
     "product": {
       "name": "rsigma",
       "vendor_name": "rsigma",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     "uid": "00000000-0000-4000-8000-000000000001",
     "version": "1.1.0"

--- a/crates/rsigma-runtime/tests/golden/ocsf/incident_resolved.json
+++ b/crates/rsigma-runtime/tests/golden/ocsf/incident_resolved.json
@@ -35,7 +35,7 @@
     "product": {
       "name": "rsigma",
       "vendor_name": "rsigma",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     "uid": "00000000-0000-4000-8000-000000000001",
     "version": "1.1.0"

--- a/crates/rsigma-runtime/tests/golden/ocsf/risk_incident.json
+++ b/crates/rsigma-runtime/tests/golden/ocsf/risk_incident.json
@@ -54,7 +54,7 @@
     "product": {
       "name": "rsigma",
       "vendor_name": "rsigma",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     "uid": "00000000-0000-4000-8000-000000000001",
     "version": "1.1.0"

--- a/crates/rstix/README.md
+++ b/crates/rstix/README.md
@@ -19,11 +19,11 @@ Six optional Cargo features extend the default `serde` bundle model (each implie
 
 ```toml
 [dependencies]
-rstix = "0.20.0"
+rstix = "0.21.0"
 # Pattern Engine + Validation Pipeline:
-# rstix = { version = "0.20.0", features = ["pattern", "validate"] }
+# rstix = { version = "0.21.0", features = ["pattern", "validate"] }
 # Graph, marking, store (combine as needed):
-# rstix = { version = "0.20.0", features = ["graph", "marking", "store"] }
+# rstix = { version = "0.21.0", features = ["graph", "marking", "store"] }
 ```
 
 This library is part of [rsigma].

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-convert"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "log",
  "regex",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-ir"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ciborium",
  "rsigma-parser",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "globset",
  "log",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "rsigma-runtime"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "rstix"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.23.0",
  "email_address",


### PR DESCRIPTION
Bump the workspace and all inter-crate version pins from 0.20.0 to 0.21.0, sync the workspace, fuzz, and wasm-smoke lockfiles, bump OCSF golden `metadata.product.version` pins and the rstix README install examples, and finalize the CHANGELOG by promoting the `[Unreleased]` section to `[0.21.0]` with a TL;DR summary, a compare link, and a release reference link.

Once merged, publishing the `v0.21.0` GitHub Release triggers the crates.io, binary, and Docker workflows.

## TL;DR

RSigma v0.21.0 is the "daemon throughput and STIX interop" release: the evaluation and daemon path gain witness-based candidate indexing, parallel parsing, multicore batching, and jemalloc on musl; `rstix` completes OASIS STIX 2.1 Interoperability use-case coverage with a self-certification CI gate; and detection engineering gains verified rule tuning, OCSF findings, and post-pipeline rule inspection.

- Daemon throughput: jemalloc for the musl allocator (#412, thanks to @alltilla), parallel batch parsing and single-parse DLQ (#415), default multicore batching (#408), witness-based candidate indexing with pre-filter soundness fixes (#406), concurrent multi-batch detection (#426, #428), short-circuit condition evaluation (#427), ASCII case-insensitive Aho-Corasick and top-level key probes (#420, #419), plus representative performance baselines and cross-architecture gates (#404, #409, #429).
- `rstix` STIX interop: OASIS CSD01 golden harness through all 21 use cases (#403, #410, #413, #433, #438), self-certification CI gate (#440), STIX 2.1 wire conformance (#388), and TAXII collection ingest with DANE DNSSEC (#387, #381), thanks to @SecurityEnthusiast.
- Detection engineering: verified false-positive-driven `rule tune` (#431), post-pipeline rule retrieval for embedders (#437), OCSF Detection Finding output (#397), incident bundle export (#400), and list-valued `add_condition` (#399, thanks to @frack113).
- Operator surfaces: per-sink output formats (#396), complete `--output-format` coverage (#389), and a documentation accuracy overhaul (#435).
- Dependencies: Dependabot batches across Rust, CI actions, and the VS Code extension (#402, #432, #444).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --locked --no-deps`
- [x] `cargo metadata --locked` for the workspace, `fuzz/`, and `ci/wasm-smoke/`
- [x] `cargo test -p rsigma-runtime --test ocsf_golden --locked`
- [x] `npm run docs:build` and `npm run docs:validate`