### PR TITLE
Add rsigma --features for compiled-in Cargo feature introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Compiled-in feature introspection (`rsigma --features`)
+
+`--help` is not a detector for Cargo features: several of them have no unique flag (`evtx`, `logfmt`, `cef`, `daemon-otlp`), and `--input-format` is a free string so clap never lists the gated values. The binary now embeds the enabled `rsigma` features at compile time. `rsigma --features` prints them one per line, `rsigma --version` includes the same list, and `rsigma --help` shows a "Compiled-in features" footer.
+
 ### Docs
 
 * Added [Garmr](https://github.com/hentorp/garmr), [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma), and [Sheut](https://github.com/PerceptraHQ/sheut-community) to the `Built with RSigma` section on the docs home page (#462).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 `--help` is not a detector for Cargo features: several of them have no unique flag (`evtx`, `logfmt`, `cef`, `daemon-otlp`), and `--input-format` is a free string so clap never lists the gated values. The binary now embeds the enabled `rsigma` features at compile time. `rsigma --features` prints them one per line, `rsigma --version` includes the same list, and `rsigma --help` shows a "Compiled-in features" footer.
 
-### Docs
+### Docs (#462)
 
-* Added [Garmr](https://github.com/hentorp/garmr), [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma), and [Sheut](https://github.com/PerceptraHQ/sheut-community) to the `Built with RSigma` section on the docs home page (#462).
+* Added [Garmr](https://github.com/hentorp/garmr), [sagan2sigma](https://github.com/NRGLine4Sec/sagan2sigma), and [Sheut](https://github.com/PerceptraHQ/sheut-community) to the `Built with RSigma` section on the docs home page.
 
 ### rstix: TAXII 2.1 TXC interop self-certification (C-1) (#451)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### rstix: clippy `chunks_exact_to_as_chunks`
+
+`Pattern` hex decoding walks pairs with `as_chunks::<2>()` so workspace clippy on Rust 1.98 (`-D warnings`) stays clean.
+
 ### Compiled-in feature introspection (`rsigma --features`)
 
 `--help` is not a detector for Cargo features: several of them have no unique flag (`evtx`, `logfmt`, `cef`, `daemon-otlp`), and `--input-format` is a free string so clap never lists the gated values. The binary now embeds the enabled `rsigma` features at compile time. `rsigma --features` prints them one per line, `rsigma --version` includes the same list, and `rsigma --help` shows a "Compiled-in features" footer.

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -67,6 +67,8 @@ These flags work with every subcommand, mirroring how `--log-format` does, and t
 | `--no-stats` | off | Suppress only the trailing summary; progress messages still appear. |
 | `--log-format <FORMAT>` | unset | When set, initialises a stderr `tracing` subscriber in `text` or `json`. Diagnostic logs only; does not affect stdout. |
 
+`--version` and `--features` are top-level introspection flags (not per-command globals). `--features` prints the Cargo features compiled into this binary, one name per line; `--version` and the `--help` footer carry the same list.
+
 ## Subcommands
 
 Commands are grouped into four noun-led groups: `engine` (eval/daemon), `rule` (parse/validate/lint/fields/draft/tune/doc/backtest/coverage/scorecard/visibility/hygiene/condition/stdin), `backend` (convert/targets/formats), and `pipeline` (resolve).

--- a/crates/rsigma-cli/src/features.rs
+++ b/crates/rsigma-cli/src/features.rs
@@ -1,0 +1,132 @@
+//! Compile-time inventory of optional Cargo features for the `rsigma` binary.
+//!
+//! `--help` is not a reliable detector: several features have no unique flag
+//! (`evtx`, `logfmt`, `cef`, `daemon-otlp`), and `--input-format` is a free
+//! string so clap never lists the gated values. This module is the source of
+//! truth for `rsigma --features`, `rsigma --version`, and the `--help` footer.
+
+/// Every optional Cargo feature the `rsigma` binary can be built with, in
+/// sorted order. Keep in sync with `[features]` in this crate's `Cargo.toml`.
+macro_rules! cli_features {
+    ($($name:literal),+ $(,)?) => {
+        #[cfg(test)]
+        pub const ALL: &[&str] = &[$($name),+];
+
+        pub const ENABLED: &[&str] = &[
+            $(
+                #[cfg(feature = $name)]
+                $name,
+            )+
+        ];
+    };
+}
+
+cli_features! {
+    "cef",
+    "daachorse-index",
+    "daemon",
+    "daemon-nats",
+    "daemon-otlp",
+    "daemon-tls",
+    "evtx",
+    "logfmt",
+    "mcp",
+}
+
+pub fn print_enabled() {
+    for name in ENABLED {
+        println!("{name}");
+    }
+}
+
+pub fn help_footer() -> &'static str {
+    static FOOTER: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+    FOOTER.get_or_init(|| leak(format!("Compiled-in features: {}", format_enabled())))
+}
+
+pub fn long_version() -> &'static str {
+    static VERSION: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+    VERSION.get_or_init(|| {
+        leak(format!(
+            "{}\nfeatures: {}",
+            env!("CARGO_PKG_VERSION"),
+            format_enabled(),
+        ))
+    })
+}
+
+fn leak(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
+fn format_enabled() -> String {
+    ENABLED.join(", ")
+}
+
+/// True when argv asks for the feature list and does not name a subcommand.
+///
+/// clap still requires a subcommand, so `rsigma --features` has to be handled
+/// before `get_matches`. A non-flag token (a command group) is left to clap.
+pub fn requested(args: impl IntoIterator<Item = impl AsRef<str>>) -> bool {
+    let mut has_features = false;
+    for arg in args {
+        let arg = arg.as_ref();
+        if arg == "--features" {
+            has_features = true;
+            continue;
+        }
+        if arg == "--" || !arg.starts_with('-') {
+            return false;
+        }
+    }
+    has_features
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogues_are_sorted() {
+        let mut all = ALL.to_vec();
+        all.sort_unstable();
+        assert_eq!(ALL, all.as_slice());
+        let mut enabled = ENABLED.to_vec();
+        enabled.sort_unstable();
+        assert_eq!(ENABLED, enabled.as_slice());
+    }
+
+    #[test]
+    fn enabled_is_a_subset_of_all() {
+        for name in ENABLED {
+            assert!(ALL.contains(name), "unknown feature {name}");
+        }
+    }
+
+    #[test]
+    fn daemon_tracks_the_cfg() {
+        assert_eq!(ENABLED.contains(&"daemon"), cfg!(feature = "daemon"));
+    }
+
+    #[test]
+    fn format_enabled_joins_enabled_names() {
+        assert_eq!(format_enabled(), ENABLED.join(", "));
+    }
+
+    #[test]
+    fn long_version_starts_with_the_crate_version() {
+        let version = long_version();
+        assert!(version.starts_with(env!("CARGO_PKG_VERSION")), "{version}");
+        assert!(version.contains("features:"));
+    }
+
+    #[test]
+    fn requested_is_true_only_without_a_subcommand() {
+        assert!(requested(["--features"]));
+        assert!(requested(["--quiet", "--features"]));
+        assert!(!requested(["--features", "engine"]));
+        assert!(!requested(["engine", "eval", "--features"]));
+        assert!(!requested(["--help"]));
+        assert!(!requested(Vec::<&str>::new()));
+    }
+}

--- a/crates/rsigma-cli/src/main.rs
+++ b/crates/rsigma-cli/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 #[cfg(feature = "daemon")]
 mod daemon;
 pub(crate) mod exit_code;
+mod features;
 mod fix;
 pub(crate) mod logsource_opts;
 pub(crate) mod metrics_source;
@@ -91,6 +92,10 @@ struct Cli {
     /// summary footer but the operator still wants to see what happened.
     #[arg(long = "no-stats", global = true)]
     no_stats: bool,
+
+    /// Print compiled-in Cargo features and exit.
+    #[arg(long = "features")]
+    list_features: bool,
 
     #[command(subcommand)]
     command: Commands,
@@ -263,14 +268,28 @@ enum PipelineCommands {
 }
 
 fn main() {
+    // `rsigma --features` has no subcommand, so clap would reject it. Detect
+    // that invocation before `get_matches` and print the compile-time list.
+    if features::requested(std::env::args().skip(1)) {
+        features::print_enabled();
+        return;
+    }
+
     // Parse into `ArgMatches` (not just the typed `Cli`) so commands can ask
     // clap which flags were set explicitly on the command line. That drives
     // the config precedence (CLI flag > env > file > default).
-    let matches = Cli::command().get_matches();
+    let matches = Cli::command()
+        .long_version(features::long_version())
+        .after_help(features::help_footer())
+        .get_matches();
     let cli = match Cli::from_arg_matches(&matches) {
         Ok(cli) => cli,
         Err(e) => e.exit(),
     };
+    if cli.list_features {
+        features::print_enabled();
+        return;
+    }
 
     // Daemon installs its own JSON subscriber unconditionally; only init for
     // other subcommands when the user opts in via --log-format.

--- a/crates/rsigma-cli/tests/cli_eval.rs
+++ b/crates/rsigma-cli/tests/cli_eval.rs
@@ -751,7 +751,9 @@ fn version_flag() {
         .args(["--version"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("rsigma"));
+        .stdout(predicate::str::contains("rsigma"))
+        .stdout(predicate::str::contains("features:"))
+        .stdout(predicate::str::contains("rsigma rsigma").not());
 }
 
 #[test]
@@ -760,7 +762,30 @@ fn help_flag() {
         .args(["--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Parse, validate, and evaluate"));
+        .stdout(predicate::str::contains("Parse, validate, and evaluate"))
+        .stdout(predicate::str::contains("--features"))
+        .stdout(predicate::str::contains("Compiled-in features:"));
+}
+
+#[test]
+fn features_flag_prints_sorted_compiled_in_features() {
+    let output = rsigma().args(["--features"]).output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().filter(|line| !line.is_empty()).collect();
+    let mut sorted = lines.clone();
+    sorted.sort_unstable();
+    assert_eq!(lines, sorted);
+    for name in &lines {
+        assert!(
+            name.chars().all(|c| c.is_ascii_lowercase() || c == '-'),
+            "unexpected feature name {name}"
+        );
+    }
+    #[cfg(feature = "daemon")]
+    assert!(lines.contains(&"daemon"));
+    #[cfg(feature = "mcp")]
+    assert!(lines.contains(&"mcp"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rstix/src/pattern/lexer.rs
+++ b/crates/rstix/src/pattern/lexer.rs
@@ -412,9 +412,9 @@ fn decode_hex(raw: &str) -> Result<Vec<u8>, String> {
         return Err("hex literal must have an even number of digits".into());
     }
     let mut out = Vec::with_capacity(bytes.len() / 2);
-    for chunk in bytes.chunks_exact(2) {
-        let hi = hex_nibble(chunk[0]).ok_or_else(|| format!("invalid hex digit in {raw:?}"))?;
-        let lo = hex_nibble(chunk[1]).ok_or_else(|| format!("invalid hex digit in {raw:?}"))?;
+    for &[hi_byte, lo_byte] in bytes.as_chunks::<2>().0 {
+        let hi = hex_nibble(hi_byte).ok_or_else(|| format!("invalid hex digit in {raw:?}"))?;
+        let lo = hex_nibble(lo_byte).ok_or_else(|| format!("invalid hex digit in {raw:?}"))?;
         out.push((hi << 4) | lo);
     }
     Ok(out)

--- a/docs/content/cli/index.md
+++ b/docs/content/cli/index.md
@@ -31,6 +31,8 @@ Every subcommand accepts five global flags. They share the same layered preceden
 
 `--log-format` adds the diagnostic-log stream alongside the existing stdout/stderr output; it never replaces them. See [Observability](../guide/observability.md) for the full RUST_LOG target catalog. For the output formats and color resolution model see the [Output reference](../reference/output.md).
 
+`--version` and `--features` are top-level introspection flags, not per-command globals. `--features` prints the Cargo features compiled into this binary, one name per line. `--version` and the `--help` footer carry the same list. See [Feature Flags](../reference/feature-flags.md#detecting-features-at-runtime).
+
 ## Command tree
 
 ```text

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -127,10 +127,11 @@ A workspace build produces every binary: the CLI (`target/release/rsigma`) and t
 
 ```bash
 rsigma --version
+rsigma --features
 rsigma --help
 ```
 
-You should see `rsigma {{ rsigma.version }}` and a list of the top-level command groups (`engine`, `rule`, `backend`, `pipeline`, `config`, and `mcp` when built with the `mcp` feature).
+You should see `rsigma {{ rsigma.version }}`, the Cargo features compiled into that binary, and a list of the top-level command groups (`engine`, `rule`, `backend`, `pipeline`, `config`, and `mcp` when built with the `mcp` feature).
 
 ## Next steps
 

--- a/docs/content/guide/performance-tuning.md
+++ b/docs/content/guide/performance-tuning.md
@@ -92,7 +92,7 @@ The flag is feature-gated. The default `cargo install rsigma` does NOT include i
 cargo install --locked rsigma --features daachorse-index
 ```
 
-The released archives (`x86_64-unknown-linux-gnu.tar.gz` and friends) and the GHCR Docker image are built with `--all-features`, so they already include the flag. Run `rsigma engine eval --help | grep cross-rule-ac` to confirm.
+The released archives (`x86_64-unknown-linux-gnu.tar.gz` and friends) and the GHCR Docker image are built with `--all-features`, so they already include the flag. Run `rsigma --features | grep -qx daachorse-index` to confirm.
 
 ```bash
 rsigma engine eval -r rules/ --cross-rule-ac -e @events.ndjson

--- a/docs/content/reference/feature-flags.md
+++ b/docs/content/reference/feature-flags.md
@@ -116,17 +116,19 @@ If a feature combination matters to you (and especially if a build with `--no-de
 
 ## Detecting features at runtime
 
-The binary's `--help` enumerates only the flags compiled in. If a NATS flag is missing from `rsigma engine daemon --help`, the binary was built without `daemon-nats`. Equivalent shells for the other gated surfaces:
+The binary embeds the `rsigma` crate's enabled Cargo features at compile time. `--help` is not a detector: several features have no unique flag (`evtx`, `logfmt`, `cef`, `daemon-otlp`), and `--input-format` is a free string so clap never lists the gated values.
 
 ```bash
-# daachorse-index?
-rsigma engine daemon --help | grep -q cross-rule-ac && echo on || echo off
+# One enabled feature per line (script-friendly).
+rsigma --features
+rsigma --features | grep -qx daemon-nats && echo on || echo off
 
-# evtx?
-echo "" | rsigma engine eval -r /dev/null -e @/dev/null --input-format json 2>&1 | grep -q "evtx" || echo "evtx feature not required for JSON inputs"
+# Same list on the version line and at the bottom of `--help`.
+rsigma --version
+rsigma --help
 ```
 
-There is no first-class `rsigma --features` introspection flag. Use `--help` presence checks as above.
+`rsigma --features` prints only the optional features of the `rsigma` binary (`rsigma-cli` table above), sorted, one name per line. Library-crate features (`rsigma-eval`, `rsigma-runtime`, `rstix`, and the rest) are not listed; they matter at compile time for embedders, not for an installed CLI. Prebuilt release archives and the GHCR Docker image print every `rsigma-cli` feature. A default `cargo install rsigma` prints `daemon` only.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Embed the `rsigma` binary's enabled Cargo features at compile time and expose them via `rsigma --features` (one name per line), `rsigma --version`, and a `--help` footer.
- Replace the incorrect "grep `--help` for gated flags" recipes. Several features have no unique flag (`evtx`, `logfmt`, `cef`, `daemon-otlp`), and `--input-format` is a free string so clap never lists the gated values.

## Test plan
- [x] `rsigma --features` prints a sorted list of enabled `rsigma-cli` features (default install: `daemon` only; `--all-features`: the full CLI table).
- [x] `rsigma --version` includes a `features:` line; `-V` stays `rsigma X.Y.Z` only.
- [x] `rsigma --help` lists `--features` and ends with `Compiled-in features:`.
- [x] `rsigma --features | grep -qx daemon-nats` is a reliable on/off check.
- [x] `cargo test -p rsigma --all-features --locked features::` and `cargo test -p rsigma --all-features --locked --test cli_eval flag`.