### PR TITLE
docs: worked examples and field schema for rule exemplars

### DIFF
--- a/docs/content/cli/rule/test.md
+++ b/docs/content/cli/rule/test.md
@@ -30,8 +30,39 @@ Output uses the global `--output-format` layer. Without an explicit format the c
 
 ### Test a rule file
 
+Given a rule that carries one positive and one negative exemplar:
+
+```yaml
+title: Whoami
+id: 11111111-2222-3333-4444-555555555555
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: whoami
+    condition: selection
+custom_attributes:
+    rsigma.exemplars:
+        - name: whoami fires
+          expect: match
+          event:
+              CommandLine: whoami /all
+        - name: benign hostname
+          expect: no-match
+          event:
+              CommandLine: hostname
+```
+
 ```bash
 rsigma rule test -r rules/windows/whoami.yml
+```
+
+```text
+RULE                                  KIND       INDEX  NAME             EXPECT    ACTUAL    RESULT
+------------------------------------  ---------  -----  ---------------  --------  --------  ------
+11111111-2222-3333-4444-555555555555  detection      0  whoami fires     match     match     pass
+11111111-2222-3333-4444-555555555555  detection      1  benign hostname  no-match  no-match  pass
 ```
 
 ### Gate a ruleset in CI
@@ -43,7 +74,29 @@ rsigma rule test -r rules/ --fail-on-missing
 ### JSON report
 
 ```bash
-rsigma rule test -r rules/ --output-format json
+rsigma rule test -r rules/windows/whoami.yml --output-format json
+```
+
+A failed assertion carries a `diagnostic` and the command exits `1`:
+
+```json
+{
+  "source": "rules/windows/whoami.yml",
+  "summary": { "rules": 1, "exemplars": 1, "passed": 0, "failed": 1, "missing": 0 },
+  "results": [
+    {
+      "rule_id": "11111111-2222-3333-4444-555555555555",
+      "rule_title": "Whoami",
+      "rule_kind": "detection",
+      "index": 0,
+      "name": "should fire",
+      "expect": "match",
+      "actual": "no-match",
+      "passed": false,
+      "diagnostic": "the rule did not match the event"
+    }
+  ]
+}
 ```
 
 ## Exit codes

--- a/docs/content/reference/custom-attributes.md
+++ b/docs/content/reference/custom-attributes.md
@@ -61,7 +61,18 @@ custom_attributes:
               CommandLine: hostname
 ```
 
-Correlation rules use a timestamped `events` sequence. Offsets are relative durations parsed by the existing timespan parser and applied from a fixed base timestamp:
+Each entry accepts exactly these keys:
+
+| Key | Required | Value |
+|-----|----------|-------|
+| `name` | no | Display name, unique within the rule. Defaults to the 0-based list index. |
+| `expect` | yes | `match` or `no-match`. |
+| `event` | detection rules | The example event as a mapping. |
+| `events` | correlation rules | A sequence of `{ offset, event }` entries. |
+
+Exactly one of `event` or `events` must be present, and the payload must match the host rule kind. The list itself must not be empty, and unknown keys are rejected. All of these constraints are checked statically by the [`exemplar_shape` and `exemplar_wrong_rule_kind`](lint-rules.md) lint rules and again by `rule test` before execution.
+
+Correlation rules use a timestamped `events` sequence. Each `offset` is a relative duration string (`0s`, `30s`, `5m`) parsed by the existing timespan parser and applied from a fixed base timestamp; offsets must be non-decreasing:
 
 ```yaml
 custom_attributes:


### PR DESCRIPTION
Follow-up to #469.

- `cli/rule/test.md`: the first example now shows the exemplar-carrying rule, the default table output, and a failing JSON report with its `diagnostic`, so the page is self-contained instead of invocation-only. Output is taken from the committed golden files.
- `reference/custom-attributes.md`: a per-key schema table for exemplar entries (`name` optional and unique, defaulting to the list index; `expect` required as `match`/`no-match`; `event` xor `events` matching the rule kind) plus the non-decreasing duration constraint on `offset`, which previously only appeared inside the `exemplar_shape` row of the lint-rules page.

`docs:build` and `docs:validate` pass.