### PR TITLE
chore(deps): batch dependency updates (Sep 2026)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,7 +41,7 @@ jobs:
           rustup override set stable
       # Pull `cargo-audit` from prebuilt artifacts rather than building
       # it from source every run; saves ~30s per audit invocation.
-      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
+      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-audit
       - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # a transitive `wasm-bindgen` import would fail instantiation here, and a
       # semantic regression would trap the module.
       - name: Install Wasmtime
-        uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: wasmtime
       - name: Instantiate the WASM module in a host-neutral runtime
@@ -284,7 +284,7 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
           rustup override set stable
-      - uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
+      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -116,7 +116,7 @@ jobs:
         id: resolve
         run: echo "digest=sha256:$(ls /tmp/digests)" >> "${GITHUB_OUTPUT}"
 
-      - uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+      - uses: anchore/scan-action@8964e60c6fabdb85fdbbbfd9834d8f19c97a3086 # v7.4.1
         id: grype
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.resolve.outputs.digest }}
@@ -128,7 +128,7 @@ jobs:
           # so pin grype to the matrix arch instead of the host default.
           GRYPE_PLATFORM: linux/${{ matrix.arch }}
 
-      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         if: always()
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
+### Dependency batch (Sep 2026)
+
+Rolls up the open Dependabot PRs into a single merge, regenerated against current `main` rather than replaying stale lockfile bases. Rust (workspace `Cargo.lock`, with `fuzz/Cargo.lock` and `ci/wasm-smoke/Cargo.lock` synced): the patch group (#472) updates `log` 0.4.33 to 0.4.34, `jsonpath-rust` 1.0.8 to 1.0.10, `cel` 0.14.3 to 0.14.4, and `rustls-webpki` 0.103.14 to 0.103.15; standalone updates move `daachorse` 3.0.3 to 5.0.0 (#475) and `webpki-roots` 0.26.11 to 1.0.9 (#473). `yamlpath` 1.26.1 to 1.27.0 with `tree-sitter-iter` 1.26.1 to 1.27.0 (#474 requested 1.29.0; 1.28+ pulls `tree-sitter-iter` 1.28+ which requires rustc 1.97). `yamlpatch` stays at 1.26.1 (no 1.27 release; 1.28+ requires `yamlpath` ^1.28). CI (all repinned by commit SHA, batched via the `actions-updates` group, #471): `taiki-e/install-action` v2.86.4 to v2.87.0, `anchore/scan-action` v7.4.0 to v7.4.1, and `github/codeql-action/upload-sarif` v4.37.7 to v4.37.9. Held back: `tikv-jemallocator` 0.7.0 (#425, jemalloc 5.3.1) still regresses musl routed daemon throughput about 4-7% versus 0.6.1.
+
 ### Fire name-referenced temporal correlations (#477)
 
 A `temporal` or `temporal_ordered` correlation that referenced a detection rule by `name` never fired when that rule also carried an `id`: the engine tracked the id in the temporal window while the condition compared against the referenced name. The engine now tracks whichever identity the correlation actually references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to RSigma are documented in this file. Each entry correspond
 
 ## [Unreleased]
 
-### Dependency batch (Sep 2026)
+### Dependency batch (Sep 2026) (#479)
 
 Rolls up the open Dependabot PRs into a single merge, regenerated against current `main` rather than replaying stale lockfile bases. Rust (workspace `Cargo.lock`, with `fuzz/Cargo.lock` and `ci/wasm-smoke/Cargo.lock` synced): the patch group (#472) updates `log` 0.4.33 to 0.4.34, `jsonpath-rust` 1.0.8 to 1.0.10, `cel` 0.14.3 to 0.14.4, and `rustls-webpki` 0.103.14 to 0.103.15; standalone updates move `daachorse` 3.0.3 to 5.0.0 (#475) and `webpki-roots` 0.26.11 to 1.0.9 (#473). `yamlpath` 1.26.1 to 1.27.0 with `tree-sitter-iter` 1.26.1 to 1.27.0 (#474 requested 1.29.0; 1.28+ pulls `tree-sitter-iter` 1.28+ which requires rustc 1.97). `yamlpatch` stays at 1.26.1 (no 1.27 release; 1.28+ requires `yamlpath` ^1.28). CI (all repinned by commit SHA, batched via the `actions-updates` group, #471): `taiki-e/install-action` v2.86.4 to v2.87.0, `anchore/scan-action` v7.4.0 to v7.4.1, and `github/codeql-action/upload-sarif` v4.37.7 to v4.37.9. Held back: `tikv-jemallocator` 0.7.0 (#425, jemalloc 5.3.1) still regresses musl routed daemon throughput about 4-7% versus 0.6.1.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82399e72d100a28a0cac14251a8aba16d124af2a237d8a60ab7997ba7380cc3"
+checksum = "9f93082a93da8fd78394852602ced1e2e7754ed8c29dc813fa80b01a1baf9032"
 dependencies = [
  "antlr4rust",
  "chrono",
@@ -1144,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "daachorse"
-version = "3.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5614204febbc33cc07a2806aa6440b904ac012b68eecc37f4493ea4a76455a3d"
+checksum = "cd10668980c9e7ba8aa2e616207d9ec52f7db66ebb47db857ed1f3c342530dad"
 
 [[package]]
 name = "darling"
@@ -1365,7 +1365,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1554,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
+checksum = "8edb06feabbd4c3fe17e2572f391510e08a011b92f53a7b76236eeb18191cfbe"
 dependencies = [
  "pest",
  "pest_derive",
@@ -2896,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-cache"
@@ -3130,7 +3130,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3985,7 +3985,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4289,7 +4289,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -4711,7 +4711,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.9",
  "wiremock",
 ]
 
@@ -4777,7 +4777,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4836,7 +4836,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4847,9 +4847,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5392,7 +5392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5669,7 +5669,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6044,7 +6044,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -6235,9 +6235,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-iter"
-version = "1.26.1"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa36a1486a196f8de9ded8047a5c6e42d8b9d83a530a67e8316ba8468a325d4"
+checksum = "0cbef0ee83b87916292355e78f4fdee268d719ececa729be8914882428ca86b0"
 dependencies = [
  "tree-sitter",
 ]
@@ -6373,7 +6373,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -6644,14 +6644,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6697,7 +6697,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7069,9 +7069,9 @@ dependencies = [
 
 [[package]]
 name = "yamlpath"
-version = "1.26.1"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eed75b3170866fd4ad5848fb7e19ce9344f3dbc12238d9b175ef0632d27779"
+checksum = "1362068e6e34bf985c39ee42ee8d410fcc398fedbd5f9303602616db26f542b5"
 dependencies = [
  "line-index",
  "self_cell",

--- a/ci/wasm-smoke/Cargo.lock
+++ b/ci/wasm-smoke/Cargo.lock
@@ -336,9 +336,9 @@ checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"

--- a/crates/rsigma-eval/Cargo.toml
+++ b/crates/rsigma-eval/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "2"
 flate2 = "1"
 log = "0.4"
 rayon = { version = "1", optional = true }
-daachorse = { version = "3", optional = true }
+daachorse = { version = "5", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 ahash = { version = "0.8", default-features = false, features = ["compile-time-rng", "std"] }

--- a/crates/rsigma-parser/Cargo.toml
+++ b/crates/rsigma-parser/Cargo.toml
@@ -20,7 +20,7 @@ pest = "2"
 pest_derive = "2"
 serde = { version = "1", features = ["derive"] }
 yaml_serde = "0.10"
-yamlpath = { version = "1.26", optional = true }
+yamlpath = { version = "1.27", optional = true }
 yamlpatch = { version = "1.26", optional = true }
 serde_json = "1"
 thiserror = "2"

--- a/crates/rstix/Cargo.toml
+++ b/crates/rstix/Cargo.toml
@@ -75,7 +75,7 @@ hickory-resolver = { version = "0.26", default-features = false, features = ["to
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring", "logging"], optional = true }
 rustls-pki-types = { version = "1.9", features = ["std"], optional = true }
 rustls_webpki = { package = "rustls-webpki", version = "0.103", optional = true }
-webpki-roots = { version = "0.26", optional = true }
+webpki-roots = { version = "1.0", optional = true }
 sha2 = { version = "0.11", optional = true }
 p12-keystore = { version = "0.3", optional = true }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82399e72d100a28a0cac14251a8aba16d124af2a237d8a60ab7997ba7380cc3"
+checksum = "9f93082a93da8fd78394852602ced1e2e7754ed8c29dc813fa80b01a1baf9032"
 dependencies = [
  "antlr4rust",
  "chrono",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
+checksum = "8edb06feabbd4c3fe17e2572f391510e08a011b92f53a7b76236eeb18191cfbe"
 dependencies = [
  "pest",
  "pest_derive",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -1967,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Rolls up Dependabot PRs #472 (Rust patch group), #471 (GitHub Actions), #473 (`webpki-roots` 1.0.9), #475 (`daachorse` 5.0.0), and #474 (`yamlpath`, taken at 1.27.0) into one merge. Lockfiles are regenerated against current `main` (`Cargo.lock`, `fuzz/Cargo.lock`, `ci/wasm-smoke/Cargo.lock`) rather than replaying stale Dependabot bases. CI actions stay SHA-pinned.
- `yamlpath` 1.29.0 (#474) fails MSRV: `tree-sitter-iter` 1.28+ requires rustc 1.97. The latest pair that matches MSRV 1.95.0 is `yamlpath` 1.27.0 with `tree-sitter-iter` 1.27.0. `yamlpatch` stays at 1.26.1 (no 1.27; 1.28+ requires `yamlpath` ^1.28).
- Excludes `tikv-jemallocator` 0.7.0 (#425) after the earlier musl artifact A/B: jemalloc 5.3.1 still regresses routed daemon throughput about 4-7% versus 0.6.1. Leave #425 open for a dedicated `rsigma-perf-*` recheck.

Closes #472, closes #471, closes #473, closes #475, closes #474.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo check --locked --workspace --all-targets --all-features`
- [x] `cargo check --locked --manifest-path fuzz/Cargo.toml`
- [x] `cargo deny check`
- [x] `cargo doc --workspace --all-features --locked --no-deps`
- [x] `zizmor --pedantic .github/workflows`
- [x] `cargo test -p rsigma-eval --features daachorse-index --lib engine::cross_rule_ac`
- [x] `cargo test -p rsigma-parser --lib lint::fix`
- [x] `cargo build --release --target wasm32-unknown-unknown --manifest-path ci/wasm-smoke/Cargo.toml --locked`
- [x] CI green on all platforms