### PR TITLE
docs: add Garmr, sagan2sigma, and Sheut to Built with RSigma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ### Docs
 
-* Added [Garmr](https://github.com/hentorp/garmr), [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma), and [Sheut](https://github.com/PerceptraHQ/sheut-community) to the `Built with RSigma` section on the docs home page.
+* Added [Garmr](https://github.com/hentorp/garmr), [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma), and [Sheut](https://github.com/PerceptraHQ/sheut-community) to the `Built with RSigma` section on the docs home page (#462).
 
 ### rstix: TAXII 2.1 TXC interop self-certification (C-1) (#451)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Docs
+
+* Added [Garmr](https://github.com/hentorp/garmr), [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma), and [Sheut](https://github.com/PerceptraHQ/sheut-community) to the `Built with RSigma` section on the docs home page.
+
 ### rstix: TAXII 2.1 TXC interop self-certification (C-1) (#451)
 
 Adds an OASIS TAXII 2.1 Interoperability CSD01 (2022-03-30) **TXC** self-certification suite: all **39 Mandatory** §4.1 Table 51 rows as automated scenarios (wiremock mock TXS + local rustls mTLS for §3.1.3), with the **5 Optional** §3.13.2 rows as `REPORT_ONLY`. Scenarios assert CSD01 Tables 2–50 depth (`User-Agent`, `WWW-Authenticate` challenges, absolute/relative `api_roots`, collection id ordering, date-added headers, versions pagination via `added_after`, Status Table 28, envelope/Status `x_*` via `TaxiiEnvelope::with_custom`). Three-layer report gate matches STIX interop (export invariants, committed `gate-expectations.json`, `scripts/taxii-interop-report-gate.py`). CI job `rstix TAXII TXC interop self-certification` gates the package. Also fixes bugs the suite surfaced: preserve `added_after` when clock skew is unset (all three `with_clock_skew_*` helpers); pin rustls `ring` for mTLS when `ring` and `aws-lc-rs` are both linked; run scenarios in registry/section order (not lexicographic `test_id`); mint §3.1.3 PEMs in-process with `rcgen` so CI does not depend on gitignored `taxii-live` certs. Channels (TAXII §6 RESERVED) and TXS persona remain out of scope.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -88,8 +88,11 @@ RSigma combines pySigma-style conversion with a streaming evaluator in one self-
 | Project | Role |
 |---|---|
 | [detection.studio](https://github.com/northsh/detection.studio) | Browser-based Sigma playground with real-time evaluation via RSigma compiled to WebAssembly |
+| [Garmr](https://github.com/hentorp/garmr) | Self-hosted application-audit and insider-risk platform using RSigma for per-event Sigma detection |
 | [LocalObserve](https://github.com/JJediny/LocalObserve) | Local-first Linux security observability stack using RSigma for edge Sigma detection and webhook alerting |
 | [Rustinel](https://github.com/Karib0u/rustinel) | Cross-platform endpoint detection engine with RSigma as an opt-in Sigma backend for live telemetry |
+| [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma) | Converts Sagan rules to Sigma and verifies them with RSigma |
+| [Sheut](https://github.com/PerceptraHQ/sheut-community) | Local-first cyber threat intelligence workbench using RSigma for STIX 2.1 validation and interchange |
 | [Sigmacatch](https://github.com/frack113/sigmacatch) | Captures live Windows Event Log events, matches them with RSigma, and writes SigmaHQ-ready regression data |
 
 ## Read the deep dives


### PR DESCRIPTION
## Summary
- Add Garmr, sagan2sigma, and Sheut to the docs home-page `Built with RSigma` table.
- Garmr evaluates Sigma rules with RSigma, sagan2sigma verifies converted Sagan rules with RSigma, and Sheut uses rstix for STIX 2.1 interchange.

## Test plan
- [x] Confirm the three new rows read consistently with the existing Built with entries
- [x] `cd docs && npm run docs:validate`