### PR TITLE
feat: draft temporal correlations from grouped exemplars

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # always LF. Pin them to LF so a Windows checkout does not rewrite them to CRLF.
 crates/rsigma-cli/tests/golden/** text eol=lf
 crates/rsigma-convert/tests/golden/** text eol=lf
+crates/rsigma-eval/src/rule_draft/golden/** text eol=lf

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -50,6 +50,8 @@ jobs:
             max_len: 4096
           - target: fuzz_rule_tune
             max_len: 65536
+          - target: fuzz_draft_groups
+            max_len: 65536
           - target: fuzz_pipeline_sources_yaml
             max_len: 8192
           - target: fuzz_alert_pipeline_config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Fire name-referenced temporal correlations
+### Fire name-referenced temporal correlations (#477)
 
 A `temporal` or `temporal_ordered` correlation that referenced a detection rule by `name` never fired when that rule also carried an `id`: the engine tracked the id in the temporal window while the condition compared against the referenced name. The engine now tracks whichever identity the correlation actually references.
 
-### Correlation drafting
+### Correlation drafting (#477)
 
 `rsigma rule draft --groups` turns grouped timestamped or offset exemplar sequences into verified multi-document `temporal`/`temporal_ordered` Sigma rules. It infers recurring event slots, an unambiguous grouping entity, conservative ordering, and a rounded evidence-based window; drafts disjoint named detection rules for the slots; embeds a representative positive group under `rsigma.exemplars`; and verifies every positive/negative group in a fresh correlation engine. Strict envelope validation, repeated-slot rejection, target-id filtering, field floors, and terminal cross-slot/negative failures prevent broad or state-contaminated drafts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Correlation drafting
+
+`rsigma rule draft --groups` turns grouped timestamped or offset exemplar sequences into verified multi-document `temporal`/`temporal_ordered` Sigma rules. It infers recurring event slots, an unambiguous grouping entity, conservative ordering, and a rounded evidence-based window; drafts disjoint named detection rules for the slots; embeds a representative positive group under `rsigma.exemplars`; and verifies every positive/negative group in a fresh correlation engine. Strict envelope validation, repeated-slot rejection, target-id filtering, field floors, and terminal cross-slot/negative failures prevent broad or state-contaminated drafts.
+
 ### Verdict-driven corpora (#476)
 
 Opt-in, byte-bounded capture of detection results admitted by a `group_by` alert pipeline. Capture runs after inhibition/silencing and before dedup, retains payloads internally at startup, and strips them before sink delivery unless `--include-event` was also set. Accepted dispositions enqueue one versioned bundle per original verdict: TP/BTP directories contain a bare-event backtest corpus, full `expectations.yml`, provenance, and manifest; FP directories feed `rule tune --from-dispositions`. The ring is not persisted to SQLite, not readable through the API, and gated by `capture:write` on HTTP ingest. Correlation results and `entity_graph` grouping are rejected. Closes #345.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Fire name-referenced temporal correlations
+
+A `temporal` or `temporal_ordered` correlation that referenced a detection rule by `name` never fired when that rule also carried an `id`: the engine tracked the id in the temporal window while the condition compared against the referenced name. The engine now tracks whichever identity the correlation actually references.
+
 ### Correlation drafting
 
 `rsigma rule draft --groups` turns grouped timestamped or offset exemplar sequences into verified multi-document `temporal`/`temporal_ordered` Sigma rules. It infers recurring event slots, an unambiguous grouping entity, conservative ordering, and a rounded evidence-based window; drafts disjoint named detection rules for the slots; embeds a representative positive group under `rsigma.exemplars`; and verifies every positive/negative group in a fresh correlation engine. Strict envelope validation, repeated-slot rejection, target-id filtering, field floors, and terminal cross-slot/negative failures prevent broad or state-contaminated drafts.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Full documentation, including guides, CLI reference, and library API docs, lives
 
 * **[Sigma parsing](https://rsigma.io/library/parser/):** Parses Sigma YAML into a strongly-typed AST with support for detection, correlation, and filter rules
 * **[Array matching](https://rsigma.io/guide/array-matching/) (experimental):** Matches members of arrays in nested event data with any/all-member semantics, same-element correlation, and positional indexing, opt-in via `sigma-version: 3`
-* **[Rule drafting](https://rsigma.io/guide/rule-drafting/):** Drafts a detection rule from exemplar events contrasted against a baseline corpus with `rule draft`
+* **[Rule drafting](https://rsigma.io/guide/rule-drafting/):** Drafts detection rules and temporal correlations from exemplar events contrasted against a baseline corpus with `rule draft`
 * **[Rule tuning](https://rsigma.io/guide/rule-tuning/):** Proposes a spec-native filter from false-positive events, verifies that every known true positive still fires, and refuses unsafe separators with `rule tune`
 * **[Built-in linter](https://rsigma.io/guide/linting-rules/):** Validates rules with 85 checks, four severity levels, suppressions, custom tag namespaces, and auto-fix for 14 safe rules
 * **[ADS metadata](https://rsigma.io/guide/detection-strategy/):** Documents rules with [Palantir ADS](https://github.com/palantir/alerting-detection-strategy-framework) sections under `rsigma.ads.*`, enforced by the linter and scaffolded with `rule doc`
@@ -231,6 +231,9 @@ rsigma backend convert rules/ -t splunk
 
 # Draft a detection rule from exemplar events, contrasted against a baseline corpus
 rsigma rule draft -e @incident.ndjson --baseline @normal-day.ndjson
+
+# Draft a temporal correlation from grouped, timed exemplars
+rsigma rule draft --groups @observed.ndjson --negative @benign.ndjson
 
 # Backtest a corpus against per-rule expectations (CI fixture harness)
 rsigma rule backtest -r rules/ --corpus ci/corpus/ --expectations ci/expectations.yml

--- a/crates/rsigma-cli/README.md
+++ b/crates/rsigma-cli/README.md
@@ -48,6 +48,10 @@ rsigma backend convert -r rules/ -t postgres
 # List all fields referenced by rules (with optional pipeline mapping)
 rsigma rule fields -r rules/ -p ecs_windows
 
+# Draft a detection or a grouped temporal correlation
+rsigma rule draft -e @incident.ndjson --baseline @normal.ndjson
+rsigma rule draft --groups @observed.ndjson --negative @benign.ndjson
+
 # Propose a verified filter from classified false-positive and true-positive events
 rsigma rule tune -r rules/ --rule <RULE_ID> --fp @false-positives.ndjson --tp @true-positives.ndjson
 

--- a/crates/rsigma-cli/src/commands/draft.rs
+++ b/crates/rsigma-cli/src/commands/draft.rs
@@ -281,7 +281,15 @@ fn cmd_correlation_draft(args: DraftArgs, ctx: OutputCtx) {
     };
     let baseline = match args.baseline.as_deref() {
         Some(spec) if spec.starts_with('@') => match read_events(Some(spec), "baseline") {
-            Ok(corpus) => corpus.events,
+            Ok(corpus) => {
+                if corpus.parse_errors > 0 {
+                    eprintln!(
+                        "warning: {} baseline line(s) failed to parse as JSON and were skipped",
+                        corpus.parse_errors
+                    );
+                }
+                corpus.events
+            }
             Err(error) => {
                 eprintln!("{error}");
                 process::exit(crate::exit_code::RULE_ERROR);
@@ -430,7 +438,15 @@ fn read_grouped_file(
             )
         })?;
         let group = match directory_group {
-            Some(group) => group.to_string(),
+            Some(group) => {
+                if object.contains_key("group") {
+                    return Err(format!(
+                        "{}:{line_number}: 'group' is not allowed in directory input; the filename stem is the group id",
+                        path.display()
+                    ));
+                }
+                group.to_string()
+            }
             None => object
                 .get("group")
                 .and_then(serde_json::Value::as_str)

--- a/crates/rsigma-cli/src/commands/draft.rs
+++ b/crates/rsigma-cli/src/commands/draft.rs
@@ -43,6 +43,7 @@ pub(crate) enum CorrelationTypeArg {
     #[default]
     Auto,
     Temporal,
+    #[value(name = "temporal_ordered")]
     TemporalOrdered,
 }
 

--- a/crates/rsigma-cli/src/commands/draft.rs
+++ b/crates/rsigma-cli/src/commands/draft.rs
@@ -14,10 +14,14 @@
 
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::{Args, ValueEnum};
+use rsigma_eval::rule_draft::correlation::{
+    CorrelationDraftConfig, CorrelationDraftReport, CorrelationDraftType, GroupedExemplar,
+    SourceLocation, TimedEvent, draft_correlation,
+};
 use rsigma_eval::{DraftConfig, DraftReport, JsonEvent, draft_rule};
 use serde::Serialize;
 
@@ -34,6 +38,24 @@ pub(crate) enum EmitMode {
     Report,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub(crate) enum CorrelationTypeArg {
+    #[default]
+    Auto,
+    Temporal,
+    TemporalOrdered,
+}
+
+impl From<CorrelationTypeArg> for CorrelationDraftType {
+    fn from(value: CorrelationTypeArg) -> Self {
+        match value {
+            CorrelationTypeArg::Auto => Self::Auto,
+            CorrelationTypeArg::Temporal => Self::Temporal,
+            CorrelationTypeArg::TemporalOrdered => Self::TemporalOrdered,
+        }
+    }
+}
+
 /// Arguments for `rsigma rule draft`.
 #[derive(Args, Debug)]
 pub(crate) struct DraftArgs {
@@ -42,6 +64,30 @@ pub(crate) struct DraftArgs {
     /// NDJSON from stdin.
     #[arg(short, long)]
     pub event: Option<String>,
+
+    /// Grouped, timed exemplars from an envelope NDJSON file or directory.
+    #[arg(long, value_name = "@PATH")]
+    pub groups: Option<String>,
+
+    /// Grouped negative examples that the drafted correlation must not match.
+    #[arg(long, value_name = "@PATH")]
+    pub negative: Option<String>,
+
+    /// Correlation grouping field (repeatable for an explicit composite key).
+    #[arg(long = "group-by", value_name = "FIELD")]
+    pub group_by: Vec<String>,
+
+    /// Correlation ordering behavior.
+    #[arg(long, value_enum, default_value_t = CorrelationTypeArg::Auto)]
+    pub correlation_type: CorrelationTypeArg,
+
+    /// Minimum number of positive groups.
+    #[arg(long, default_value_t = 3)]
+    pub min_groups: usize,
+
+    /// Margin applied to the maximum observed group span.
+    #[arg(long, default_value_t = 1.5)]
+    pub window_margin: f64,
 
     /// Baseline corpus of normal traffic (@path to NDJSON, or .evtx with the
     /// evtx feature). Used to score fields by rarity and to estimate the
@@ -93,6 +139,14 @@ pub(crate) struct DraftArgs {
 }
 
 pub(crate) fn cmd_draft(args: DraftArgs, ctx: OutputCtx) {
+    if args.groups.is_some() {
+        cmd_correlation_draft(args, ctx);
+        return;
+    }
+    if args.negative.is_some() || !args.group_by.is_empty() {
+        eprintln!("--negative and --group-by require --groups");
+        process::exit(crate::exit_code::CONFIG_ERROR);
+    }
     let exemplars = match read_events(args.event.as_deref(), "exemplar") {
         Ok(c) => c,
         Err(e) => {
@@ -202,6 +256,114 @@ pub(crate) fn cmd_draft(args: DraftArgs, ctx: OutputCtx) {
     }
 }
 
+fn cmd_correlation_draft(args: DraftArgs, ctx: OutputCtx) {
+    if args.event.is_some() {
+        eprintln!("--event cannot be combined with --groups");
+        process::exit(crate::exit_code::CONFIG_ERROR);
+    }
+    let groups = match read_grouped(args.groups.as_deref().unwrap(), "group") {
+        Ok(groups) => groups,
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(crate::exit_code::RULE_ERROR);
+        }
+    };
+    let negatives = match args.negative.as_deref() {
+        Some(spec) => match read_grouped(spec, "negative group") {
+            Ok(groups) => groups,
+            Err(error) => {
+                eprintln!("{error}");
+                process::exit(crate::exit_code::RULE_ERROR);
+            }
+        },
+        None => Vec::new(),
+    };
+    let baseline = match args.baseline.as_deref() {
+        Some(spec) if spec.starts_with('@') => match read_events(Some(spec), "baseline") {
+            Ok(corpus) => corpus.events,
+            Err(error) => {
+                eprintln!("{error}");
+                process::exit(crate::exit_code::RULE_ERROR);
+            }
+        },
+        Some(_) => {
+            eprintln!("--baseline expects @path to an NDJSON file");
+            process::exit(crate::exit_code::CONFIG_ERROR);
+        }
+        None => Vec::new(),
+    };
+    let detection = DraftConfig {
+        max_fields: args.max_fields,
+        min_prevalence: args.min_prevalence,
+        include_fields: args.include_fields,
+        exclude_fields: args.exclude_fields,
+        title: args.title.clone(),
+        logsource_category: args.logsource_category,
+        logsource_product: args.logsource_product,
+        logsource_service: args.logsource_service,
+        evaluate_baseline: false,
+        ..DraftConfig::default()
+    };
+    let config = CorrelationDraftConfig {
+        min_groups: args.min_groups,
+        window_margin: args.window_margin,
+        correlation_type: args.correlation_type.into(),
+        group_by: args.group_by,
+        title: args.title,
+        correlation_id: Some(new_uuid_v4()),
+        slot_ids: (0..64).map(|_| new_uuid_v4()).collect(),
+        detection,
+        ..CorrelationDraftConfig::default()
+    };
+    let report = match draft_correlation(&groups, &negatives, &baseline, &config) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("Error drafting correlation: {error}");
+            process::exit(crate::exit_code::RULE_ERROR);
+        }
+    };
+    match args.emit {
+        EmitMode::Yaml => {
+            if ctx.explicit_format {
+                ctx.warn_unsupported("rule draft --groups", "Sigma YAML");
+            }
+            print!("{}", report.rule_yaml);
+            if ctx.show_stats() {
+                print_correlation_summary(&report);
+            }
+        }
+        EmitMode::Report => match ctx.format {
+            OutputFormat::Json => render_json(&report, true),
+            OutputFormat::Ndjson => render_json(&report, false),
+            OutputFormat::Table | OutputFormat::Csv | OutputFormat::Tsv => {
+                print_correlation_summary(&report);
+                print!("{}", report.rule_yaml);
+            }
+        },
+    }
+}
+
+fn print_correlation_summary(report: &CorrelationDraftReport) {
+    eprintln!(
+        "Drafted {} correlation with {} slots, group-by {}, timespan {}",
+        report.correlation_type,
+        report.slots.len(),
+        report.group_by.join(", "),
+        report.timespan
+    );
+    for slot in &report.slots {
+        eprintln!(
+            "  {}: {} events, fields {}",
+            slot.name,
+            slot.support,
+            slot.selected_fields.join(", ")
+        );
+    }
+    for warning in &report.warnings {
+        eprintln!("warning: {warning}");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // UUIDv4 (kept out of rsigma-eval so the core stays deterministic)
 // ---------------------------------------------------------------------------
@@ -209,6 +371,117 @@ pub(crate) fn cmd_draft(args: DraftArgs, ctx: OutputCtx) {
 /// A random version-4 UUID for the draft's `id`.
 fn new_uuid_v4() -> String {
     uuid::Uuid::new_v4().to_string()
+}
+
+fn read_grouped(spec: &str, label: &str) -> Result<Vec<GroupedExemplar>, String> {
+    let Some(raw_path) = spec.strip_prefix('@') else {
+        return Err(format!(
+            "--{label}s expects @path to an NDJSON file or directory"
+        ));
+    };
+    let path = PathBuf::from(raw_path);
+    if !path.exists() {
+        return Err(format!("{label} path not found: {}", path.display()));
+    }
+    if path.is_dir() {
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&path)
+            .map_err(|error| format!("Error reading {}: {error}", path.display()))?
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| path.is_file())
+            .collect();
+        files.sort();
+        let mut groups = Vec::with_capacity(files.len());
+        for file in files {
+            let id = file
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .ok_or_else(|| format!("Invalid group filename: {}", file.display()))?
+                .to_string();
+            let mut parsed = read_grouped_file(&file, Some(&id))?;
+            groups.append(&mut parsed);
+        }
+        Ok(groups)
+    } else {
+        read_grouped_file(&path, None)
+    }
+}
+
+fn read_grouped_file(
+    path: &Path,
+    directory_group: Option<&str>,
+) -> Result<Vec<GroupedExemplar>, String> {
+    let file =
+        File::open(path).map_err(|error| format!("Error opening '{}': {error}", path.display()))?;
+    let mut groups: std::collections::BTreeMap<String, Vec<TimedEvent>> =
+        std::collections::BTreeMap::new();
+    for (index, line) in BufReader::new(file).lines().enumerate() {
+        let line_number = index + 1;
+        let line = line.map_err(|error| format!("Error reading '{}': {error}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(&line)
+            .map_err(|error| format!("{}:{line_number}: invalid JSON: {error}", path.display()))?;
+        let object = value.as_object().ok_or_else(|| {
+            format!(
+                "{}:{line_number}: grouped envelope must be a JSON object",
+                path.display()
+            )
+        })?;
+        let group = match directory_group {
+            Some(group) => group.to_string(),
+            None => object
+                .get("group")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| {
+                    format!(
+                        "{}:{line_number}: grouped envelope requires string 'group'",
+                        path.display()
+                    )
+                })?
+                .to_string(),
+        };
+        let timestamp = optional_string(object, "timestamp", path, line_number)?;
+        let offset = optional_string(object, "offset", path, line_number)?;
+        let event = object
+            .get("event")
+            .filter(|event| event.is_object())
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "{}:{line_number}: grouped envelope requires object 'event'",
+                    path.display()
+                )
+            })?;
+        groups.entry(group).or_default().push(TimedEvent {
+            timestamp,
+            offset,
+            event,
+            source: SourceLocation {
+                file: Some(path.display().to_string()),
+                line: Some(line_number),
+            },
+        });
+    }
+    Ok(groups
+        .into_iter()
+        .map(|(id, events)| GroupedExemplar { id, events })
+        .collect())
+}
+
+fn optional_string(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    path: &Path,
+    line: usize,
+) -> Result<Option<String>, String> {
+    match object.get(key) {
+        None => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(|value| Some(value.to_string()))
+            .ok_or_else(|| format!("{}:{line}: '{key}' must be a string", path.display())),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsigma-cli/tests/cli_draft.rs
+++ b/crates/rsigma-cli/tests/cli_draft.rs
@@ -396,3 +396,24 @@ fn grouped_auto_mode_downgrades_inverted_order() {
         .success()
         .stdout(predicate::str::contains("type: temporal\n"));
 }
+
+#[test]
+fn grouped_forced_order_uses_sigma_spelling_and_rejects_inversion() {
+    let input = CORRELATION_GROUPS.replace(
+        r#"{"group":"g3","offset":"0s","event":{"kind":"reset""#,
+        r#"{"group":"g3","offset":"40s","event":{"kind":"reset""#,
+    );
+    let groups = temp_file(".ndjson", &input);
+    rsigma()
+        .args([
+            "rule",
+            "draft",
+            "--groups",
+            &format!("@{}", groups.path().display()),
+            "--correlation-type",
+            "temporal_ordered",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("groups disagree on slot order"));
+}

--- a/crates/rsigma-cli/tests/cli_draft.rs
+++ b/crates/rsigma-cli/tests/cli_draft.rs
@@ -22,6 +22,21 @@ const SYSMON_EXEMPLARS: &str = concat!(
     "\n",
 );
 
+const CORRELATION_GROUPS: &str = concat!(
+    r#"{"group":"g1","offset":"0s","event":{"kind":"reset","user":"alice","factor":"totp","reset_reason":"recovery"}}"#,
+    "\n",
+    r#"{"group":"g1","offset":"20s","event":{"kind":"session","user":"alice","new_asn":true,"asn":64512,"session_type":"web"}}"#,
+    "\n",
+    r#"{"group":"g2","offset":"0s","event":{"kind":"reset","user":"bob","factor":"totp","reset_reason":"recovery"}}"#,
+    "\n",
+    r#"{"group":"g2","offset":"25s","event":{"kind":"session","user":"bob","new_asn":true,"asn":64512,"session_type":"web"}}"#,
+    "\n",
+    r#"{"group":"g3","offset":"0s","event":{"kind":"reset","user":"carol","factor":"totp","reset_reason":"recovery"}}"#,
+    "\n",
+    r#"{"group":"g3","offset":"30s","event":{"kind":"session","user":"carol","new_asn":true,"asn":64512,"session_type":"web"}}"#,
+    "\n",
+);
+
 /// Replace the volatile `id:` (random UUIDv4) and `date:` (today) lines with
 /// placeholders so the draft compares byte-for-byte against the golden.
 /// Splitting on `lines()` also normalizes CRLF to LF.
@@ -291,4 +306,93 @@ fn all_volatile_exemplars_fail_with_guidance() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("no candidate fields"));
+}
+
+#[test]
+fn grouped_draft_emits_reparseable_temporal_collection() {
+    let groups = temp_file(".ndjson", CORRELATION_GROUPS);
+    let output = rsigma()
+        .args([
+            "rule",
+            "draft",
+            "--groups",
+            &format!("@{}", groups.path().display()),
+        ])
+        .output()
+        .expect("run grouped draft");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let yaml = String::from_utf8(output.stdout).unwrap();
+    assert!(yaml.contains("type: temporal_ordered"));
+    assert!(yaml.contains("rsigma.exemplars:"));
+    let rule = temp_file(".yml", &yaml);
+    rsigma()
+        .args(["rule", "lint", rule.path().to_str().unwrap()])
+        .assert()
+        .success();
+    rsigma()
+        .args(["rule", "test", "--rules", rule.path().to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn grouped_directory_uses_file_stems_as_group_ids() {
+    let directory = tempfile::tempdir().unwrap();
+    for (id, user) in [("g1", "alice"), ("g2", "bob"), ("g3", "carol")] {
+        let contents = format!(
+            "{{\"offset\":\"0s\",\"event\":{{\"kind\":\"reset\",\"user\":\"{user}\",\"factor\":\"totp\",\"reset_reason\":\"recovery\"}}}}\n{{\"offset\":\"20s\",\"event\":{{\"kind\":\"session\",\"user\":\"{user}\",\"new_asn\":true,\"asn\":64512,\"session_type\":\"web\"}}}}\n"
+        );
+        std::fs::write(directory.path().join(format!("{id}.ndjson")), contents).unwrap();
+    }
+    rsigma()
+        .args([
+            "rule",
+            "draft",
+            "--groups",
+            &format!("@{}", directory.path().display()),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("type: temporal_ordered"));
+}
+
+#[test]
+fn grouped_draft_reports_malformed_line_context() {
+    let groups = temp_file(
+        ".ndjson",
+        "{\"group\":\"g1\",\"offset\":\"0s\",\"event\":{}}\nnot-json\n",
+    );
+    rsigma()
+        .args([
+            "rule",
+            "draft",
+            "--groups",
+            &format!("@{}", groups.path().display()),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(":2: invalid JSON"));
+}
+
+#[test]
+fn grouped_auto_mode_downgrades_inverted_order() {
+    let input = CORRELATION_GROUPS.replace(
+        r#"{"group":"g3","offset":"0s","event":{"kind":"reset""#,
+        r#"{"group":"g3","offset":"40s","event":{"kind":"reset""#,
+    );
+    let groups = temp_file(".ndjson", &input);
+    rsigma()
+        .args([
+            "rule",
+            "draft",
+            "--groups",
+            &format!("@{}", groups.path().display()),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("type: temporal\n"));
 }

--- a/crates/rsigma-cli/tests/cli_draft.rs
+++ b/crates/rsigma-cli/tests/cli_draft.rs
@@ -361,6 +361,28 @@ fn grouped_directory_uses_file_stems_as_group_ids() {
 }
 
 #[test]
+fn grouped_directory_rejects_embedded_group_key() {
+    let directory = tempfile::tempdir().unwrap();
+    std::fs::write(
+        directory.path().join("g1.ndjson"),
+        "{\"group\":\"other\",\"offset\":\"0s\",\"event\":{\"kind\":\"reset\"}}\n",
+    )
+    .unwrap();
+    rsigma()
+        .args([
+            "rule",
+            "draft",
+            "--groups",
+            &format!("@{}", directory.path().display()),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "'group' is not allowed in directory input",
+        ));
+}
+
+#[test]
 fn grouped_draft_reports_malformed_line_context() {
     let groups = temp_file(
         ".ndjson",

--- a/crates/rsigma-eval/README.md
+++ b/crates/rsigma-eval/README.md
@@ -122,13 +122,15 @@ Opt-in counter that records every observed field name and surfaces gap and broke
 
 ### Rule drafting (`rule_draft` module)
 
-Turns exemplar events into a complete draft Sigma rule, verified end-to-end through the real parse/compile/evaluate path. Backs `rsigma rule draft`.
+Turns exemplar events into complete draft Sigma detection and temporal correlation rules, verified end-to-end through the real parse/compile/evaluate path. Backs `rsigma rule draft`.
 
 | Type / function | Description |
 |-----------------|-------------|
 | `draft_rule(exemplars, baseline, &DraftConfig)` | Profile the exemplars, drop volatile fields (timestamps, GUIDs, counters, high-entropy uniques), score by stability times baseline rarity, infer value forms and modifiers (equals, OR list, `endswith`/`startswith`/`contains` with Sigma wildcard escaping), infer the logsource via `SchemaClassifier`, and emit + verify the rule (every exemplar must match; bounded relaxation with a minimum-field floor) |
 | `DraftConfig` | Tunables: `max_fields`, `min_fields`, `min_prevalence`, `max_value_cardinality`, `min_token_len`, `max_baseline_token_prevalence`, include/exclude fields, title/logsource overrides, `rule_id` (caller-supplied; the core is deterministic and never generates one), `date`, `evaluate_baseline` |
 | `DraftReport` | `rule_yaml` (parse- and lint-checked), ranked `fields` (`DraftFieldReport` with score, `Stability` class, chosen modifier, values, baseline prevalence), `exemplar_matched`, `baseline_hits`/`baseline_hit_rate`, warnings |
+| `rule_draft::correlation::draft_correlation(groups, negatives, baseline, &CorrelationDraftConfig)` | Validate grouped timed events, infer recurring slots, grouping entity, order, and window, emit named detection documents plus a temporal correlation, and verify every group in an isolated `CorrelationEngine` |
+| `CorrelationDraftReport` | Multi-document YAML, correlation type, group-by fields, chosen timespan, observed spans/gaps, per-slot support and selected forms, isolated verification rows, warnings |
 | `DraftError` | `NoExemplars`, `NoCandidateFields`, `CannotMatchExemplars` (the floor error: an over-broad draft is refused, not emitted), `ForcedFieldMismatch` (a forced include-field absent from some exemplars is named, never silently dropped) |
 
 ### Rule exemplars (`exemplar` module)

--- a/crates/rsigma-eval/src/correlation_engine/mod.rs
+++ b/crates/rsigma-eval/src/correlation_engine/mod.rs
@@ -723,7 +723,11 @@ impl CorrelationEngine {
         if let Some(name) = rule_name.as_deref() {
             ref_strs.push(name);
         }
-        let rule_ref = rule_id.as_deref().or(rule_name.as_deref()).unwrap_or("");
+        let rule_ref = ref_strs
+            .iter()
+            .copied()
+            .find(|identity| corr.rule_refs.iter().any(|rule_ref| rule_ref == identity))
+            .unwrap_or("");
 
         // Extract group key
         let group_key = GroupKey::extract(event, &corr.group_by, &ref_strs);

--- a/crates/rsigma-eval/src/correlation_engine/tests.rs
+++ b/crates/rsigma-eval/src/correlation_engine/tests.rs
@@ -926,6 +926,66 @@ level: high
     );
 }
 
+#[test]
+fn test_temporal_referenced_by_name_when_rule_also_has_id() {
+    // Regression: when a rule carries both `id` and `name` and the temporal
+    // correlation references it by `name`, the tracked identity must be the
+    // referenced name; tracking the id means the window never satisfies the
+    // condition and the correlation silently never fires.
+    let yaml = r#"
+title: Recon A
+id: recon-a
+name: recon_a
+logsource:
+    category: process
+detection:
+    selection:
+        CommandLine|contains: 'whoami'
+    condition: selection
+---
+title: Recon B
+id: recon-b
+name: recon_b
+logsource:
+    category: process
+detection:
+    selection:
+        CommandLine|contains: 'ipconfig'
+    condition: selection
+---
+title: Recon Combo By Name
+id: corr-temporal-by-name
+correlation:
+    type: temporal
+    rules:
+        - recon_a
+        - recon_b
+    group-by:
+        - User
+    timespan: 60s
+    condition:
+        gte: 2
+level: high
+"#;
+    let collection = parse_sigma_yaml(yaml).unwrap();
+    let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+    engine.add_collection(&collection).unwrap();
+
+    let ts = 1000i64;
+    let v1 = json!({"CommandLine": "whoami", "User": "admin"});
+    let ev1 = JsonEvent::borrow(&v1);
+    assert_eq!(engine.process_event_at(&ev1, ts).correlation_count(), 0);
+
+    let v2 = json!({"CommandLine": "ipconfig /all", "User": "admin"});
+    let ev2 = JsonEvent::borrow(&v2);
+    let r2 = engine.process_event_at(&ev2, ts + 10);
+    assert_eq!(
+        r2.correlation_count(),
+        1,
+        "temporal correlation referencing rules by name must fire when the rules also carry ids"
+    );
+}
+
 // =========================================================================
 // Temporal ordered correlation
 // =========================================================================

--- a/crates/rsigma-eval/src/key_shape.rs
+++ b/crates/rsigma-eval/src/key_shape.rs
@@ -1,0 +1,97 @@
+//! Deterministic greedy clustering for event field-key shapes.
+
+use std::collections::BTreeSet;
+
+/// Cluster ordered items by Jaccard similarity to each cluster's first item.
+///
+/// The caller owns cluster state and may reject otherwise-similar merges with
+/// `can_merge`. Cluster indexes are stable for a stable input order.
+pub(crate) fn cluster_by_key_shape<I, C>(
+    items: &[I],
+    similarity: f64,
+    keys: impl Fn(&I) -> &[String],
+    seed_keys: impl Fn(&C) -> &[String],
+    from_item: impl Fn(&I) -> C,
+    can_merge: impl Fn(&C, &I) -> bool,
+    merge: impl Fn(&mut C, &I),
+) -> Vec<C> {
+    let mut clusters = Vec::new();
+    for item in items {
+        let mut placed = false;
+        for cluster in &mut clusters {
+            if jaccard(keys(item), seed_keys(cluster)) >= similarity && can_merge(cluster, item) {
+                merge(cluster, item);
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            clusters.push(from_item(item));
+        }
+    }
+    clusters
+}
+
+fn jaccard(a: &[String], b: &[String]) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let a: BTreeSet<&String> = a.iter().collect();
+    let b: BTreeSet<&String> = b.iter().collect();
+    let intersection = a.intersection(&b).count();
+    let union = a.union(&b).count();
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Cluster {
+        seed: Vec<String>,
+        members: Vec<usize>,
+    }
+
+    fn cluster(items: &[Vec<String>]) -> Vec<Cluster> {
+        cluster_by_key_shape(
+            items,
+            0.6,
+            Vec::as_slice,
+            |cluster: &Cluster| &cluster.seed,
+            |keys| Cluster {
+                seed: keys.clone(),
+                members: Vec::new(),
+            },
+            |_, _| true,
+            |cluster, keys| {
+                cluster.members.push(
+                    items
+                        .iter()
+                        .position(|candidate| std::ptr::eq(candidate, keys))
+                        .unwrap(),
+                );
+            },
+        )
+    }
+
+    #[test]
+    fn equivalent_key_sets_get_stable_cluster_indexes() {
+        let items = vec![
+            vec!["a".into(), "b".into(), "c".into()],
+            vec!["a".into(), "b".into()],
+            vec!["x".into(), "y".into()],
+            vec!["a".into(), "b".into(), "c".into()],
+        ];
+        let first = cluster(&items);
+        let second = cluster(&items);
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[0].seed, items[0]);
+        assert_eq!(first[1].seed, items[2]);
+    }
+}

--- a/crates/rsigma-eval/src/lib.rs
+++ b/crates/rsigma-eval/src/lib.rs
@@ -101,6 +101,7 @@ pub mod exemplar;
 pub mod explain;
 pub mod field_observer;
 pub mod fields;
+mod key_shape;
 pub mod logsource;
 pub mod matcher;
 pub mod pipeline;

--- a/crates/rsigma-eval/src/rule_draft.rs
+++ b/crates/rsigma-eval/src/rule_draft.rs
@@ -35,6 +35,7 @@ use crate::engine::Engine;
 use crate::event::Event;
 use crate::schema::SchemaClassifier;
 
+pub mod correlation;
 pub(crate) mod draft_core;
 use draft_core::*;
 
@@ -299,6 +300,15 @@ impl DraftCandidate {
     }
 
     pub(crate) fn emit<E: Event>(&self, exemplars: &[E], config: &DraftConfig) -> String {
+        self.emit_named(exemplars, config, None)
+    }
+
+    pub(crate) fn emit_named<E: Event>(
+        &self,
+        exemplars: &[E],
+        config: &DraftConfig,
+        name: Option<&str>,
+    ) -> String {
         let detection = build_detection(&self.profiles, &self.selected, exemplars, config);
         emit_rule_yaml(
             &self.profiles,
@@ -306,6 +316,7 @@ impl DraftCandidate {
             &detection,
             &self.logsource,
             config,
+            name,
         )
     }
 
@@ -777,6 +788,7 @@ fn emit_rule_yaml(
     detection: &DetectionBlock,
     logsource: &DraftLogsource,
     config: &DraftConfig,
+    name: Option<&str>,
 ) -> String {
     let title = config.title.clone().unwrap_or_else(|| {
         title_marker(profiles, selected)
@@ -790,6 +802,9 @@ fn emit_rule_yaml(
 
     let mut out = String::new();
     out.push_str(&format!("title: {}\n", yaml_title_str(&title)));
+    if let Some(name) = name {
+        out.push_str(&format!("name: {}\n", yaml_str(name)));
+    }
     if let Some(id) = &config.rule_id {
         out.push_str(&format!("id: {id}\n"));
     }

--- a/crates/rsigma-eval/src/rule_draft.rs
+++ b/crates/rsigma-eval/src/rule_draft.rs
@@ -226,6 +226,110 @@ pub struct DraftReport {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct DraftCandidate {
+    pub(crate) profiles: Vec<DraftFieldProfile>,
+    pub(crate) selected: Vec<usize>,
+    logsource: DraftLogsource,
+    pub(crate) warnings: Vec<String>,
+}
+
+impl DraftCandidate {
+    pub(crate) fn build<E: Event>(
+        exemplars: &[E],
+        baseline: &[E],
+        config: &DraftConfig,
+    ) -> Result<Self, DraftError> {
+        if exemplars.is_empty() {
+            return Err(DraftError::NoExemplars);
+        }
+        let mut warnings = Vec::new();
+        let mut profiles = profile_fields(exemplars, config, &mut warnings);
+        if profiles.is_empty() {
+            return Err(DraftError::NoCandidateFields(exemplars.len()));
+        }
+        for profile in &mut profiles {
+            infer_form(profile, config);
+        }
+        if !baseline.is_empty() {
+            for profile in &mut profiles {
+                apply_baseline(profile, baseline, config);
+            }
+        }
+        let has_baseline = !baseline.is_empty();
+        for profile in &mut profiles {
+            profile.score = score_field(profile, has_baseline);
+        }
+        profiles.sort_by(|a, b| {
+            b.forced
+                .cmp(&a.forced)
+                .then_with(|| {
+                    b.score
+                        .partial_cmp(&a.score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .then_with(|| a.field().cmp(b.field()))
+        });
+        let usable: Vec<usize> = profiles
+            .iter()
+            .enumerate()
+            .filter(|(_, profile)| {
+                profile.form.is_some() && profile.stability != Stability::Volatile
+            })
+            .map(|(index, _)| index)
+            .collect();
+        if usable.is_empty() {
+            return Err(DraftError::NoCandidateFields(exemplars.len()));
+        }
+        let selected: Vec<usize> = usable.iter().copied().take(config.max_fields).collect();
+        if selected.len() < config.min_fields {
+            warnings.push(format!(
+                "only {} usable field(s) found (floor is {}); the draft may be broad",
+                selected.len(),
+                config.min_fields
+            ));
+        }
+        let logsource = infer_logsource(exemplars, config, &mut warnings);
+        Ok(Self {
+            profiles,
+            selected,
+            logsource,
+            warnings,
+        })
+    }
+
+    pub(crate) fn emit<E: Event>(&self, exemplars: &[E], config: &DraftConfig) -> String {
+        let detection = build_detection(&self.profiles, &self.selected, exemplars, config);
+        emit_rule_yaml(
+            &self.profiles,
+            &self.selected,
+            &detection,
+            &self.logsource,
+            config,
+        )
+    }
+
+    pub(crate) fn drop_lowest_eligible(&mut self, failing: Option<&[usize]>) -> Option<usize> {
+        let absent_in_failing = |index: usize| {
+            failing.is_some_and(|indexes| {
+                indexes
+                    .iter()
+                    .any(|&event| self.profiles[index].values[event].is_none())
+            })
+        };
+        let position = self
+            .selected
+            .iter()
+            .rposition(|&index| !self.profiles[index].forced && absent_in_failing(index))
+            .or_else(|| {
+                self.selected
+                    .iter()
+                    .rposition(|&index| !self.profiles[index].forced)
+            })?;
+        Some(self.selected.remove(position))
+    }
+}
+
 // =============================================================================
 // Entry point
 // =============================================================================
@@ -240,74 +344,12 @@ pub fn draft_rule<E: Event>(
     baseline: &[E],
     config: &DraftConfig,
 ) -> Result<DraftReport, DraftError> {
-    if exemplars.is_empty() {
-        return Err(DraftError::NoExemplars);
-    }
-    let mut warnings: Vec<String> = Vec::new();
-
-    // ---- Profile ----------------------------------------------------------
-    let mut profiles = profile_fields(exemplars, config, &mut warnings);
-    if profiles.is_empty() {
-        return Err(DraftError::NoCandidateFields(exemplars.len()));
-    }
-
-    // ---- Infer value forms -------------------------------------------------
-    for p in &mut profiles {
-        infer_form(p, config);
-    }
-
-    // ---- Baseline prevalence + token guard ---------------------------------
-    if !baseline.is_empty() {
-        for p in &mut profiles {
-            apply_baseline(p, baseline, config);
-        }
-    }
-
-    // ---- Score -------------------------------------------------------------
-    let has_baseline = !baseline.is_empty();
-    for p in &mut profiles {
-        p.score = score_field(p, has_baseline);
-    }
-    // Rank: forced first, then score descending, then field name ascending
-    // (the deterministic tie-break).
-    profiles.sort_by(|a, b| {
-        b.forced
-            .cmp(&a.forced)
-            .then_with(|| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .then_with(|| a.field().cmp(b.field()))
-    });
-
-    // ---- Select ------------------------------------------------------------
-    let usable: Vec<usize> = profiles
-        .iter()
-        .enumerate()
-        .filter(|(_, p)| p.form.is_some() && p.stability != Stability::Volatile)
-        .map(|(i, _)| i)
-        .collect();
-    if usable.is_empty() {
-        return Err(DraftError::NoCandidateFields(exemplars.len()));
-    }
-    let mut selected: Vec<usize> = usable.iter().copied().take(config.max_fields).collect();
-    if selected.len() < config.min_fields {
-        warnings.push(format!(
-            "only {} usable field(s) found (floor is {}); the draft may be broad",
-            selected.len(),
-            config.min_fields
-        ));
-    }
-
-    // ---- Logsource ---------------------------------------------------------
-    let logsource = infer_logsource(exemplars, config, &mut warnings);
+    let mut candidate = DraftCandidate::build(exemplars, baseline, config)?;
+    let floor = config.min_fields.min(candidate.selected.len()).max(1);
 
     // ---- Emit + verify (bounded relaxation) --------------------------------
-    let floor = config.min_fields.min(selected.len()).max(1);
     let (yaml, matched, failing) = loop {
-        let detection = build_detection(&profiles, &selected, exemplars, config);
-        let yaml = emit_rule_yaml(&profiles, &selected, &detection, &logsource, config);
+        let yaml = candidate.emit(exemplars, config);
         let engine = compile_draft(&yaml)?;
         let failing: Vec<usize> = exemplars
             .iter()
@@ -322,16 +364,20 @@ pub fn draft_rule<E: Event>(
         // A field is a provable culprit when it is absent from a failing
         // exemplar (the common case: partial-prevalence fields admitted by
         // `min_prevalence`).
-        let absent_in_failing =
-            |i: usize| failing.iter().any(|&idx| profiles[i].values[idx].is_none());
+        let absent_in_failing = |i: usize| {
+            failing
+                .iter()
+                .any(|&idx| candidate.profiles[i].values[idx].is_none())
+        };
 
         // A forced field that provably breaks the match is a user decision we
         // refuse to override; dropping other fields could never fix it, so
         // error out immediately with the culprit named.
-        let forced_culprits: Vec<String> = selected
+        let forced_culprits: Vec<String> = candidate
+            .selected
             .iter()
-            .filter(|&&i| profiles[i].forced && absent_in_failing(i))
-            .map(|&i| profiles[i].field().to_string())
+            .filter(|&&i| candidate.profiles[i].forced && absent_in_failing(i))
+            .map(|&i| candidate.profiles[i].field().to_string())
             .collect();
         if !forced_culprits.is_empty() {
             return Err(DraftError::ForcedFieldMismatch {
@@ -340,7 +386,7 @@ pub fn draft_rule<E: Event>(
             });
         }
 
-        if selected.len() <= floor {
+        if candidate.selected.len() <= floor {
             return Err(DraftError::CannotMatchExemplars {
                 matched: exemplars.len() - failing.len(),
                 total: exemplars.len(),
@@ -351,11 +397,7 @@ pub fn draft_rule<E: Event>(
 
         // Drop the lowest-ranked non-forced culprit; when no field is provably
         // at fault (a value-form edge case), shed the weakest non-forced field.
-        let drop_pos = selected
-            .iter()
-            .rposition(|&i| !profiles[i].forced && absent_in_failing(i))
-            .or_else(|| selected.iter().rposition(|&i| !profiles[i].forced));
-        let Some(pos) = drop_pos else {
+        let Some(dropped) = candidate.drop_lowest_eligible(Some(&failing)) else {
             return Err(DraftError::CannotMatchExemplars {
                 matched: exemplars.len() - failing.len(),
                 total: exemplars.len(),
@@ -363,10 +405,9 @@ pub fn draft_rule<E: Event>(
                 failing,
             });
         };
-        let dropped = selected.remove(pos);
-        warnings.push(format!(
+        candidate.warnings.push(format!(
             "relaxed: dropped field '{}' because the draft did not match every exemplar with it",
-            profiles[dropped].field()
+            candidate.profiles[dropped].field()
         ));
     };
     debug_assert!(failing.is_empty());
@@ -380,7 +421,7 @@ pub fn draft_rule<E: Event>(
             .count();
         let rate = hits as f64 / baseline.len() as f64;
         if hits > 0 {
-            warnings.push(format!(
+            candidate.warnings.push(format!(
                 "draft matches {hits}/{} baseline events ({:.1}%); consider a tighter field",
                 baseline.len(),
                 rate * 100.0
@@ -393,12 +434,15 @@ pub fn draft_rule<E: Event>(
 
     // ---- Lint ----------------------------------------------------------------
     for w in rsigma_parser::lint_yaml_str(&yaml) {
-        warnings.push(format!("lint {}: {}", w.rule, w.message));
+        candidate
+            .warnings
+            .push(format!("lint {}: {}", w.rule, w.message));
     }
 
     // ---- Report ---------------------------------------------------------------
-    let selected_set: BTreeSet<usize> = selected.iter().copied().collect();
-    let fields = profiles
+    let selected_set: BTreeSet<usize> = candidate.selected.iter().copied().collect();
+    let fields = candidate
+        .profiles
         .iter()
         .enumerate()
         .map(|(i, p)| DraftFieldReport {
@@ -434,7 +478,7 @@ pub fn draft_rule<E: Event>(
         baseline_total: baseline.len(),
         baseline_hits,
         baseline_hit_rate,
-        warnings,
+        warnings: candidate.warnings,
     })
 }
 
@@ -950,6 +994,54 @@ mod tests {
         let a = draft(&exemplars, &[], &fixed_config()).unwrap().rule_yaml;
         let b = draft(&exemplars, &[], &fixed_config()).unwrap().rule_yaml;
         assert_eq!(a, b, "draft output must be byte-identical across runs");
+    }
+
+    #[test]
+    fn structured_candidate_reemits_deterministically_after_drop() {
+        let exemplars: Vec<Value> = (0..3)
+            .map(|_| json!({"vendor": "acme", "action": "alert", "kind": "auth"}))
+            .collect();
+        let events = events(&exemplars);
+        let mut candidate = DraftCandidate::build(&events, &[], &fixed_config()).unwrap();
+        assert!(candidate.drop_lowest_eligible(None).is_some());
+        let first = candidate.emit(&events, &fixed_config());
+        let second = candidate.emit(&events, &fixed_config());
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn structured_candidate_never_drops_forced_fields() {
+        let exemplars: Vec<Value> = (0..3)
+            .map(|_| json!({"forced": "keep", "action": "alert"}))
+            .collect();
+        let events = events(&exemplars);
+        let config = DraftConfig {
+            include_fields: vec!["forced".to_string()],
+            max_fields: 1,
+            ..fixed_config()
+        };
+        let mut candidate = DraftCandidate::build(&events, &[], &config).unwrap();
+        assert!(candidate.drop_lowest_eligible(None).is_none());
+        assert_eq!(candidate.profiles[candidate.selected[0]].field(), "forced");
+    }
+
+    #[test]
+    fn structured_candidate_excludes_all_grouping_fields() {
+        let exemplars: Vec<Value> = (0..3)
+            .map(|_| json!({"tenant": "one", "user": "alice", "action": "alert"}))
+            .collect();
+        let events = events(&exemplars);
+        let config = DraftConfig {
+            exclude_fields: vec!["tenant".to_string(), "user".to_string()],
+            ..fixed_config()
+        };
+        let candidate = DraftCandidate::build(&events, &[], &config).unwrap();
+        assert!(
+            candidate
+                .profiles
+                .iter()
+                .all(|profile| !matches!(profile.field(), "tenant" | "user"))
+        );
     }
 
     // ---- Modifier inference ---------------------------------------------------

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1501,13 +1501,27 @@ mod tests {
                 event.event["tenant"] = json!(tenant);
             }
         }
-        assert!(matches!(
-            draft_correlation(&ambiguous, &[], &[], &config()),
-            Err(CorrelationDraftError::AmbiguousEntity { .. })
-        ));
+        match draft_correlation(&ambiguous, &[], &[], &config()) {
+            Err(CorrelationDraftError::AmbiguousEntity { candidates }) => {
+                assert_eq!(candidates, vec!["tenant", "user"]);
+            }
+            other => panic!("expected deterministic entity ambiguity, got {other:?}"),
+        }
         assert!(matches!(
             draft_correlation(&groups(), &[group("bad", "mallory", false)], &[], &config()),
             Err(CorrelationDraftError::NegativeGroupMatched { .. })
+        ));
+    }
+
+    #[test]
+    fn entity_inference_refuses_to_guess_when_no_field_is_group_stable() {
+        let mut values = groups();
+        for group in &mut values {
+            group.events[1].event["user"] = json!(format!("{}-other", group.id));
+        }
+        assert!(matches!(
+            draft_correlation(&values, &[], &[], &config()),
+            Err(CorrelationDraftError::AmbiguousEntity { candidates }) if candidates.is_empty()
         ));
     }
 

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -385,32 +385,31 @@ pub fn draft_correlation(
             }
         })?;
 
-        match verify_identity(&collection, &groups, &retained, &slots)? {
-            Some((slot_index, local_event)) => {
-                let slot = &mut slots[slot_index];
-                let floor = slot
-                    .config
-                    .min_fields
-                    .min(slot.candidate.selected.len())
-                    .max(1);
-                if slot.candidate.selected.len() <= floor
-                    || slot
-                        .candidate
-                        .drop_lowest_eligible(Some(&[local_event]))
-                        .is_none()
-                {
-                    return Err(CorrelationDraftError::SlotFloor {
-                        slot: slot.name.clone(),
-                        floor,
-                    });
-                }
-                warnings.push(format!(
-                    "relaxed slot '{}' after an assigned positive failed verification",
-                    slot.name
-                ));
-                continue;
+        if let Some((slot_index, local_event)) =
+            verify_identity(&collection, &groups, &retained, &slots)?
+        {
+            let slot = &mut slots[slot_index];
+            let floor = slot
+                .config
+                .min_fields
+                .min(slot.candidate.selected.len())
+                .max(1);
+            if slot.candidate.selected.len() <= floor
+                || slot
+                    .candidate
+                    .drop_lowest_eligible(Some(&[local_event]))
+                    .is_none()
+            {
+                return Err(CorrelationDraftError::SlotFloor {
+                    slot: slot.name.clone(),
+                    floor,
+                });
             }
-            None => {}
+            warnings.push(format!(
+                "relaxed slot '{}' after an assigned positive failed verification",
+                slot.name
+            ));
+            continue;
         }
 
         let mut verification =
@@ -511,7 +510,7 @@ fn normalize_groups(
                             kind: "offset",
                             value: raw.to_string(),
                         })?;
-                    let seconds = i64::try_from(parsed.seconds).map_err(|_| {
+                    i64::try_from(parsed.seconds).map_err(|_| {
                         CorrelationDraftError::InvalidTime {
                             group: group.id.clone(),
                             event: index,
@@ -519,8 +518,7 @@ fn normalize_groups(
                             kind: "offset",
                             value: raw.to_string(),
                         }
-                    })?;
-                    seconds
+                    })?
                 }
             };
             let json = JsonEvent::borrow(&timed.event);

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1,0 +1,1498 @@
+//! Draft temporal correlations from grouped, timed exemplar events.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::DateTime;
+use rsigma_parser::Timespan;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::correlation_engine::{CorrelationConfig, CorrelationEngine};
+use crate::event::{Event, JsonEvent};
+use crate::key_shape::cluster_by_key_shape;
+
+use super::draft_core::{ValueForm, yaml_str, yaml_title_str};
+use super::{DraftCandidate, DraftConfig, DraftError};
+
+/// Source context attached by a grouped-input reader.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SourceLocation {
+    /// Input file, when the event came from a file.
+    pub file: Option<String>,
+    /// One-based source line, when available.
+    pub line: Option<usize>,
+}
+
+impl SourceLocation {
+    fn label(&self) -> String {
+        match (&self.file, self.line) {
+            (Some(file), Some(line)) => format!("{file}:{line}"),
+            (Some(file), None) => file.clone(),
+            (None, Some(line)) => format!("line {line}"),
+            (None, None) => "unknown source".to_string(),
+        }
+    }
+}
+
+/// One event carrying exactly one absolute timestamp or relative offset.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TimedEvent {
+    /// RFC3339 timestamp. Mutually exclusive with [`Self::offset`].
+    pub timestamp: Option<String>,
+    /// Sigma timespan offset. Mutually exclusive with [`Self::timestamp`].
+    pub offset: Option<String>,
+    /// Event body.
+    pub event: Value,
+    /// Optional file/line context for validation errors.
+    pub source: SourceLocation,
+}
+
+/// One observed instance of the multi-event behavior.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct GroupedExemplar {
+    /// Stable group identifier.
+    pub id: String,
+    /// Timed events in arbitrary input order.
+    pub events: Vec<TimedEvent>,
+}
+
+/// Requested correlation ordering.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CorrelationDraftType {
+    /// Infer ordered only when every positive group agrees.
+    #[default]
+    Auto,
+    /// Emit an unordered temporal correlation.
+    Temporal,
+    /// Require and emit identical ordering across groups.
+    TemporalOrdered,
+}
+
+impl CorrelationDraftType {
+    fn emitted_name(self, ordered: bool) -> &'static str {
+        match self {
+            Self::Temporal => "temporal",
+            Self::Auto if !ordered => "temporal",
+            Self::Auto | Self::TemporalOrdered => "temporal_ordered",
+        }
+    }
+}
+
+/// Tunables and caller-supplied metadata for correlation drafting.
+#[derive(Debug, Clone)]
+pub struct CorrelationDraftConfig {
+    /// Minimum number of positive groups.
+    pub min_groups: usize,
+    /// Minimum number of recurring slots.
+    pub min_slots: usize,
+    /// Key-shape Jaccard threshold.
+    pub similarity: f64,
+    /// Multiplier applied to the maximum observed positive span.
+    pub window_margin: f64,
+    /// Ordering mode.
+    pub correlation_type: CorrelationDraftType,
+    /// Explicit grouping fields. Empty means infer one field.
+    pub group_by: Vec<String>,
+    /// Correlation title override.
+    pub title: Option<String>,
+    /// Caller-supplied correlation id.
+    pub correlation_id: Option<String>,
+    /// Caller-supplied slot ids, in inferred slot order.
+    pub slot_ids: Vec<String>,
+    /// Shared per-slot detection drafting configuration.
+    pub detection: DraftConfig,
+}
+
+impl Default for CorrelationDraftConfig {
+    fn default() -> Self {
+        Self {
+            min_groups: 3,
+            min_slots: 2,
+            similarity: 0.6,
+            window_margin: 1.5,
+            correlation_type: CorrelationDraftType::Auto,
+            group_by: Vec::new(),
+            title: None,
+            correlation_id: None,
+            slot_ids: Vec::new(),
+            detection: DraftConfig::default(),
+        }
+    }
+}
+
+/// One drafted slot in the report.
+#[derive(Debug, Clone, Serialize)]
+pub struct CorrelationSlotReport {
+    /// Correlation rule reference.
+    pub name: String,
+    /// Detection rule id.
+    pub id: Option<String>,
+    /// Positive event count assigned to the slot.
+    pub support: usize,
+    /// Number of positive groups represented.
+    pub group_support: usize,
+    /// Selected detection field descriptions.
+    pub selected_fields: Vec<String>,
+}
+
+/// Isolated replay result for one positive or negative group.
+#[derive(Debug, Clone, Serialize)]
+pub struct CorrelationVerification {
+    /// Group identifier.
+    pub group: String,
+    /// Whether this was a negative group.
+    pub negative: bool,
+    /// Whether the target correlation fired.
+    pub fired: bool,
+}
+
+/// A verified drafted correlation and its evidence.
+#[derive(Debug, Clone, Serialize)]
+pub struct CorrelationDraftReport {
+    /// Paste-ready multi-document Sigma YAML.
+    pub rule_yaml: String,
+    /// `temporal` or `temporal_ordered`.
+    pub correlation_type: String,
+    /// Explicit or inferred grouping fields.
+    pub group_by: Vec<String>,
+    /// Chosen window.
+    pub timespan: String,
+    /// Raw positive first-to-last spans in seconds.
+    pub span_seconds: Vec<u64>,
+    /// Consecutive retained-slot gaps in seconds.
+    pub gap_seconds: Vec<u64>,
+    /// Per-slot drafting evidence.
+    pub slots: Vec<CorrelationSlotReport>,
+    /// Isolated positive and negative verification rows.
+    pub verification: Vec<CorrelationVerification>,
+    /// Advisory inference and lint notes.
+    pub warnings: Vec<String>,
+}
+
+/// Why a grouped correlation draft could not be produced.
+#[derive(Debug, thiserror::Error)]
+pub enum CorrelationDraftError {
+    /// Too few positive groups were provided.
+    #[error("at least {minimum} positive groups are required, got {actual}")]
+    TooFewGroups { minimum: usize, actual: usize },
+    /// A group has fewer than two events.
+    #[error("group '{group}' needs at least two events, got {actual}")]
+    TooFewEvents { group: String, actual: usize },
+    /// An event carries neither or both supported time keys.
+    #[error(
+        "group '{group}' event {event} at {location} must contain exactly one of timestamp or offset"
+    )]
+    InvalidTimeKeys {
+        group: String,
+        event: usize,
+        location: String,
+    },
+    /// A group mixes absolute and relative time.
+    #[error("group '{group}' mixes timestamp and offset time modes")]
+    MixedTimeMode { group: String },
+    /// A timestamp or offset is invalid.
+    #[error("group '{group}' event {event} at {location} has invalid {kind} value '{value}'")]
+    InvalidTime {
+        group: String,
+        event: usize,
+        location: String,
+        kind: &'static str,
+        value: String,
+    },
+    /// Two events in a group have the same parsed time.
+    #[error(
+        "group '{group}' events {first_event} and {second_event} have duplicate parsed time {time}"
+    )]
+    DuplicateTime {
+        group: String,
+        first_event: usize,
+        second_event: usize,
+        time: i64,
+    },
+    /// Too few recurring event slots survived.
+    #[error("at least {minimum} recurring slots are required, got {actual}")]
+    TooFewSlots { minimum: usize, actual: usize },
+    /// A recurring slot appears more than once in one group.
+    #[error("group '{group}' repeats slot {slot} at event indexes {events:?}")]
+    DuplicateSlot {
+        group: String,
+        slot: usize,
+        events: Vec<usize>,
+    },
+    /// Forced ordering disagrees with observed groups.
+    #[error("temporal_ordered was requested but groups disagree on slot order: {groups:?}")]
+    OrderInversion { groups: Vec<String> },
+    /// Window margin is invalid.
+    #[error("window margin must be finite and at least 1.0, got {0}")]
+    InvalidWindowMargin(f64),
+    /// The inferred window overflowed.
+    #[error("inferred correlation window overflowed")]
+    WindowOverflow,
+    /// Grouping inference found zero or multiple valid fields.
+    #[error("correlation entity is ambiguous; candidates: {candidates:?}")]
+    AmbiguousEntity { candidates: Vec<String> },
+    /// An explicit grouping field is absent or unstable.
+    #[error(
+        "group-by field '{field}' is absent or unstable in group '{group}' at retained event {event}"
+    )]
+    InvalidEntity {
+        field: String,
+        group: String,
+        event: usize,
+    },
+    /// A per-slot detection could not be drafted.
+    #[error("failed to draft slot {slot}: {source}")]
+    SlotDraft {
+        slot: usize,
+        #[source]
+        source: DraftError,
+    },
+    /// One event matches the wrong slot rules.
+    #[error(
+        "group '{group}' event {event} assigned to '{assigned}' collides with {colliding:?}; selected forms: {forms:?}. Use cleaner exemplars, a representative baseline, or manual rule editing"
+    )]
+    CrossSlotMatch {
+        group: String,
+        event: usize,
+        assigned: String,
+        colliding: Vec<String>,
+        forms: Vec<String>,
+    },
+    /// A slot cannot match its assigned positives at the field floor.
+    #[error("slot '{slot}' cannot match assigned positives at the {floor}-field floor")]
+    SlotFloor { slot: String, floor: usize },
+    /// Emitted YAML did not parse or compile.
+    #[error("internal correlation draft error during {stage}: {message}")]
+    Internal {
+        stage: &'static str,
+        message: String,
+    },
+    /// An isolated positive group did not fire correctly.
+    #[error("positive group '{group}' {reason}")]
+    PositiveVerification { group: String, reason: String },
+    /// One or more negative groups fired the target correlation.
+    #[error("drafted correlation matched negative groups: {groups:?}")]
+    NegativeGroupMatched { groups: Vec<String> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeMode {
+    Timestamp,
+    Offset,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedEvent {
+    input_index: usize,
+    time: i64,
+    event: Value,
+    keys: Vec<String>,
+    cluster: usize,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedGroup {
+    id: String,
+    events: Vec<NormalizedEvent>,
+}
+
+#[derive(Debug)]
+struct ShapeCluster {
+    seed_keys: Vec<String>,
+    members: Vec<(usize, usize)>,
+}
+
+#[derive(Debug)]
+struct ShapeItem {
+    keys: Vec<String>,
+    member: (usize, usize),
+}
+
+#[derive(Debug)]
+struct Slot {
+    cluster: usize,
+    name: String,
+    id: Option<String>,
+    members: Vec<(usize, usize)>,
+    candidate: DraftCandidate,
+    config: DraftConfig,
+}
+
+/// Draft, emit, and verify a temporal correlation from positive groups.
+///
+/// Every positive and negative group is replayed through a fresh correlation
+/// engine. `baseline` is a flat corpus used only for per-slot contrast.
+pub fn draft_correlation(
+    groups: &[GroupedExemplar],
+    negative_groups: &[GroupedExemplar],
+    baseline: &[Value],
+    config: &CorrelationDraftConfig,
+) -> Result<CorrelationDraftReport, CorrelationDraftError> {
+    let mut groups = normalize_groups(groups, config.min_groups)?;
+    let negatives = normalize_groups(negative_groups, 0)?;
+    let positive_count = groups.len();
+    groups.extend(negatives);
+    assign_clusters(&mut groups, config.similarity);
+    let negatives = groups.split_off(positive_count);
+
+    let (retained, mut warnings) = retained_clusters(&groups, config.min_slots)?;
+    validate_slot_counts(&groups, &retained)?;
+    let group_by = resolve_group_by(&groups, &retained, &config.group_by)?;
+    let (ordered, order, disagreeing) = infer_order(&groups, &retained);
+    if config.correlation_type == CorrelationDraftType::TemporalOrdered && !disagreeing.is_empty() {
+        return Err(CorrelationDraftError::OrderInversion {
+            groups: disagreeing,
+        });
+    }
+    if config.correlation_type == CorrelationDraftType::Auto && !disagreeing.is_empty() {
+        warnings.push(format!(
+            "slot order differs in groups {}; emitted temporal instead of temporal_ordered",
+            disagreeing.join(", ")
+        ));
+    }
+    let correlation_type = config.correlation_type.emitted_name(ordered);
+    let (timespan, spans, gaps) = infer_window(&groups, &retained, config.window_margin)?;
+    let correlation_id = config
+        .correlation_id
+        .clone()
+        .unwrap_or_else(|| "draft-correlation".to_string());
+
+    let mut slots = build_slots(
+        &groups,
+        baseline,
+        &group_by,
+        &order,
+        &config.slot_ids,
+        &config.detection,
+    )?;
+
+    let (rule_yaml, verification) = loop {
+        let yaml = emit_collection(
+            &groups,
+            &retained,
+            &slots,
+            correlation_type,
+            &group_by,
+            &timespan,
+            &correlation_id,
+            config,
+        );
+        let collection = rsigma_parser::parse_sigma_yaml(&yaml).map_err(|error| {
+            CorrelationDraftError::Internal {
+                stage: "parse",
+                message: error.to_string(),
+            }
+        })?;
+
+        match verify_identity(&collection, &groups, &retained, &slots)? {
+            Some((slot_index, local_event)) => {
+                let slot = &mut slots[slot_index];
+                let floor = slot
+                    .config
+                    .min_fields
+                    .min(slot.candidate.selected.len())
+                    .max(1);
+                if slot.candidate.selected.len() <= floor
+                    || slot
+                        .candidate
+                        .drop_lowest_eligible(Some(&[local_event]))
+                        .is_none()
+                {
+                    return Err(CorrelationDraftError::SlotFloor {
+                        slot: slot.name.clone(),
+                        floor,
+                    });
+                }
+                warnings.push(format!(
+                    "relaxed slot '{}' after an assigned positive failed verification",
+                    slot.name
+                ));
+                continue;
+            }
+            None => {}
+        }
+
+        let mut verification =
+            verify_groups(&collection, &groups, &retained, &correlation_id, false)?;
+        let mut negative_rows =
+            verify_groups(&collection, &negatives, &retained, &correlation_id, true)?;
+        verification.append(&mut negative_rows);
+        break (yaml, verification);
+    };
+
+    for finding in rsigma_parser::lint_yaml_str(&rule_yaml) {
+        warnings.push(format!("lint {}: {}", finding.rule, finding.message));
+    }
+
+    let slot_reports = slots
+        .iter()
+        .map(|slot| CorrelationSlotReport {
+            name: slot.name.clone(),
+            id: slot.id.clone(),
+            support: slot.members.len(),
+            group_support: groups.len(),
+            selected_fields: selected_forms(slot),
+        })
+        .collect();
+
+    Ok(CorrelationDraftReport {
+        rule_yaml,
+        correlation_type: correlation_type.to_string(),
+        group_by,
+        timespan: timespan.original,
+        span_seconds: spans,
+        gap_seconds: gaps,
+        slots: slot_reports,
+        verification,
+        warnings,
+    })
+}
+
+fn normalize_groups(
+    groups: &[GroupedExemplar],
+    minimum: usize,
+) -> Result<Vec<NormalizedGroup>, CorrelationDraftError> {
+    if groups.len() < minimum {
+        return Err(CorrelationDraftError::TooFewGroups {
+            minimum,
+            actual: groups.len(),
+        });
+    }
+    let mut normalized = Vec::with_capacity(groups.len());
+    for group in groups {
+        if group.events.len() < 2 {
+            return Err(CorrelationDraftError::TooFewEvents {
+                group: group.id.clone(),
+                actual: group.events.len(),
+            });
+        }
+        let mut mode = None;
+        let mut events = Vec::with_capacity(group.events.len());
+        for (index, timed) in group.events.iter().enumerate() {
+            let current = match (&timed.timestamp, &timed.offset) {
+                (Some(_), None) => TimeMode::Timestamp,
+                (None, Some(_)) => TimeMode::Offset,
+                _ => {
+                    return Err(CorrelationDraftError::InvalidTimeKeys {
+                        group: group.id.clone(),
+                        event: index,
+                        location: timed.source.label(),
+                    });
+                }
+            };
+            if mode.is_some_and(|expected| expected != current) {
+                return Err(CorrelationDraftError::MixedTimeMode {
+                    group: group.id.clone(),
+                });
+            }
+            mode = Some(current);
+            let time = match current {
+                TimeMode::Timestamp => {
+                    let raw = timed.timestamp.as_deref().unwrap();
+                    let parsed = DateTime::parse_from_rfc3339(raw).map_err(|_| {
+                        CorrelationDraftError::InvalidTime {
+                            group: group.id.clone(),
+                            event: index,
+                            location: timed.source.label(),
+                            kind: "timestamp",
+                            value: raw.to_string(),
+                        }
+                    })?;
+                    parsed.timestamp()
+                }
+                TimeMode::Offset => {
+                    let raw = timed.offset.as_deref().unwrap();
+                    let parsed =
+                        Timespan::parse(raw).map_err(|_| CorrelationDraftError::InvalidTime {
+                            group: group.id.clone(),
+                            event: index,
+                            location: timed.source.label(),
+                            kind: "offset",
+                            value: raw.to_string(),
+                        })?;
+                    let seconds = i64::try_from(parsed.seconds).map_err(|_| {
+                        CorrelationDraftError::InvalidTime {
+                            group: group.id.clone(),
+                            event: index,
+                            location: timed.source.label(),
+                            kind: "offset",
+                            value: raw.to_string(),
+                        }
+                    })?;
+                    seconds
+                }
+            };
+            let json = JsonEvent::borrow(&timed.event);
+            let mut keys: Vec<String> = json
+                .field_keys()
+                .into_iter()
+                .map(|key| key.into_owned())
+                .collect();
+            keys.sort();
+            keys.dedup();
+            events.push(NormalizedEvent {
+                input_index: index,
+                time,
+                event: timed.event.clone(),
+                keys,
+                cluster: usize::MAX,
+            });
+        }
+        events.sort_by_key(|event| (event.time, event.input_index));
+        for pair in events.windows(2) {
+            if pair[0].time == pair[1].time {
+                return Err(CorrelationDraftError::DuplicateTime {
+                    group: group.id.clone(),
+                    first_event: pair[0].input_index,
+                    second_event: pair[1].input_index,
+                    time: pair[0].time,
+                });
+            }
+        }
+        normalized.push(NormalizedGroup {
+            id: group.id.clone(),
+            events,
+        });
+    }
+    normalized.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(normalized)
+}
+
+fn assign_clusters(groups: &mut [NormalizedGroup], similarity: f64) {
+    let items: Vec<ShapeItem> = groups
+        .iter()
+        .enumerate()
+        .flat_map(|(group, value)| {
+            value
+                .events
+                .iter()
+                .enumerate()
+                .map(move |(event, value)| ShapeItem {
+                    keys: value.keys.clone(),
+                    member: (group, event),
+                })
+        })
+        .collect();
+    let clusters = cluster_by_key_shape(
+        &items,
+        similarity,
+        |item| &item.keys,
+        |cluster: &ShapeCluster| &cluster.seed_keys,
+        |item| ShapeCluster {
+            seed_keys: item.keys.clone(),
+            members: vec![item.member],
+        },
+        |_, _| true,
+        |cluster, item| cluster.members.push(item.member),
+    );
+    for (cluster_index, cluster) in clusters.iter().enumerate() {
+        for &(group, event) in &cluster.members {
+            groups[group].events[event].cluster = cluster_index;
+        }
+    }
+}
+
+fn retained_clusters(
+    groups: &[NormalizedGroup],
+    minimum: usize,
+) -> Result<(BTreeSet<usize>, Vec<String>), CorrelationDraftError> {
+    let all: BTreeSet<usize> = groups
+        .iter()
+        .flat_map(|group| group.events.iter().map(|event| event.cluster))
+        .collect();
+    let retained: BTreeSet<usize> = all
+        .iter()
+        .copied()
+        .filter(|cluster| {
+            groups
+                .iter()
+                .all(|group| group.events.iter().any(|event| event.cluster == *cluster))
+        })
+        .collect();
+    if retained.len() < minimum {
+        return Err(CorrelationDraftError::TooFewSlots {
+            minimum,
+            actual: retained.len(),
+        });
+    }
+    let dropped: Vec<String> = all
+        .difference(&retained)
+        .map(|cluster| cluster.to_string())
+        .collect();
+    let warnings = if dropped.is_empty() {
+        Vec::new()
+    } else {
+        vec![format!(
+            "dropped incidental key-shape clusters absent from one or more positive groups: {}",
+            dropped.join(", ")
+        )]
+    };
+    Ok((retained, warnings))
+}
+
+fn validate_slot_counts(
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+) -> Result<(), CorrelationDraftError> {
+    for group in groups {
+        for &slot in retained {
+            let events: Vec<usize> = group
+                .events
+                .iter()
+                .enumerate()
+                .filter(|(_, event)| event.cluster == slot)
+                .map(|(index, _)| index)
+                .collect();
+            if events.len() > 1 {
+                return Err(CorrelationDraftError::DuplicateSlot {
+                    group: group.id.clone(),
+                    slot,
+                    events,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn infer_order(
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+) -> (bool, Vec<usize>, Vec<String>) {
+    let orders: Vec<Vec<usize>> = groups
+        .iter()
+        .map(|group| {
+            group
+                .events
+                .iter()
+                .filter(|event| retained.contains(&event.cluster))
+                .map(|event| event.cluster)
+                .collect()
+        })
+        .collect();
+    let expected = orders.first().cloned().unwrap_or_default();
+    let disagreeing: Vec<String> = groups
+        .iter()
+        .zip(&orders)
+        .filter(|(_, order)| **order != expected)
+        .map(|(group, _)| group.id.clone())
+        .collect();
+    (disagreeing.is_empty(), expected, disagreeing)
+}
+
+fn infer_window(
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+    margin: f64,
+) -> Result<(Timespan, Vec<u64>, Vec<u64>), CorrelationDraftError> {
+    if !margin.is_finite() || margin < 1.0 {
+        return Err(CorrelationDraftError::InvalidWindowMargin(margin));
+    }
+    let mut spans = Vec::with_capacity(groups.len());
+    let mut gaps = Vec::new();
+    for group in groups {
+        let times: Vec<i64> = group
+            .events
+            .iter()
+            .filter(|event| retained.contains(&event.cluster))
+            .map(|event| event.time)
+            .collect();
+        let first = *times.first().expect("retained slots exist");
+        let last = *times.last().expect("retained slots exist");
+        spans.push(
+            u64::try_from(
+                last.checked_sub(first)
+                    .ok_or(CorrelationDraftError::WindowOverflow)?,
+            )
+            .map_err(|_| CorrelationDraftError::WindowOverflow)?,
+        );
+        for pair in times.windows(2) {
+            gaps.push(
+                u64::try_from(
+                    pair[1]
+                        .checked_sub(pair[0])
+                        .ok_or(CorrelationDraftError::WindowOverflow)?,
+                )
+                .map_err(|_| CorrelationDraftError::WindowOverflow)?,
+            );
+        }
+    }
+    let maximum = spans.iter().copied().max().unwrap_or(0).max(1);
+    let scaled = (maximum as f64 * margin).ceil();
+    if !scaled.is_finite() || scaled > u64::MAX as f64 {
+        return Err(CorrelationDraftError::WindowOverflow);
+    }
+    let rounded = round_window(scaled as u64)?;
+    let timespan = Timespan::parse(&rounded).map_err(|error| CorrelationDraftError::Internal {
+        stage: "window construction",
+        message: error.to_string(),
+    })?;
+    Ok((timespan, spans, gaps))
+}
+
+fn round_window(seconds: u64) -> Result<String, CorrelationDraftError> {
+    const STEPS: &[(u64, &str)] = &[
+        (30, "30s"),
+        (60, "1m"),
+        (300, "5m"),
+        (900, "15m"),
+        (3_600, "1h"),
+        (21_600, "6h"),
+        (86_400, "24h"),
+    ];
+    if let Some((_, label)) = STEPS.iter().find(|(step, _)| seconds <= *step) {
+        return Ok((*label).to_string());
+    }
+    let days = seconds
+        .checked_add(86_399)
+        .ok_or(CorrelationDraftError::WindowOverflow)?
+        / 86_400;
+    Ok(format!("{days}d"))
+}
+
+fn resolve_group_by(
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+    explicit: &[String],
+) -> Result<Vec<String>, CorrelationDraftError> {
+    if !explicit.is_empty() {
+        for field in explicit {
+            validate_entity_field(groups, retained, field)?;
+        }
+        return Ok(explicit.to_vec());
+    }
+    let mut common: Option<BTreeSet<String>> = None;
+    for group in groups {
+        for event in group
+            .events
+            .iter()
+            .filter(|event| retained.contains(&event.cluster))
+        {
+            let keys: BTreeSet<String> = event.keys.iter().cloned().collect();
+            common = Some(match common {
+                Some(existing) => existing.intersection(&keys).cloned().collect(),
+                None => keys,
+            });
+        }
+    }
+    let candidates: Vec<String> = common
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|field| validate_entity_field(groups, retained, field).is_ok())
+        .filter(|field| {
+            let values: BTreeSet<String> = groups
+                .iter()
+                .filter_map(|group| stable_group_value(group, retained, field))
+                .collect();
+            values.len() == groups.len()
+        })
+        .collect();
+    if candidates.len() != 1 {
+        return Err(CorrelationDraftError::AmbiguousEntity { candidates });
+    }
+    Ok(candidates)
+}
+
+fn validate_entity_field(
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+    field: &str,
+) -> Result<(), CorrelationDraftError> {
+    for group in groups {
+        let mut expected = None;
+        for (index, event) in group
+            .events
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| retained.contains(&event.cluster))
+        {
+            let value = JsonEvent::borrow(&event.event)
+                .get_field(field)
+                .map(|value| format!("{value:?}"));
+            if value.is_none()
+                || expected
+                    .as_ref()
+                    .is_some_and(|known| Some(known) != value.as_ref())
+            {
+                return Err(CorrelationDraftError::InvalidEntity {
+                    field: field.to_string(),
+                    group: group.id.clone(),
+                    event: index,
+                });
+            }
+            expected = value;
+        }
+    }
+    Ok(())
+}
+
+fn stable_group_value(
+    group: &NormalizedGroup,
+    retained: &BTreeSet<usize>,
+    field: &str,
+) -> Option<String> {
+    let mut values = group
+        .events
+        .iter()
+        .filter(|event| retained.contains(&event.cluster))
+        .map(|event| {
+            JsonEvent::borrow(&event.event)
+                .get_field(field)
+                .map(|value| format!("{value:?}"))
+        });
+    let first = values.next()??;
+    values
+        .all(|value| value.as_deref() == Some(first.as_str()))
+        .then_some(first)
+}
+
+fn build_slots(
+    groups: &[NormalizedGroup],
+    baseline: &[Value],
+    group_by: &[String],
+    order: &[usize],
+    slot_ids: &[String],
+    detection_config: &DraftConfig,
+) -> Result<Vec<Slot>, CorrelationDraftError> {
+    let mut slots = Vec::with_capacity(order.len());
+    let mut used_names = BTreeMap::new();
+    for (position, &cluster) in order.iter().enumerate() {
+        let members: Vec<(usize, usize)> = groups
+            .iter()
+            .enumerate()
+            .flat_map(|(group_index, group)| {
+                group
+                    .events
+                    .iter()
+                    .enumerate()
+                    .filter(move |(_, event)| event.cluster == cluster)
+                    .map(move |(event_index, _)| (group_index, event_index))
+            })
+            .collect();
+        let positives: Vec<Value> = members
+            .iter()
+            .map(|&(group, event)| groups[group].events[event].event.clone())
+            .collect();
+        let mut contrast = baseline.to_vec();
+        for group in groups {
+            contrast.extend(
+                group
+                    .events
+                    .iter()
+                    .filter(|event| event.cluster != cluster)
+                    .map(|event| event.event.clone()),
+            );
+        }
+        let mut slot_config = detection_config.clone();
+        for field in group_by {
+            if !slot_config
+                .exclude_fields
+                .iter()
+                .any(|excluded| excluded.eq_ignore_ascii_case(field))
+            {
+                slot_config.exclude_fields.push(field.clone());
+            }
+        }
+        slot_config.rule_id = slot_ids.get(position).cloned().or_else(|| {
+            detection_config
+                .rule_id
+                .as_ref()
+                .map(|base| format!("{base}-{}", position + 1))
+        });
+        let positive_events: Vec<JsonEvent<'_>> = positives.iter().map(JsonEvent::borrow).collect();
+        let contrast_events: Vec<JsonEvent<'_>> = contrast.iter().map(JsonEvent::borrow).collect();
+        let candidate = DraftCandidate::build(&positive_events, &contrast_events, &slot_config)
+            .map_err(|source| CorrelationDraftError::SlotDraft {
+                slot: position,
+                source,
+            })?;
+        let base = slot_name(&candidate, position);
+        let count = used_names.entry(base.clone()).or_insert(0usize);
+        *count += 1;
+        let name = if *count == 1 {
+            base
+        } else {
+            format!("{base}_{count}")
+        };
+        slots.push(Slot {
+            cluster,
+            name,
+            id: slot_config.rule_id.clone(),
+            members,
+            candidate,
+            config: slot_config,
+        });
+    }
+    Ok(slots)
+}
+
+fn slot_name(candidate: &DraftCandidate, position: usize) -> String {
+    let marker = candidate.selected.first().and_then(|&index| {
+        candidate.profiles[index]
+            .form
+            .as_ref()
+            .and_then(form_marker)
+    });
+    let slug = marker
+        .as_deref()
+        .map(slugify)
+        .filter(|slug| !slug.is_empty())
+        .unwrap_or_else(|| format!("{}", position + 1));
+    format!("slot_{slug}")
+}
+
+fn form_marker(form: &ValueForm) -> Option<String> {
+    match form {
+        ValueForm::Exact(value) => Some(value.as_display()),
+        ValueForm::OneOf(values) => values.first().map(|value| value.as_display()),
+        ValueForm::EndsWith(value) | ValueForm::StartsWith(value) | ValueForm::Contains(value) => {
+            Some(value.clone())
+        }
+        ValueForm::ContainsAll(values) => values.first().cloned(),
+    }
+}
+
+fn slugify(value: &str) -> String {
+    let mut slug = String::new();
+    let mut separator = false;
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+            separator = false;
+        } else if !slug.is_empty() && !separator {
+            slug.push('_');
+            separator = true;
+        }
+    }
+    while slug.ends_with('_') {
+        slug.pop();
+    }
+    slug
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_collection(
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+    slots: &[Slot],
+    correlation_type: &str,
+    group_by: &[String],
+    timespan: &Timespan,
+    correlation_id: &str,
+    config: &CorrelationDraftConfig,
+) -> String {
+    let mut output = String::new();
+    for (index, slot) in slots.iter().enumerate() {
+        if index > 0 {
+            output.push_str("---\n");
+        }
+        let positives: Vec<Value> = slot
+            .members
+            .iter()
+            .map(|&(group, event)| groups[group].events[event].event.clone())
+            .collect();
+        let events: Vec<JsonEvent<'_>> = positives.iter().map(JsonEvent::borrow).collect();
+        output.push_str(
+            &slot
+                .candidate
+                .emit_named(&events, &slot.config, Some(&slot.name)),
+        );
+    }
+    output.push_str("---\n");
+    let title = config
+        .title
+        .clone()
+        .unwrap_or_else(|| "Draft temporal correlation".to_string());
+    output.push_str(&format!("title: {}\n", yaml_title_str(&title)));
+    output.push_str(&format!("id: {}\n", yaml_str(correlation_id)));
+    output.push_str("status: experimental\n");
+    output.push_str("correlation:\n");
+    output.push_str(&format!("    type: {correlation_type}\n"));
+    output.push_str("    rules:\n");
+    for slot in slots {
+        output.push_str(&format!("        - {}\n", yaml_str(&slot.name)));
+    }
+    output.push_str("    group-by:\n");
+    for field in group_by {
+        output.push_str(&format!("        - {}\n", yaml_str(field)));
+    }
+    output.push_str(&format!("    timespan: {}\n", timespan.original));
+    output.push_str("    condition:\n");
+    output.push_str(&format!("        gte: {}\n", slots.len()));
+    output.push_str("custom_attributes:\n");
+    output.push_str("    rsigma.exemplars:\n");
+    let representative = representative_group(groups, retained);
+    output.push_str(&format!(
+        "        - name: {}\n",
+        yaml_str(&format!("observed group {}", representative.id))
+    ));
+    output.push_str("          expect: match\n");
+    output.push_str("          events:\n");
+    let first = representative
+        .events
+        .iter()
+        .find(|event| retained.contains(&event.cluster))
+        .map(|event| event.time)
+        .unwrap_or(0);
+    for event in representative
+        .events
+        .iter()
+        .filter(|event| retained.contains(&event.cluster))
+    {
+        output.push_str(&format!(
+            "              - offset: {}s\n",
+            event.time - first
+        ));
+        output.push_str("                event:\n");
+        emit_json_mapping(&mut output, &event.event, "                    ");
+    }
+    output.push_str("level: medium\n");
+    output
+}
+
+fn representative_group<'a>(
+    groups: &'a [NormalizedGroup],
+    retained: &BTreeSet<usize>,
+) -> &'a NormalizedGroup {
+    let mut ranked: Vec<(u64, &str, &NormalizedGroup)> = groups
+        .iter()
+        .map(|group| {
+            let times: Vec<i64> = group
+                .events
+                .iter()
+                .filter(|event| retained.contains(&event.cluster))
+                .map(|event| event.time)
+                .collect();
+            let span = times
+                .last()
+                .zip(times.first())
+                .and_then(|(last, first)| last.checked_sub(*first))
+                .and_then(|value| u64::try_from(value).ok())
+                .unwrap_or(0);
+            (span, group.id.as_str(), group)
+        })
+        .collect();
+    ranked.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    ranked[ranked.len() / 2].2
+}
+
+fn emit_json_mapping(output: &mut String, value: &Value, indent: &str) {
+    let Some(mapping) = value.as_object() else {
+        output.push_str(&format!(
+            "{indent}value: {}\n",
+            yaml_str(&value.to_string())
+        ));
+        return;
+    };
+    let mut keys: Vec<&String> = mapping.keys().collect();
+    keys.sort();
+    for key in keys {
+        emit_json_value(output, key, &mapping[key], indent);
+    }
+}
+
+fn emit_json_value(output: &mut String, key: &str, value: &Value, indent: &str) {
+    let key = yaml_str(key);
+    match value {
+        Value::Null => output.push_str(&format!("{indent}{key}: null\n")),
+        Value::Bool(value) => output.push_str(&format!("{indent}{key}: {value}\n")),
+        Value::Number(value) => output.push_str(&format!("{indent}{key}: {value}\n")),
+        Value::String(value) => {
+            output.push_str(&format!("{indent}{key}: {}\n", yaml_str(value)));
+        }
+        Value::Object(_) => {
+            output.push_str(&format!("{indent}{key}:\n"));
+            emit_json_mapping(output, value, &format!("{indent}    "));
+        }
+        Value::Array(values) => {
+            output.push_str(&format!("{indent}{key}:\n"));
+            for value in values {
+                match value {
+                    Value::Null => output.push_str(&format!("{indent}    - null\n")),
+                    Value::Bool(value) => {
+                        output.push_str(&format!("{indent}    - {value}\n"));
+                    }
+                    Value::Number(value) => {
+                        output.push_str(&format!("{indent}    - {value}\n"));
+                    }
+                    Value::String(value) => {
+                        output.push_str(&format!("{indent}    - {}\n", yaml_str(value)));
+                    }
+                    _ => output
+                        .push_str(&format!("{indent}    - {}\n", yaml_str(&value.to_string()))),
+                }
+            }
+        }
+    }
+}
+
+fn verify_identity(
+    collection: &rsigma_parser::SigmaCollection,
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+    slots: &[Slot],
+) -> Result<Option<(usize, usize)>, CorrelationDraftError> {
+    for (group_index, group) in groups.iter().enumerate() {
+        for (event_index, event) in group
+            .events
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| retained.contains(&event.cluster))
+        {
+            let assigned = slots
+                .iter()
+                .position(|slot| slot.cluster == event.cluster)
+                .expect("retained cluster has a slot");
+            let local_event = slots[assigned]
+                .members
+                .iter()
+                .position(|member| *member == (group_index, event_index))
+                .expect("slot member exists");
+            let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+            engine
+                .add_collection(collection)
+                .map_err(|error| CorrelationDraftError::Internal {
+                    stage: "compile",
+                    message: error.to_string(),
+                })?;
+            let json = JsonEvent::borrow(&event.event);
+            let results = engine.process_event_at(&json, 1_700_000_000);
+            let matched: BTreeSet<&str> = results
+                .iter()
+                .filter(|result| result.is_detection())
+                .filter_map(|result| result.header.rule_id.as_deref())
+                .collect();
+            let assigned_id = slots[assigned].id.as_deref();
+            if assigned_id.is_none_or(|id| !matched.contains(id)) {
+                return Ok(Some((assigned, local_event)));
+            }
+            let colliding: Vec<String> = slots
+                .iter()
+                .enumerate()
+                .filter(|(index, slot)| {
+                    *index != assigned && slot.id.as_deref().is_some_and(|id| matched.contains(id))
+                })
+                .map(|(_, slot)| slot.name.clone())
+                .collect();
+            if !colliding.is_empty() {
+                let mut forms = selected_forms(&slots[assigned]);
+                for slot in slots.iter().filter(|slot| colliding.contains(&slot.name)) {
+                    forms.extend(selected_forms(slot));
+                }
+                return Err(CorrelationDraftError::CrossSlotMatch {
+                    group: group.id.clone(),
+                    event: event_index,
+                    assigned: slots[assigned].name.clone(),
+                    colliding,
+                    forms,
+                });
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn selected_forms(slot: &Slot) -> Vec<String> {
+    slot.candidate
+        .selected
+        .iter()
+        .map(|&index| {
+            let profile = &slot.candidate.profiles[index];
+            format!(
+                "{}={:?}",
+                profile.field(),
+                profile.form.as_ref().expect("selected form")
+            )
+        })
+        .collect()
+}
+
+fn verify_groups(
+    collection: &rsigma_parser::SigmaCollection,
+    groups: &[NormalizedGroup],
+    retained: &BTreeSet<usize>,
+    correlation_id: &str,
+    negative: bool,
+) -> Result<Vec<CorrelationVerification>, CorrelationDraftError> {
+    let mut rows = Vec::with_capacity(groups.len());
+    let mut failed_negatives = Vec::new();
+    for group in groups {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        engine
+            .add_collection(collection)
+            .map_err(|error| CorrelationDraftError::Internal {
+                stage: "compile",
+                message: error.to_string(),
+            })?;
+        let retained_events: Vec<&NormalizedEvent> = group
+            .events
+            .iter()
+            .filter(|event| retained.contains(&event.cluster))
+            .collect();
+        let first = retained_events.first().map(|event| event.time).unwrap_or(0);
+        let mut fired = false;
+        for (index, event) in retained_events.iter().enumerate() {
+            let json = JsonEvent::borrow(&event.event);
+            let timestamp = 1_700_000_000i64
+                .checked_add(event.time - first)
+                .ok_or(CorrelationDraftError::WindowOverflow)?;
+            let target = engine
+                .process_event_at(&json, timestamp)
+                .iter()
+                .any(|result| {
+                    result.is_correlation()
+                        && result.header.rule_id.as_deref() == Some(correlation_id)
+                });
+            if target {
+                fired = true;
+                if !negative && index + 1 < retained_events.len() {
+                    return Err(CorrelationDraftError::PositiveVerification {
+                        group: group.id.clone(),
+                        reason: format!("fired prematurely at retained event {index}"),
+                    });
+                }
+            }
+        }
+        if negative && fired {
+            failed_negatives.push(group.id.clone());
+        } else if !negative && !fired {
+            return Err(CorrelationDraftError::PositiveVerification {
+                group: group.id.clone(),
+                reason: "did not fire by the end of the group".to_string(),
+            });
+        }
+        rows.push(CorrelationVerification {
+            group: group.id.clone(),
+            negative,
+            fired,
+        });
+    }
+    if !failed_negatives.is_empty() {
+        return Err(CorrelationDraftError::NegativeGroupMatched {
+            groups: failed_negatives,
+        });
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn timed(offset: Option<&str>, timestamp: Option<&str>, event: Value) -> TimedEvent {
+        TimedEvent {
+            timestamp: timestamp.map(str::to_string),
+            offset: offset.map(str::to_string),
+            event,
+            source: SourceLocation::default(),
+        }
+    }
+
+    fn group(id: &str, user: &str, reversed: bool) -> GroupedExemplar {
+        let first = timed(
+            Some(if reversed { "20s" } else { "0s" }),
+            None,
+            json!({"kind": "reset", "user": user, "factor": "totp", "reset_reason": "recovery"}),
+        );
+        let second = timed(
+            Some(if reversed { "0s" } else { "20s" }),
+            None,
+            json!({"kind": "session", "user": user, "new_asn": true, "asn": 64512, "session_type": "web"}),
+        );
+        GroupedExemplar {
+            id: id.to_string(),
+            events: vec![first, second],
+        }
+    }
+
+    fn groups() -> Vec<GroupedExemplar> {
+        vec![
+            group("g1", "alice", false),
+            group("g2", "bob", false),
+            group("g3", "carol", false),
+        ]
+    }
+
+    fn config() -> CorrelationDraftConfig {
+        CorrelationDraftConfig {
+            correlation_id: Some("00000000-0000-4000-8000-000000000003".to_string()),
+            slot_ids: vec![
+                "00000000-0000-4000-8000-000000000001".to_string(),
+                "00000000-0000-4000-8000-000000000002".to_string(),
+            ],
+            detection: DraftConfig {
+                date: Some("2026-09-04".to_string()),
+                min_fields: 1,
+                ..DraftConfig::default()
+            },
+            ..CorrelationDraftConfig::default()
+        }
+    }
+
+    #[test]
+    fn validates_and_sorts_timestamp_groups() {
+        let mut values = groups();
+        for (index, group) in values.iter_mut().enumerate() {
+            group.events[0].offset = None;
+            group.events[0].timestamp = Some(format!("2026-01-01T00:00:{:02}Z", 20 + index));
+            group.events[1].offset = None;
+            group.events[1].timestamp = Some(format!("2026-01-01T00:00:{index:02}Z"));
+        }
+        let normalized = normalize_groups(&values, 3).unwrap();
+        assert!(
+            normalized
+                .iter()
+                .all(|group| group.events[0].time < group.events[1].time)
+        );
+    }
+
+    #[test]
+    fn validates_offset_groups() {
+        let normalized = normalize_groups(&groups(), 3).unwrap();
+        assert_eq!(normalized[0].events[0].time, 0);
+        assert_eq!(normalized[0].events[1].time, 20);
+    }
+
+    #[test]
+    fn rejects_mixed_neither_both_invalid_and_duplicate_times() {
+        let mut mixed = groups();
+        mixed[0].events[1].offset = None;
+        mixed[0].events[1].timestamp = Some("2026-01-01T00:00:00Z".to_string());
+        assert!(matches!(
+            normalize_groups(&mixed, 3),
+            Err(CorrelationDraftError::MixedTimeMode { .. })
+        ));
+
+        let mut neither = groups();
+        neither[0].events[0].offset = None;
+        assert!(matches!(
+            normalize_groups(&neither, 3),
+            Err(CorrelationDraftError::InvalidTimeKeys { .. })
+        ));
+
+        let mut both = groups();
+        both[0].events[0].timestamp = Some("2026-01-01T00:00:00Z".to_string());
+        assert!(matches!(
+            normalize_groups(&both, 3),
+            Err(CorrelationDraftError::InvalidTimeKeys { .. })
+        ));
+
+        let mut invalid = groups();
+        invalid[0].events[0].offset = Some("bad".to_string());
+        assert!(matches!(
+            normalize_groups(&invalid, 3),
+            Err(CorrelationDraftError::InvalidTime { .. })
+        ));
+
+        let mut duplicate = groups();
+        duplicate[0].events[1].offset = Some("0s".to_string());
+        assert!(matches!(
+            normalize_groups(&duplicate, 3),
+            Err(CorrelationDraftError::DuplicateTime { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_too_few_groups_and_events() {
+        assert!(matches!(
+            normalize_groups(&groups()[..2], 3),
+            Err(CorrelationDraftError::TooFewGroups { .. })
+        ));
+        let mut values = groups();
+        values[0].events.pop();
+        assert!(matches!(
+            normalize_groups(&values, 3),
+            Err(CorrelationDraftError::TooFewEvents { .. })
+        ));
+    }
+
+    #[test]
+    fn drafts_ordered_collection_deterministically() {
+        let first = draft_correlation(&groups(), &[], &[], &config()).unwrap();
+        let second = draft_correlation(&groups(), &[], &[], &config()).unwrap();
+        assert_eq!(first.rule_yaml, second.rule_yaml);
+        assert_eq!(first.correlation_type, "temporal_ordered");
+        assert_eq!(first.group_by, vec!["user"]);
+        assert!(first.rule_yaml.contains("rsigma.exemplars:"));
+        assert!(rsigma_parser::parse_sigma_yaml(&first.rule_yaml).is_ok());
+        assert!(first.verification.iter().all(|row| row.fired));
+    }
+
+    #[test]
+    fn auto_downgrades_order_inversions_and_forced_order_errors() {
+        let mut values = groups();
+        values[2] = group("g3", "carol", true);
+        let report = draft_correlation(&values, &[], &[], &config()).unwrap();
+        assert_eq!(report.correlation_type, "temporal");
+        assert!(report.warnings.iter().any(|warning| warning.contains("g3")));
+
+        let mut forced = config();
+        forced.correlation_type = CorrelationDraftType::TemporalOrdered;
+        assert!(matches!(
+            draft_correlation(&values, &[], &[], &forced),
+            Err(CorrelationDraftError::OrderInversion { .. })
+        ));
+    }
+
+    #[test]
+    fn window_uses_maximum_span_and_never_rounds_down() {
+        let mut values = groups();
+        values[1].events[1].offset = Some("61s".to_string());
+        let report = draft_correlation(&values, &[], &[], &config()).unwrap();
+        assert_eq!(report.span_seconds, vec![20, 61, 20]);
+        assert_eq!(report.timespan, "5m");
+        assert!(matches!(
+            infer_window(
+                &normalize_groups(&groups(), 3).unwrap(),
+                &BTreeSet::new(),
+                0.9
+            ),
+            Err(CorrelationDraftError::InvalidWindowMargin(_))
+        ));
+        assert_eq!(round_window(86_401).unwrap(), "2d");
+    }
+
+    #[test]
+    fn explicit_composite_entity_is_excluded_from_slots() {
+        let mut values = groups();
+        for group in &mut values {
+            let tenant = format!("tenant-{}", group.id);
+            for event in &mut group.events {
+                event.event["tenant"] = json!(tenant);
+            }
+        }
+        let mut cfg = config();
+        cfg.group_by = vec!["user".to_string(), "tenant".to_string()];
+        let report = draft_correlation(&values, &[], &[], &cfg).unwrap();
+        assert_eq!(report.group_by, cfg.group_by);
+        assert!(
+            report
+                .slots
+                .iter()
+                .flat_map(|slot| &slot.selected_fields)
+                .all(|field| !field.starts_with("user=") && !field.starts_with("tenant="))
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_entity_and_negative_matches() {
+        let mut ambiguous = groups();
+        for group in &mut ambiguous {
+            let tenant = format!("tenant-{}", group.id);
+            for event in &mut group.events {
+                event.event["tenant"] = json!(tenant);
+            }
+        }
+        assert!(matches!(
+            draft_correlation(&ambiguous, &[], &[], &config()),
+            Err(CorrelationDraftError::AmbiguousEntity { .. })
+        ));
+        assert!(matches!(
+            draft_correlation(&groups(), &[group("bad", "mallory", false)], &[], &config()),
+            Err(CorrelationDraftError::NegativeGroupMatched { .. })
+        ));
+    }
+}

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1223,14 +1223,19 @@ fn verify_groups(
                 stage: "compile",
                 message: error.to_string(),
             })?;
-        let retained_events: Vec<&NormalizedEvent> = group
+        // Positives replay only retained-slot events: incidental clusters are
+        // dropped noise by design. Negatives replay every event, because slot
+        // rules match on field predicates, not key shapes; an event that
+        // clusters away from every retained slot can still satisfy a slot
+        // selection and must not be skipped.
+        let replay_events: Vec<&NormalizedEvent> = group
             .events
             .iter()
-            .filter(|event| retained.contains(&event.cluster))
+            .filter(|event| negative || retained.contains(&event.cluster))
             .collect();
-        let first = retained_events.first().map(|event| event.time).unwrap_or(0);
+        let first = replay_events.first().map(|event| event.time).unwrap_or(0);
         let mut fired = false;
-        for (index, event) in retained_events.iter().enumerate() {
+        for (index, event) in replay_events.iter().enumerate() {
             let json = JsonEvent::borrow(&event.event);
             let timestamp = 1_700_000_000i64
                 .checked_add(event.time - first)
@@ -1244,7 +1249,7 @@ fn verify_groups(
                 });
             if target {
                 fired = true;
-                if !negative && index + 1 < retained_events.len() {
+                if !negative && index + 1 < replay_events.len() {
                     return Err(CorrelationDraftError::PositiveVerification {
                         group: group.id.clone(),
                         reason: format!("fired prematurely at retained event {index}"),
@@ -1595,6 +1600,24 @@ mod tests {
                 .iter()
                 .any(|row| { row.group == "benign" && row.negative && !row.fired })
         );
+    }
+
+    #[test]
+    fn negative_events_outside_retained_clusters_still_replay() {
+        // Slot rules match on field predicates, not key shapes. These negative
+        // events carry enough extra keys to fall below the Jaccard threshold
+        // against every retained slot, yet still satisfy the slot selections,
+        // so skipping them would falsely pass the negative gate.
+        let mut negative = group("shifted", "mallory", false);
+        for (event, extras) in negative.events.iter_mut().zip([3usize, 4]) {
+            for extra in 0..extras {
+                event.event[format!("extra_{extra}")] = json!("noise");
+            }
+        }
+        assert!(matches!(
+            draft_correlation(&groups(), &[negative], &[], &config()),
+            Err(CorrelationDraftError::NegativeGroupMatched { groups }) if groups == vec!["shifted"]
+        ));
     }
 
     #[test]

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1526,6 +1526,23 @@ mod tests {
     }
 
     #[test]
+    fn clean_negative_group_isolated_replay_stays_clear() {
+        let mut negative = group("benign", "mallory", false);
+        negative.events[0].event["factor"] = json!("webauthn");
+        negative.events[0].event["reset_reason"] = json!("admin");
+        negative.events[1].event["asn"] = json!(64496);
+        negative.events[1].event["new_asn"] = json!(false);
+        negative.events[1].event["session_type"] = json!("mobile");
+        let report = draft_correlation(&groups(), &[negative], &[], &config()).unwrap();
+        assert!(
+            report
+                .verification
+                .iter()
+                .any(|row| { row.group == "benign" && row.negative && !row.fired })
+        );
+    }
+
+    #[test]
     fn verification_ignores_unrelated_correlation_results() {
         let report = draft_correlation(&groups(), &[], &[], &config()).unwrap();
         let collection = rsigma_parser::parse_sigma_yaml(&report.rule_yaml).unwrap();

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -664,6 +664,10 @@ fn validate_slot_counts(
     Ok(())
 }
 
+/// Infer the expected slot order from the majority of groups so that the
+/// disagreeing list names the actual outliers, not everyone who differs from
+/// whichever group happens to sort first. Ties break to the smallest order
+/// for determinism.
 fn infer_order(
     groups: &[NormalizedGroup],
     retained: &BTreeSet<usize>,
@@ -679,7 +683,15 @@ fn infer_order(
                 .collect()
         })
         .collect();
-    let expected = orders.first().cloned().unwrap_or_default();
+    let mut counts: BTreeMap<&Vec<usize>, usize> = BTreeMap::new();
+    for order in &orders {
+        *counts.entry(order).or_default() += 1;
+    }
+    let expected = counts
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then_with(|| b.0.cmp(a.0)))
+        .map(|(order, _)| (*order).clone())
+        .unwrap_or_default();
     let disagreeing: Vec<String> = groups
         .iter()
         .zip(&orders)
@@ -1471,6 +1483,19 @@ mod tests {
             draft_correlation(&values, &[], &[], &forced),
             Err(CorrelationDraftError::OrderInversion { .. })
         ));
+    }
+
+    #[test]
+    fn majority_order_blames_the_actual_outlier() {
+        // g1 is the inverted group; the warning must name g1 alone, not the
+        // majority that happens to differ from the first-sorted group.
+        let mut values = groups();
+        values[0] = group("g1", "alice", true);
+        let report = draft_correlation(&values, &[], &[], &config()).unwrap();
+        assert_eq!(report.correlation_type, "temporal");
+        assert!(report.warnings.iter().any(|warning| {
+            warning.contains("g1") && !warning.contains("g2") && !warning.contains("g3")
+        }));
     }
 
     #[test]

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1471,6 +1471,63 @@ mod tests {
     }
 
     #[test]
+    fn incidental_clusters_are_dropped_with_a_warning() {
+        let mut values = groups();
+        values[0].events.push(timed(
+            Some("10s"),
+            None,
+            json!({"audit_only": true, "trace_marker": "one"}),
+        ));
+        let report = draft_correlation(&values, &[], &[], &config()).unwrap();
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("incidental key-shape"))
+        );
+        assert_eq!(report.slots.len(), 2);
+    }
+
+    #[test]
+    fn repeated_retained_slot_is_a_pointed_error() {
+        let mut values = groups();
+        values[0].events.push(timed(
+            Some("10s"),
+            None,
+            json!({"kind": "reset", "user": "alice", "factor": "totp", "reset_reason": "recovery"}),
+        ));
+        assert!(matches!(
+            draft_correlation(&values, &[], &[], &config()),
+            Err(CorrelationDraftError::DuplicateSlot {
+                group,
+                slot: _,
+                events
+            }) if group == "g1" && events == vec![0, 1]
+        ));
+    }
+
+    #[test]
+    fn too_few_recurring_slots_is_an_error() {
+        let values: Vec<GroupedExemplar> = [("g1", "alice"), ("g2", "bob"), ("g3", "carol")]
+            .into_iter()
+            .map(|(id, user)| GroupedExemplar {
+                id: id.to_string(),
+                events: vec![
+                    timed(Some("0s"), None, json!({"kind": "same", "user": user})),
+                    timed(Some("10s"), None, json!({"kind": "other", "user": user})),
+                ],
+            })
+            .collect();
+        assert!(matches!(
+            draft_correlation(&values, &[], &[], &config()),
+            Err(CorrelationDraftError::TooFewSlots {
+                minimum: 2,
+                actual: 1
+            })
+        ));
+    }
+
+    #[test]
     fn explicit_composite_entity_is_excluded_from_slots() {
         let mut values = groups();
         for group in &mut values {

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -214,7 +214,7 @@ pub enum CorrelationDraftError {
     #[error("at least {minimum} recurring slots are required, got {actual}")]
     TooFewSlots { minimum: usize, actual: usize },
     /// A recurring slot appears more than once in one group.
-    #[error("group '{group}' repeats slot {slot} at event indexes {events:?}")]
+    #[error("group '{group}' repeats slot {slot} at input events {events:?}")]
     DuplicateSlot {
         group: String,
         slot: usize,
@@ -234,13 +234,18 @@ pub enum CorrelationDraftError {
     AmbiguousEntity { candidates: Vec<String> },
     /// An explicit grouping field is absent or unstable.
     #[error(
-        "group-by field '{field}' is absent or unstable in group '{group}' at retained event {event}"
+        "group-by field '{field}' is absent or unstable in group '{group}' at input event {event}"
     )]
     InvalidEntity {
         field: String,
         group: String,
         event: usize,
     },
+    /// Fewer slot ids than inferred slots and no base rule id to derive from.
+    #[error(
+        "every drafted slot rule needs an id: {slots} slots were inferred but only {provided} slot ids were supplied"
+    )]
+    MissingSlotIds { slots: usize, provided: usize },
     /// A per-slot detection could not be drafted.
     #[error("failed to draft slot {slot}: {source}")]
     SlotDraft {
@@ -430,7 +435,12 @@ pub fn draft_correlation(
             name: slot.name.clone(),
             id: slot.id.clone(),
             support: slot.members.len(),
-            group_support: groups.len(),
+            group_support: slot
+                .members
+                .iter()
+                .map(|(group, _)| group)
+                .collect::<BTreeSet<_>>()
+                .len(),
             selected_fields: selected_forms(slot),
         })
         .collect();
@@ -635,13 +645,13 @@ fn validate_slot_counts(
 ) -> Result<(), CorrelationDraftError> {
     for group in groups {
         for &slot in retained {
-            let events: Vec<usize> = group
+            let mut events: Vec<usize> = group
                 .events
                 .iter()
-                .enumerate()
-                .filter(|(_, event)| event.cluster == slot)
-                .map(|(index, _)| index)
+                .filter(|event| event.cluster == slot)
+                .map(|event| event.input_index)
                 .collect();
+            events.sort_unstable();
             if events.len() > 1 {
                 return Err(CorrelationDraftError::DuplicateSlot {
                     group: group.id.clone(),
@@ -799,11 +809,10 @@ fn validate_entity_field(
 ) -> Result<(), CorrelationDraftError> {
     for group in groups {
         let mut expected = None;
-        for (index, event) in group
+        for event in group
             .events
             .iter()
-            .enumerate()
-            .filter(|(_, event)| retained.contains(&event.cluster))
+            .filter(|event| retained.contains(&event.cluster))
         {
             let value = JsonEvent::borrow(&event.event)
                 .get_field(field)
@@ -816,7 +825,7 @@ fn validate_entity_field(
                 return Err(CorrelationDraftError::InvalidEntity {
                     field: field.to_string(),
                     group: group.id.clone(),
-                    event: index,
+                    event: event.input_index,
                 });
             }
             expected = value;
@@ -853,6 +862,15 @@ fn build_slots(
     slot_ids: &[String],
     detection_config: &DraftConfig,
 ) -> Result<Vec<Slot>, CorrelationDraftError> {
+    // Identity verification keys on slot rule ids, so a slot without one can
+    // never pass and would grind through relaxation into a misleading
+    // floor error. Refuse up front instead.
+    if slot_ids.len() < order.len() && detection_config.rule_id.is_none() {
+        return Err(CorrelationDraftError::MissingSlotIds {
+            slots: order.len(),
+            provided: slot_ids.len(),
+        });
+    }
     let mut slots = Vec::with_capacity(order.len());
     let mut used_names = BTreeMap::new();
     for (position, &cluster) in order.iter().enumerate() {
@@ -1180,7 +1198,7 @@ fn verify_identity(
                 }
                 return Err(CorrelationDraftError::CrossSlotMatch {
                     group: group.id.clone(),
-                    event: event_index,
+                    event: event.input_index,
                     assigned: slots[assigned].name.clone(),
                     colliding,
                     forms,
@@ -1499,13 +1517,29 @@ mod tests {
             None,
             json!({"kind": "reset", "user": "alice", "factor": "totp", "reset_reason": "recovery"}),
         ));
+        // Input positions, not time-sorted positions: the duplicate reset was
+        // appended as input event 2 even though it sorts between the others.
         assert!(matches!(
             draft_correlation(&values, &[], &[], &config()),
             Err(CorrelationDraftError::DuplicateSlot {
                 group,
                 slot: _,
                 events
-            }) if group == "g1" && events == vec![0, 1]
+            }) if group == "g1" && events == vec![0, 2]
+        ));
+    }
+
+    #[test]
+    fn missing_slot_ids_error_before_verification() {
+        let mut cfg = config();
+        cfg.slot_ids.truncate(1);
+        cfg.detection.rule_id = None;
+        assert!(matches!(
+            draft_correlation(&groups(), &[], &[], &cfg),
+            Err(CorrelationDraftError::MissingSlotIds {
+                slots: 2,
+                provided: 1
+            })
         ));
     }
 
@@ -1570,6 +1604,26 @@ mod tests {
         assert!(matches!(
             draft_correlation(&groups(), &[group("bad", "mallory", false)], &[], &config()),
             Err(CorrelationDraftError::NegativeGroupMatched { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_entity_reports_input_position() {
+        // g1 arrives in reverse input order, so input event 1 sorts first.
+        // Dropping the group-by field there must blame input position 1.
+        let mut values = groups();
+        values[0] = group("g1", "alice", true);
+        values[0].events[1]
+            .event
+            .as_object_mut()
+            .unwrap()
+            .remove("user");
+        let mut cfg = config();
+        cfg.group_by = vec!["user".to_string()];
+        assert!(matches!(
+            draft_correlation(&values, &[], &[], &cfg),
+            Err(CorrelationDraftError::InvalidEntity { field, group, event })
+                if field == "user" && group == "g1" && event == 1
         ));
     }
 

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1510,4 +1510,50 @@ mod tests {
             Err(CorrelationDraftError::NegativeGroupMatched { .. })
         ));
     }
+
+    #[test]
+    fn verification_ignores_unrelated_correlation_results() {
+        let report = draft_correlation(&groups(), &[], &[], &config()).unwrap();
+        let collection = rsigma_parser::parse_sigma_yaml(&report.rule_yaml).unwrap();
+        let mut normalized = normalize_groups(&groups(), 3).unwrap();
+        assign_clusters(&mut normalized, 0.6);
+        let (retained, _) = retained_clusters(&normalized, 2).unwrap();
+        assert!(matches!(
+            verify_groups(
+                &collection,
+                &normalized,
+                &retained,
+                "unrelated-correlation",
+                false
+            ),
+            Err(CorrelationDraftError::PositiveVerification { .. })
+        ));
+    }
+
+    #[test]
+    fn verification_rejects_premature_target_firing() {
+        let report = draft_correlation(&groups(), &[], &[], &config()).unwrap();
+        let yaml = report
+            .rule_yaml
+            .replace(
+                "        - slot_totp\n        - slot_64512\n",
+                "        - slot_totp\n",
+            )
+            .replace("        gte: 2\n", "        gte: 1\n");
+        let collection = rsigma_parser::parse_sigma_yaml(&yaml).unwrap();
+        let mut normalized = normalize_groups(&groups(), 3).unwrap();
+        assign_clusters(&mut normalized, 0.6);
+        let (retained, _) = retained_clusters(&normalized, 2).unwrap();
+        assert!(matches!(
+            verify_groups(
+                &collection,
+                &normalized,
+                &retained,
+                "00000000-0000-4000-8000-000000000003",
+                false
+            ),
+            Err(CorrelationDraftError::PositiveVerification { reason, .. })
+                if reason.contains("prematurely")
+        ));
+    }
 }

--- a/crates/rsigma-eval/src/rule_draft/correlation.rs
+++ b/crates/rsigma-eval/src/rule_draft/correlation.rs
@@ -1414,11 +1414,26 @@ mod tests {
         let first = draft_correlation(&groups(), &[], &[], &config()).unwrap();
         let second = draft_correlation(&groups(), &[], &[], &config()).unwrap();
         assert_eq!(first.rule_yaml, second.rule_yaml);
+        assert_eq!(
+            first.rule_yaml,
+            include_str!("golden/correlation_ordered.yaml")
+        );
         assert_eq!(first.correlation_type, "temporal_ordered");
         assert_eq!(first.group_by, vec!["user"]);
         assert!(first.rule_yaml.contains("rsigma.exemplars:"));
         assert!(rsigma_parser::parse_sigma_yaml(&first.rule_yaml).is_ok());
         assert!(first.verification.iter().all(|row| row.fired));
+    }
+
+    #[test]
+    fn unordered_collection_matches_golden() {
+        let mut cfg = config();
+        cfg.correlation_type = CorrelationDraftType::Temporal;
+        let report = draft_correlation(&groups(), &[], &[], &cfg).unwrap();
+        assert_eq!(
+            report.rule_yaml,
+            include_str!("golden/correlation_unordered.yaml")
+        );
     }
 
     #[test]

--- a/crates/rsigma-eval/src/rule_draft/golden/correlation_ordered.yaml
+++ b/crates/rsigma-eval/src/rule_draft/golden/correlation_ordered.yaml
@@ -1,0 +1,71 @@
+title: 'Draft: totp (factor)'
+name: slot_totp
+id: 00000000-0000-4000-8000-000000000001
+status: experimental
+description: 'TODO: describe what this rule detects and why it matters.'
+author: 'TODO: your name'
+date: 2026-09-04
+logsource:
+    product: todo
+detection:
+    selection:
+        factor: totp
+        kind: reset
+        reset_reason: recovery
+    condition: selection
+falsepositives:
+    - 'TODO: list known benign triggers.'
+level: medium
+---
+title: 'Draft: 64512 (asn)'
+name: slot_64512
+id: 00000000-0000-4000-8000-000000000002
+status: experimental
+description: 'TODO: describe what this rule detects and why it matters.'
+author: 'TODO: your name'
+date: 2026-09-04
+logsource:
+    product: todo
+detection:
+    selection:
+        asn: 64512
+        kind: session
+        new_asn: true
+        session_type: web
+    condition: selection
+falsepositives:
+    - 'TODO: list known benign triggers.'
+level: medium
+---
+title: Draft temporal correlation
+id: 00000000-0000-4000-8000-000000000003
+status: experimental
+correlation:
+    type: temporal_ordered
+    rules:
+        - slot_totp
+        - slot_64512
+    group-by:
+        - user
+    timespan: 30s
+    condition:
+        gte: 2
+custom_attributes:
+    rsigma.exemplars:
+        - name: 'observed group g2'
+          expect: match
+          events:
+              - offset: 0s
+                event:
+                    factor: totp
+                    kind: reset
+                    reset_reason: recovery
+                    user: bob
+              - offset: 20s
+                event:
+                    asn: 64512
+                    kind: session
+                    new_asn: true
+                    session_type: web
+                    user: bob
+level: medium

--- a/crates/rsigma-eval/src/rule_draft/golden/correlation_unordered.yaml
+++ b/crates/rsigma-eval/src/rule_draft/golden/correlation_unordered.yaml
@@ -1,0 +1,71 @@
+title: 'Draft: totp (factor)'
+name: slot_totp
+id: 00000000-0000-4000-8000-000000000001
+status: experimental
+description: 'TODO: describe what this rule detects and why it matters.'
+author: 'TODO: your name'
+date: 2026-09-04
+logsource:
+    product: todo
+detection:
+    selection:
+        factor: totp
+        kind: reset
+        reset_reason: recovery
+    condition: selection
+falsepositives:
+    - 'TODO: list known benign triggers.'
+level: medium
+---
+title: 'Draft: 64512 (asn)'
+name: slot_64512
+id: 00000000-0000-4000-8000-000000000002
+status: experimental
+description: 'TODO: describe what this rule detects and why it matters.'
+author: 'TODO: your name'
+date: 2026-09-04
+logsource:
+    product: todo
+detection:
+    selection:
+        asn: 64512
+        kind: session
+        new_asn: true
+        session_type: web
+    condition: selection
+falsepositives:
+    - 'TODO: list known benign triggers.'
+level: medium
+---
+title: Draft temporal correlation
+id: 00000000-0000-4000-8000-000000000003
+status: experimental
+correlation:
+    type: temporal
+    rules:
+        - slot_totp
+        - slot_64512
+    group-by:
+        - user
+    timespan: 30s
+    condition:
+        gte: 2
+custom_attributes:
+    rsigma.exemplars:
+        - name: 'observed group g2'
+          expect: match
+          events:
+              - offset: 0s
+                event:
+                    factor: totp
+                    kind: reset
+                    reset_reason: recovery
+                    user: bob
+              - offset: 20s
+                event:
+                    asn: 64512
+                    kind: session
+                    new_asn: true
+                    session_type: web
+                    user: bob
+level: medium

--- a/crates/rsigma-eval/src/schema_discovery.rs
+++ b/crates/rsigma-eval/src/schema_discovery.rs
@@ -39,6 +39,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use serde::Serialize;
 
 use crate::event::Event;
+use crate::key_shape::cluster_by_key_shape;
 use crate::schema::{
     SchemaClassifier, SchemaPredicate, SchemaSignature, UnknownShapeEntry, validate_schema_config,
 };
@@ -529,23 +530,15 @@ fn build_report(
 /// `shapes` already ordered most-frequent-first (the merge anchor is the first
 /// shape of each cluster), so the result is deterministic.
 fn cluster_shapes(shapes: &[ShapeStat], config: &DiscoveryConfig) -> Vec<Cluster> {
-    let mut clusters: Vec<Cluster> = Vec::new();
-    for shape in shapes {
-        let mut placed = false;
-        for cluster in &mut clusters {
-            if jaccard(&shape.keys, &cluster.seed_keys) >= config.similarity
-                && diversity_ok(cluster, shape)
-            {
-                cluster.merge(shape);
-                placed = true;
-                break;
-            }
-        }
-        if !placed {
-            clusters.push(Cluster::from_shape(shape));
-        }
-    }
-    clusters
+    cluster_by_key_shape(
+        shapes,
+        config.similarity,
+        |shape| &shape.keys,
+        |cluster| &cluster.seed_keys,
+        Cluster::from_shape,
+        diversity_ok,
+        Cluster::merge,
+    )
 }
 
 /// Refuse to merge a shape into a cluster when they disagree on a single
@@ -791,21 +784,6 @@ fn unique_name(name: String, used: &mut BTreeMap<String, u32>) -> String {
 // =============================================================================
 // Small helpers
 // =============================================================================
-
-fn jaccard(a: &[String], b: &[String]) -> f64 {
-    if a.is_empty() && b.is_empty() {
-        return 1.0;
-    }
-    let sa: BTreeSet<&String> = a.iter().collect();
-    let sb: BTreeSet<&String> = b.iter().collect();
-    let inter = sa.intersection(&sb).count();
-    let union = sa.union(&sb).count();
-    if union == 0 {
-        0.0
-    } else {
-        inter as f64 / union as f64
-    }
-}
 
 fn truncate_keys(keys: &[String]) -> Vec<String> {
     keys.iter().take(MAX_SAMPLE_KEYS_PER_SET).cloned().collect()

--- a/docs/content/cli/rule/draft.md
+++ b/docs/content/cli/rule/draft.md
@@ -1,6 +1,6 @@
 # `rsigma rule draft`
 
-Draft a Sigma detection rule from exemplar events, optionally contrasted against a baseline corpus.
+Draft a Sigma detection rule or temporal correlation from exemplar events, optionally contrasted against a baseline corpus.
 
 ## Synopsis
 
@@ -23,6 +23,12 @@ Two things stay yours: the metadata (title, description, tags, level are placeho
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-e, --event <EVENT>` | stdin | Exemplars: a single event as a JSON string, or `@path` to an NDJSON file (or `.evtx` in builds with the `evtx` feature). If omitted, reads NDJSON from stdin. |
+| `--groups <@PATH>` | unset | Grouped, timed exemplars from one envelope NDJSON file or a directory containing one NDJSON file per group. |
+| `--negative <@PATH>` | unset | Grouped examples that the drafted correlation must not match. Requires `--groups`. |
+| `--group-by <FIELD>` | inferred | Correlation entity field. Repeatable for an explicit composite key. |
+| `--correlation-type <auto\|temporal\|temporal_ordered>` | `auto` | Infer consistent ordering, force unordered temporal behavior, or require consistent ordering. |
+| `--min-groups <N>` | `3` | Minimum positive groups required for correlation drafting. |
+| `--window-margin <F>` | `1.5` | Multiplier applied to the maximum observed positive-group span before rounding up. |
 | `--baseline <@PATH>` | unset | Baseline corpus of normal traffic (NDJSON or `.evtx`). Used for contrastive field scoring and the final false-positive estimate. |
 | `--max-fields <N>` | `4` | Maximum fields in the drafted selection. |
 | `--min-prevalence <F>` | `1.0` | Fraction of exemplars a field must appear in to be a candidate. |
@@ -91,12 +97,38 @@ rsigma engine eval --rules draft.yml -e @incident.ndjson
 
 The command already runs this loop internally (the draft is guaranteed to parse, lint findings surface as warnings, and every exemplar matches), but re-running it after your metadata edits catches typos.
 
+### Draft a temporal correlation
+
+Envelope NDJSON carries a group id, exactly one time key, and an event:
+
+```json
+{"group":"incident-1","offset":"0s","event":{"eventType":"factor.reset","user":"alice"}}
+{"group":"incident-1","offset":"4m","event":{"eventType":"session.start","user":"alice","newAsn":true}}
+```
+
+Provide at least three observed groups by default:
+
+```bash
+rsigma rule draft --groups @observed.ndjson --negative @benign.ndjson > correlation.yml
+rsigma rule test --rules correlation.yml
+```
+
+Absolute RFC3339 `timestamp` values can replace offsets, but one group cannot mix the two modes. Directory input uses each filename stem as the group id, so each line contains only `timestamp`/`offset` and `event`.
+
+The command clusters recurring event key shapes into slots, drops incidental clusters missing from any positive group, and rejects repeated retained slots. `auto` emits `temporal_ordered` only when every group has the same slot order. Otherwise it emits `temporal` and reports the disagreeing groups. A forced `temporal_ordered` request errors on an inversion.
+
+The window is the maximum positive first-to-last retained-slot span multiplied by `--window-margin`, rounded up to a human-readable duration. Each slot rule is contrasted against sibling slots and the optional baseline. Grouping fields are excluded from slot predicates.
+
+Without `--group-by`, exactly one field must be present and stable within every positive group and distinct across groups. Zero or multiple candidates return an ambiguity error. Composite keys always require repeated `--group-by`.
+
+Each group is verified in a fresh correlation engine. Positive groups must fire only after all slots are consumed, and negative groups must never fire. The correlation document embeds a median-span positive group under `rsigma.exemplars`, so `rule test` replays the draft directly.
+
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
 | `0` | A verified draft was emitted. |
-| `2` | Exemplars could not be read, or no rule could honestly cover them (all fields volatile, a forced `--include-field` absent from some exemplars, or the exemplars are too heterogeneous to match at the minimum-field floor). |
+| `2` | Exemplars could not be read, no rule could honestly cover them, grouped input was invalid, entity/slot inference was ambiguous, or isolated verification failed. |
 | `3` | A `--baseline` value without the `@path` prefix. |
 
 ## See also

--- a/docs/content/guide/detection-strategy.md
+++ b/docs/content/guide/detection-strategy.md
@@ -112,4 +112,5 @@ Each contributing rule in the bundle reports how its key resolved (`unique`, `am
 - [Lint Rules: ADS detection-strategy metadata](../reference/lint-rules.md#ads-detection-strategy-metadata-11) for the enforcement checks and config.
 - [Custom Attributes: `rsigma.ads.*`](../reference/custom-attributes.md#ads-detection-strategy-attributes-rsigmaads) for the attribute reference.
 - [Rule Hygiene](rule-hygiene.md) for the `incomplete-ads` retirement signal.
+- [Drafting Rules from Logs](rule-drafting.md#drafting-correlations) to create verified temporal rules with an embedded match exemplar.
 - [CI/CD](ci-cd.md) for wiring the gate into a pipeline.

--- a/docs/content/guide/rule-drafting.md
+++ b/docs/content/guide/rule-drafting.md
@@ -131,9 +131,38 @@ The exemplars are classified with the built-in schema classifier ([schema routin
 
 The rule uses the exemplars' field names as they appear in the events. ECS exemplars produce `process.command_line`, Sysmon exemplars produce `CommandLine`. Evaluate the draft against the same telemetry shape it was mined from, without a mapping pipeline; if you need the generic SigmaHQ field vocabulary, rename the fields as part of your review. Pipelines are out of scope at draft time: map or rename after you accept the draft.
 
+## Drafting correlations
+
+Use `--groups` when each positive example is a timed sequence rather than one event. An envelope NDJSON file identifies every event's group and supplies exactly one RFC3339 `timestamp` or Sigma `offset`:
+
+```json
+{"group":"g1","offset":"0s","event":{"eventType":"factor.reset","user":"alice"}}
+{"group":"g1","offset":"4m","event":{"eventType":"session.start","user":"alice","newAsn":true}}
+```
+
+A directory is also accepted. Each filename stem becomes the group id, and each line contains the time key plus `event`. The command requires at least three groups and two events per group by default. Mixed time modes, duplicate times, repeated recurring slots, and malformed envelopes are errors with group and source-line context.
+
+Recurring slots are inferred from event field-key shapes. Clusters missing from any positive group are treated as incidental noise and reported. Each retained slot must appear exactly once per group. Slot rules are drafted against their assigned positives while sibling slots and `--baseline` provide contrast. The selected group-by fields are always excluded from slot predicates.
+
+Pass repeatable `--group-by` fields for an explicit entity, especially a composite key. Without it, one field must be stable inside every group and distinct across groups. The command reports zero or multiple candidates as an ambiguity instead of choosing one.
+
+The default `--correlation-type auto` emits `temporal_ordered` only when every group agrees on slot order. An inversion downgrades to `temporal` with a warning. Use `--correlation-type temporal_ordered` to make an inversion an error, or `temporal` to request unordered behavior.
+
+The timespan starts from the maximum observed first-to-last retained-slot span, not the median. The maximum is multiplied by `--window-margin` and rounded up. The median-span group is used only as the embedded `rsigma.exemplars` sequence.
+
+Verification uses a fresh correlation engine for every positive and negative group. Every assigned event must match only its slot rule. A positive correlation cannot fire before all slots and must fire by the end. Any `--negative` group that fires is a terminal error. Clean up heterogeneous exemplars, add a representative baseline, or edit the emitted rules manually when slot rules collide.
+
+```bash
+rsigma rule draft --groups @observed.ndjson --negative @benign.ndjson > correlation.yml
+rsigma rule test --rules correlation.yml
+```
+
+The emitted multi-document YAML contains named slot detections, the temporal correlation, and a representative positive sequence under `rsigma.exemplars`. This makes the draft directly testable after metadata edits.
+
 ## What it will not do
 
-- No correlation or filter rules; detection rules only.
+- No aggregate correlation synthesis (`event_count`, `value_count`, or numeric aggregates) and no filter rules.
+- No repeated retained stage within one group.
 - No ATT&CK tags or severity judgment; the metadata placeholders are yours to fill.
 - No regex synthesis; patterns stay within prefix/suffix/token modifiers a reviewer can read at a glance.
 - No online drafting from the daemon: the daemon never retains event values, and presence-only rules are not useful detections. Draft from captured NDJSON or EVTX instead.

--- a/docs/content/guide/rule-drafting.md
+++ b/docs/content/guide/rule-drafting.md
@@ -140,7 +140,7 @@ Use `--groups` when each positive example is a timed sequence rather than one ev
 {"group":"g1","offset":"4m","event":{"eventType":"session.start","user":"alice","newAsn":true}}
 ```
 
-A directory is also accepted. Each filename stem becomes the group id, and each line contains the time key plus `event`. The command requires at least three groups and two events per group by default. Mixed time modes, duplicate times, repeated recurring slots, and malformed envelopes are errors with group and source-line context.
+A directory is also accepted. Each filename stem becomes the group id, and each line contains the time key plus `event`; an embedded `group` key is an error in directory form. The command requires at least three groups and two events per group by default. Mixed time modes, duplicate times, repeated recurring slots, and malformed envelopes are errors with group and source-line context.
 
 Recurring slots are inferred from event field-key shapes. Clusters missing from any positive group are treated as incidental noise and reported. Each retained slot must appear exactly once per group. Slot rules are drafted against their assigned positives while sibling slots and `--baseline` provide contrast. The selected group-by fields are always excluded from slot predicates.
 

--- a/docs/content/library/eval.md
+++ b/docs/content/library/eval.md
@@ -47,6 +47,7 @@ serde_json = "1"   # only if you use the JsonEvent shim
 | `ProcessResultExt` | Extension trait on `[EvaluationResult]` exposing `detections()` / `correlations()` iterators and `detection_count()` / `correlation_count()`. Bring this into scope when you want kind-filtered iteration without pattern matching. |
 | `CompiledMatcher`, `CompiledRule` | Internal matcher tree types; consume via the AST conversion or build them yourself for an alternative front-end. |
 | `draft_rule`, `DraftConfig`, `DraftReport` | Profile positive exemplars against an optional baseline and emit a verified detection-rule draft. |
+| `rule_draft::correlation::{draft_correlation, GroupedExemplar, TimedEvent, CorrelationDraftConfig, CorrelationDraftReport}` | Infer recurring slots, entity, order, and window from grouped timed exemplars, then emit and verify a multi-document temporal correlation. |
 | `tune_rule`, `TuneConfig`, `TuneReport` | Contrast false-positive and true-positive exemplars and emit a verified Sigma filter rule that suppresses no TP. |
 
 The full enum of modifiers, the matcher-optimizer constants, the `rsigma.*` custom-attribute table, and the bloom/cross-rule prefilters live in [the crate README](https://github.com/timescale/rsigma/blob/main/crates/rsigma-eval/README.md).
@@ -174,6 +175,8 @@ for raw in events {
 ```
 
 `process_with_detections(event, Vec<EvaluationResult>)` is the lower-overhead variant for hot loops (pre-compute detections in parallel, feed sequentially to correlation). `CorrelationConfig` enforces `max_state_entries` (default 100,000) and the 10-deep correlation-chain limit; see [Security Hardening](../reference/security.md#input-size-and-depth-caps). A correlation whose `rules:` list other correlations (for example a `temporal` of two `event_count` rules) emits the parent result when the chain condition is met, the same way a temporal of detections does.
+
+`rule_draft::correlation::draft_correlation` accepts positive and negative `GroupedExemplar` collections, an optional flat baseline, and `CorrelationDraftConfig`. Each `TimedEvent` carries exactly one RFC3339 timestamp or Sigma offset plus a JSON event. The result contains paste-ready YAML, inferred grouping/order/window evidence, per-slot support, gap distributions, warnings, and the isolated verification matrix. Caller-supplied ids keep the library deterministic; command-line callers generate UUIDs.
 
 ## Custom attributes
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -65,6 +65,11 @@ path = "fuzz_targets/fuzz_rule_tune.rs"
 doc = false
 
 [[bin]]
+name = "fuzz_draft_groups"
+path = "fuzz_targets/fuzz_draft_groups.rs"
+doc = false
+
+[[bin]]
 name = "fuzz_pipeline_sources_yaml"
 path = "fuzz_targets/fuzz_pipeline_sources_yaml.rs"
 doc = false

--- a/fuzz/corpus/fuzz_draft_groups/malformed.ndjson
+++ b/fuzz/corpus/fuzz_draft_groups/malformed.ndjson
@@ -1,0 +1,3 @@
+{"group":"g1","timestamp":"not-a-time","offset":"1s","event":null}
+{"group":7,"event":[]}
+not json

--- a/fuzz/corpus/fuzz_draft_groups/offsets.ndjson
+++ b/fuzz/corpus/fuzz_draft_groups/offsets.ndjson
@@ -1,0 +1,6 @@
+{"group":"g1","offset":"0s","event":{"kind":"reset","user":"alice","factor":"totp","reset_reason":"recovery"}}
+{"group":"g1","offset":"20s","event":{"kind":"session","user":"alice","new_asn":true,"asn":64512,"session_type":"web"}}
+{"group":"g2","offset":"0s","event":{"kind":"reset","user":"bob","factor":"totp","reset_reason":"recovery"}}
+{"group":"g2","offset":"25s","event":{"kind":"session","user":"bob","new_asn":true,"asn":64512,"session_type":"web"}}
+{"group":"g3","offset":"0s","event":{"kind":"reset","user":"carol","factor":"totp","reset_reason":"recovery"}}
+{"group":"g3","offset":"30s","event":{"kind":"session","user":"carol","new_asn":true,"asn":64512,"session_type":"web"}}

--- a/fuzz/fuzz_targets/fuzz_draft_groups.rs
+++ b/fuzz/fuzz_targets/fuzz_draft_groups.rs
@@ -1,0 +1,60 @@
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::fuzz_target;
+use rsigma_eval::DraftConfig;
+use rsigma_eval::rule_draft::correlation::{
+    CorrelationDraftConfig, GroupedExemplar, SourceLocation, TimedEvent, draft_correlation,
+};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(input) = std::str::from_utf8(data) else {
+        return;
+    };
+    let mut grouped: BTreeMap<String, Vec<TimedEvent>> = BTreeMap::new();
+    for line in input.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        let group = object
+            .get("group")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        grouped.entry(group).or_default().push(TimedEvent {
+            timestamp: object
+                .get("timestamp")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            offset: object
+                .get("offset")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            event: object
+                .get("event")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+            source: SourceLocation::default(),
+        });
+    }
+    let groups: Vec<GroupedExemplar> = grouped
+        .into_iter()
+        .map(|(id, events)| GroupedExemplar { id, events })
+        .collect();
+    let config = CorrelationDraftConfig {
+        correlation_id: Some("00000000-0000-4000-8000-000000000003".to_string()),
+        slot_ids: (0..32)
+            .map(|index| format!("00000000-0000-4000-8000-{index:012}"))
+            .collect(),
+        detection: DraftConfig {
+            date: Some("2026-09-04".to_string()),
+            ..DraftConfig::default()
+        },
+        ..CorrelationDraftConfig::default()
+    };
+    let _ = draft_correlation(&groups, &[], &[], &config);
+});


### PR DESCRIPTION
## Summary

`rsigma rule draft --groups` turns grouped, timed exemplar sequences into a verified multi-document Sigma correlation: one named detection rule per recurring event slot plus a `temporal` or `temporal_ordered` correlation document referencing them.

- **Grouped input.** `--groups @file` reads envelope NDJSON lines of `group` + `timestamp`/`offset` + `event`; `--groups @directory` uses filename stems as group ids. Validation is strict: exactly one time key per event, one time mode per group, RFC3339 timestamps or Sigma offsets, no duplicate parsed times, and errors carry file/line context.
- **Slot inference.** Events cluster by field-key shape (shared Jaccard helper extracted from schema discovery). Clusters absent from any positive group are dropped as incidental noise with a warning; a retained slot appearing twice in one group is a pointed error.
- **Ordering and window.** `--correlation-type auto` emits `temporal_ordered` only when every group agrees on slot order, inferring the expected order from the majority so diagnostics name the actual outliers; disagreement downgrades to `temporal` with a warning, and a forced `temporal_ordered` errors. The timespan is the maximum observed first-to-last span times `--window-margin`, rounded up through human-readable steps with checked arithmetic.
- **Entity.** `--group-by` is the explicit (repeatable, composite) grouping key; when absent, exactly one direct field that is stable within every group and distinct across groups is inferred, and zero or multiple candidates refuse with a deterministic list rather than guessing.
- **Disjoint slot rules.** Each slot is drafted from its assigned positives with sibling slots plus the optional `--baseline` as contrast, grouping fields excluded. Every retained event must match its assigned slot rule and no sibling; cross-slot collisions are terminal errors naming the colliding slots and selected forms.
- **Isolated verification.** Every positive and negative group replays through a fresh correlation engine, counting only results whose id equals the emitted correlation id. Positives must fire exactly at completion; any `--negative` group firing at any event is terminal. Negative groups replay all of their events, not just retained-shaped ones, since slot rules match on predicates rather than key shapes.
- **Self-regressing output.** The emitted collection embeds a median-span positive group under `rsigma.exemplars`, reparsed and linted before returning, so `rsigma rule test` replays the draft directly.

## Engine fix

A `temporal`/`temporal_ordered` correlation that referenced a detection rule by `name` never fired when that rule also carried an `id`: the engine tracked the id in the temporal window while the condition compared against the referenced name. The engine now tracks whichever identity the correlation actually references, with a dedicated regression test.

## Testing

- Unit coverage for the grouped model, slot/order/window inference, entity inference, identity matrix, isolated verification, and negative gates, including tests that fail under shared engine state, premature firing, or skipped negative events.
- Fixed-id goldens for ordered and unordered output; byte-determinism asserted across runs.
- CLI integration tests for envelope and directory input, malformed line context, ordering flags, embedded group key rejection, and end-to-end reparse plus `rule lint`/`rule test` of emitted YAML.
- New fuzz target `fuzz_draft_groups` over arbitrary grouped-envelope bytes, seeded and registered in the fuzz workflow with a bounded max_len.
- Full workspace suite: 3,939 tests passing; fmt, clippy (workspace, all targets/features, deny warnings), rustdoc, and docs build/validate clean.

Closes #335 