### PR TITLE
Emit nested correlation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Emit nested correlation results
+
+A temporal (or any parent correlation) whose `rules:` list other correlations already updated window state and marked the parent `met`, but `chain_correlations` never appended those firings to the eval result. `engine eval` and the daemon therefore showed the inner `event_count` / `value_count` alerts and omitted the parent. Chained firings are now emitted, with the same suppression and reset action as first-level correlations. Parents that reference a child by `name` rather than `id` are resolved as well. Fixes issue 458.
+
 ### rsigma-mcp: rmcp 3.0 (#467)
 
 Migrates `rsigma-mcp` from `rmcp` 2.2 to 3.0.1 (#448). The SDK models MCP 2026-07-28 (MRTR-aware `read_resource` responses, cache hints on list results). `#[tool]` methods keep their signatures; the manual `ServerHandler` resource methods wrap `ReadResourceResponse` and build list results with `ListResourcesResult::with_all_items`. `serve()` and Streamable HTTP still use the legacy `initialize` handshake, so existing clients keep the 2025-11-25 wire shape.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Emit nested correlation results
+### Emit nested correlation results (#468)
 
-A temporal (or any parent correlation) whose `rules:` list other correlations already updated window state and marked the parent `met`, but `chain_correlations` never appended those firings to the eval result. `engine eval` and the daemon therefore showed the inner `event_count` / `value_count` alerts and omitted the parent. Chained firings are now emitted, with the same suppression and reset action as first-level correlations. Parents that reference a child by `name` rather than `id` are resolved as well. Fixes issue 458.
+A temporal (or any parent correlation) whose `rules:` list other correlations already updated window state and marked the parent `met`, but `chain_correlations` never appended those firings to the eval result. `engine eval` and the daemon therefore showed the inner `event_count` / `value_count` alerts and omitted the parent. Chained firings are now emitted, with the same suppression and reset action as first-level correlations. Parents that reference a child by `name` rather than `id` are resolved as well. Fixes #458.
 
 ### rsigma-mcp: rmcp 3.0 (#467)
 

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -233,7 +233,7 @@ Stateful processing with sliding time windows, group-by aggregation, and all 8 c
 ### Core Features
 
 - **Group-by partitioning**: composite keys with field aliasing across referenced rules
-- **Correlation chaining**: correlation results propagate to higher-level correlations (max depth: **10**, `MAX_CHAIN_DEPTH`)
+- **Correlation chaining**: correlation results propagate to higher-level correlations and those parent firings are emitted (max depth: **10**, `MAX_CHAIN_DEPTH`)
 - **Extended temporal conditions**: boolean expressions over rule references (e.g. `rule_a and rule_b and not rule_c`)
 - **Cycle detection**: DFS-based validation of the correlation reference graph at load time
 

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -44,6 +44,13 @@ use crate::rule_metadata::{RuleBundleMetadata, RuleMetadataLookup};
 /// Current snapshot schema version. Bump when the serialized format changes.
 const SNAPSHOT_VERSION: u32 = 1;
 
+/// Parent hops evaluated after a first-level correlation fire in one event.
+/// The first-level result is produced by `feed_detections`; each loop
+/// iteration here walks one parent. A chain longer than this is updated
+/// and emitted through this many hops, then leftover parents are dropped
+/// with a `WARN`.
+const MAX_CHAIN_DEPTH: usize = 10;
+
 /// Stateful correlation engine.
 ///
 /// Wraps the stateless `Engine` for detection rules and adds time-windowed
@@ -927,7 +934,6 @@ impl CorrelationEngine {
         ts: i64,
         out: &mut Vec<EvaluationResult>,
     ) {
-        const MAX_CHAIN_DEPTH: usize = 10;
         let mut pending: Vec<EvaluationResult> = fired.to_vec();
         let mut depth = 0;
 

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -500,8 +500,11 @@ impl CorrelationEngine {
         let mut correlations: Vec<EvaluationResult> = Vec::new();
         self.feed_detections(event, &all_detections, timestamp_secs, &mut correlations);
 
-        // Chain — correlation results may trigger higher-level correlations
-        self.chain_correlations(&correlations, timestamp_secs);
+        // Chain — parent firings go into a separate vec so we do not
+        // alias `correlations` as both the input slice and the output.
+        let mut chained = Vec::new();
+        self.chain_correlations(&correlations, timestamp_secs, &mut chained);
+        correlations.extend(chained);
 
         // Filter detections by generate flag, then append the correlations.
         let mut out = self.filter_detections(all_detections);
@@ -891,11 +894,39 @@ impl CorrelationEngine {
         }
     }
 
+    /// IDs and names a fired correlation can be referenced by.
+    ///
+    /// Parents index `rule_refs` as written in YAML (id or name). The
+    /// emitted result only carries `rule_id`, so name-based parents need
+    /// this extra key or they never see the child.
+    fn chain_lookup_keys(&self, result: &EvaluationResult) -> Vec<String> {
+        let Some(id) = result.header.rule_id.as_deref() else {
+            return Vec::new();
+        };
+        let mut keys = vec![id.to_string()];
+        if let Some(name) = self
+            .correlations
+            .iter()
+            .find(|c| c.id.as_deref() == Some(id))
+            .and_then(|c| c.name.as_deref())
+            && name != id
+        {
+            keys.push(name.to_string());
+        }
+        keys
+    }
+
     /// Propagate correlation results to higher-level correlations (chaining).
     ///
     /// When a correlation fires, any correlation that references it (by ID or name)
-    /// is updated. Limits chain depth to 10 to prevent infinite loops.
-    fn chain_correlations(&mut self, fired: &[EvaluationResult], ts: i64) {
+    /// is updated. Newly fired parents are appended to `out` and become the next
+    /// `pending` set. Limits chain depth to 10 to prevent infinite loops.
+    fn chain_correlations(
+        &mut self,
+        fired: &[EvaluationResult],
+        ts: i64,
+        out: &mut Vec<EvaluationResult>,
+    ) {
         const MAX_CHAIN_DEPTH: usize = 10;
         let mut pending: Vec<EvaluationResult> = fired.to_vec();
         let mut depth = 0;
@@ -906,22 +937,19 @@ impl CorrelationEngine {
             // Collect work items: (corr_idx, group_key_pairs, fired_ref)
             #[allow(clippy::type_complexity)]
             let mut work: Vec<(usize, Vec<(String, String)>, String)> = Vec::new();
+            let mut seen = std::collections::HashSet::<(usize, String)>::new();
             for result in &pending {
                 // Only correlation results chain. Detections never reach here.
                 let Some(body) = result.as_correlation() else {
                     continue;
                 };
-                if let Some(ref id) = result.header.rule_id
-                    && let Some(indices) = self.rule_index.get(id)
-                {
-                    let fired_ref = result
-                        .header
-                        .rule_id
-                        .as_deref()
-                        .unwrap_or(&result.header.rule_title)
-                        .to_string();
-                    for &corr_idx in indices {
-                        work.push((corr_idx, body.group_key.clone(), fired_ref.clone()));
+                for key in self.chain_lookup_keys(result) {
+                    if let Some(indices) = self.rule_index.get(&key) {
+                        for &corr_idx in indices {
+                            if seen.insert((corr_idx, key.clone())) {
+                                work.push((corr_idx, body.group_key.clone(), key.clone()));
+                            }
+                        }
                     }
                 }
             }
@@ -934,12 +962,14 @@ impl CorrelationEngine {
                 let window_mode = corr.window_mode;
                 let gap_secs = corr.gap_secs;
                 let level = corr.level;
+                let suppress_secs = corr.suppress_secs.or(self.config.suppress);
+                let action = corr.action.unwrap_or(self.config.action_on_match);
 
                 let group_key = GroupKey::from_pairs(&group_key_pairs, &corr.group_by);
                 let state_key = (corr_idx, group_key.clone());
                 let state = self
                     .state
-                    .entry(state_key)
+                    .entry(state_key.clone())
                     .or_insert_with(|| WindowState::new_for(corr_type));
 
                 // Late arrivals in an earlier tumbling bucket are discarded;
@@ -977,8 +1007,20 @@ impl CorrelationEngine {
                 );
 
                 if let Some(agg_value) = fired {
+                    let alert_key = state_key;
+                    let suppressed = if let Some(suppress) = suppress_secs {
+                        self.last_alert
+                            .get(&alert_key)
+                            .is_some_and(|&last_ts| (ts - last_ts) < suppress as i64)
+                    } else {
+                        false
+                    };
+                    if suppressed {
+                        continue;
+                    }
+
                     let corr = &self.correlations[corr_idx];
-                    next_pending.push(EvaluationResult {
+                    let result = EvaluationResult {
                         header: RuleHeader {
                             rule_title: corr.title.clone(),
                             rule_id: corr.id.clone(),
@@ -998,7 +1040,16 @@ impl CorrelationEngine {
                             events: None,
                             event_refs: None,
                         }),
-                    });
+                    };
+                    next_pending.push(result.clone());
+                    out.push(result);
+                    self.last_alert.insert(alert_key.clone(), ts);
+
+                    if action == CorrelationAction::Reset
+                        && let Some(state) = self.state.get_mut(&alert_key)
+                    {
+                        state.clear();
+                    }
                 }
             }
 

--- a/crates/rsigma-eval/src/correlation_engine/tests.rs
+++ b/crates/rsigma-eval/src/correlation_engine/tests.rs
@@ -1379,6 +1379,12 @@ level: critical
                     .any(|c| c.header.rule_title == "Multiple failed logins"),
                 "Expected event_count correlation to fire"
             );
+            // temporal_ordered still needs the successful-login detection
+            assert!(
+                r.correlations()
+                    .all(|c| c.header.rule_title != "Brute Force Followed by Login"),
+                "temporal_ordered must not fire before the success detection"
+            );
         }
     }
 
@@ -1397,6 +1403,11 @@ level: critical
     assert_eq!(
         r.detections().next().unwrap().header.rule_title,
         "Successful login"
+    );
+    assert!(
+        r.correlations()
+            .any(|c| c.header.rule_title == "Brute Force Followed by Login"),
+        "chained temporal_ordered must be emitted, not only stored"
     );
 }
 
@@ -2593,6 +2604,237 @@ level: high
     assert!(
         result.is_ok(),
         "valid chain should not be rejected: {result:?}"
+    );
+}
+
+#[test]
+fn test_chaining_temporal_of_two_correlations() {
+    // Reproduces issue #458: a temporal whose rules are other correlations
+    // must emit when both children fire. The port-scan child groups by an
+    // extra field; the parent projects down to src_ip.
+    let yaml = r#"
+title: Firewall Drop Event
+id: drop-det
+logsource:
+    category: firewall
+detection:
+    selection:
+        action: block
+    condition: selection
+---
+title: Multiple Firewall Drops
+id: drop-corr
+correlation:
+    type: event_count
+    rules:
+        - drop-det
+    group-by:
+        - src_ip
+    timespan: 10m
+    condition:
+        gte: 3
+level: medium
+---
+title: Firewall Port Event
+id: port-det
+logsource:
+    category: firewall
+detection:
+    selection:
+        dst_port|exists: true
+    condition: selection
+---
+title: Port Scan
+id: port-corr
+correlation:
+    type: value_count
+    rules:
+        - port-det
+    group-by:
+        - src_ip
+        - dst_ip
+    timespan: 1m
+    condition:
+        gte: 3
+        field: dst_port
+level: medium
+---
+title: Firewall Temporal Correlation
+id: nest-temporal
+correlation:
+    type: temporal
+    rules:
+        - port-corr
+        - drop-corr
+    group-by:
+        - src_ip
+    timespan: 1h
+    condition:
+        gte: 2
+level: medium
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let ts = 1_000i64;
+    let ports = [21, 22, 23];
+    let mut last = None;
+    for (i, port) in ports.iter().enumerate() {
+        let v = json!({
+            "action": "block",
+            "src_ip": "10.1.1.1",
+            "dst_ip": "10.1.1.2",
+            "dst_port": port,
+        });
+        let event = JsonEvent::borrow(&v);
+        last = Some(engine.process_event_at(&event, ts + i as i64));
+    }
+    let r = last.expect("processed events");
+    let titles: Vec<_> = r
+        .correlations()
+        .map(|c| c.header.rule_title.as_str())
+        .collect();
+    assert!(
+        titles.contains(&"Multiple Firewall Drops"),
+        "inner event_count should fire: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Port Scan"),
+        "inner value_count should fire: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Firewall Temporal Correlation"),
+        "temporal of two correlations must be emitted: {titles:?}"
+    );
+}
+
+#[test]
+fn test_chaining_event_count_of_event_count() {
+    // detection -> corr-A (gte 2) -> corr-B (gte 2). Both parents must emit.
+    let yaml = r#"
+title: click
+id: det-rule
+logsource:
+    product: test
+detection:
+    selection:
+        action: click
+    condition: selection
+---
+title: correlation A
+id: corr-a
+correlation:
+    type: event_count
+    rules:
+        - det-rule
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+level: high
+---
+title: correlation B
+id: corr-b
+correlation:
+    type: event_count
+    rules:
+        - corr-a
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let ts = 1_000i64;
+    for i in 0..3 {
+        let v = json!({"action": "click", "User": "alice"});
+        let event = JsonEvent::borrow(&v);
+        let r = engine.process_event_at(&event, ts + i);
+        if i == 1 {
+            let titles: Vec<_> = r
+                .correlations()
+                .map(|c| c.header.rule_title.as_str())
+                .collect();
+            assert_eq!(titles, ["correlation A"], "A fires once, B still at 1");
+        }
+        if i == 2 {
+            let titles: Vec<_> = r
+                .correlations()
+                .map(|c| c.header.rule_title.as_str())
+                .collect();
+            assert!(
+                titles.contains(&"correlation A") && titles.contains(&"correlation B"),
+                "second A fire must emit chained B: {titles:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_chaining_parent_referenced_by_child_name() {
+    let yaml = r#"
+title: click
+id: det-rule
+logsource:
+    product: test
+detection:
+    selection:
+        action: click
+    condition: selection
+---
+title: correlation A
+id: corr-a
+name: corr_a_name
+correlation:
+    type: event_count
+    rules:
+        - det-rule
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 2
+level: high
+---
+title: correlation B
+id: corr-b
+correlation:
+    type: event_count
+    rules:
+        - corr_a_name
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 1
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let ts = 1_000i64;
+    let mut last = None;
+    for i in 0..2 {
+        let v = json!({"action": "click", "User": "alice"});
+        let event = JsonEvent::borrow(&v);
+        last = Some(engine.process_event_at(&event, ts + i));
+    }
+    let r = last.expect("processed events");
+    let titles: Vec<_> = r
+        .correlations()
+        .map(|c| c.header.rule_title.as_str())
+        .collect();
+    assert!(
+        titles.contains(&"correlation A") && titles.contains(&"correlation B"),
+        "parent referenced by child name must emit: {titles:?}"
     );
 }
 

--- a/crates/rsigma-eval/src/correlation_engine/tests.rs
+++ b/crates/rsigma-eval/src/correlation_engine/tests.rs
@@ -2838,6 +2838,117 @@ level: high
     );
 }
 
+/// Linear `event_count` chain of `levels` correlations, each `gte: 1`.
+/// `corr-0` references the detection; `corr-i` references `corr-(i-1)`.
+fn nested_event_count_chain_yaml(levels: usize) -> String {
+    let mut yaml = String::from(
+        r#"title: click
+id: det-rule
+logsource:
+    product: test
+detection:
+    selection:
+        action: click
+    condition: selection
+"#,
+    );
+    for i in 0..levels {
+        let parent = if i == 0 {
+            "det-rule".to_string()
+        } else {
+            format!("corr-{}", i - 1)
+        };
+        yaml.push_str(&format!(
+            r#"---
+title: level {i}
+id: corr-{i}
+correlation:
+    type: event_count
+    rules:
+        - {parent}
+    group-by:
+        - User
+    timespan: 5m
+    condition:
+        gte: 1
+level: high
+"#
+        ));
+    }
+    yaml
+}
+
+fn process_one_click(engine: &mut CorrelationEngine) -> Vec<String> {
+    let v = json!({"action": "click", "User": "alice"});
+    let event = JsonEvent::borrow(&v);
+    engine
+        .process_event_at(&event, 1_000)
+        .correlations()
+        .map(|c| c.header.rule_title.clone())
+        .collect()
+}
+
+#[test]
+fn test_chaining_ten_levels_all_emit() {
+    let levels = MAX_CHAIN_DEPTH;
+    let collection = parse_sigma_yaml(&nested_event_count_chain_yaml(levels)).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+    assert_eq!(engine.correlation_rule_count(), levels);
+
+    let titles = process_one_click(&mut engine);
+    let expected: Vec<String> = (0..levels).map(|i| format!("level {i}")).collect();
+    for title in &expected {
+        assert!(
+            titles.contains(title),
+            "10-deep chain must emit {title}: {titles:?}"
+        );
+    }
+    assert_eq!(titles.len(), levels, "exactly {levels} firings: {titles:?}");
+}
+
+#[test]
+fn test_chaining_eleventh_hop_is_dropped() {
+    // First-level fire + 10 parent hops emit corr-0 .. corr-10.
+    // corr-11 is the leftover hop past MAX_CHAIN_DEPTH: no emit, no window.
+    let levels = MAX_CHAIN_DEPTH + 2;
+    let collection = parse_sigma_yaml(&nested_event_count_chain_yaml(levels)).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+    assert_eq!(engine.correlation_rule_count(), levels);
+
+    let titles = process_one_click(&mut engine);
+    for i in 0..=MAX_CHAIN_DEPTH {
+        let title = format!("level {i}");
+        assert!(
+            titles.contains(&title),
+            "hop {i} must still emit: {titles:?}"
+        );
+    }
+    assert!(
+        !titles.iter().any(|t| t == "level 11"),
+        "11th hop must not be emitted: {titles:?}"
+    );
+
+    let snap = engine.introspect();
+    let info = |id: &str| {
+        snap.correlations
+            .iter()
+            .find(|c| c.id.as_deref() == Some(id))
+            .unwrap_or_else(|| panic!("missing {id}"))
+    };
+    assert_eq!(
+        info("corr-10").active_groups,
+        1,
+        "last in-cap hop has state"
+    );
+    assert_eq!(
+        info("corr-11").active_groups,
+        0,
+        "hop past the cap must not update window state"
+    );
+}
+
 #[test]
 fn test_correlation_cycle_transitive() {
     // Transitive cycle: A -> B -> C -> A

--- a/docs/content/library/eval.md
+++ b/docs/content/library/eval.md
@@ -173,7 +173,7 @@ for raw in events {
 }
 ```
 
-`process_with_detections(event, Vec<EvaluationResult>)` is the lower-overhead variant for hot loops (pre-compute detections in parallel, feed sequentially to correlation). `CorrelationConfig` enforces `max_state_entries` (default 100,000) and the 10-deep correlation-chain limit; see [Security Hardening](../reference/security.md#input-size-and-depth-caps).
+`process_with_detections(event, Vec<EvaluationResult>)` is the lower-overhead variant for hot loops (pre-compute detections in parallel, feed sequentially to correlation). `CorrelationConfig` enforces `max_state_entries` (default 100,000) and the 10-deep correlation-chain limit; see [Security Hardening](../reference/security.md#input-size-and-depth-caps). A correlation whose `rules:` list other correlations (for example a `temporal` of two `event_count` rules) emits the parent result when the chain condition is met, the same way a temporal of detections does.
 
 ## Custom attributes
 


### PR DESCRIPTION
## Summary
- Fixes #458: a temporal (or any parent) whose `rules:` are other correlations updated window state but never appeared in `engine eval` or daemon output.
- `chain_correlations` now emits those parent firings, with the same suppress/reset path as first-level correlations, and resolves a child by `name` as well as `id`.
- Regression tests cover the reporter shape (temporal of `event_count` + `value_count`), a two-level `event_count` chain, name-based refs, a 10-deep chain, and the hop past `MAX_CHAIN_DEPTH`.

## Test plan
- [x] `cargo test -p rsigma-eval --lib chaining`
- [x] Replay the #458 fixture: both inner correlations fire and `Firewall Temporal Correlation` is now in the eval output
- [ ] CI green