### PR TITLE
Raise MSRV from 1.88.0 to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             "${RUNNER_TEMP}/wasm-smoke-target/wasm32-unknown-unknown/release/rsigma_wasm_smoke.wasm"
 
   msrv:
-    name: MSRV (1.88.0)
+    name: MSRV (1.95.0)
     runs-on: ubuntu-latest
     permissions:
       contents: read # read repo
@@ -100,11 +100,11 @@ jobs:
         with:
           persist-credentials: false
       # Install MSRV inline. No `rustup override set` here because the
-      # workspace's `rust-toolchain.toml` already pins to 1.88.0, so
+      # workspace's `rust-toolchain.toml` already pins to 1.95.0, so
       # `cargo` will pick that toolchain automatically once it is
       # installed.
-      - name: Install Rust 1.88.0
-        run: rustup toolchain install 1.88.0 --profile minimal --no-self-update
+      - name: Install Rust 1.95.0
+        run: rustup toolchain install 1.95.0 --profile minimal --no-self-update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### MSRV 1.95.0
+### MSRV 1.95.0 (#464)
 
 Workspace `rust-version` and `rust-toolchain.toml` move from 1.88.0 to 1.95.0. The MSRV CI job, README badge, and CONTRIBUTING prerequisites follow. Cargo's MSRV-aware resolver can now select transitive crate versions that require Rust 1.89 through 1.95. `rstix` CAPEC/CVE external-ref checks use match guards so `clippy::collapsible_match` stays clean on the new MSRV. The workspace lockfile moves `h2` 0.4.15 to 0.4.19 (RUSTSEC-2026-0258).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### MSRV 1.95.0
+
+Workspace `rust-version` and `rust-toolchain.toml` move from 1.88.0 to 1.95.0. The MSRV CI job, README badge, and CONTRIBUTING prerequisites follow. Cargo's MSRV-aware resolver can now select transitive crate versions that require Rust 1.89 through 1.95. `rstix` CAPEC/CVE external-ref checks use match guards so `clippy::collapsible_match` stays clean on the new MSRV. The workspace lockfile moves `h2` 0.4.15 to 0.4.19 (RUSTSEC-2026-0258).
+
 ### rstix: clippy `chunks_exact_to_as_chunks` (#463)
 
 `Pattern` hex decoding walks pairs with `as_chunks::<2>()` so workspace clippy on Rust 1.98 (`-D warnings`) stays clean.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering a contribution to rsigma! This document covers the bas
 
 ### Prerequisites
 
-- Rust toolchain (MSRV: 1.88.0). Install via [rustup](https://rustup.rs/).
+- Rust toolchain (MSRV: 1.95.0). Install via [rustup](https://rustup.rs/).
 - Docker (optional, required for integration tests that use testcontainers).
 - Node.js 20+ (optional, only for building the documentation site under `docs/`; not needed for the Rust workspace).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1554,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3130,7 +3130,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3985,7 +3985,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4777,7 +4777,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4836,7 +4836,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5392,7 +5392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5669,7 +5669,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6697,7 +6697,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["fuzz", "ci/wasm-smoke"]
 [workspace.package]
 version = "0.21.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 license = "MIT"
 repository = "https://github.com/timescale/rsigma"
 homepage = "https://github.com/timescale/rsigma"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <a href="https://github.com/timescale/rsigma/actions/workflows/ci.yml"><img src="https://github.com/timescale/rsigma/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
     <a href="https://rsigma.io"><img src="https://img.shields.io/badge/docs-website-blue" alt="Documentation" /></a>
     <a href="https://crates.io/crates/rsigma"><img src="https://img.shields.io/crates/v/rsigma.svg" alt="crates.io" /></a>
-    <a href="https://github.com/timescale/rsigma/blob/main/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.88.0-blue" alt="MSRV" /></a>
+    <a href="https://github.com/timescale/rsigma/blob/main/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.95.0-blue" alt="MSRV" /></a>
     <a href="https://ghcr.io/timescale/rsigma"><img src="https://img.shields.io/badge/ghcr.io-rsigma-blue?logo=docker" alt="Docker" /></a>
     <a href="https://github.com/timescale/rsigma/releases/latest"><img src="https://img.shields.io/github/v/release/timescale/rsigma" alt="GitHub Release" /></a>
     <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT" /></a>

--- a/crates/rstix/src/validate/semantic.rs
+++ b/crates/rstix/src/validate/semantic.rs
@@ -77,29 +77,29 @@ pub(crate) fn run_cross_object_semantics(bundle: &Bundle, report: &mut Validatio
 
         if let StixObject::Sdo(sdo) = object {
             match sdo {
-                SdoObject::AttackPattern(AttackPattern { common, .. }) => {
-                    if validate_capec_external_refs(&common.external_references).is_err() {
-                        report.push(
-                            Diagnostic::new(
-                                DiagnosticCode::W0010,
-                                "CAPEC external reference should use source_name `capec` with external_id prefixed `CAPEC-`",
-                            )
-                            .with_object_id(object_id.clone())
-                            .with_property_path(EXTERNAL_REF_CAPEC),
-                        );
-                    }
+                SdoObject::AttackPattern(AttackPattern { common, .. })
+                    if validate_capec_external_refs(&common.external_references).is_err() =>
+                {
+                    report.push(
+                        Diagnostic::new(
+                            DiagnosticCode::W0010,
+                            "CAPEC external reference should use source_name `capec` with external_id prefixed `CAPEC-`",
+                        )
+                        .with_object_id(object_id.clone())
+                        .with_property_path(EXTERNAL_REF_CAPEC),
+                    );
                 }
-                SdoObject::Vulnerability(Vulnerability { common, .. }) => {
-                    if validate_cve_external_refs(&common.external_references).is_err() {
-                        report.push(
-                            Diagnostic::new(
-                                DiagnosticCode::W0010,
-                                "CVE external reference should use source_name `cve` with external_id prefixed `CVE-`",
-                            )
-                            .with_object_id(object_id.clone())
-                            .with_property_path(EXTERNAL_REF_CVE),
-                        );
-                    }
+                SdoObject::Vulnerability(Vulnerability { common, .. })
+                    if validate_cve_external_refs(&common.external_references).is_err() =>
+                {
+                    report.push(
+                        Diagnostic::new(
+                            DiagnosticCode::W0010,
+                            "CVE external reference should use source_name `cve` with external_id prefixed `CVE-`",
+                        )
+                        .with_object_id(object_id.clone())
+                        .with_property_path(EXTERNAL_REF_CVE),
+                    );
                 }
                 SdoObject::Location(Location {
                     country, region, ..

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,6 @@
 # (`stable`, `nightly`, …) via `dtolnay/rust-toolchain`, so this file
 # only affects ambient invocations.
 [toolchain]
-channel = "1.88.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
## Summary
- Bump workspace `rust-version` and `rust-toolchain.toml` to 1.95.0. The MSRV CI job, README badge, and CONTRIBUTING prerequisites follow.
- Collapse `rstix` CAPEC/CVE external-ref checks into match guards so `clippy::collapsible_match` stays clean on 1.95.
- Move `h2` 0.4.15 to 0.4.19 in the workspace lockfile (RUSTSEC-2026-0258). `rusqlite` 0.39 and `tikv-jemallocator` 0.6 stay pinned.

## Test plan
- [x] `cargo fmt --all -- --check` on 1.95 and stable
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` on 1.95 and stable
- [x] `cargo check --workspace --all-targets --all-features --locked`
- [x] `cargo deny check`
- [x] `cargo doc --workspace --all-features --locked --no-deps`
- [x] CI MSRV job on 1.95.0